### PR TITLE
fixup feature flags around rocksdb

### DIFF
--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -11,14 +11,13 @@ description = "Fuel client."
 [[bin]]
 name = "fuel-core"
 path = "src/main.rs"
-required-features = ["default"]
 # Prevent the test suite from running twice (lib + bin targets)
 # Bin target doesn't perform any additional testing beyond lib target.
 test = false
 
 [dependencies]
 async-graphql = { version = "2.9", features = ["chrono", "chrono-tz"] }
-axum = { version = "0.2", optional = true }
+axum = { version = "0.2" }
 bincode = "1.3"
 chrono = { version = "0.4", features = ["serde"] }
 derive_more = { version = "0.99" }
@@ -52,4 +51,4 @@ uuid = { version = "0.8", features = ["v4"] }
 fuel-vm = { git = "ssh://git@github.com/FuelLabs/fuel-vm.git", features = ["serde-types", "random"] }
 
 [features]
-default = ["rocksdb", "axum"]
+default = ["rocksdb"]

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "default")]
+#[cfg(feature = "rocksdb")]
 use crate::database::columns::COLUMN_NUM;
 use crate::database::transactional::DatabaseTransaction;
 use crate::model::fuel_block::FuelBlock;
-#[cfg(feature = "default")]
+#[cfg(feature = "rocksdb")]
 use crate::state::rocks_db::RocksDb;
 use crate::state::{
     in_memory::memory_store::MemoryStore, ColumnId, DataSource, Error, IterDirection,
@@ -11,7 +11,7 @@ use fuel_storage::Storage;
 use fuel_vm::prelude::{Address, Bytes32, InterpreterError, InterpreterStorage};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
-#[cfg(feature = "default")]
+#[cfg(feature = "rocksdb")]
 use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
@@ -49,7 +49,7 @@ pub mod columns {
     pub const BLOCK_IDS: u32 = 12;
 
     // Number of columns
-    #[cfg(feature = "default")]
+    #[cfg(feature = "rocksdb")]
     pub const COLUMN_NUM: u32 = 13;
 }
 
@@ -59,7 +59,7 @@ pub struct Database {
 }
 
 impl Database {
-    #[cfg(feature = "default")]
+    #[cfg(feature = "rocksdb")]
     pub fn open(path: &Path) -> Result<Self, Error> {
         let db = RocksDb::open(path, COLUMN_NUM)?;
 

--- a/fuel-core/src/lib.rs
+++ b/fuel-core/src/lib.rs
@@ -2,7 +2,6 @@ pub mod database;
 pub mod executor;
 pub mod model;
 pub mod schema;
-#[cfg(feature = "default")]
 pub mod service;
 pub mod state;
 pub mod tx_pool;

--- a/fuel-core/src/main.rs
+++ b/fuel-core/src/main.rs
@@ -19,10 +19,10 @@ async fn main() -> io::Result<()> {
     let addr = config.addr;
 
     let database = match config.database_type {
-        #[cfg(feature = "default")]
+        #[cfg(feature = "rocksdb")]
         DbType::RocksDb => Database::open(&config.database_path).expect("unable to open database"),
         DbType::InMemory => Database::default(),
-        #[cfg(not(feature = "default"))]
+        #[cfg(not(feature = "rocksdb"))]
         _ => Database::default(),
     };
 

--- a/fuel-core/src/state.rs
+++ b/fuel-core/src/state.rs
@@ -118,5 +118,5 @@ pub enum TransactionError {
 }
 
 pub mod in_memory;
-#[cfg(feature = "default")]
+#[cfg(feature = "rocksdb")]
 pub mod rocks_db;


### PR DESCRIPTION
Erroneously excluded too much when the default features were disabled. This allows `service` to be used via `lib` so that sway can spin up a node in process for integ testing.