### PR TITLE
Use prefix for directory and not just commit message

### DIFF
--- a/.github/workflows/deploy-nightlies.yml
+++ b/.github/workflows/deploy-nightlies.yml
@@ -132,7 +132,7 @@ jobs:
         mv x86_64-apple-darwin/fuel-core sway-nightly-binaries/$FOLDER_NAME/x86_64-apple-darwin/
         mv x86_64-unknown-linux-gnu/fuel-core sway-nightly-binaries/$FOLDER_NAME/x86_64-unknown-linux-gnu/
       env: 
-        FOLDER_NAME: nightly-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha_short }}
+        FOLDER_NAME: fuel-core-nightly-${{ steps.vars.outputs.date }}-${{ steps.vars.outputs.sha_short }}
 
     - name: Push Binaries
       run: |


### PR DESCRIPTION
Upload nightlies to directory prefixed with `fuel-core-`, not just the commit message.