### PR TITLE
Update to handle breaking vm api changes

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: stable
         override: true
 
     # Build caching action

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 [[package]]
 name = "fuel-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/FuelLabs/fuel-types.git#565ac6a25343e487faf10c13c42fb5168f92b087"
+source = "git+ssh://git@github.com/FuelLabs/fuel-types.git#84ef8780dfdb04b6a49242349621656545d544f1"
 dependencies = [
  "rand 0.8.4",
  "serde",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "fuel-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/FuelLabs/fuel-vm.git#c022c95895fa7b35a35b7af1cb8729e6ccd75087"
+source = "git+ssh://git@github.com/FuelLabs/fuel-vm.git#4c7f3072a490bd3247449e30d28ce55293718d5e"
 dependencies = [
  "fuel-asm",
  "fuel-storage",


### PR DESCRIPTION
version bump to use latest vm
need to use nightly due to extensive use of `const fn`'s in the vm