### PR TITLE
Add GraphQL Account type

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -1,9 +1,12 @@
+type Account {
+	address: HexString256!
+}
 type Block {
 	id: HexString256!
 	height: U64!
 	transactions: [Transaction!]!
 	time: DateTime!
-	producer: HexString256!
+	producer: Account!
 }
 type BlockConnection {
 	"""
@@ -188,6 +191,7 @@ type Query {
 	coin(utxoId: HexStringUtxoId!): Coin
 	coins(after: String, before: String, first: Int, last: Int, filter: CoinFilterInput!): CoinConnection!
 	coinsToSpend(owner: HexString256!, spendQuery: [SpendQueryElementInput!]!, maxInputs: Int): [Coin!]!
+	account(address: HexString256!): Account
 }
 type Receipt {
 	id: HexString256

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -1,5 +1,6 @@
 type Account {
 	address: HexString256!
+	transactions(first: Int, after: String, last: Int, before: String): TransactionConnection!
 }
 type Block {
 	id: HexString256!
@@ -38,13 +39,13 @@ type ChainInfo {
 	peerCount: Int!
 }
 type ChangeOutput {
-	to: HexString256!
+	to: Account!
 	amount: Int!
 	color: HexString256!
 }
 type Coin {
 	utxoId: HexStringUtxoId!
-	owner: HexString256!
+	owner: Account!
 	amount: U64!
 	color: HexString256!
 	maturity: U64!
@@ -85,7 +86,7 @@ input CoinFilterInput {
 	color: HexString256
 }
 type CoinOutput {
-	to: HexString256!
+	to: Account!
 	amount: Int!
 	color: HexString256!
 }
@@ -120,7 +121,7 @@ scalar HexStringUtxoId
 union Input = | InputCoin | InputContract
 type InputCoin {
 	utxoId: HexStringUtxoId!
-	owner: HexString256!
+	owner: Account!
 	amount: Int!
 	color: HexString256!
 	witnessIndex: Int!
@@ -198,7 +199,7 @@ type Receipt {
 	pc: U64
 	is: U64
 	to: HexString256
-	toAddress: HexString256
+	toAddress: Account
 	amount: U64
 	color: HexString256
 	gas: U64
@@ -306,12 +307,12 @@ type TransactionEdge {
 union TransactionStatus = | SubmittedStatus | SuccessStatus | FailureStatus
 scalar U64
 type VariableOutput {
-	to: HexString256!
+	to: Account!
 	amount: Int!
 	color: HexString256!
 }
 type WithdrawalOutput {
-	to: HexString256!
+	to: Account!
 	amount: Int!
 	color: HexString256!
 }

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -22,7 +22,7 @@ use crate::client::types::{TransactionResponse, TransactionStatus};
 pub use schema::{PageDirection, PaginatedResult, PaginationRequest};
 use std::io::ErrorKind;
 
-use self::schema::coin::SpendQueryElementInput;
+use self::schema::{account::AccountByAddressArgs, coin::SpendQueryElementInput};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FuelClient {
@@ -290,6 +290,16 @@ impl FuelClient {
 
         let coins = self.query(query).await?.coins_to_spend;
         Ok(coins)
+    }
+
+    pub async fn account(&self, address: &str) -> io::Result<Option<schema::account::Account>> {
+        let query = schema::account::AccountByAddressQuery::build(&AccountByAddressArgs {
+            address: address.parse()?,
+        });
+
+        let account = self.query(query).await?.account;
+
+        Ok(account)
     }
 }
 

--- a/fuel-client/src/client/schema.rs
+++ b/fuel-client/src/client/schema.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 
 pub use primitives::*;
 
+pub mod account;
 pub mod block;
 pub mod chain;
 pub mod coin;

--- a/fuel-client/src/client/schema/account.rs
+++ b/fuel-client/src/client/schema/account.rs
@@ -1,7 +1,37 @@
 use crate::client::schema::{schema, HexString256};
 
+#[derive(cynic::FragmentArguments, Debug)]
+pub struct AccountByAddressArgs {
+    pub address: HexString256,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    argument_struct = "AccountByAddressArgs"
+)]
+pub struct AccountByAddressQuery {
+    #[arguments(address = &args.address)]
+    pub account: Option<Account>,
+}
+
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Account {
     pub address: HexString256,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_by_address_query_gql_output() {
+        use cynic::QueryBuilder;
+        let operation = AccountByAddressQuery::build(AccountByAddressArgs {
+            address: HexString256::default(),
+        });
+        insta::assert_snapshot!(operation.query)
+    }
 }

--- a/fuel-client/src/client/schema/account.rs
+++ b/fuel-client/src/client/schema/account.rs
@@ -1,0 +1,7 @@
+use crate::client::schema::{schema, HexString256};
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct Account {
+    pub address: HexString256,
+}

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -4,6 +4,8 @@ use crate::client::schema::{
 };
 use crate::client::PaginatedResult;
 
+use super::account::Account;
+
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct BlockByIdArgs {
     pub id: HexString256,
@@ -65,7 +67,7 @@ pub struct Block {
     pub height: U64,
     pub id: HexString256,
     pub time: DateTime,
-    pub producer: HexString256,
+    pub producer: Account,
     pub transactions: Vec<OpaqueTransaction>,
 }
 

--- a/fuel-client/src/client/schema/coin.rs
+++ b/fuel-client/src/client/schema/coin.rs
@@ -1,6 +1,8 @@
 use crate::client::schema::{schema, HexString256, HexStringUtxoId, PageInfo, U64};
 use crate::client::{PageDirection, PaginatedResult, PaginationRequest};
 
+use super::account::Account;
+
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct CoinByIdArgs {
     pub utxo_id: HexStringUtxoId,
@@ -155,7 +157,7 @@ pub struct Coin {
     pub color: HexString256,
     pub utxo_id: HexStringUtxoId,
     pub maturity: U64,
-    pub owner: HexString256,
+    pub owner: Account,
     pub status: CoinStatus,
 }
 

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__account__tests__account_by_address_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__account__tests__account_by_address_query_gql_output.snap
@@ -1,0 +1,12 @@
+---
+source: fuel-client/src/client/schema/account.rs
+assertion_line: 35
+expression: operation.query
+
+---
+query Query($_0: HexString256!) {
+  account(address: $_0) {
+    address
+  }
+}
+

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_by_id_query_gql_output.snap
@@ -1,6 +1,6 @@
 ---
 source: fuel-client/src/client/schema/block.rs
-assertion_line: 82
+assertion_line: 84
 expression: operation.query
 
 ---
@@ -9,7 +9,9 @@ query Query($_0: HexString256) {
     height
     id
     time
-    producer
+    producer {
+      address
+    }
     transactions {
       rawPayload
       receipts {

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__blocks_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__blocks_connection_query_gql_output.snap
@@ -1,6 +1,6 @@
 ---
 source: fuel-client/src/client/schema/block.rs
-assertion_line: 94
+assertion_line: 96
 expression: operation.query
 
 ---
@@ -12,7 +12,9 @@ query Query($_0: String, $_1: String, $_2: Int, $_3: Int) {
         height
         id
         time
-        producer
+        producer {
+          address
+        }
         transactions {
           rawPayload
           receipts {

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -13,7 +13,9 @@ query Query {
       height
       id
       time
-      producer
+      producer {
+        address
+      }
       transactions {
         rawPayload
         receipts {

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coin_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coin_by_id_query_gql_output.snap
@@ -1,6 +1,6 @@
 ---
 source: fuel-client/src/client/schema/coin.rs
-assertion_line: 124
+assertion_line: 181
 expression: operation.query
 
 ---
@@ -11,7 +11,9 @@ query Query($_0: HexStringUtxoId!) {
     color
     utxoId
     maturity
-    owner
+    owner {
+      address
+    }
     status
   }
 }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coins_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coins_connection_query_gql_output.snap
@@ -1,6 +1,6 @@
 ---
 source: fuel-client/src/client/schema/coin.rs
-assertion_line: 155
+assertion_line: 197
 expression: operation.query
 
 ---
@@ -14,7 +14,9 @@ query Query($_0: CoinFilterInput!, $_1: String, $_2: String, $_3: Int, $_4: Int)
         color
         utxoId
         maturity
-        owner
+        owner {
+          address
+        }
         status
       }
     }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -16,7 +16,9 @@ query Query($_0: HexString256!) {
       __typename
       ... on InputCoin {
         utxoId
-        owner
+        owner {
+          address
+        }
         amount
         color
         witnessIndex
@@ -35,7 +37,9 @@ query Query($_0: HexString256!) {
     outputs {
       __typename
       ... on CoinOutput {
-        to
+        to {
+          address
+        }
         amount
         color
       }
@@ -45,17 +49,23 @@ query Query($_0: HexString256!) {
         stateRoot
       }
       ... on WithdrawalOutput {
-        to
+        to {
+          address
+        }
         amount
         color
       }
       ... on ChangeOutput {
-        to
+        to {
+          address
+        }
         amount
         color
       }
       ... on VariableOutput {
-        to
+        to {
+          address
+        }
         amount
         color
       }
@@ -108,7 +118,9 @@ query Query($_0: HexString256!) {
       reason
       receiptType
       to
-      toAddress
+      toAddress {
+        address
+      }
       val
       len
       result

--- a/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
@@ -1,5 +1,6 @@
 use crate::client::schema::{
-    schema, ConversionError, ConversionError::MissingField, HexString, HexString256, U64,
+    account::Account, schema, ConversionError, ConversionError::MissingField, HexString,
+    HexString256, U64,
 };
 use fuel_types::Word;
 
@@ -23,7 +24,7 @@ pub struct Receipt {
     pub reason: Option<U64>,
     pub receipt_type: ReceiptType,
     pub to: Option<HexString256>,
-    pub to_address: Option<HexString256>,
+    pub to_address: Option<Account>,
     pub val: Option<U64>,
     pub len: Option<U64>,
     pub result: Option<U64>,

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -1,4 +1,5 @@
 use crate::client::schema::{
+    account::Account,
     schema,
     tx::{tests::transparent_receipt::Receipt, TransactionStatus, TxIdArgs},
     ConnectionArgs, ConversionError, HexString, HexString256, HexStringUtxoId, PageInfo,
@@ -171,7 +172,7 @@ pub enum Input {
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct InputCoin {
     pub utxo_id: HexStringUtxoId,
-    pub owner: HexString256,
+    pub owner: Account,
     pub amount: i32,
     pub color: HexString256,
     pub witness_index: i32,
@@ -196,7 +197,7 @@ impl TryFrom<Input> for fuel_tx::Input {
         Ok(match input {
             Input::InputCoin(coin) => fuel_tx::Input::Coin {
                 utxo_id: coin.utxo_id.into(),
-                owner: coin.owner.into(),
+                owner: coin.owner.address.into(),
                 amount: coin.amount.try_into()?,
                 color: coin.color.into(),
                 witness_index: coin.witness_index.try_into()?,
@@ -228,7 +229,7 @@ pub enum Output {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct CoinOutput {
-    pub to: HexString256,
+    pub to: Account,
     pub amount: i32,
     pub color: HexString256,
 }
@@ -236,7 +237,7 @@ pub struct CoinOutput {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct WithdrawalOutput {
-    pub to: HexString256,
+    pub to: Account,
     pub amount: i32,
     pub color: HexString256,
 }
@@ -244,7 +245,7 @@ pub struct WithdrawalOutput {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ChangeOutput {
-    pub to: HexString256,
+    pub to: Account,
     pub amount: i32,
     pub color: HexString256,
 }
@@ -252,7 +253,7 @@ pub struct ChangeOutput {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct VariableOutput {
-    pub to: HexString256,
+    pub to: Account,
     pub amount: i32,
     pub color: HexString256,
 }
@@ -278,7 +279,7 @@ impl TryFrom<Output> for fuel_tx::Output {
     fn try_from(value: Output) -> Result<Self, Self::Error> {
         Ok(match value {
             Output::CoinOutput(coin) => Self::Coin {
-                to: coin.to.into(),
+                to: coin.to.address.into(),
                 amount: coin.amount.try_into()?,
                 color: coin.color.into(),
             },
@@ -288,17 +289,17 @@ impl TryFrom<Output> for fuel_tx::Output {
                 state_root: contract.state_root.into(),
             },
             Output::WithdrawalOutput(withdrawal) => Self::Withdrawal {
-                to: withdrawal.to.into(),
+                to: withdrawal.to.address.into(),
                 amount: withdrawal.amount.try_into()?,
                 color: withdrawal.color.into(),
             },
             Output::ChangeOutput(change) => Self::Change {
-                to: change.to.into(),
+                to: change.to.address.into(),
                 amount: change.amount.try_into()?,
                 color: change.color.into(),
             },
             Output::VariableOutput(variable) => Self::Variable {
-                to: variable.to.into(),
+                to: variable.to.address.into(),
                 amount: variable.amount.try_into()?,
                 color: variable.color.into(),
             },

--- a/fuel-core/src/schema.rs
+++ b/fuel-core/src/schema.rs
@@ -1,5 +1,6 @@
 use async_graphql::{EmptySubscription, MergedObject, Schema, SchemaBuilder};
 
+pub mod account;
 pub mod block;
 pub mod chain;
 pub mod coin;
@@ -16,6 +17,7 @@ pub struct Query(
     tx::TxQuery,
     health::HealthQuery,
     coin::CoinQuery,
+    account::AccountQuery,
 );
 
 #[derive(MergedObject, Default)]

--- a/fuel-core/src/schema/account.rs
+++ b/fuel-core/src/schema/account.rs
@@ -116,7 +116,6 @@ pub struct AccountQuery;
 impl AccountQuery {
     async fn account(
         &self,
-        ctx: &Context<'_>,
         #[graphql(desc = "Address of the Account")] address: HexString256,
     ) -> async_graphql::Result<Option<Account>> {
         let account = Account(address.into());

--- a/fuel-core/src/schema/account.rs
+++ b/fuel-core/src/schema/account.rs
@@ -157,7 +157,7 @@ mod tests {
 
         for (i, tx) in txns.iter().enumerate() {
             let tx_id = tx.id();
-            Storage::<Bytes32, FuelTx>::insert(&mut db, &tx_id, &tx).unwrap();
+            Storage::<Bytes32, FuelTx>::insert(&mut db, &tx_id, tx).unwrap();
             db.record_tx_id_owner(&owner, 0u64.into(), i as TransactionIndex, &tx_id)
                 .unwrap();
         }

--- a/fuel-core/src/schema/account.rs
+++ b/fuel-core/src/schema/account.rs
@@ -1,0 +1,33 @@
+use crate::schema::scalars::HexString256;
+use async_graphql::{Context, Object};
+use fuel_tx::Address;
+
+pub struct Account(Address);
+
+impl From<Address> for Account {
+    fn from(address: Address) -> Self {
+        Self(address)
+    }
+}
+
+#[Object]
+impl Account {
+    async fn address(&self) -> HexString256 {
+        self.0.into()
+    }
+}
+
+#[derive(Default)]
+pub struct AccountQuery;
+
+#[Object]
+impl AccountQuery {
+    async fn account(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "Address of the Account")] address: HexString256,
+    ) -> async_graphql::Result<Option<Account>> {
+        let account = Account(address.into());
+        Ok(Some(account))
+    }
+}

--- a/fuel-core/src/schema/account.rs
+++ b/fuel-core/src/schema/account.rs
@@ -1,6 +1,15 @@
-use crate::schema::scalars::HexString256;
-use async_graphql::{Context, Object};
-use fuel_tx::Address;
+use crate::database::transaction::OwnedTransactionIndexCursor;
+use crate::database::KvStoreError;
+use crate::schema::scalars::HexString;
+use crate::schema::tx::types::Transaction;
+use crate::state::IterDirection;
+use crate::{database::Database, schema::scalars::HexString256};
+use async_graphql::connection::{Connection, Edge, EmptyFields};
+use async_graphql::{connection::query, Context, Object};
+use fuel_storage::Storage;
+use fuel_tx::Transaction as FuelTx;
+use fuel_tx::{Address, Bytes32};
+use itertools::Itertools;
 
 pub struct Account(Address);
 
@@ -14,6 +23,89 @@ impl From<Address> for Account {
 impl Account {
     async fn address(&self) -> HexString256 {
         self.0.into()
+    }
+
+    async fn transactions(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<i32>,
+        after: Option<String>,
+        last: Option<i32>,
+        before: Option<String>,
+    ) -> async_graphql::Result<Connection<HexString, Transaction, EmptyFields, EmptyFields>> {
+        let db = ctx.data_unchecked::<Database>();
+        let owner = self.0;
+
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after: Option<HexString>, before: Option<HexString>, first, last| async move {
+                let (records_to_fetch, direction) = if let Some(first) = first {
+                    (first, IterDirection::Forward)
+                } else if let Some(last) = last {
+                    (last, IterDirection::Reverse)
+                } else {
+                    (0, IterDirection::Forward)
+                };
+
+                let after = after.map(OwnedTransactionIndexCursor::from);
+                let before = before.map(OwnedTransactionIndexCursor::from);
+
+                let start;
+                let end;
+
+                if direction == IterDirection::Forward {
+                    start = after;
+                    end = before;
+                } else {
+                    start = before;
+                    end = after;
+                }
+
+                let mut txs = db.owned_transactions(&owner, start.as_ref(), Some(direction));
+                let mut started = None;
+                if start.is_some() {
+                    // skip initial result
+                    started = txs.next();
+                }
+
+                // take desired amount of results
+                let txs = txs
+                    .take_while(|r| {
+                        // take until we've reached the end
+                        if let (Ok(t), Some(end)) = (r, end.as_ref()) {
+                            if &t.0 == end {
+                                return false;
+                            }
+                        }
+                        true
+                    })
+                    .take(records_to_fetch)
+                    .map(|res| {
+                        res.and_then(|(cursor, tx_id)| {
+                            let tx = Storage::<Bytes32, FuelTx>::get(db, &tx_id)?
+                                .ok_or(KvStoreError::NotFound)?
+                                .into_owned();
+                            Ok((cursor, tx))
+                        })
+                    });
+                let mut txs: Vec<(OwnedTransactionIndexCursor, FuelTx)> = txs.try_collect()?;
+                if direction == IterDirection::Reverse {
+                    txs.reverse();
+                }
+
+                let mut connection =
+                    Connection::new(started.is_some(), records_to_fetch <= txs.len());
+                connection.append(
+                    txs.into_iter()
+                        .map(|item| Edge::new(HexString::from(item.0), Transaction(item.1))),
+                );
+                Ok(connection)
+            },
+        )
+        .await
     }
 }
 

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -1,4 +1,5 @@
 use crate::database::Database;
+use crate::schema::account::Account;
 use crate::schema::scalars::U64;
 use crate::{
     database::KvStoreError,
@@ -50,7 +51,7 @@ impl Block {
         self.0.time
     }
 
-    async fn producer(&self) -> HexString256 {
+    async fn producer(&self) -> Account {
         self.0.producer.into()
     }
 }

--- a/fuel-core/src/schema/coin.rs
+++ b/fuel-core/src/schema/coin.rs
@@ -13,6 +13,7 @@ use fuel_tx::consts::MAX_INPUTS;
 use fuel_tx::{Address, Color as FuelTxColor, UtxoId};
 use itertools::Itertools;
 
+use super::account::Account;
 use super::scalars::HexStringUtxoId;
 
 pub struct Coin(UtxoId, CoinModel);
@@ -23,7 +24,7 @@ impl Coin {
         self.0.into()
     }
 
-    async fn owner(&self) -> HexString256 {
+    async fn owner(&self) -> Account {
         self.1.owner.into()
     }
 

--- a/fuel-core/src/schema/tx/receipt.rs
+++ b/fuel-core/src/schema/tx/receipt.rs
@@ -1,4 +1,7 @@
-use crate::schema::scalars::{HexString, HexString256, U64};
+use crate::schema::{
+    account::Account,
+    scalars::{HexString, HexString256, U64},
+};
 use async_graphql::{Enum, Object};
 use derive_more::Display;
 use fuel_asm::Word;
@@ -52,7 +55,7 @@ impl Receipt {
     async fn to(&self) -> Option<HexString256> {
         self.0.to().copied().map(Into::into)
     }
-    async fn to_address(&self) -> Option<HexString256> {
+    async fn to_address(&self) -> Option<Account> {
         self.0.to_address().copied().map(Into::into)
     }
     async fn amount(&self) -> Option<U64> {

--- a/fuel-core/src/schema/tx/types.rs
+++ b/fuel-core/src/schema/tx/types.rs
@@ -1,4 +1,5 @@
 use crate::database::Database;
+use crate::schema::account::Account;
 use crate::schema::scalars::{HexString, HexString256, HexStringUtxoId};
 use crate::tx_pool::TransactionStatus as TxStatus;
 use async_graphql::{Context, Enum, Object, Union};
@@ -32,8 +33,8 @@ impl InputCoin {
     async fn utxo_id(&self) -> HexStringUtxoId {
         self.utxo_id
     }
-    async fn owner(&self) -> HexString256 {
-        self.owner
+    async fn owner(&self) -> Account {
+        Address::from(self.owner.0).into()
     }
 
     async fn amount(&self) -> Word {
@@ -142,8 +143,8 @@ pub struct CoinOutput {
 
 #[Object]
 impl CoinOutput {
-    async fn to(&self) -> HexString256 {
-        HexString256(*self.to.deref())
+    async fn to(&self) -> Account {
+        self.to.into()
     }
 
     async fn amount(&self) -> Word {
@@ -159,8 +160,8 @@ pub struct WithdrawalOutput(CoinOutput);
 
 #[Object]
 impl WithdrawalOutput {
-    async fn to(&self) -> HexString256 {
-        HexString256(*self.0.to.deref())
+    async fn to(&self) -> Account {
+        self.0.to.into()
     }
 
     async fn amount(&self) -> Word {
@@ -176,8 +177,8 @@ pub struct ChangeOutput(CoinOutput);
 
 #[Object]
 impl ChangeOutput {
-    async fn to(&self) -> HexString256 {
-        HexString256(*self.0.to.deref())
+    async fn to(&self) -> Account {
+        self.0.to.into()
     }
 
     async fn amount(&self) -> Word {
@@ -193,8 +194,8 @@ pub struct VariableOutput(CoinOutput);
 
 #[Object]
 impl VariableOutput {
-    async fn to(&self) -> HexString256 {
-        HexString256(*self.0.to.deref())
+    async fn to(&self) -> Account {
+        self.0.to.into()
     }
 
     async fn amount(&self) -> Word {


### PR DESCRIPTION
This PR basically tries to do two things:

- Add `Account` type
- Change fields that represent an Account (like `Block.producer`) from `HexString256` to `Account`

---

The Account type can be extended with fields like `balances` and `transactions` so this:
```gql
query {
  balances(address: $address) { ... }
  transactions(address: $address) { ... }
}
```
can become this:
```gql
query {
  account(address: $address) {
    balances { ... }
    transactions { ... }
  }
}
```

---

The change from `HexString256` to `Account` is so we can pack requirements of a UI into one query:
```ts
// Before
let block = await q(`query {
  block(height: ${height}) {
    producer
  }
}`);

let producer = await q(`query {
  account(id: ${block.producer}) {
    address
    producedBlocks { count }
  }
}`);

console.log(`${height} produced by ${producer.address} who produced ${producer.producedBlocks.count} so far!`)

// After
let block = await q(`query {
  block(height: ${height}) {
    producer {
      address
      producedBlocks { count }
    }
  }
}`);

let producer = block.producer;

console.log(`${height} produced by ${producer.address} who produced ${producer.producedBlocks.count} so far!`)
```

---

Given the green light, I will:
- [x] Change `HexString256` to `Account` in all fields necessary
- [x] Add `Account.transactions`
- [x] Add `fuel-client` implementation and tests