### PR TITLE
incorporate log data in receipts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,9 +326,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -944,12 +944,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
- "darling_core 0.13.0",
- "darling_macro 0.13.0",
+ "darling_core 0.13.1",
+ "darling_macro 0.13.1",
 ]
 
 [[package]]
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
 dependencies = [
  "fnv",
  "ident_case",
@@ -993,11 +993,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
- "darling_core 0.13.0",
+ "darling_core 0.13.1",
  "quote",
  "syn",
 ]
@@ -1113,9 +1113,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.29"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
 ]
@@ -1135,7 +1135,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6451128aa6655d880755345d085494cf7561a6bee7c8dc821e5d77e6d267ecd4"
 dependencies = [
- "darling 0.13.0",
+ "darling 0.13.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -1344,7 +1344,7 @@ source = "git+ssh://git@github.com/FuelLabs/fuel-storage.git#fa46eddcba6c3f1788e
 [[package]]
 name = "fuel-tx"
 version = "0.1.0"
-source = "git+ssh://git@github.com/FuelLabs/fuel-tx.git#95a38738d101d517194615e77e07829f92f60245"
+source = "git+ssh://git@github.com/FuelLabs/fuel-tx.git#5e1d4c6fc7ad22f2fa1b197c3d2f32c6dd5944a3"
 dependencies = [
  "fuel-asm",
  "fuel-types",
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "fuel-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/FuelLabs/fuel-vm.git#0aa67866558178664e3cfe0fc31d5e23b2efec7b"
+source = "git+ssh://git@github.com/FuelLabs/fuel-vm.git#82e6da37d40021617ac93d078d6d8526efc06ba2"
 dependencies = [
  "fuel-asm",
  "fuel-merkle",
@@ -1582,9 +1582,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+checksum = "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1738,9 +1738,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.15"
+version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -1868,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -2410,9 +2410,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "d1a3ea4f0dd7f1f3e512cf97bf100819aa547f36a6eccac8dbaae839eb92363e"
 
 [[package]]
 name = "polling"
@@ -2495,9 +2495,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]
@@ -2746,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.25"
+version = "0.7.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c74fc6ea0317f1ba207eef55f5401b3180237625211866703183977b57dd45"
+checksum = "66bf572c17c77322f4d858c214def56b13a3c32b8d833cd6d28a92de8325ac5f"
 dependencies = [
  "bytecheck",
  "hashbrown",
@@ -2760,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.25"
+version = "0.7.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f677bd46008257bfdf28d051a59a72b75c2714754be3f20bcb4cbd835d2723"
+checksum = "df3eca50f172b8e59e2080810fb41b65f047960c197149564d4bd0680af1888e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2811,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
@@ -2937,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
 dependencies = [
  "serde_derive",
 ]
@@ -2964,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3024,7 +3024,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
- "darling 0.13.0",
+ "darling 0.13.1",
  "proc-macro2",
  "quote",
  "syn",

--- a/assets/schema.sdl
+++ b/assets/schema.sdl
@@ -195,6 +195,7 @@ type Receipt {
 	rawPayload: HexString!
 	result: U64
 	gasUsed: U64
+	data: HexString
 }
 enum ReceiptType {
 	CALL

--- a/fuel-client/src/client/schema/snapshots/fuel_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -103,6 +103,7 @@ query Query($_0: HexString256!) {
       len
       result
       gasUsed
+      data
     }
     script
     scriptData

--- a/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
@@ -1,5 +1,5 @@
 use crate::client::schema::{
-    schema, ConversionError, ConversionError::MissingField, HexString256, U64,
+    schema, ConversionError, ConversionError::MissingField, HexString, HexString256, U64,
 };
 use fuel_types::Word;
 
@@ -28,6 +28,7 @@ pub struct Receipt {
     pub len: Option<U64>,
     pub result: Option<U64>,
     pub gas_used: Option<U64>,
+    pub data: Option<HexString>,
 }
 
 #[derive(cynic::Enum, Clone, Copy, Debug)]
@@ -119,7 +120,14 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
                     .len
                     .ok_or_else(|| MissingField("len".to_string()))?
                     .into(),
-                digest: Default::default(),
+                digest: schema
+                    .digest
+                    .ok_or_else(|| MissingField("digest".to_string()))?
+                    .into(),
+                data: schema
+                    .data
+                    .ok_or_else(|| MissingField("data".to_string()))?
+                    .into(),
                 pc: schema
                     .pc
                     .ok_or_else(|| MissingField("pc".to_string()))?
@@ -219,6 +227,10 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
                 digest: schema
                     .digest
                     .ok_or_else(|| MissingField("digest".to_string()))?
+                    .into(),
+                data: schema
+                    .data
+                    .ok_or_else(|| MissingField("data".to_string()))?
                     .into(),
                 pc: schema
                     .pc

--- a/fuel-core/src/schema/scalars.rs
+++ b/fuel-core/src/schema/scalars.rs
@@ -77,7 +77,7 @@ impl CursorType for SortedTxCursor {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, derive_more::Into, derive_more::From)]
 pub struct HexString(pub(crate) Vec<u8>);
 
 #[Scalar(name = "HexString")]

--- a/fuel-core/src/schema/tx/receipt.rs
+++ b/fuel-core/src/schema/tx/receipt.rs
@@ -19,8 +19,8 @@ pub enum ReceiptType {
     ScriptResult,
 }
 
-impl From<TxReceipt> for ReceiptType {
-    fn from(r: TxReceipt) -> Self {
+impl From<&TxReceipt> for ReceiptType {
+    fn from(r: &TxReceipt) -> Self {
         match r {
             TxReceipt::Call { .. } => ReceiptType::Call,
             TxReceipt::Return { .. } => ReceiptType::Return,
@@ -98,7 +98,7 @@ impl Receipt {
         self.0.len().map(Into::into)
     }
     async fn receipt_type(&self) -> ReceiptType {
-        self.0.into()
+        (&self.0).into()
     }
     async fn raw_payload(&self) -> HexString {
         HexString(self.0.clone().to_bytes())
@@ -108,5 +108,8 @@ impl Receipt {
     }
     async fn gas_used(&self) -> Option<U64> {
         self.0.gas_used().map(Into::into)
+    }
+    async fn data(&self) -> Option<HexString> {
+        self.0.data().map(|d| d.to_vec().into())
     }
 }


### PR DESCRIPTION
closes #87 

supports the new receipt data field at the graphql API layer.