### PR TITLE
Show possible values for configuring db-type

### DIFF
--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -1,6 +1,7 @@
 use crate::service::{Config, DbType};
 use std::{env, io, net, path::PathBuf, string::ToString};
 use structopt::StructOpt;
+use strum::VariantNames;
 use tracing_subscriber::filter::EnvFilter;
 
 lazy_static::lazy_static! {
@@ -23,7 +24,7 @@ pub struct Opt {
     )]
     pub database_path: PathBuf,
 
-    #[structopt(long = "db-type", default_value = "RocksDb")]
+    #[structopt(long = "db-type", default_value = "RocksDb", possible_values = &DbType::VARIANTS, case_insensitive = true)]
     pub database_type: DbType,
 
     /// Specify either an alias to a built-in configuration or filepath to a JSON file.

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -24,7 +24,7 @@ pub struct Opt {
     )]
     pub database_path: PathBuf,
 
-    #[structopt(long = "db-type", default_value = "RocksDb", possible_values = &DbType::VARIANTS, case_insensitive = true)]
+    #[structopt(long = "db-type", default_value = "rocks-db", possible_values = &DbType::VARIANTS, case_insensitive = true)]
     pub database_type: DbType,
 
     /// Specify either an alias to a built-in configuration or filepath to a JSON file.

--- a/fuel-core/src/service.rs
+++ b/fuel-core/src/service.rs
@@ -15,7 +15,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use strum_macros::{Display, EnumString};
+use strum_macros::{Display, EnumString, EnumVariantNames};
 use thiserror::Error;
 use tokio::task::JoinHandle;
 
@@ -40,7 +40,8 @@ impl Config {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, EnumString, Display)]
+#[derive(Clone, Debug, Display, PartialEq, EnumString, EnumVariantNames)]
+#[strum(serialize_all = "kebab_case")]
 pub enum DbType {
     InMemory,
     RocksDb,


### PR DESCRIPTION
While the node enables swapping out different db implementations at runtime, structopt/clap wasn't configured to show all possible options. This PR makes it easier for users to discover new db options.

```
fuel-core 0.2.1

USAGE:
    fuel-core [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --chain <CHAIN_CONFIG>       Specify either an alias to a built-in configuration or filepath to a JSON file
                                     [default: local_testnet]
        --db-path <DB_PATH>           [default: /home/voxelot/.fuel/db]
        --db-type <database-type>     [default: RocksDb]  [possible values: in-memory, rocks-db]
        --ip <ip>                     [default: 127.0.0.1]
        --port <port>                 [default: 4000]

```