### PR TITLE
Change LW and SW to word-aligned immediate

### DIFF
--- a/src/interpreter/execution.rs
+++ b/src/interpreter/execution.rs
@@ -160,10 +160,10 @@ impl Interpreter {
             Opcode::CFSI(imm) if self.stack_pointer_overflow(Word::overflowing_sub, imm as Word) => {}
 
             Opcode::LB(ra, rb, imm)
-                if Self::is_valid_register_couple_alu(ra, rb) && self.load_byte(ra, rb, imm as RegisterId) => {}
+                if Self::is_valid_register_couple_alu(ra, rb) && self.load_byte(ra, rb, imm as Word) => {}
 
             Opcode::LW(ra, rb, imm)
-                if Self::is_valid_register_couple_alu(ra, rb) && self.load_word(ra, rb, imm as RegisterId) => {}
+                if Self::is_valid_register_couple_alu(ra, rb) && self.load_word(ra, rb, imm as Word) => {}
 
             Opcode::ALOC(ra) if Self::is_valid_register(ra) && self.malloc(self.registers[ra]) => {}
 

--- a/src/interpreter/memory.rs
+++ b/src/interpreter/memory.rs
@@ -59,8 +59,8 @@ impl Interpreter {
         }
     }
 
-    pub fn load_byte(&mut self, ra: RegisterId, b: RegisterId, c: RegisterId) -> bool {
-        let bc = b.saturating_add(c);
+    pub fn load_byte(&mut self, ra: RegisterId, b: RegisterId, c: Word) -> bool {
+        let bc = b.saturating_add(c as RegisterId);
         self.inc_pc();
 
         if bc >= VM_MAX_RAM as RegisterId {
@@ -74,8 +74,11 @@ impl Interpreter {
         }
     }
 
-    pub fn load_word(&mut self, ra: RegisterId, b: RegisterId, c: RegisterId) -> bool {
-        let (bc, overflow) = b.overflowing_add(c);
+    pub fn load_word(&mut self, ra: RegisterId, b: RegisterId, c: Word) -> bool {
+        // LW immediate is multiple of a Word
+        let c = c << 3;
+
+        let (bc, overflow) = b.overflowing_add(c as RegisterId);
         let (bcw, of) = bc.overflowing_add(8);
         let overflow = overflow || of;
         self.inc_pc();
@@ -108,6 +111,9 @@ impl Interpreter {
     }
 
     pub fn store_word(&mut self, a: Word, b: Word, c: Word) -> bool {
+        // SW immediate is multiple of a Word
+        let c = c << 3;
+
         let (ac, overflow) = a.overflowing_add(c);
         let (result, of) = ac.overflowing_add(8);
         let overflow = overflow || of;


### PR DESCRIPTION
To maintain consistency with the high-level language, the LW and SW
immediate values will be used as word-aligned values instead of raw
memory addresses.