### PR TITLE
GA Nightly Cargo Workflow

### DIFF
--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -1,9 +1,8 @@
-name: Nightly Security Audit
-
+name: Security audit
+name: Nightly Security Cargo Audit
 on:
-  push:
-    branches:
-      - roy-cargo-audit-nightly
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   security_audit:

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -21,6 +21,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           notification_title: '{workflow} has {status_message}'
           message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>'
+          footer: ''
           notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -1,0 +1,15 @@
+name: Nightly Security Audit
+
+on:
+  push:
+    branches:
+      - roy-cargo-audit-nightly
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -10,7 +10,7 @@ on:
 
 
 jobs:
-  security_audit:
+  run_cargo_audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -25,9 +25,5 @@ jobs:
           message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
           footer: 'Linked Repo <{repo_url}|{repo}>'
           notify_when: 'failure'
-          mention_users: 'U0160UUNH8S,U0080UUAA9N'
-          mention_users_when: 'failure,warnings'
-          mention_groups: 'SAZ94GDB8'
-          mention_groups_when: 'failure,warnings'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -20,8 +20,7 @@ jobs:
           status: ${{ job.status }}
           token: ${{ secrets.GITHUB_TOKEN }}
           notification_title: '{workflow} has {status_message}'
-          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
-          footer: 'Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run Results>'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>'
           notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -1,14 +1,38 @@
-name: Security audit
 name: Nightly Security Cargo Audit
+
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    branches: ['roy-cargo-audit-nightly']
+
+#on:
+  #schedule:
+    #- cron: '0 0 * * *'
+
 
 jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Repository
       - uses: actions/checkout@v1
+
+      - name: Run Cargo Audit 
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Notify Slack Channel of Cargo Audit Failures
+      - uses: ravsamhq/notify-slack-action@v1
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notification_title: '{workflow} has {status_message}'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
+          footer: 'Linked Repo <{repo_url}|{repo}>'
+          notify_when: 'failure'
+          mention_users: 'U0160UUNH8S,U0080UUAA9N'
+          mention_users_when: 'failure,warnings'
+          mention_groups: 'SAZ94GDB8'
+          mention_groups_when: 'failure,warnings'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -1,10 +1,8 @@
 name: Nightly Security Cargo Audit
+
 on:
-  push:
-    branches: ['roy-cargo-audit-nightly']
-#on:
-  #schedule:
-    #- cron: '0 0 * * *'
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   run_cargo_audit:

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -1,9 +1,7 @@
 name: Nightly Security Cargo Audit
-
 on:
   push:
     branches: ['roy-cargo-audit-nightly']
-
 #on:
   #schedule:
     #- cron: '0 0 * * *'

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -15,13 +15,9 @@ jobs:
     steps:
       - name: Checkout Repository
       - uses: actions/checkout@v1
-
-      - name: Run Cargo Audit 
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Notify Slack Channel of Cargo Audit Failures
       - uses: ravsamhq/notify-slack-action@v1
         if: always()
         with:

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -1,13 +1,8 @@
 name: Nightly Security Cargo Audit
 
 on:
-  push:
-    branches: ['roy-cargo-audit-nightly']
-
-#on:
-  #schedule:
-    #- cron: '0 0 * * *'
-
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   run_cargo_audit:

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -1,8 +1,12 @@
 name: Nightly Security Cargo Audit
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    branches: ['roy-cargo-audit-nightly']
+
+#on:
+  #schedule:
+    #- cron: '0 0 * * *'
 
 jobs:
   run_cargo_audit:
@@ -16,9 +20,10 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           notification_title: '{workflow} has {status_message}'
           message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
-          footer: 'Linked Repo <{repo_url}|{repo}>'
+          footer: 'Linked Repo <{repo_url}|{repo}> | <{workflow_url}|View Workflow>'
           notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -13,7 +13,6 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
       - uses: actions/checkout@v1
       - uses: actions-rs/audit-check@v1
         with:

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           notification_title: '{workflow} has {status_message}'
           message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>'
-          footer: 'Linked Repo <{repo_url}|{repo}> | <{workflow_url}|View Workflow>'
+          footer: 'Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run Results>'
           notify_when: 'failure'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This GA workflow will run cargo audit against the against the HEAD of repository default branch.

Basis of GA workflow is: https://github.com/marketplace/actions/rust-audit-check