### PR TITLE
v0.3.1 prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1275,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-interfaces"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gql-client"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "cynic",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-txpool"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-gql-client"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-interfaces"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 repository = "https://github.com/FuelLabs/fuel-core"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -27,10 +27,10 @@ derive_more = { version = "0.99" }
 dirs = "3.0"
 env_logger = "0.9"
 fuel-asm = { version = "0.1", features = ["serde-types"] }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.3.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.3.1" }
 fuel-storage = { version = "0.1" }
 fuel-tx = { version = "0.5", features = ["serde-types"] }
-fuel-txpool = { path = "../fuel-txpool", version = "0.3.0" }
+fuel-txpool = { path = "../fuel-txpool", version = "0.3.1" }
 fuel-types = { version = "0.1", features = ["serde-types"] }
 fuel-vm = { version = "0.4", features = ["serde-types"] }
 futures = "0.3"

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-txpool"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 repository = "https://github.com/FuelLabs/fuel-core"
@@ -10,7 +10,7 @@ license = "BUSL-1.1"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.3.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.3.1" }
 fuel-tx = { version = "0.5", features = ["serde-types"] }
 fuel-types = { version = "0.1", features = ["serde-types"] }
 futures = "0.3"
@@ -19,6 +19,6 @@ thiserror = "1.0"
 tokio = { version = "1.14", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.3.0", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.3.1", features = [
     "test_helpers",
 ] }


### PR DESCRIPTION
Creating a patch release since the v0.3.0 publish failed crates.io validation.