### PR TITLE
Add semver tagging for release image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,8 @@ jobs:
         with:
           images: |
             ghcr.io/fuellabs/fuel-core
+          tags: |
+            type=semver,pattern={{raw}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -196,7 +198,7 @@ jobs:
           context: .
           file: deployment/Dockerfile
           push: true
-          tags: ${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
We had an issue with the fuel-core release image being able to push to the ghcr.io repo due mis configuration of the docker push step with tagging- this PR is to fix that issue