### PR TITLE
Transaction Status

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -108,6 +108,7 @@ type FailureStatus {
 	blockId: HexString256!
 	time: DateTime!
 	reason: String!
+	programState: ProgramState
 }
 scalar HexString
 scalar HexString256
@@ -164,6 +165,10 @@ type PageInfo {
 	"""
 	endCursor: String
 }
+type ProgramState {
+	returnType: ReturnType!
+	data: HexString!
+}
 type Query {
 	register(id: ID!, register: U64!): U64!
 	memory(id: ID!, start: U64!, size: U64!): String!
@@ -219,13 +224,18 @@ enum ReceiptType {
 	TRANSFER_OUT
 	SCRIPT_RESULT
 }
+enum ReturnType {
+	RETURN
+	RETURN_DATA
+	REVERT
+}
 type SubmittedStatus {
 	time: DateTime!
 }
 type SuccessStatus {
 	blockId: HexString256!
 	time: DateTime!
-	programState: HexString!
+	programState: ProgramState!
 }
 type Transaction {
 	id: HexString256!

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -169,10 +169,12 @@ impl FuelClient {
 
         let status = tx
             .status
-            .ok_or(io::Error::new(
-                ErrorKind::NotFound,
-                format!("status not found for transaction {}", id),
-            ))?
+            .ok_or_else(|| {
+                io::Error::new(
+                    ErrorKind::NotFound,
+                    format!("status not found for transaction {}", id),
+                )
+            })?
             .try_into()?;
         Ok(status)
     }

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 pub mod schema;
+pub mod types;
 
 use schema::{
     block::BlockByIdArgs,
@@ -16,6 +17,7 @@ use schema::{
 };
 
 use crate::client::schema::ConversionError;
+use crate::client::types::{TransactionResponse, TransactionStatus};
 pub use schema::{PageDirection, PaginatedResult, PaginationRequest};
 use std::io::ErrorKind;
 
@@ -149,7 +151,7 @@ impl FuelClient {
         Ok(serde_json::from_str(memory.as_str())?)
     }
 
-    pub async fn transaction(&self, id: &str) -> io::Result<Option<fuel_tx::Transaction>> {
+    pub async fn transaction(&self, id: &str) -> io::Result<Option<TransactionResponse>> {
         let query = schema::tx::TransactionQuery::build(&TxIdArgs { id: id.parse()? });
 
         let transaction = self.query(query).await?.transaction;
@@ -157,11 +159,29 @@ impl FuelClient {
         Ok(transaction.map(|tx| tx.try_into()).transpose()?)
     }
 
+    /// Get the status of a transaction
+    pub async fn transaction_status(&self, id: &str) -> io::Result<TransactionStatus> {
+        let query = schema::tx::TransactionQuery::build(&TxIdArgs { id: id.parse()? });
+
+        let tx = self.query(query).await?.transaction.ok_or_else(|| {
+            io::Error::new(ErrorKind::NotFound, format!("transaction {} not found", id))
+        })?;
+
+        let status = tx
+            .status
+            .ok_or(io::Error::new(
+                ErrorKind::NotFound,
+                format!("status not found for transaction {}", id),
+            ))?
+            .try_into()?;
+        Ok(status)
+    }
+
     /// returns a paginated set of transactions sorted by block height
     pub async fn transactions(
         &self,
         request: PaginationRequest<String>,
-    ) -> io::Result<PaginatedResult<Transaction, String>> {
+    ) -> io::Result<PaginatedResult<TransactionResponse, String>> {
         let query = schema::tx::TransactionsQuery::build(&request.into());
         let transactions = self.query(query).await?.transactions.try_into()?;
         Ok(transactions)
@@ -172,7 +192,7 @@ impl FuelClient {
         &self,
         owner: &str,
         request: PaginationRequest<String>,
-    ) -> io::Result<PaginatedResult<Transaction, String>> {
+    ) -> io::Result<PaginatedResult<TransactionResponse, String>> {
         let owner: HexString256 = owner.parse()?;
         let query = schema::tx::TransactionsByOwnerQuery::build(&(owner, request).into());
 

--- a/fuel-client/src/client/schema.rs
+++ b/fuel-client/src/client/schema.rs
@@ -5,6 +5,7 @@ pub mod schema {
 }
 
 use hex::FromHexError;
+use std::array::TryFromSliceError;
 use std::fmt::Debug;
 use std::io::ErrorKind;
 use std::num::TryFromIntError;
@@ -192,6 +193,8 @@ pub enum ConversionError {
     TransactionFromBytesError(std::io::Error),
     #[error("failed to deserialize receipt from bytes {0}")]
     ReceiptFromBytesError(std::io::Error),
+    #[error("failed to convert from bytes due to unexpected length")]
+    BytesLength,
 }
 
 impl From<FromHexError> for ConversionError {
@@ -209,5 +212,11 @@ impl From<ConversionError> for std::io::Error {
 impl From<TryFromIntError> for ConversionError {
     fn from(_: TryFromIntError) -> Self {
         ConversionError::IntegerConversion
+    }
+}
+
+impl From<TryFromSliceError> for ConversionError {
+    fn from(_: TryFromSliceError) -> Self {
+        ConversionError::BytesLength
     }
 }

--- a/fuel-client/src/client/schema/primitives.rs
+++ b/fuel-client/src/client/schema/primitives.rs
@@ -136,6 +136,12 @@ impl<'de> Deserialize<'de> for Bytes {
     }
 }
 
+impl Display for Bytes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", hex::encode(&self.0))
+    }
+}
+
 #[derive(Debug, Clone, derive_more::Into, derive_more::From, PartialOrd, PartialEq)]
 pub struct U64(pub u64);
 impl_scalar!(U64, schema::U64);

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_by_id_query_gql_output.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-client/src/client/schema/block.rs
+assertion_line: 82
 expression: operation.query
 
 ---
@@ -13,6 +14,29 @@ query Query($_0: HexString256) {
       rawPayload
       receipts {
         rawPayload
+      }
+      status {
+        __typename
+        ... on SubmittedStatus {
+          time
+        }
+        ... on SuccessStatus {
+          blockId
+          time
+          programState {
+            returnType
+            data
+          }
+        }
+        ... on FailureStatus {
+          blockId
+          time
+          reason
+          programState {
+            returnType
+            data
+          }
+        }
       }
     }
   }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__blocks_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__blocks_connection_query_gql_output.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-client/src/client/schema/block.rs
+assertion_line: 94
 expression: operation.query
 
 ---
@@ -16,6 +17,29 @@ query Query($_0: String, $_1: String, $_2: Int, $_3: Int) {
           rawPayload
           receipts {
             rawPayload
+          }
+          status {
+            __typename
+            ... on SubmittedStatus {
+              time
+            }
+            ... on SuccessStatus {
+              blockId
+              time
+              programState {
+                returnType
+                data
+              }
+            }
+            ... on FailureStatus {
+              blockId
+              time
+              reason
+              programState {
+                returnType
+                data
+              }
+            }
           }
         }
       }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-client/src/client/schema/chain.rs
+assertion_line: 26
 expression: operation.query
 
 ---
@@ -17,6 +18,29 @@ query Query {
         rawPayload
         receipts {
           rawPayload
+        }
+        status {
+          __typename
+          ... on SubmittedStatus {
+            time
+          }
+          ... on SuccessStatus {
+            blockId
+            time
+            programState {
+              returnType
+              data
+            }
+          }
+          ... on FailureStatus {
+            blockId
+            time
+            reason
+            programState {
+              returnType
+              data
+            }
+          }
         }
       }
     }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__opaque_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__opaque_transaction_by_id_query_gql_output.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
+assertion_line: 273
 expression: operation.query
 
 ---
@@ -8,6 +9,29 @@ query Query($_0: HexString256!) {
     rawPayload
     receipts {
       rawPayload
+    }
+    status {
+      __typename
+      ... on SubmittedStatus {
+        time
+      }
+      ... on SuccessStatus {
+        blockId
+        time
+        programState {
+          returnType
+          data
+        }
+      }
+      ... on FailureStatus {
+        blockId
+        time
+        reason
+        programState {
+          returnType
+          data
+        }
+      }
     }
   }
 }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transactions_by_owner_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transactions_by_owner_gql_output.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
+assertion_line: 298
 expression: operation.query
 
 ---
@@ -11,6 +12,29 @@ query Query($_0: HexString256!, $_1: String, $_2: String, $_3: Int, $_4: Int) {
         rawPayload
         receipts {
           rawPayload
+        }
+        status {
+          __typename
+          ... on SubmittedStatus {
+            time
+          }
+          ... on SuccessStatus {
+            blockId
+            time
+            programState {
+              returnType
+              data
+            }
+          }
+          ... on FailureStatus {
+            blockId
+            time
+            reason
+            programState {
+              returnType
+              data
+            }
+          }
         }
       }
     }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transactions_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transactions_connection_query_gql_output.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
+assertion_line: 285
 expression: operation.query
 
 ---
@@ -11,6 +12,29 @@ query Query($_0: String, $_1: String, $_2: Int, $_3: Int) {
         rawPayload
         receipts {
           rawPayload
+        }
+        status {
+          __typename
+          ... on SubmittedStatus {
+            time
+          }
+          ... on SuccessStatus {
+            blockId
+            time
+            programState {
+              returnType
+              data
+            }
+          }
+          ... on FailureStatus {
+            blockId
+            time
+            reason
+            programState {
+              returnType
+              data
+            }
+          }
         }
       }
     }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
+assertion_line: 264
 expression: operation.query
 
 ---
@@ -71,12 +72,19 @@ query Query($_0: HexString256!) {
       ... on SuccessStatus {
         blockId
         time
-        programState
+        programState {
+          returnType
+          data
+        }
       }
       ... on FailureStatus {
         blockId
         time
         reason
+        programState {
+          returnType
+          data
+        }
       }
     }
     witnesses

--- a/fuel-client/src/client/types.rs
+++ b/fuel-client/src/client/types.rs
@@ -1,0 +1,73 @@
+use crate::client::schema::tx::{OpaqueTransaction, TransactionStatus as SchemaTxStatus};
+use crate::client::schema::ConversionError;
+use chrono::{DateTime, Utc};
+use fuel_tx::Transaction;
+use fuel_types::bytes::Deserializable;
+use fuel_vm::prelude::ProgramState;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionResponse {
+    pub transaction: Transaction,
+    pub status: TransactionStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TransactionStatus {
+    Submitted {
+        submitted_at: DateTime<Utc>,
+    },
+    Success {
+        block_id: String,
+        time: DateTime<Utc>,
+        program_state: ProgramState,
+    },
+    Failure {
+        block_id: String,
+        time: DateTime<Utc>,
+        reason: String,
+        program_state: Option<ProgramState>,
+    },
+}
+
+impl TryFrom<SchemaTxStatus> for TransactionStatus {
+    type Error = ConversionError;
+
+    fn try_from(status: SchemaTxStatus) -> Result<Self, Self::Error> {
+        Ok(match status {
+            SchemaTxStatus::SubmittedStatus(s) => TransactionStatus::Submitted {
+                submitted_at: s.time,
+            },
+            SchemaTxStatus::SuccessStatus(s) => TransactionStatus::Success {
+                block_id: s.block_id.0.to_string(),
+                time: s.time,
+                program_state: s.program_state.try_into()?,
+            },
+            SchemaTxStatus::FailureStatus(s) => TransactionStatus::Failure {
+                block_id: s.block_id.0.to_string(),
+                time: s.time,
+                reason: s.reason,
+                program_state: s.program_state.map(TryInto::try_into).transpose()?,
+            },
+        })
+    }
+}
+
+impl TryFrom<OpaqueTransaction> for TransactionResponse {
+    type Error = ConversionError;
+
+    fn try_from(value: OpaqueTransaction) -> Result<Self, Self::Error> {
+        let bytes = value.raw_payload.0 .0;
+        let tx: fuel_tx::Transaction = fuel_tx::Transaction::from_bytes(bytes.as_slice())
+            .map_err(ConversionError::TransactionFromBytesError)?;
+        let status = value
+            .status
+            .ok_or(ConversionError::MissingField("status".to_string()))?
+            .try_into()?;
+
+        Ok(Self {
+            transaction: tx,
+            status,
+        })
+    }
+}

--- a/fuel-client/src/client/types.rs
+++ b/fuel-client/src/client/types.rs
@@ -62,7 +62,7 @@ impl TryFrom<OpaqueTransaction> for TransactionResponse {
             .map_err(ConversionError::TransactionFromBytesError)?;
         let status = value
             .status
-            .ok_or(ConversionError::MissingField("status".to_string()))?
+            .ok_or_else(|| ConversionError::MissingField("status".to_string()))?
             .try_into()?;
 
         Ok(Self {

--- a/fuel-client/tests/tx.rs
+++ b/fuel-client/tests/tx.rs
@@ -5,6 +5,7 @@ use fuel_core::{
     model::{coin::UtxoId, fuel_block::FuelBlock},
     service::{Config, FuelService},
 };
+use fuel_gql_client::client::types::TransactionStatus;
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
 use fuel_storage::Storage;
 use fuel_vm::{consts::*, prelude::*};
@@ -114,7 +115,8 @@ async fn submit() {
         .transaction(&id.0.to_string())
         .await
         .unwrap()
-        .unwrap();
+        .unwrap()
+        .transaction;
     assert_eq!(tx, ret_tx);
 }
 
@@ -139,18 +141,22 @@ async fn get_transaction_by_id() {
     // setup test data in the node
     let transaction = fuel_tx::Transaction::default();
     let id = transaction.id();
-    let mut db = Database::default();
-    Storage::<Bytes32, fuel_tx::Transaction>::insert(&mut db, &id, &transaction).unwrap();
 
     // setup server & client
-    let srv = FuelService::from_database(db, Config::local_node())
-        .await
-        .unwrap();
+    let srv = FuelService::new_node(Config::local_node()).await.unwrap();
     let client = FuelClient::from(srv.bound_address);
+    // submit tx to api
+    client.submit(&transaction).await.unwrap();
 
     // run test
-    let transaction = client.transaction(&format!("{:#x}", id)).await.unwrap();
-    assert!(transaction.is_some());
+    let transaction_response = client.transaction(&format!("{:#x}", id)).await.unwrap();
+    assert!(transaction_response.is_some());
+    if let Some(transaction_response) = transaction_response {
+        assert!(matches!(
+            transaction_response.status,
+            TransactionStatus::Success { .. }
+        ))
+    }
 }
 
 #[tokio::test]
@@ -170,7 +176,8 @@ async fn get_transparent_transaction_by_id() {
         .transaction(&format!("{:#x}", id))
         .await
         .unwrap()
-        .expect("expected some result");
+        .expect("expected some result")
+        .transaction;
 
     // run test
     let transparent_transaction = client
@@ -209,7 +216,11 @@ async fn get_transactions() {
     };
 
     let response = client.transactions(page_request.clone()).await.unwrap();
-    let transactions = &response.results.iter().map(|tx| tx.id()).collect_vec();
+    let transactions = &response
+        .results
+        .iter()
+        .map(|tx| tx.transaction.id())
+        .collect_vec();
     assert_eq!(transactions, &[tx1, tx2, tx3]);
 
     // Query backwards from last given cursor [3]: [1,2]
@@ -227,11 +238,19 @@ async fn get_transactions() {
     };
 
     let response = client.transactions(page_request_backwards).await.unwrap();
-    let transactions = &response.results.iter().map(|tx| tx.id()).collect_vec();
+    let transactions = &response
+        .results
+        .iter()
+        .map(|tx| tx.transaction.id())
+        .collect_vec();
     assert_eq!(transactions, &[tx1, tx2]);
 
     let response = client.transactions(page_request_forwards).await.unwrap();
-    let transactions = &response.results.iter().map(|tx| tx.id()).collect_vec();
+    let transactions = &response
+        .results
+        .iter()
+        .map(|tx| tx.transaction.id())
+        .collect_vec();
     assert_eq!(transactions, &[tx4, tx5, tx6]);
 }
 
@@ -278,7 +297,11 @@ async fn get_transactions_from_manual_blcoks() {
         direction: PageDirection::Forward,
     };
     let response = client.transactions(page_request_forwards).await.unwrap();
-    let transactions = &response.results.iter().map(|tx| tx.id()).collect_vec();
+    let transactions = &response
+        .results
+        .iter()
+        .map(|tx| tx.transaction.id())
+        .collect_vec();
     assert_eq!(transactions, &[txs[0].id(), txs[1].id(), txs[2].id()]);
 
     // Query forwards from last given cursor [2]: [3,4,5,6]
@@ -291,7 +314,11 @@ async fn get_transactions_from_manual_blcoks() {
         .transactions(next_page_request_forwards)
         .await
         .unwrap();
-    let transactions = &response.results.iter().map(|tx| tx.id()).collect_vec();
+    let transactions = &response
+        .results
+        .iter()
+        .map(|tx| tx.transaction.id())
+        .collect_vec();
     assert_eq!(
         transactions,
         &[txs[3].id(), txs[4].id(), txs[5].id(), txs[6].id()]
@@ -304,7 +331,11 @@ async fn get_transactions_from_manual_blcoks() {
         direction: PageDirection::Backward,
     };
     let response = client.transactions(page_request_backwards).await.unwrap();
-    let transactions = &response.results.iter().map(|tx| tx.id()).collect_vec();
+    let transactions = &response
+        .results
+        .iter()
+        .map(|tx| tx.transaction.id())
+        .collect_vec();
     assert_eq!(
         transactions,
         &[
@@ -342,7 +373,7 @@ async fn get_owned_transactions() {
         .unwrap()
         .results
         .iter()
-        .map(|tx| tx.id())
+        .map(|tx| tx.transaction.id())
         .collect_vec();
 
     let bob_txs = client
@@ -351,7 +382,7 @@ async fn get_owned_transactions() {
         .unwrap()
         .results
         .iter()
-        .map(|tx| tx.id())
+        .map(|tx| tx.transaction.id())
         .collect_vec();
 
     let charlie_txs = client
@@ -360,7 +391,7 @@ async fn get_owned_transactions() {
         .unwrap()
         .results
         .iter()
-        .map(|tx| tx.id())
+        .map(|tx| tx.transaction.id())
         .collect_vec();
 
     assert_eq!(&alice_txs, &[tx1]);

--- a/fuel-core/src/schema/tx/types.rs
+++ b/fuel-core/src/schema/tx/types.rs
@@ -1,13 +1,13 @@
 use crate::database::Database;
 use crate::schema::scalars::{HexString, HexString256};
 use crate::tx_pool::TransactionStatus as TxStatus;
-use async_graphql::{Context, Object, Union};
+use async_graphql::{Context, Enum, Object, Union};
 use chrono::{DateTime, Utc};
 use fuel_asm::Word;
 use fuel_storage::Storage;
 use fuel_tx::{Address, Bytes32, Color, ContractId, Receipt, Transaction as FuelTx};
 use fuel_types::bytes::SerializableVec;
-use fuel_vm::prelude::ProgramState;
+use fuel_vm::prelude::ProgramState as VmProgramState;
 use std::ops::Deref;
 
 #[derive(Union)]
@@ -286,6 +286,48 @@ impl From<&fuel_tx::Output> for Output {
     }
 }
 
+pub struct ProgramState {
+    return_type: ReturnType,
+    data: Vec<u8>,
+}
+
+#[Object]
+impl ProgramState {
+    async fn return_type(&self) -> ReturnType {
+        self.return_type
+    }
+
+    async fn data(&self) -> HexString {
+        self.data.clone().into()
+    }
+}
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum ReturnType {
+    Return,
+    ReturnData,
+    Revert,
+}
+
+impl From<VmProgramState> for ProgramState {
+    fn from(state: VmProgramState) -> Self {
+        match state {
+            VmProgramState::Return(d) => ProgramState {
+                return_type: ReturnType::Return,
+                data: d.to_be_bytes().to_vec(),
+            },
+            VmProgramState::ReturnData(d) => ProgramState {
+                return_type: ReturnType::ReturnData,
+                data: d.as_ref().to_vec(),
+            },
+            VmProgramState::Revert(d) => ProgramState {
+                return_type: ReturnType::Revert,
+                data: d.to_be_bytes().to_vec(),
+            },
+        }
+    }
+}
+
 #[derive(Union)]
 pub enum TransactionStatus {
     Submitted(SubmittedStatus),
@@ -305,7 +347,7 @@ impl SubmittedStatus {
 pub struct SuccessStatus {
     block_id: Bytes32,
     time: DateTime<Utc>,
-    result: ProgramState,
+    result: VmProgramState,
 }
 
 #[Object]
@@ -318,12 +360,8 @@ impl SuccessStatus {
         self.time
     }
 
-    async fn program_state(&self) -> HexString {
-        match self.result {
-            ProgramState::Return(word) => HexString(word.to_be_bytes().to_vec()),
-            ProgramState::ReturnData(data) => HexString(data.deref().to_vec()),
-            ProgramState::Revert(word) => HexString(word.to_be_bytes().to_vec()),
-        }
+    async fn program_state(&self) -> ProgramState {
+        self.result.into()
     }
 }
 
@@ -331,6 +369,7 @@ pub struct FailureStatus {
     block_id: Bytes32,
     time: DateTime<Utc>,
     reason: String,
+    state: Option<VmProgramState>,
 }
 
 #[Object]
@@ -345,6 +384,10 @@ impl FailureStatus {
 
     async fn reason(&self) -> String {
         self.reason.clone()
+    }
+
+    async fn program_state(&self) -> Option<ProgramState> {
+        self.state.map(Into::into)
     }
 }
 
@@ -365,10 +408,12 @@ impl From<TxStatus> for TransactionStatus {
                 block_id,
                 reason,
                 time,
+                result,
             } => TransactionStatus::Failed(FailureStatus {
                 block_id,
                 reason,
                 time,
+                state: result,
             }),
         }
     }

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -23,6 +23,7 @@ pub enum TransactionStatus {
         block_id: Bytes32,
         time: DateTime<Utc>,
         reason: String,
+        result: Option<ProgramState>,
     },
 }
 


### PR DESCRIPTION
closes #125

Updates error handling of transactions so that revert's / panic's are marked as failure instead of success. 

Provides more useful info about the transaction status via fuel-client.