### PR TITLE
Use localhost instead of all zeroes for GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-        --ip <ip>         [default: 0.0.0.0]
+        --ip <ip>         [default: 127.0.0.1]
         --port <port>     [default: 4000]
 ```
 

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -5,7 +5,7 @@ use std::{env, io, net};
 
 #[derive(StructOpt, Debug)]
 pub struct Opt {
-    #[structopt(long = "ip", default_value = "0.0.0.0", parse(try_from_str))]
+    #[structopt(long = "ip", default_value = "127.0.0.1", parse(try_from_str))]
     pub ip: net::IpAddr,
 
     #[structopt(long = "port", default_value = "4000")]


### PR DESCRIPTION
Bind client GraphQL endpoint by default to `localhost` (`127.0.0.1`) instead of `0.0.0.0`. It seems that the latter listens on all IPs, which means the GraphQL endpoint would be accessible via computers over the internet? I'm actually not sure about this, so please correct if I'm wrong.