### PR TITLE
Receipt saving bug

### DIFF
--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -48,13 +48,19 @@ impl Executor {
             // execute vm
             let mut vm = Transactor::new(tx_db.clone());
             vm.transact(tx);
+
+            // only commit state changes if execution was a success
+            if !result.should_revert() {
+                sub_tx.commit()?;
+            }
+
             match vm.result() {
                 Ok(result) => {
                     // persist any outputs
-                    self.persist_outputs(block.fuel_height, result.tx(), tx_db)?;
+                    self.persist_outputs(block.fuel_height, result.tx(), block_tx.deref_mut())?;
 
                     // persist receipts
-                    self.persist_receipts(tx_id, result.receipts(), tx_db)?;
+                    self.persist_receipts(tx_id, result.receipts(), block_tx.deref_mut())?;
 
                     let status = if result.should_revert() {
                         if config.backtrace {
@@ -104,14 +110,9 @@ impl Executor {
 
                     // persist tx status at the block level
                     block_tx.update_tx_status(tx_id, status)?;
-
-                    // only commit state changes if execution was a success
-                    if !result.should_revert() {
-                        sub_tx.commit()?;
-                    }
                 }
                 Err(e) => {
-                    // save error status on block_tx since the sub_tx changes are dropped
+                    // save error status on block_tx
                     block_tx.update_tx_status(
                         tx_id,
                         TransactionStatus::Failed {

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -49,13 +49,13 @@ impl Executor {
             let mut vm = Transactor::new(tx_db.clone());
             vm.transact(tx);
 
-            // only commit state changes if execution was a success
-            if !result.should_revert() {
-                sub_tx.commit()?;
-            }
 
             match vm.result() {
                 Ok(result) => {
+                    // only commit state changes if execution was a success
+                    if !result.should_revert() {
+                        sub_tx.commit()?;
+                    }
                     // persist any outputs
                     self.persist_outputs(block.fuel_height, result.tx(), block_tx.deref_mut())?;
 

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -49,7 +49,6 @@ impl Executor {
             let mut vm = Transactor::new(tx_db.clone());
             vm.transact(tx);
 
-
             match vm.result() {
                 Ok(result) => {
                     // only commit state changes if execution was a success


### PR DESCRIPTION
This addresses a bug where receipts aren't saved if the transaction panics. They were being saved to the wrong database transaction which gets dropped if the tx panics, and should only be used for state changes from the script execution.