### PR TITLE
Rename crate to `fuel-core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fuel-vm-rust"
+name = "fuel-core"
 description = "FuelVM interpreter."
 version = "0.1.0"
 authors = ["Victor Lopez <victor.lopez@fuel.sh>"]

--- a/src/bin/interpreter.rs
+++ b/src/bin/interpreter.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::fmt::Subscriber;
 
 use std::io::{self, Read};
 
-use fuel_vm_rust::prelude::*;
+use fuel_core::prelude::*;
 
 const NAME: &'static str = env!("CARGO_PKG_NAME");
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod prelude {
     pub use crate::interpreter::{Call, CallFrame, Contract, ExecuteError, Interpreter, LogEvent, MemoryRange};
     pub use fuel_asm::{Immediate06, Immediate12, Immediate18, Immediate24, Opcode, RegisterId, Word};
     pub use fuel_tx::{
+        bytes::{Deserializable, SerializableVec, SizedBytes},
         Address, Color, ContractAddress, Hash, Input, Output, Salt, Transaction, ValidationError, Witness,
     };
 }

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -1,7 +1,7 @@
 #![feature(once_cell)]
 
+use fuel_core::crypto;
 use fuel_tx::crypto as tx_crypto;
-use fuel_vm_rust::crypto;
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 use secp256k1::{PublicKey, Secp256k1, SecretKey};

--- a/tests/encoding/interpreter.rs
+++ b/tests/encoding/interpreter.rs
@@ -1,7 +1,7 @@
 use super::assert_encoding_correct;
 use super::common::r;
-use fuel_vm_rust::consts::*;
-use fuel_vm_rust::prelude::*;
+use fuel_core::consts::*;
+use fuel_core::prelude::*;
 
 #[test]
 fn call() {

--- a/tests/encoding/transaction.rs
+++ b/tests/encoding/transaction.rs
@@ -1,5 +1,5 @@
 use super::assert_encoding_correct;
-use fuel_vm_rust::prelude::*;
+use fuel_core::prelude::*;
 
 #[test]
 fn witness() {

--- a/tests/interpreter/alu.rs
+++ b/tests/interpreter/alu.rs
@@ -1,5 +1,5 @@
-use fuel_vm_rust::consts::*;
-use fuel_vm_rust::prelude::*;
+use fuel_core::consts::*;
+use fuel_core::prelude::*;
 
 fn alu(registers_init: &[(RegisterId, Immediate12)], op: Opcode, reg: RegisterId, expected: Word) {
     let mut vm = Interpreter::default();

--- a/tests/interpreter/crypto.rs
+++ b/tests/interpreter/crypto.rs
@@ -1,7 +1,7 @@
+use fuel_core::consts::*;
+use fuel_core::crypto;
+use fuel_core::prelude::*;
 use fuel_tx::crypto as tx_crypto;
-use fuel_vm_rust::consts::*;
-use fuel_vm_rust::crypto;
-use fuel_vm_rust::prelude::*;
 
 use std::convert::TryFrom;
 use std::str::FromStr;

--- a/tests/interpreter/flow.rs
+++ b/tests/interpreter/flow.rs
@@ -1,7 +1,7 @@
 use super::common::{d, r};
 use super::program_to_bytes;
-use fuel_vm_rust::consts::*;
-use fuel_vm_rust::prelude::*;
+use fuel_core::consts::*;
+use fuel_core::prelude::*;
 
 use std::mem;
 

--- a/tests/interpreter/frame.rs
+++ b/tests/interpreter/frame.rs
@@ -1,6 +1,6 @@
 /*
-use fuel_vm_rust::consts::*;
-use fuel_vm_rust::prelude::*;
+use fuel_core::consts::*;
+use fuel_core::prelude::*;
 
 #[test]
 fn call_output_ownership() {

--- a/tests/interpreter/memory.rs
+++ b/tests/interpreter/memory.rs
@@ -1,5 +1,5 @@
-use fuel_vm_rust::consts::*;
-use fuel_vm_rust::prelude::*;
+use fuel_core::consts::*;
+use fuel_core::prelude::*;
 
 #[test]
 fn memcopy() {

--- a/tests/interpreter/mod.rs
+++ b/tests/interpreter/mod.rs
@@ -1,5 +1,5 @@
-use fuel_vm_rust::consts::*;
-use fuel_vm_rust::prelude::*;
+use fuel_core::consts::*;
+use fuel_core::prelude::*;
 
 mod alu;
 mod blockchain;

--- a/tests/interpreter/predicate.rs
+++ b/tests/interpreter/predicate.rs
@@ -1,7 +1,7 @@
 use super::common::r;
+use fuel_core::consts::*;
+use fuel_core::prelude::*;
 use fuel_tx::bytes;
-use fuel_vm_rust::consts::*;
-use fuel_vm_rust::prelude::*;
 
 #[test]
 fn predicate() {


### PR DESCRIPTION
`fuel-vm-rust` don't reflect the repo name and this may be confusing
under certain contexts. Also, there is no particular reason on why these
two names should diverge.