### PR TITLE
add postgresql to installation instructions on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are several system requirements including llvm, clang and postgres.
 ###### MacOS
 ```bash
 brew update
-brew install openssl cmake llvm libpq
+brew install openssl cmake llvm libpq postgresql
 ```
 
 ###### Debian


### PR DESCRIPTION
without it, build cmd fails with:

```
  = note: ld: library not found for -lpq
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

env: mac os 11.5.2