### PR TITLE
Update fuel-core to newer receipts api

### DIFF
--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -64,7 +64,7 @@ impl FuelClient {
         }
     }
 
-    pub async fn transact(&self, tx: &Transaction) -> io::Result<Vec<LogEvent>> {
+    pub async fn transact(&self, tx: &Transaction) -> io::Result<Vec<Receipt>> {
         let tx = serde_json::to_string(tx)?;
         let query = schema::Run::build(&TxArg { tx });
 

--- a/fuel-client/tests/tx.rs
+++ b/fuel-client/tests/tx.rs
@@ -36,20 +36,15 @@ async fn transact() {
     );
 
     let log = client.transact(&tx).await.unwrap();
-    assert_eq!(3, log.len());
+    assert_eq!(2, log.len());
 
     assert!(matches!(log[0],
-        LogEvent::Register {
-            register, value, ..
-        } if register == 0x10 && value == 0xca));
+        Receipt::Log {
+            ra, rb, ..
+        } if ra == 0xca && rb == 0xba));
 
     assert!(matches!(log[1],
-        LogEvent::Register {
-            register, value, ..
-        } if register == 0x11 && value == 0xba));
-
-    assert!(matches!(log[2],
-        LogEvent::Return {
-            register, value, ..
-        } if register == REG_ONE && value == 1));
+        Receipt::Return {
+            val, ..
+        } if val == 1));
 }

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -34,6 +34,6 @@ impl TxMutation {
         )
         .await??;
 
-        Ok(serde_json::to_string(vm.log())?)
+        Ok(serde_json::to_string(vm.receipts())?)
     }
 }


### PR DESCRIPTION
Supports breaking api changes to fuel-tx/vm towards receipts instead of logs.