### PR TITLE
enable signature validation in fuel-core

### DIFF
--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -63,6 +63,7 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
+fuel-tx = { version = "0.6", features = ["serde-types", "builder", "internals"] }
 fuel-vm = { version = "0.5", features = ["serde-types", "random", "test-helpers"] }
 insta = "1.8"
 


### PR DESCRIPTION
closes: #190 

This PR utilize fuel-tx signature validation in the fuel-core executor, gated under the utxo-valdation flag. 