### PR TITLE
Avoid potential publishing issues by adding all crate manifest fields

### DIFF
--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -2,10 +2,13 @@
 name = "fuel-core-interfaces"
 version = "0.3.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
+categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
+homepage = "https://fuel.network/"
+keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
+license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
 description = "Fuel core interfaces"
-license = "BUSL-1.1"
 
 [dependencies]
 anyhow = "1.0"

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -2,10 +2,13 @@
 name = "fuel-txpool"
 version = "0.3.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
+categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
+homepage = "https://fuel.network/"
+keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
+license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
 description = "Transaction pool"
-license = "BUSL-1.1"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
while the license field is now added to the new crates, also adding other fields just in case crates.io also requires them.