### PR TITLE
Master Branch Fix - Update Rust toolchain in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ The service relies on the environment variable `RUST_LOG`. For more information,
 ## Docker & Kubernetes
 ```
 # Create Docker Image
-ssh-add ~/.ssh/id_ed25519 && DOCKER_BUILDKIT=1 docker build --ssh default -t fuel-core . -f deployment/Dockerfile
-
-ssh-add ~/.ssh/id_rsa && DOCKER_BUILDKIT=1 docker build --ssh default -t fuel-core . -f deployment/Dockerfile
+docker build -t fuel-core . -f deployment/Dockerfile
 
 # Delete Docker Image
 docker image rm fuel-core

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM rust:1.56 as builder
+FROM rust:1.58.1 as builder
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
@@ -16,7 +16,7 @@ WORKDIR /build/
 
 COPY . .
 
-RUN cargo build --release
+RUN cargo build --release -p fuel-core
 
 # Stage 2: Run
 FROM ubuntu:20.04 as run


### PR DESCRIPTION
Master branch is currently failing CI due to an outdated rust toolchain.

closes #158 