### PR TITLE
Restructure Schema

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -96,7 +96,7 @@ enum CoinStatus {
 }
 type Contract {
 	id: ContractId!
-	bytes: HexString!
+	bytecode: HexString!
 }
 type ContractCreated {
 	contract: Contract!

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -1,9 +1,11 @@
+scalar Address
+scalar AssetId
 type Block {
-	id: HexString256!
+	id: BlockId!
 	height: U64!
 	transactions: [Transaction!]!
 	time: DateTime!
-	producer: HexString256!
+	producer: Address!
 }
 type BlockConnection {
 	"""
@@ -28,6 +30,8 @@ type BlockEdge {
 	"""
 	cursor: String!
 }
+scalar BlockId
+scalar Bytes32
 type ChainInfo {
 	name: String!
 	latestBlock: Block!
@@ -35,15 +39,15 @@ type ChainInfo {
 	peerCount: Int!
 }
 type ChangeOutput {
-	to: HexString256!
-	amount: Int!
-	assetId: HexString256!
+	to: Address!
+	amount: U64!
+	assetId: AssetId!
 }
 type Coin {
-	utxoId: HexStringUtxoId!
-	owner: HexString256!
+	utxoId: UtxoId!
+	owner: Address!
 	amount: U64!
-	assetId: HexString256!
+	assetId: AssetId!
 	maturity: U64!
 	status: CoinStatus!
 	blockCreated: U64!
@@ -75,29 +79,34 @@ input CoinFilterInput {
 	"""
 	address of the owner
 	"""
-	owner: HexString256!
+	owner: Address!
 	"""
 	asset ID of the coins
 	"""
-	assetId: HexString256
+	assetId: AssetId
 }
 type CoinOutput {
-	to: HexString256!
-	amount: Int!
-	assetId: HexString256!
+	to: Address!
+	amount: U64!
+	assetId: AssetId!
 }
 enum CoinStatus {
 	UNSPENT
 	SPENT
 }
-type ContractCreated {
-	contractId: HexString256!
-	stateRoot: HexString256!
+type Contract {
+	id: ContractId!
+	bytes: HexString!
 }
+type ContractCreated {
+	contract: Contract!
+	stateRoot: Bytes32!
+}
+scalar ContractId
 type ContractOutput {
 	inputIndex: Int!
-	balanceRoot: HexString256!
-	stateRoot: HexString256!
+	balanceRoot: Bytes32!
+	stateRoot: Bytes32!
 }
 """
 Implement the DateTime<Utc> scalar
@@ -106,30 +115,28 @@ The input/output is a string in RFC3339 format.
 """
 scalar DateTime
 type FailureStatus {
-	blockId: HexString256!
+	block: Block!
 	time: DateTime!
 	reason: String!
 	programState: ProgramState
 }
 scalar HexString
-scalar HexString256
-scalar HexStringUtxoId
 union Input = | InputCoin | InputContract
 type InputCoin {
-	utxoId: HexStringUtxoId!
-	owner: HexString256!
-	amount: Int!
-	assetId: HexString256!
+	utxoId: UtxoId!
+	owner: Address!
+	amount: U64!
+	assetId: AssetId!
 	witnessIndex: Int!
-	maturity: Int!
+	maturity: U64!
 	predicate: HexString!
 	predicateData: HexString!
 }
 type InputContract {
-	utxoId: HexStringUtxoId!
-	balanceRoot: HexString256!
-	stateRoot: HexString256!
-	contractId: HexString256!
+	utxoId: UtxoId!
+	balanceRoot: Bytes32!
+	stateRoot: Bytes32!
+	contract: Contract!
 }
 type Mutation {
 	startSession: ID!
@@ -143,7 +150,7 @@ type Mutation {
 	"""
 	Submits transaction to the pool
 	"""
-	submit(tx: HexString!): HexString256!
+	submit(tx: HexString!): Transaction!
 }
 union Output = | CoinOutput | ContractOutput | WithdrawalOutput | ChangeOutput | VariableOutput | ContractCreated
 """
@@ -174,35 +181,36 @@ type ProgramState {
 type Query {
 	register(id: ID!, register: U64!): U64!
 	memory(id: ID!, start: U64!, size: U64!): String!
-	block(id: HexString256, height: Int): Block
-	blocks(after: String, before: String, first: Int, last: Int): BlockConnection!
+	block(id: BlockId, height: U64): Block
+	blocks(first: Int, after: String, last: Int, before: String): BlockConnection!
 	chain: ChainInfo!
 	version: String!
-	transaction(id: HexString256!): Transaction
-	transactions(after: String, before: String, first: Int, last: Int): TransactionConnection!
-	transactionsByOwner(owner: HexString256!, after: String, before: String, first: Int, last: Int): TransactionConnection!
+	transaction(id: TransactionId!): Transaction
+	transactions(first: Int, after: String, last: Int, before: String): TransactionConnection!
+	transactionsByOwner(owner: Address!, first: Int, after: String, last: Int, before: String): TransactionConnection!
 	"""
 	Returns true when the GraphQL API is serving requests.
 	"""
 	health: Boolean!
-	coin(utxoId: HexStringUtxoId!): Coin
-	coins(after: String, before: String, first: Int, last: Int, filter: CoinFilterInput!): CoinConnection!
-	coinsToSpend(owner: HexString256!, spendQuery: [SpendQueryElementInput!]!, maxInputs: Int): [Coin!]!
+	coin(utxoId: UtxoId!): Coin
+	coins(filter: CoinFilterInput!, first: Int, after: String, last: Int, before: String): CoinConnection!
+	coinsToSpend(owner: Address!, spendQuery: [SpendQueryElementInput!]!, maxInputs: Int): [Coin!]!
+	contract(id: ContractId!): Contract
 }
 type Receipt {
-	id: HexString256
+	contract: Contract
 	pc: U64
 	is: U64
-	to: HexString256
-	toAddress: HexString256
+	to: Contract
+	toAddress: Address
 	amount: U64
-	assetId: HexString256
+	assetId: AssetId
 	gas: U64
 	a: U64
 	b: U64
 	val: U64
 	ptr: U64
-	digest: HexString256
+	digest: Bytes32
 	reason: U64
 	ra: U64
 	rb: U64
@@ -232,11 +240,12 @@ enum ReturnType {
 	RETURN_DATA
 	REVERT
 }
+scalar Salt
 input SpendQueryElementInput {
 	"""
 	asset ID of the coins
 	"""
-	assetId: HexString256!
+	assetId: AssetId!
 	"""
 	address of the owner
 	"""
@@ -246,30 +255,30 @@ type SubmittedStatus {
 	time: DateTime!
 }
 type SuccessStatus {
-	blockId: HexString256!
+	block: Block!
 	time: DateTime!
 	programState: ProgramState!
 }
 type Transaction {
-	id: HexString256!
-	inputAssetIds: [HexString256!]!
-	inputContracts: [HexString256!]!
-	gasPrice: Int!
-	gasLimit: Int!
-	bytePrice: Int!
-	maturity: Int!
+	id: TransactionId!
+	inputAssetIds: [AssetId!]!
+	inputContracts: [Contract!]!
+	gasPrice: U64!
+	gasLimit: U64!
+	bytePrice: U64!
+	maturity: U64!
 	isScript: Boolean!
 	inputs: [Input!]!
 	outputs: [Output!]!
 	witnesses: [HexString!]!
-	receiptsRoot: HexString256
+	receiptsRoot: Bytes32
 	status: TransactionStatus
 	receipts: [Receipt!]
 	script: HexString
 	scriptData: HexString
 	bytecodeWitnessIndex: Int
-	salt: HexString256
-	staticContracts: [HexString256!]
+	salt: Salt
+	staticContracts: [Contract!]
 	storageSlots: [HexString!]
 	"""
 	Return the transaction bytes using canonical encoding
@@ -299,17 +308,19 @@ type TransactionEdge {
 	"""
 	cursor: String!
 }
+scalar TransactionId
 union TransactionStatus = | SubmittedStatus | SuccessStatus | FailureStatus
 scalar U64
+scalar UtxoId
 type VariableOutput {
-	to: HexString256!
-	amount: Int!
-	assetId: HexString256!
+	to: Address!
+	amount: U64!
+	assetId: AssetId!
 }
 type WithdrawalOutput {
-	to: HexString256!
-	amount: Int!
-	assetId: HexString256!
+	to: Address!
+	amount: U64!
+	assetId: AssetId!
 }
 schema {
 	query: Query

--- a/fuel-client/src/client/schema.rs
+++ b/fuel-client/src/client/schema.rs
@@ -16,6 +16,7 @@ pub use primitives::*;
 pub mod block;
 pub mod chain;
 pub mod coin;
+pub mod contract;
 pub mod primitives;
 pub mod tx;
 

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -1,12 +1,13 @@
 use crate::client::schema::{
-    primitives::DateTime, schema, tx::OpaqueTransaction, ConnectionArgs, HexString256, PageInfo,
-    U64,
+    primitives::Address, primitives::DateTime, schema, BlockId, ConnectionArgs, PageInfo, U64,
 };
 use crate::client::PaginatedResult;
 
+use super::tx::TransactionIdFragment;
+
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct BlockByIdArgs {
-    pub id: HexString256,
+    pub id: BlockId,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -63,10 +64,16 @@ pub struct BlockEdge {
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Block {
     pub height: U64,
-    pub id: HexString256,
+    pub id: BlockId,
     pub time: DateTime,
-    pub producer: HexString256,
-    pub transactions: Vec<OpaqueTransaction>,
+    pub producer: Address,
+    pub transactions: Vec<TransactionIdFragment>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Block")]
+pub struct BlockIdFragment {
+    pub id: BlockId,
 }
 
 #[cfg(test)]
@@ -77,7 +84,7 @@ mod tests {
     fn block_by_id_query_gql_output() {
         use cynic::QueryBuilder;
         let operation = BlockByIdQuery::build(BlockByIdArgs {
-            id: HexString256::default(),
+            id: BlockId::default(),
         });
         insta::assert_snapshot!(operation.query)
     }

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -1,4 +1,4 @@
-use crate::client::schema::{schema, ContractId};
+use crate::client::schema::{schema, ContractId, HexString};
 
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct ContractByIdArgs {
@@ -20,6 +20,7 @@ pub struct ContractByIdQuery {
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Contract {
     pub id: ContractId,
+    pub bytecode: HexString,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -1,0 +1,43 @@
+use crate::client::schema::{schema, ContractId};
+
+#[derive(cynic::FragmentArguments, Debug)]
+pub struct ContractByIdArgs {
+    pub id: ContractId,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    argument_struct = "ContractByIdArgs"
+)]
+pub struct ContractByIdQuery {
+    #[arguments(id = &args.id)]
+    pub contract: Option<Contract>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct Contract {
+    pub id: ContractId,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Contract")]
+pub struct ContractIdFragment {
+    pub id: ContractId,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract_by_id_query_gql_output() {
+        use cynic::QueryBuilder;
+        let operation = ContractByIdQuery::build(ContractByIdArgs {
+            id: ContractId::default(),
+        });
+        insta::assert_snapshot!(operation.query)
+    }
+}

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__account__tests__account_by_address_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__account__tests__account_by_address_query_gql_output.snap
@@ -1,0 +1,12 @@
+---
+source: fuel-client/src/client/schema/account.rs
+assertion_line: 35
+expression: operation.query
+
+---
+query Query($_0: HexString256!) {
+  account(address: $_0) {
+    address
+  }
+}
+

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_by_id_query_gql_output.snap
@@ -1,43 +1,17 @@
 ---
 source: fuel-client/src/client/schema/block.rs
-assertion_line: 82
+assertion_line: 90
 expression: operation.query
 
 ---
-query Query($_0: HexString256) {
+query Query($_0: BlockId) {
   block(id: $_0) {
     height
     id
     time
     producer
     transactions {
-      rawPayload
-      receipts {
-        rawPayload
-      }
-      status {
-        __typename
-        ... on SubmittedStatus {
-          time
-        }
-        ... on SuccessStatus {
-          blockId
-          time
-          programState {
-            returnType
-            data
-          }
-        }
-        ... on FailureStatus {
-          blockId
-          time
-          reason
-          programState {
-            returnType
-            data
-          }
-        }
-      }
+      id
     }
   }
 }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__blocks_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__blocks_connection_query_gql_output.snap
@@ -1,11 +1,11 @@
 ---
 source: fuel-client/src/client/schema/block.rs
-assertion_line: 94
+assertion_line: 102
 expression: operation.query
 
 ---
-query Query($_0: String, $_1: String, $_2: Int, $_3: Int) {
-  blocks(after: $_0, before: $_1, first: $_2, last: $_3) {
+query Query($_0: Int, $_1: String, $_2: Int, $_3: String) {
+  blocks(first: $_0, after: $_1, last: $_2, before: $_3) {
     edges {
       cursor
       node {
@@ -14,33 +14,7 @@ query Query($_0: String, $_1: String, $_2: Int, $_3: Int) {
         time
         producer
         transactions {
-          rawPayload
-          receipts {
-            rawPayload
-          }
-          status {
-            __typename
-            ... on SubmittedStatus {
-              time
-            }
-            ... on SuccessStatus {
-              blockId
-              time
-              programState {
-                returnType
-                data
-              }
-            }
-            ... on FailureStatus {
-              blockId
-              time
-              reason
-              programState {
-                returnType
-                data
-              }
-            }
-          }
+          id
         }
       }
     }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -15,33 +15,7 @@ query Query {
       time
       producer
       transactions {
-        rawPayload
-        receipts {
-          rawPayload
-        }
-        status {
-          __typename
-          ... on SubmittedStatus {
-            time
-          }
-          ... on SuccessStatus {
-            blockId
-            time
-            programState {
-              returnType
-              data
-            }
-          }
-          ... on FailureStatus {
-            blockId
-            time
-            reason
-            programState {
-              returnType
-              data
-            }
-          }
-        }
+        id
       }
     }
   }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coin_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coin_by_id_query_gql_output.snap
@@ -1,10 +1,10 @@
 ---
 source: fuel-client/src/client/schema/coin.rs
-assertion_line: 124
+assertion_line: 179
 expression: operation.query
 
 ---
-query Query($_0: HexStringUtxoId!) {
+query Query($_0: UtxoId!) {
   coin(utxoId: $_0) {
     amount
     blockCreated

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coins_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__coin__tests__coins_connection_query_gql_output.snap
@@ -1,11 +1,11 @@
 ---
 source: fuel-client/src/client/schema/coin.rs
-assertion_line: 155
+assertion_line: 195
 expression: operation.query
 
 ---
-query Query($_0: CoinFilterInput!, $_1: String, $_2: String, $_3: Int, $_4: Int) {
-  coins(filter: $_0, after: $_1, before: $_2, first: $_3, last: $_4) {
+query Query($_0: CoinFilterInput!, $_1: Int, $_2: String, $_3: Int, $_4: String) {
+  coins(filter: $_0, first: $_1, after: $_2, last: $_3, before: $_4) {
     edges {
       cursor
       node {

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__contract__tests__contract_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__contract__tests__contract_by_id_query_gql_output.snap
@@ -1,0 +1,12 @@
+---
+source: fuel-client/src/client/schema/contract.rs
+assertion_line: 35
+expression: operation.query
+
+---
+query Query($_0: ContractId!) {
+  contract(id: $_0) {
+    id
+  }
+}
+

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__contract__tests__contract_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__contract__tests__contract_by_id_query_gql_output.snap
@@ -1,12 +1,13 @@
 ---
 source: fuel-client/src/client/schema/contract.rs
-assertion_line: 35
+assertion_line: 42
 expression: operation.query
 
 ---
 query Query($_0: ContractId!) {
   contract(id: $_0) {
     id
+    bytecode
   }
 }
 

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__opaque_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__opaque_transaction_by_id_query_gql_output.snap
@@ -1,10 +1,10 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
-assertion_line: 273
+assertion_line: 280
 expression: operation.query
 
 ---
-query Query($_0: HexString256!) {
+query Query($_0: TransactionId!) {
   transaction(id: $_0) {
     rawPayload
     receipts {
@@ -16,7 +16,9 @@ query Query($_0: HexString256!) {
         time
       }
       ... on SuccessStatus {
-        blockId
+        block {
+          id
+        }
         time
         programState {
           returnType
@@ -24,7 +26,9 @@ query Query($_0: HexString256!) {
         }
       }
       ... on FailureStatus {
-        blockId
+        block {
+          id
+        }
         time
         reason
         programState {

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__submit_tx_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__submit_tx_gql_output.snap
@@ -1,9 +1,12 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
+assertion_line: 325
 expression: query.query
 
 ---
 mutation Mutation($_0: HexString!) {
-  submit(tx: $_0)
+  submit(tx: $_0) {
+    id
+  }
 }
 

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transactions_by_owner_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transactions_by_owner_gql_output.snap
@@ -1,11 +1,11 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
-assertion_line: 298
+assertion_line: 305
 expression: operation.query
 
 ---
-query Query($_0: HexString256!, $_1: String, $_2: String, $_3: Int, $_4: Int) {
-  transactionsByOwner(owner: $_0, after: $_1, before: $_2, first: $_3, last: $_4) {
+query Query($_0: Address!, $_1: Int, $_2: String, $_3: Int, $_4: String) {
+  transactionsByOwner(owner: $_0, first: $_1, after: $_2, last: $_3, before: $_4) {
     edges {
       cursor
       node {
@@ -19,7 +19,9 @@ query Query($_0: HexString256!, $_1: String, $_2: String, $_3: Int, $_4: Int) {
             time
           }
           ... on SuccessStatus {
-            blockId
+            block {
+              id
+            }
             time
             programState {
               returnType
@@ -27,7 +29,9 @@ query Query($_0: HexString256!, $_1: String, $_2: String, $_3: Int, $_4: Int) {
             }
           }
           ... on FailureStatus {
-            blockId
+            block {
+              id
+            }
             time
             reason
             programState {

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transactions_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transactions_connection_query_gql_output.snap
@@ -1,11 +1,11 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
-assertion_line: 285
+assertion_line: 292
 expression: operation.query
 
 ---
-query Query($_0: String, $_1: String, $_2: Int, $_3: Int) {
-  transactions(after: $_0, before: $_1, first: $_2, last: $_3) {
+query Query($_0: Int, $_1: String, $_2: Int, $_3: String) {
+  transactions(first: $_0, after: $_1, last: $_2, before: $_3) {
     edges {
       cursor
       node {
@@ -19,7 +19,9 @@ query Query($_0: String, $_1: String, $_2: Int, $_3: Int) {
             time
           }
           ... on SuccessStatus {
-            blockId
+            block {
+              id
+            }
             time
             programState {
               returnType
@@ -27,7 +29,9 @@ query Query($_0: String, $_1: String, $_2: Int, $_3: Int) {
             }
           }
           ... on FailureStatus {
-            blockId
+            block {
+              id
+            }
             time
             reason
             programState {

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -1,17 +1,19 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
-assertion_line: 264
+assertion_line: 271
 expression: operation.query
 
 ---
-query Query($_0: HexString256!) {
+query Query($_0: TransactionId!) {
   transaction(id: $_0) {
     gasLimit
     gasPrice
     bytePrice
     id
     inputAssetIds
-    inputContracts
+    inputContracts {
+      id
+    }
     inputs {
       __typename
       ... on InputCoin {
@@ -28,7 +30,9 @@ query Query($_0: HexString256!) {
         utxoId
         balanceRoot
         stateRoot
-        contractId
+        contract {
+          id
+        }
       }
     }
     isScript
@@ -60,7 +64,9 @@ query Query($_0: HexString256!) {
         assetId
       }
       ... on ContractCreated {
-        contractId
+        contract {
+          id
+        }
         stateRoot
       }
     }
@@ -72,7 +78,9 @@ query Query($_0: HexString256!) {
         time
       }
       ... on SuccessStatus {
-        blockId
+        block {
+          id
+        }
         time
         programState {
           returnType
@@ -80,7 +88,9 @@ query Query($_0: HexString256!) {
         }
       }
       ... on FailureStatus {
-        blockId
+        block {
+          id
+        }
         time
         reason
         programState {
@@ -97,7 +107,9 @@ query Query($_0: HexString256!) {
       assetId
       gas
       digest
-      id
+      contract {
+        id
+      }
       is
       pc
       ptr
@@ -107,7 +119,9 @@ query Query($_0: HexString256!) {
       rd
       reason
       receiptType
-      to
+      to {
+        id
+      }
       toAddress
       val
       len
@@ -118,7 +132,9 @@ query Query($_0: HexString256!) {
     script
     scriptData
     salt
-    staticContracts
+    staticContracts {
+      id
+    }
     storageSlots
     bytecodeWitnessIndex
   }

--- a/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
@@ -1,5 +1,6 @@
 use crate::client::schema::{
-    schema, ConversionError, ConversionError::MissingField, HexString, HexString256, U64,
+    contract::Contract, schema, Address, AssetId, Bytes32, ConversionError,
+    ConversionError::MissingField, HexString, U64,
 };
 use fuel_types::Word;
 
@@ -9,10 +10,10 @@ pub struct Receipt {
     pub a: Option<U64>,
     pub b: Option<U64>,
     pub amount: Option<U64>,
-    pub asset_id: Option<HexString256>,
+    pub asset_id: Option<AssetId>,
     pub gas: Option<U64>,
-    pub digest: Option<HexString256>,
-    pub id: Option<HexString256>,
+    pub digest: Option<Bytes32>,
+    pub contract: Option<Contract>,
     pub is: Option<U64>,
     pub pc: Option<U64>,
     pub ptr: Option<U64>,
@@ -22,8 +23,8 @@ pub struct Receipt {
     pub rd: Option<U64>,
     pub reason: Option<U64>,
     pub receipt_type: ReceiptType,
-    pub to: Option<HexString256>,
-    pub to_address: Option<HexString256>,
+    pub to: Option<Contract>,
+    pub to_address: Option<Address>,
     pub val: Option<U64>,
     pub len: Option<U64>,
     pub result: Option<U64>,
@@ -53,12 +54,14 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
         Ok(match schema.receipt_type {
             ReceiptType::Call => fuel_vm::prelude::Receipt::Call {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 to: schema
                     .to
                     .ok_or_else(|| MissingField("to".to_string()))?
+                    .id
                     .into(),
                 amount: schema
                     .amount
@@ -91,8 +94,9 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
             },
             ReceiptType::Return => fuel_vm::prelude::Receipt::Return {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 val: schema
                     .val
@@ -109,8 +113,9 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
             },
             ReceiptType::ReturnData => fuel_vm::prelude::Receipt::ReturnData {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 ptr: schema
                     .ptr
@@ -139,8 +144,9 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
             },
             ReceiptType::Panic => fuel_vm::prelude::Receipt::Panic {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 reason: schema
                     .reason
@@ -157,8 +163,9 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
             },
             ReceiptType::Revert => fuel_vm::prelude::Receipt::Revert {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 ra: schema
                     .ra
@@ -175,8 +182,9 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
             },
             ReceiptType::Log => fuel_vm::prelude::Receipt::Log {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 ra: schema
                     .ra
@@ -205,8 +213,9 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
             },
             ReceiptType::LogData => fuel_vm::prelude::Receipt::LogData {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 ra: schema
                     .ra
@@ -243,12 +252,14 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
             },
             ReceiptType::Transfer => fuel_vm::prelude::Receipt::Transfer {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 to: schema
                     .to
                     .ok_or_else(|| MissingField("to".to_string()))?
+                    .id
                     .into(),
                 amount: schema
                     .amount
@@ -269,12 +280,13 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
             },
             ReceiptType::TransferOut => fuel_vm::prelude::Receipt::TransferOut {
                 id: schema
+                    .contract
+                    .ok_or_else(|| MissingField("contract".to_string()))?
                     .id
-                    .ok_or_else(|| MissingField("id".to_string()))?
                     .into(),
                 to: schema
-                    .to
-                    .ok_or_else(|| MissingField("to".to_string()))?
+                    .to_address
+                    .ok_or_else(|| MissingField("to_address".to_string()))?
                     .into(),
                 amount: schema
                     .amount

--- a/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
@@ -1,5 +1,5 @@
 use crate::client::schema::{
-    contract::Contract, schema, Address, AssetId, Bytes32, ConversionError,
+    contract::ContractIdFragment, schema, Address, AssetId, Bytes32, ConversionError,
     ConversionError::MissingField, HexString, U64,
 };
 use fuel_types::Word;
@@ -13,7 +13,7 @@ pub struct Receipt {
     pub asset_id: Option<AssetId>,
     pub gas: Option<U64>,
     pub digest: Option<Bytes32>,
-    pub contract: Option<Contract>,
+    pub contract: Option<ContractIdFragment>,
     pub is: Option<U64>,
     pub pc: Option<U64>,
     pub ptr: Option<U64>,
@@ -23,7 +23,7 @@ pub struct Receipt {
     pub rd: Option<U64>,
     pub reason: Option<U64>,
     pub receipt_type: ReceiptType,
-    pub to: Option<Contract>,
+    pub to: Option<ContractIdFragment>,
     pub to_address: Option<Address>,
     pub val: Option<U64>,
     pub len: Option<U64>,

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -1,5 +1,5 @@
 use crate::client::schema::{
-    contract::Contract,
+    contract::ContractIdFragment,
     schema,
     tx::{tests::transparent_receipt::Receipt, TransactionStatus, TxIdArgs},
     Address, AssetId, Bytes32, ConnectionArgs, ConversionError, HexString, PageInfo, Salt,
@@ -54,7 +54,7 @@ pub struct Transaction {
     pub byte_price: U64,
     pub id: TransactionId,
     pub input_asset_ids: Vec<AssetId>,
-    pub input_contracts: Vec<Contract>,
+    pub input_contracts: Vec<ContractIdFragment>,
     pub inputs: Vec<Input>,
     pub is_script: bool,
     pub outputs: Vec<Output>,
@@ -66,7 +66,7 @@ pub struct Transaction {
     pub script: Option<HexString>,
     pub script_data: Option<HexString>,
     pub salt: Option<Salt>,
-    pub static_contracts: Option<Vec<Contract>>,
+    pub static_contracts: Option<Vec<ContractIdFragment>>,
     pub storage_slots: Option<Vec<HexString>>,
     pub bytecode_witness_index: Option<i32>,
 }
@@ -189,7 +189,7 @@ pub struct InputContract {
     pub utxo_id: UtxoId,
     pub balance_root: Bytes32,
     pub state_root: Bytes32,
-    pub contract: Contract,
+    pub contract: ContractIdFragment,
 }
 
 impl TryFrom<Input> for fuel_tx::Input {
@@ -271,7 +271,7 @@ pub struct ContractOutput {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractCreated {
-    contract: Contract,
+    contract: ContractIdFragment,
     state_root: Bytes32,
 }
 

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -1,11 +1,12 @@
 use crate::client::schema::{
+    contract::Contract,
     schema,
     tx::{tests::transparent_receipt::Receipt, TransactionStatus, TxIdArgs},
-    ConnectionArgs, ConversionError, HexString, HexString256, HexStringUtxoId, PageInfo,
+    Address, AssetId, Bytes32, ConnectionArgs, ConversionError, HexString, PageInfo, Salt,
+    TransactionId, UtxoId, U64,
 };
 use core::convert::{TryFrom, TryInto};
 use fuel_tx::StorageSlot;
-use fuel_types::Bytes32;
 use itertools::Itertools;
 
 /// Retrieves the transaction in opaque form
@@ -48,24 +49,24 @@ pub struct TransactionEdge {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Transaction {
-    pub gas_limit: i32,
-    pub gas_price: i32,
-    pub byte_price: i32,
-    pub id: HexString256,
-    pub input_asset_ids: Vec<HexString256>,
-    pub input_contracts: Vec<HexString256>,
+    pub gas_limit: U64,
+    pub gas_price: U64,
+    pub byte_price: U64,
+    pub id: TransactionId,
+    pub input_asset_ids: Vec<AssetId>,
+    pub input_contracts: Vec<Contract>,
     pub inputs: Vec<Input>,
     pub is_script: bool,
     pub outputs: Vec<Output>,
-    pub maturity: i32,
-    pub receipts_root: Option<HexString256>,
+    pub maturity: U64,
+    pub receipts_root: Option<Bytes32>,
     pub status: Option<TransactionStatus>,
     pub witnesses: Vec<HexString>,
     pub receipts: Option<Vec<Receipt>>,
     pub script: Option<HexString>,
     pub script_data: Option<HexString>,
-    pub salt: Option<HexString256>,
-    pub static_contracts: Option<Vec<HexString256>>,
+    pub salt: Option<Salt>,
+    pub static_contracts: Option<Vec<Contract>>,
     pub storage_slots: Option<Vec<HexString>>,
     pub bytecode_witness_index: Option<i32>,
 }
@@ -76,10 +77,10 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
     fn try_from(tx: Transaction) -> Result<Self, Self::Error> {
         Ok(match tx.is_script {
             true => Self::Script {
-                gas_price: tx.gas_price.try_into()?,
-                gas_limit: tx.gas_limit.try_into()?,
-                byte_price: tx.byte_price.try_into()?,
-                maturity: tx.maturity.try_into()?,
+                gas_price: tx.gas_price.into(),
+                gas_limit: tx.gas_limit.into(),
+                byte_price: tx.byte_price.into(),
+                maturity: tx.maturity.into(),
                 receipts_root: tx
                     .receipts_root
                     .ok_or_else(|| ConversionError::MissingField("receipts_root".to_string()))?
@@ -106,10 +107,10 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
                 metadata: None,
             },
             false => Self::Create {
-                gas_price: tx.gas_price.try_into()?,
-                gas_limit: tx.gas_limit.try_into()?,
-                byte_price: tx.byte_price.try_into()?,
-                maturity: tx.maturity.try_into()?,
+                gas_price: tx.gas_price.into(),
+                gas_limit: tx.gas_limit.into(),
+                byte_price: tx.byte_price.into(),
+                maturity: tx.maturity.into(),
                 bytecode_witness_index: tx
                     .bytecode_witness_index
                     .ok_or_else(|| {
@@ -124,7 +125,7 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
                     .static_contracts
                     .ok_or_else(|| ConversionError::MissingField("static_contracts".to_string()))?
                     .into_iter()
-                    .map(Into::into)
+                    .map(|c| c.id.into())
                     .collect(),
                 storage_slots: tx
                     .storage_slots
@@ -138,8 +139,10 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
                         let value = &slot.0 .0[32..];
                         Ok(StorageSlot::new(
                             // unwrap is safe because length is checked
-                            Bytes32::try_from(key).map_err(|_| ConversionError::BytesLength)?,
-                            Bytes32::try_from(value).map_err(|_| ConversionError::BytesLength)?,
+                            fuel_types::Bytes32::try_from(key)
+                                .map_err(|_| ConversionError::BytesLength)?,
+                            fuel_types::Bytes32::try_from(value)
+                                .map_err(|_| ConversionError::BytesLength)?,
                         ))
                     })
                     .try_collect()?,
@@ -170,12 +173,12 @@ pub enum Input {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct InputCoin {
-    pub utxo_id: HexStringUtxoId,
-    pub owner: HexString256,
-    pub amount: i32,
-    pub asset_id: HexString256,
+    pub utxo_id: UtxoId,
+    pub owner: Address,
+    pub amount: U64,
+    pub asset_id: AssetId,
     pub witness_index: i32,
-    pub maturity: i32,
+    pub maturity: U64,
     pub predicate: HexString,
     pub predicate_data: HexString,
 }
@@ -183,10 +186,10 @@ pub struct InputCoin {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct InputContract {
-    pub utxo_id: HexStringUtxoId,
-    pub balance_root: HexString256,
-    pub state_root: HexString256,
-    pub contract_id: HexString256,
+    pub utxo_id: UtxoId,
+    pub balance_root: Bytes32,
+    pub state_root: Bytes32,
+    pub contract: Contract,
 }
 
 impl TryFrom<Input> for fuel_tx::Input {
@@ -197,10 +200,10 @@ impl TryFrom<Input> for fuel_tx::Input {
             Input::InputCoin(coin) => fuel_tx::Input::Coin {
                 utxo_id: coin.utxo_id.into(),
                 owner: coin.owner.into(),
-                amount: coin.amount.try_into()?,
+                amount: coin.amount.into(),
                 asset_id: coin.asset_id.into(),
                 witness_index: coin.witness_index.try_into()?,
-                maturity: coin.maturity.try_into()?,
+                maturity: coin.maturity.into(),
                 predicate: coin.predicate.into(),
                 predicate_data: coin.predicate_data.into(),
             },
@@ -208,7 +211,7 @@ impl TryFrom<Input> for fuel_tx::Input {
                 utxo_id: contract.utxo_id.into(),
                 balance_root: contract.balance_root.into(),
                 state_root: contract.state_root.into(),
-                contract_id: contract.contract_id.into(),
+                contract_id: contract.contract.id.into(),
             },
         })
     }
@@ -228,48 +231,48 @@ pub enum Output {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct CoinOutput {
-    pub to: HexString256,
-    pub amount: i32,
-    pub asset_id: HexString256,
+    pub to: Address,
+    pub amount: U64,
+    pub asset_id: AssetId,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct WithdrawalOutput {
-    pub to: HexString256,
-    pub amount: i32,
-    pub asset_id: HexString256,
+    pub to: Address,
+    pub amount: U64,
+    pub asset_id: AssetId,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ChangeOutput {
-    pub to: HexString256,
-    pub amount: i32,
-    pub asset_id: HexString256,
+    pub to: Address,
+    pub amount: U64,
+    pub asset_id: AssetId,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct VariableOutput {
-    pub to: HexString256,
-    pub amount: i32,
-    pub asset_id: HexString256,
+    pub to: Address,
+    pub amount: U64,
+    pub asset_id: AssetId,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractOutput {
     pub input_index: i32,
-    pub balance_root: HexString256,
-    pub state_root: HexString256,
+    pub balance_root: Bytes32,
+    pub state_root: Bytes32,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractCreated {
-    contract_id: HexString256,
-    state_root: HexString256,
+    contract: Contract,
+    state_root: Bytes32,
 }
 
 impl TryFrom<Output> for fuel_tx::Output {
@@ -279,7 +282,7 @@ impl TryFrom<Output> for fuel_tx::Output {
         Ok(match value {
             Output::CoinOutput(coin) => Self::Coin {
                 to: coin.to.into(),
-                amount: coin.amount.try_into()?,
+                amount: coin.amount.into(),
                 asset_id: coin.asset_id.into(),
             },
             Output::ContractOutput(contract) => Self::Contract {
@@ -289,21 +292,21 @@ impl TryFrom<Output> for fuel_tx::Output {
             },
             Output::WithdrawalOutput(withdrawal) => Self::Withdrawal {
                 to: withdrawal.to.into(),
-                amount: withdrawal.amount.try_into()?,
+                amount: withdrawal.amount.into(),
                 asset_id: withdrawal.asset_id.into(),
             },
             Output::ChangeOutput(change) => Self::Change {
                 to: change.to.into(),
-                amount: change.amount.try_into()?,
+                amount: change.amount.into(),
                 asset_id: change.asset_id.into(),
             },
             Output::VariableOutput(variable) => Self::Variable {
                 to: variable.to.into(),
-                amount: variable.amount.try_into()?,
+                amount: variable.amount.into(),
                 asset_id: variable.asset_id.into(),
             },
             Output::ContractCreated(contract) => Self::ContractCreated {
-                contract_id: contract.contract_id.into(),
+                contract_id: contract.contract.id.into(),
                 state_root: contract.state_root.into(),
             },
         })

--- a/fuel-client/src/client/types.rs
+++ b/fuel-client/src/client/types.rs
@@ -39,12 +39,12 @@ impl TryFrom<SchemaTxStatus> for TransactionStatus {
                 submitted_at: s.time,
             },
             SchemaTxStatus::SuccessStatus(s) => TransactionStatus::Success {
-                block_id: s.block_id.0.to_string(),
+                block_id: s.block.id.0.to_string(),
                 time: s.time,
                 program_state: s.program_state.try_into()?,
             },
             SchemaTxStatus::FailureStatus(s) => TransactionStatus::Failure {
-                block_id: s.block_id.0.to_string(),
+                block_id: s.block.id.0.to_string(),
                 time: s.time,
                 reason: s.reason,
                 program_state: s.program_state.map(TryInto::try_into).transpose()?,

--- a/fuel-client/src/main.rs
+++ b/fuel-client/src/main.rs
@@ -40,7 +40,7 @@ impl CliArgs {
                         serde_json::from_str(tx).expect("invalid transaction json");
 
                     let result = client.submit(&tx).await;
-                    println!("{}", result.unwrap().0);
+                    println!("{}", result.unwrap());
                 }
                 TransactionCommands::DryRun { tx } => {
                     let tx: Transaction =

--- a/fuel-client/tests/blocks.rs
+++ b/fuel-client/tests/blocks.rs
@@ -3,12 +3,11 @@ use fuel_core::database::Database;
 use fuel_core::model::fuel_block::FuelBlockHeader;
 use fuel_core::{
     model::fuel_block::FuelBlockDb,
-    schema::scalars::HexString256,
+    schema::scalars::BlockId,
     service::{Config, FuelService},
 };
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
 use fuel_storage::Storage;
-use fuel_vm::prelude::Bytes32;
 use itertools::{rev, Itertools};
 
 #[tokio::test]
@@ -17,7 +16,7 @@ async fn block() {
     let block = FuelBlockDb::default();
     let id = block.id();
     let mut db = Database::default();
-    Storage::<Bytes32, FuelBlockDb>::insert(&mut db, &id, &block).unwrap();
+    Storage::<fuel_types::Bytes32, FuelBlockDb>::insert(&mut db, &id, &block).unwrap();
 
     // setup server & client
     let srv = FuelService::from_database(db, Config::local_node())
@@ -27,7 +26,7 @@ async fn block() {
 
     // run test
     let block = client
-        .block(HexString256::from(id).to_string().as_str())
+        .block(BlockId::from(id).to_string().as_str())
         .await
         .unwrap();
     assert!(block.is_some());
@@ -55,7 +54,7 @@ async fn block_connection_first_5() {
     let mut db = Database::default();
     for block in blocks {
         let id = block.id();
-        Storage::<Bytes32, FuelBlockDb>::insert(&mut db, &id, &block).unwrap();
+        Storage::<fuel_types::Bytes32, FuelBlockDb>::insert(&mut db, &id, &block).unwrap();
     }
 
     // setup server & client
@@ -104,7 +103,7 @@ async fn block_connection_last_5() {
     let mut db = Database::default();
     for block in blocks {
         let id = block.id();
-        Storage::<Bytes32, FuelBlockDb>::insert(&mut db, &id, &block).unwrap();
+        Storage::<fuel_types::Bytes32, FuelBlockDb>::insert(&mut db, &id, &block).unwrap();
     }
 
     // setup server & client

--- a/fuel-client/tests/contract.rs
+++ b/fuel-client/tests/contract.rs
@@ -1,0 +1,29 @@
+use fuel_core::{
+    database::Database,
+    service::{Config, FuelService},
+};
+use fuel_gql_client::client::FuelClient;
+use fuel_storage::Storage;
+use fuel_vm::prelude::Contract as FuelVmContract;
+
+#[tokio::test]
+async fn contract() {
+    // setup test data in the node
+    let contract = FuelVmContract::default();
+    let id = fuel_types::ContractId::new(Default::default());
+
+    let mut db = Database::default();
+    Storage::<fuel_types::ContractId, FuelVmContract>::insert(&mut db, &id, &contract).unwrap();
+    // setup server & client
+    let srv = FuelService::from_database(db, Config::local_node())
+        .await
+        .unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    // run test
+    let contract = client
+        .contract(format!("{:#x}", id).as_str())
+        .await
+        .unwrap();
+    assert!(contract.is_some());
+}

--- a/fuel-client/tests/lib.rs
+++ b/fuel-client/tests/lib.rs
@@ -1,5 +1,6 @@
 mod blocks;
 mod coin;
+mod contract;
 mod dap;
 mod health;
 mod tx;

--- a/fuel-core/src/schema.rs
+++ b/fuel-core/src/schema.rs
@@ -3,6 +3,7 @@ use async_graphql::{EmptySubscription, MergedObject, Schema, SchemaBuilder};
 pub mod block;
 pub mod chain;
 pub mod coin;
+pub mod contract;
 pub mod dap;
 pub mod health;
 pub mod scalars;
@@ -16,6 +17,7 @@ pub struct Query(
     tx::TxQuery,
     health::HealthQuery,
     coin::CoinQuery,
+    contract::ContractQuery,
 );
 
 #[derive(MergedObject, Default)]

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -1,10 +1,11 @@
 use crate::database::Database;
-use crate::schema::scalars::U64;
+use crate::schema::{
+    scalars::{BlockId, U64},
+    tx::types::Transaction,
+};
 use crate::{
     database::KvStoreError,
     model::fuel_block::{BlockHeight, FuelBlockDb},
-    schema::scalars::HexString256,
-    schema::tx::types::Transaction,
     state::IterDirection,
 };
 use async_graphql::{
@@ -13,18 +14,18 @@ use async_graphql::{
 };
 use chrono::{DateTime, Utc};
 use fuel_storage::Storage;
-use fuel_tx::Bytes32;
 use itertools::Itertools;
 use std::borrow::Cow;
 use std::convert::TryInto;
-use std::ops::Deref;
+
+use super::scalars::Address;
 
 pub struct Block(pub(crate) FuelBlockDb);
 
 #[Object]
 impl Block {
-    async fn id(&self) -> HexString256 {
-        HexString256(*self.0.id().deref())
+    async fn id(&self) -> BlockId {
+        self.0.id().into()
     }
 
     async fn height(&self) -> U64 {
@@ -38,7 +39,7 @@ impl Block {
             .iter()
             .map(|tx_id| {
                 Ok(Transaction(
-                    Storage::<Bytes32, fuel_tx::Transaction>::get(&db, tx_id)
+                    Storage::<fuel_types::Bytes32, fuel_tx::Transaction>::get(&db, tx_id)
                         .and_then(|v| v.ok_or(KvStoreError::NotFound))?
                         .into_owned(),
                 ))
@@ -50,7 +51,7 @@ impl Block {
         self.0.headers.time
     }
 
-    async fn producer(&self) -> HexString256 {
+    async fn producer(&self) -> Address {
         self.0.headers.producer.into()
     }
 }
@@ -63,8 +64,8 @@ impl BlockQuery {
     async fn block(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "id of the block")] id: Option<HexString256>,
-        #[graphql(desc = "height of the block")] height: Option<u32>,
+        #[graphql(desc = "id of the block")] id: Option<BlockId>,
+        #[graphql(desc = "height of the block")] height: Option<U64>,
     ) -> async_graphql::Result<Option<Block>> {
         let db = ctx.data_unchecked::<Database>();
         let id = match (id, height) {
@@ -75,6 +76,7 @@ impl BlockQuery {
             }
             (Some(id), None) => id.into(),
             (None, Some(height)) => {
+                let height: u64 = height.into();
                 if height == 0 {
                     return Err(async_graphql::Error::new(
                         "Genesis block isn't implemented yet",
@@ -87,17 +89,18 @@ impl BlockQuery {
             (None, None) => return Err(async_graphql::Error::new("missing either id or height")),
         };
 
-        let block = Storage::<Bytes32, FuelBlockDb>::get(db, &id)?.map(|b| Block(b.into_owned()));
+        let block = Storage::<fuel_types::Bytes32, FuelBlockDb>::get(db, &id)?
+            .map(|b| Block(b.into_owned()));
         Ok(block)
     }
 
     async fn blocks(
         &self,
         ctx: &Context<'_>,
-        after: Option<String>,
-        before: Option<String>,
         first: Option<i32>,
+        after: Option<String>,
         last: Option<i32>,
+        before: Option<String>,
     ) -> async_graphql::Result<Connection<usize, Block, EmptyFields, EmptyFields>> {
         let db = ctx.data_unchecked::<Database>().clone();
 
@@ -144,7 +147,7 @@ impl BlockQuery {
                         true
                     })
                     .take(records_to_fetch);
-                let mut blocks: Vec<(BlockHeight, Bytes32)> = blocks.try_collect()?;
+                let mut blocks: Vec<(BlockHeight, fuel_types::Bytes32)> = blocks.try_collect()?;
                 if direction == IterDirection::Forward {
                     blocks.reverse();
                 }
@@ -153,7 +156,7 @@ impl BlockQuery {
                 let blocks: Vec<Cow<FuelBlockDb>> = blocks
                     .iter()
                     .map(|(_, id)| {
-                        Storage::<Bytes32, FuelBlockDb>::get(&db, id)
+                        Storage::<fuel_types::Bytes32, FuelBlockDb>::get(&db, id)
                             .transpose()
                             .ok_or(KvStoreError::NotFound)?
                     })

--- a/fuel-core/src/schema/chain.rs
+++ b/fuel-core/src/schema/chain.rs
@@ -4,7 +4,6 @@ use crate::schema::block::Block;
 use crate::schema::scalars::U64;
 use async_graphql::{Context, Object};
 use fuel_storage::Storage;
-use fuel_tx::Bytes32;
 
 pub const DEFAULT_NAME: &str = "Fuel.testnet";
 
@@ -20,7 +19,7 @@ impl ChainInfo {
         let db = ctx.data_unchecked::<Database>().clone();
         let height = db.get_block_height()?.unwrap_or_default();
         let id = db.get_block_id(height)?.unwrap_or_default();
-        let block = Storage::<Bytes32, FuelBlockDb>::get(&db, &id)?.unwrap_or_default();
+        let block = Storage::<fuel_types::Bytes32, FuelBlockDb>::get(&db, &id)?.unwrap_or_default();
         Ok(Block(block.into_owned()))
     }
 

--- a/fuel-core/src/schema/coin.rs
+++ b/fuel-core/src/schema/coin.rs
@@ -1,7 +1,7 @@
 use crate::coin_query::{random_improve, SpendQueryElement};
 use crate::database::{Database, KvStoreError};
 use crate::model::coin::{Coin as CoinModel, CoinStatus};
-use crate::schema::scalars::{HexString256, U64};
+use crate::schema::scalars::{Address, AssetId, UtxoId, U64};
 use crate::state::IterDirection;
 use async_graphql::InputObject;
 use async_graphql::{
@@ -10,20 +10,17 @@ use async_graphql::{
 };
 use fuel_storage::Storage;
 use fuel_tx::consts::MAX_INPUTS;
-use fuel_tx::{Address, AssetId as FuelTxAssetId, UtxoId};
 use itertools::Itertools;
 
-use super::scalars::HexStringUtxoId;
-
-pub struct Coin(UtxoId, CoinModel);
+pub struct Coin(fuel_tx::UtxoId, CoinModel);
 
 #[Object]
 impl Coin {
-    async fn utxo_id(&self) -> HexStringUtxoId {
+    async fn utxo_id(&self) -> UtxoId {
         self.0.into()
     }
 
-    async fn owner(&self) -> HexString256 {
+    async fn owner(&self) -> Address {
         self.1.owner.into()
     }
 
@@ -31,7 +28,7 @@ impl Coin {
         self.1.amount.into()
     }
 
-    async fn asset_id(&self) -> HexString256 {
+    async fn asset_id(&self) -> AssetId {
         self.1.asset_id.into()
     }
 
@@ -51,15 +48,15 @@ impl Coin {
 #[derive(InputObject)]
 struct CoinFilterInput {
     /// address of the owner
-    owner: HexString256,
+    owner: Address,
     /// asset ID of the coins
-    asset_id: Option<HexString256>,
+    asset_id: Option<AssetId>,
 }
 
 #[derive(InputObject)]
 struct SpendQueryElementInput {
     /// asset ID of the coins
-    asset_id: HexString256,
+    asset_id: AssetId,
     /// address of the owner
     amount: U64,
 }
@@ -72,11 +69,11 @@ impl CoinQuery {
     async fn coin(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "utxo_id of the coin")] utxo_id: HexStringUtxoId,
+        #[graphql(desc = "utxo_id of the coin")] utxo_id: UtxoId,
     ) -> async_graphql::Result<Option<Coin>> {
         let utxo_id = utxo_id.0;
         let db = ctx.data_unchecked::<Database>().clone();
-        let block = Storage::<UtxoId, CoinModel>::get(&db, &utxo_id)?
+        let block = Storage::<fuel_tx::UtxoId, CoinModel>::get(&db, &utxo_id)?
             .map(|coin| Coin(utxo_id, coin.into_owned()));
         Ok(block)
     }
@@ -84,12 +81,12 @@ impl CoinQuery {
     async fn coins(
         &self,
         ctx: &Context<'_>,
-        after: Option<String>,
-        before: Option<String>,
-        first: Option<i32>,
-        last: Option<i32>,
         filter: CoinFilterInput,
-    ) -> async_graphql::Result<Connection<HexStringUtxoId, Coin, EmptyFields, EmptyFields>> {
+        first: Option<i32>,
+        after: Option<String>,
+        last: Option<i32>,
+        before: Option<String>,
+    ) -> async_graphql::Result<Connection<UtxoId, Coin, EmptyFields, EmptyFields>> {
         let db = ctx.data_unchecked::<Database>();
 
         query(
@@ -97,7 +94,7 @@ impl CoinQuery {
             before,
             first,
             last,
-            |after: Option<HexStringUtxoId>, before: Option<HexStringUtxoId>, first, last| async move {
+            |after: Option<UtxoId>, before: Option<UtxoId>, first, last| async move {
                 let (records_to_fetch, direction) = if let Some(first) = first {
                     (first, IterDirection::Forward)
                 } else if let Some(last) = last {
@@ -106,8 +103,8 @@ impl CoinQuery {
                     (0, IterDirection::Forward)
                 };
 
-                let after = after.map(UtxoId::from);
-                let before = before.map(UtxoId::from);
+                let after = after.map(fuel_tx::UtxoId::from);
+                let before = before.map(fuel_tx::UtxoId::from);
 
                 let start;
                 let end;
@@ -120,7 +117,7 @@ impl CoinQuery {
                     end = after;
                 }
 
-                let owner: Address = filter.owner.into();
+                let owner: fuel_tx::Address = filter.owner.into();
 
                 let mut coin_ids = db.owned_coins(owner, start, Some(direction));
                 let mut started = None;
@@ -141,7 +138,7 @@ impl CoinQuery {
                         true
                     })
                     .take(records_to_fetch);
-                let mut coins: Vec<UtxoId> = coins.try_collect()?;
+                let mut coins: Vec<fuel_tx::UtxoId> = coins.try_collect()?;
                 if direction == IterDirection::Reverse {
                     coins.reverse();
                 }
@@ -150,7 +147,7 @@ impl CoinQuery {
                 let coins: Vec<Coin> = coins
                     .into_iter()
                     .map(|id| {
-                        Storage::<UtxoId, CoinModel>::get(db, &id)
+                        Storage::<fuel_tx::UtxoId, CoinModel>::get(db, &id)
                             .transpose()
                             .ok_or(KvStoreError::NotFound)?
                             .map(|coin| Coin(id, coin.into_owned()))
@@ -160,7 +157,7 @@ impl CoinQuery {
                 // filter coins by asset ID
                 let mut coins = coins;
                 if let Some(asset_id) = filter.asset_id {
-                    coins.retain(|coin| coin.1.asset_id == asset_id.0.into());
+                    coins.retain(|coin| coin.1.asset_id == asset_id.0);
                 }
 
                 // filter coins by status
@@ -171,7 +168,7 @@ impl CoinQuery {
                 connection.append(
                     coins
                         .into_iter()
-                        .map(|item| Edge::new(HexStringUtxoId::from(item.0), item)),
+                        .map(|item| Edge::new(UtxoId::from(item.0), item)),
                 );
                 Ok(connection)
             },
@@ -182,16 +179,16 @@ impl CoinQuery {
     async fn coins_to_spend(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "The Address of the utxo owner")] owner: HexString256,
+        #[graphql(desc = "The Address of the utxo owner")] owner: Address,
         #[graphql(desc = "The total amount of each asset type to spend")] spend_query: Vec<
             SpendQueryElementInput,
         >,
         #[graphql(desc = "The max number of utxos that can be used")] max_inputs: Option<u8>,
     ) -> async_graphql::Result<Vec<Coin>> {
-        let owner: Address = owner.0.into();
+        let owner: fuel_tx::Address = owner.0;
         let spend_query: Vec<SpendQueryElement> = spend_query
             .iter()
-            .map(|e| (owner, FuelTxAssetId::from(e.asset_id.0), e.amount.0))
+            .map(|e| (owner, e.asset_id.0, e.amount.0))
             .collect();
         let max_inputs: u8 = max_inputs.unwrap_or(MAX_INPUTS);
 

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -1,0 +1,51 @@
+use crate::database::{Database, KvStoreError};
+use crate::schema::scalars::ContractId;
+use crate::schema::scalars::HexString;
+use async_graphql::{Context, Object};
+use fuel_storage::Storage;
+use fuel_vm::prelude::Contract as FuelVmContract;
+
+pub struct Contract(pub(crate) fuel_types::ContractId);
+
+impl From<fuel_types::ContractId> for Contract {
+    fn from(id: fuel_types::ContractId) -> Self {
+        Self(id)
+    }
+}
+
+#[Object]
+impl Contract {
+    async fn id(&self) -> ContractId {
+        self.0.into()
+    }
+
+    async fn bytes(&self, ctx: &Context<'_>) -> async_graphql::Result<HexString> {
+        let db = ctx.data_unchecked::<Database>().clone();
+        let contract = Storage::<fuel_types::ContractId, FuelVmContract>::get(&db, &self.0)?
+            .ok_or(KvStoreError::NotFound)?
+            .into_owned();
+        Ok(HexString(contract.into()))
+    }
+}
+
+#[derive(Default)]
+pub struct ContractQuery;
+
+#[Object]
+impl ContractQuery {
+    async fn contract(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "ID of the Contract")] id: ContractId,
+    ) -> async_graphql::Result<Option<Contract>> {
+        let id: fuel_types::ContractId = id.0;
+        let db = ctx.data_unchecked::<Database>().clone();
+        let contract_exists =
+            Storage::<fuel_types::ContractId, FuelVmContract>::contains_key(&db, &id)?;
+        if !contract_exists {
+            return Ok(None);
+        }
+        let contract = Contract(id);
+        Ok(Some(contract))
+    }
+}

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -19,7 +19,7 @@ impl Contract {
         self.0.into()
     }
 
-    async fn bytes(&self, ctx: &Context<'_>) -> async_graphql::Result<HexString> {
+    async fn bytecode(&self, ctx: &Context<'_>) -> async_graphql::Result<HexString> {
         let db = ctx.data_unchecked::<Database>().clone();
         let contract = Storage::<fuel_types::ContractId, FuelVmContract>::get(&db, &self.0)?
             .ok_or(KvStoreError::NotFound)?

--- a/fuel-core/src/schema/tx/input.rs
+++ b/fuel-core/src/schema/tx/input.rs
@@ -1,0 +1,120 @@
+use crate::schema::{
+    contract::Contract,
+    scalars::{Address, AssetId, Bytes32, ContractId, HexString, UtxoId, U64},
+};
+use async_graphql::{Object, Union};
+use fuel_asm::Word;
+
+#[derive(Union)]
+pub enum Input {
+    Coin(InputCoin),
+    Contract(InputContract),
+}
+
+pub struct InputCoin {
+    utxo_id: UtxoId,
+    owner: Address,
+    amount: Word,
+    asset_id: AssetId,
+    witness_index: u8,
+    maturity: Word,
+    predicate: HexString,
+    predicate_data: HexString,
+}
+
+#[Object]
+impl InputCoin {
+    async fn utxo_id(&self) -> UtxoId {
+        self.utxo_id
+    }
+    async fn owner(&self) -> Address {
+        self.owner
+    }
+
+    async fn amount(&self) -> U64 {
+        self.amount.into()
+    }
+
+    async fn asset_id(&self) -> AssetId {
+        self.asset_id
+    }
+
+    async fn witness_index(&self) -> u8 {
+        self.witness_index
+    }
+
+    async fn maturity(&self) -> U64 {
+        self.maturity.into()
+    }
+
+    async fn predicate(&self) -> HexString {
+        self.predicate.clone()
+    }
+
+    async fn predicate_data(&self) -> HexString {
+        self.predicate_data.clone()
+    }
+}
+
+pub struct InputContract {
+    utxo_id: UtxoId,
+    balance_root: Bytes32,
+    state_root: Bytes32,
+    contract_id: ContractId,
+}
+
+#[Object]
+impl InputContract {
+    async fn utxo_id(&self) -> UtxoId {
+        self.utxo_id
+    }
+
+    async fn balance_root(&self) -> Bytes32 {
+        self.balance_root
+    }
+
+    async fn state_root(&self) -> Bytes32 {
+        self.state_root
+    }
+
+    async fn contract(&self) -> Contract {
+        self.contract_id.0.into()
+    }
+}
+
+impl From<&fuel_tx::Input> for Input {
+    fn from(input: &fuel_tx::Input) -> Self {
+        match input {
+            fuel_tx::Input::Coin {
+                utxo_id,
+                owner,
+                amount,
+                asset_id,
+                witness_index,
+                maturity,
+                predicate,
+                predicate_data,
+            } => Input::Coin(InputCoin {
+                utxo_id: UtxoId(*utxo_id),
+                owner: Address(*owner),
+                amount: *amount,
+                asset_id: AssetId(*asset_id),
+                witness_index: *witness_index,
+                maturity: *maturity,
+                predicate: HexString(predicate.clone()),
+                predicate_data: HexString(predicate_data.clone()),
+            }),
+            fuel_tx::Input::Contract {
+                utxo_id,
+                balance_root,
+                state_root,
+                contract_id,
+            } => Input::Contract(InputContract {
+                utxo_id: UtxoId(*utxo_id),
+                balance_root: Bytes32(*balance_root),
+                state_root: Bytes32(*state_root),
+                contract_id: ContractId(*contract_id),
+            }),
+        }
+    }
+}

--- a/fuel-core/src/schema/tx/output.rs
+++ b/fuel-core/src/schema/tx/output.rs
@@ -1,0 +1,182 @@
+use crate::schema::contract::Contract;
+use crate::schema::scalars::{Address, AssetId, Bytes32, U64};
+use async_graphql::{Object, Union};
+use fuel_asm::Word;
+
+#[derive(Union)]
+pub enum Output {
+    Coin(CoinOutput),
+    Contract(ContractOutput),
+    Withdrawal(WithdrawalOutput),
+    Change(ChangeOutput),
+    Variable(VariableOutput),
+    ContractCreated(ContractCreated),
+}
+
+pub struct CoinOutput {
+    to: fuel_types::Address,
+    amount: Word,
+    asset_id: fuel_types::AssetId,
+}
+
+#[Object]
+impl CoinOutput {
+    async fn to(&self) -> Address {
+        self.to.into()
+    }
+
+    async fn amount(&self) -> U64 {
+        self.amount.into()
+    }
+
+    async fn asset_id(&self) -> AssetId {
+        self.asset_id.into()
+    }
+}
+
+pub struct WithdrawalOutput(CoinOutput);
+
+#[Object]
+impl WithdrawalOutput {
+    async fn to(&self) -> Address {
+        self.0.to.into()
+    }
+
+    async fn amount(&self) -> U64 {
+        self.0.amount.into()
+    }
+
+    async fn asset_id(&self) -> AssetId {
+        self.0.asset_id.into()
+    }
+}
+
+pub struct ChangeOutput(CoinOutput);
+
+#[Object]
+impl ChangeOutput {
+    async fn to(&self) -> Address {
+        self.0.to.into()
+    }
+
+    async fn amount(&self) -> U64 {
+        self.0.amount.into()
+    }
+
+    async fn asset_id(&self) -> AssetId {
+        self.0.asset_id.into()
+    }
+}
+
+pub struct VariableOutput(CoinOutput);
+
+#[Object]
+impl VariableOutput {
+    async fn to(&self) -> Address {
+        self.0.to.into()
+    }
+
+    async fn amount(&self) -> U64 {
+        self.0.amount.into()
+    }
+
+    async fn asset_id(&self) -> AssetId {
+        self.0.asset_id.into()
+    }
+}
+
+pub struct ContractOutput {
+    input_index: u8,
+    balance_root: fuel_types::Bytes32,
+    state_root: fuel_types::Bytes32,
+}
+
+#[Object]
+impl ContractOutput {
+    async fn input_index(&self) -> u8 {
+        self.input_index
+    }
+
+    async fn balance_root(&self) -> Bytes32 {
+        self.balance_root.into()
+    }
+
+    async fn state_root(&self) -> Bytes32 {
+        self.state_root.into()
+    }
+}
+
+pub struct ContractCreated {
+    contract_id: fuel_types::ContractId,
+    state_root: fuel_types::Bytes32,
+}
+
+#[Object]
+impl ContractCreated {
+    async fn contract(&self) -> Contract {
+        self.contract_id.into()
+    }
+
+    async fn state_root(&self) -> Bytes32 {
+        self.state_root.into()
+    }
+}
+
+impl From<&fuel_tx::Output> for Output {
+    fn from(output: &fuel_tx::Output) -> Self {
+        match output {
+            fuel_tx::Output::Coin {
+                to,
+                amount,
+                asset_id,
+            } => Output::Coin(CoinOutput {
+                to: *to,
+                amount: *amount,
+                asset_id: *asset_id,
+            }),
+            fuel_tx::Output::Contract {
+                input_index,
+                balance_root,
+                state_root,
+            } => Output::Contract(ContractOutput {
+                input_index: *input_index,
+                balance_root: *balance_root,
+                state_root: *state_root,
+            }),
+            fuel_tx::Output::Withdrawal {
+                to,
+                amount,
+                asset_id,
+            } => Output::Withdrawal(WithdrawalOutput(CoinOutput {
+                to: *to,
+                amount: *amount,
+                asset_id: *asset_id,
+            })),
+            fuel_tx::Output::Change {
+                to,
+                amount,
+                asset_id,
+            } => Output::Change(ChangeOutput(CoinOutput {
+                to: *to,
+                amount: *amount,
+                asset_id: *asset_id,
+            })),
+            fuel_tx::Output::Variable {
+                to,
+                amount,
+                asset_id,
+            } => Output::Variable(VariableOutput(CoinOutput {
+                to: *to,
+                amount: *amount,
+                asset_id: *asset_id,
+            })),
+            fuel_tx::Output::ContractCreated {
+                contract_id,
+                state_root,
+            } => Output::ContractCreated(ContractCreated {
+                contract_id: *contract_id,
+                state_root: *state_root,
+            }),
+        }
+    }
+}


### PR DESCRIPTION
- Rename types: `HexString256` -> `Bytes32`, `HexStringUtxoId` -> `UtxoId`
- Add new scalars: `Address`, `BlockId`, `Color`, `Salt`, `TransactionId`
- Add new object: `Contract`. Currently this only has an `id` field since we can't fetch the rest yet.
- Refine fields with `HexString256` types: `WithdrawalOutput.to: HexString256` -> `...: Address`, etc.
- Rename and retype id fields: `SuccessStatus.block_id: HexString256` -> `SuccessStatus.block: Block`, etc.
- Reorder connection args so `first` and `after` comes first. They map nicely to traditional limit/offset and more widely used.
- Resolves #161

Note: This PR doesn't add `Account`. Leaving that on #173.