### PR TITLE
`coinsByOwner(owner, color)` to `coins(filter:{owner,color})`

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -71,6 +71,10 @@ type CoinEdge {
 	"""
 	cursor: String!
 }
+input CoinFilterInput {
+	owner: HexString256!
+	color: HexString256
+}
 type CoinOutput {
 	to: HexString256!
 	amount: Int!
@@ -169,7 +173,7 @@ type Query {
 	"""
 	health: Boolean!
 	coin(id: HexString256!): Coin
-	coinsByOwner(after: String, before: String, first: Int, last: Int, owner: HexString256!, color: HexString256): CoinConnection!
+	coins(after: String, before: String, first: Int, last: Int, filter: CoinFilterInput!): CoinConnection!
 }
 type Receipt {
 	id: HexString256

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -72,7 +72,13 @@ type CoinEdge {
 	cursor: String!
 }
 input CoinFilterInput {
+	"""
+	address of the owner
+	"""
 	owner: HexString256!
+	"""
+	color of the coins
+	"""
 	color: HexString256
 }
 type CoinOutput {

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -224,7 +224,7 @@ impl FuelClient {
     }
 
     /// Retrieve a page of coins by their owner
-    pub async fn coins_by_owner(
+    pub async fn coins(
         &self,
         owner: &str,
         color: Option<&str>,
@@ -237,7 +237,7 @@ impl FuelClient {
         };
         let query = schema::coin::CoinsQuery::build(&(owner, color, request).into());
 
-        let coins = self.query(query).await?.coins_by_owner.into();
+        let coins = self.query(query).await?.coins.into();
         Ok(coins)
     }
 }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coins_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coins_connection_query_gql_output.snap
@@ -1,11 +1,11 @@
 ---
 source: fuel-client/src/client/schema/coin.rs
-assertion_line: 142
+assertion_line: 155
 expression: operation.query
 
 ---
-query Query($_0: HexString256!, $_1: String, $_2: String, $_3: Int, $_4: Int, $_5: HexString256) {
-  coinsByOwner(owner: $_0, after: $_1, before: $_2, first: $_3, last: $_4, color: $_5) {
+query Query($_0: CoinFilterInput!, $_1: String, $_2: String, $_3: Int, $_4: Int) {
+  coins(filter: $_0, after: $_1, before: $_2, first: $_3, last: $_4) {
     edges {
       cursor
       node {

--- a/fuel-client/tests/coin.rs
+++ b/fuel-client/tests/coin.rs
@@ -77,7 +77,7 @@ async fn first_5_coins() {
 
     // run test
     let coins = client
-        .coins_by_owner(
+        .coins(
             format!("{:#x}", owner).as_str(),
             None,
             PaginationRequest {
@@ -133,7 +133,7 @@ async fn only_color_filtered_coins() {
 
     // run test
     let coins = client
-        .coins_by_owner(
+        .coins(
             format!("{:#x}", owner).as_str(),
             Some(format!("{:#x}", Color::new([1u8; 32])).as_str()),
             PaginationRequest {
@@ -189,7 +189,7 @@ async fn only_spent_coins() {
 
     // run test
     let coins = client
-        .coins_by_owner(
+        .coins(
             format!("{:#x}", owner).as_str(),
             None,
             PaginationRequest {

--- a/fuel-core/src/schema/coin.rs
+++ b/fuel-core/src/schema/coin.rs
@@ -47,9 +47,9 @@ impl Coin {
 
 #[derive(InputObject)]
 struct CoinFilterInput {
-    // #[graphql(desc = "address of the owner")]
+    /// address of the owner
     owner: HexString256,
-    // #[graphql(desc = "color of the coins")]
+    /// color of the coins
     color: Option<HexString256>,
 }
 


### PR DESCRIPTION
This PR renames `coinsByOwner` to `coins` and packs the `owner` and `color` fields into a `filter` arg.

Normally, a filter would be optional, and all of its fields would also be optional, but there is no implementation to query without an owner so both `filter` and `filter.owner` are non-null.

(For example, if we were to pack `transactions` and `transactionsByOwner` together the `filter` arg would be optional.)