### PR TITLE
fuel-core `--version` doesn't work with `v0.4.1`

### DIFF
--- a/fuel-client/src/main.rs
+++ b/fuel-client/src/main.rs
@@ -22,6 +22,7 @@ enum TransactionCommands {
 }
 
 #[derive(Parser)]
+#[clap(name = "fuel-gql-cli", about = "Fuel GraphQL Endpoint CLI", version)]
 struct CliArgs {
     #[clap(name = "endpoint", default_value = "127.0.0.1:4000", long = "endpoint")]
     endpoint: String,

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -9,6 +9,8 @@ lazy_static::lazy_static! {
 }
 
 #[derive(Parser, Debug)]
+#[clap(name = "fuel-core", about = "Fuel client implementation", version)]
+
 pub struct Opt {
     #[clap(long = "ip", default_value = "127.0.0.1", parse(try_from_str))]
     pub ip: net::IpAddr,

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -10,7 +10,6 @@ lazy_static::lazy_static! {
 
 #[derive(Parser, Debug)]
 #[clap(name = "fuel-core", about = "Fuel client implementation", version)]
-
 pub struct Opt {
     #[clap(long = "ip", default_value = "127.0.0.1", parse(try_from_str))]
     pub ip: net::IpAddr,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,7 +7,7 @@ use commands::{
 mod commands;
 
 #[derive(Debug, Parser)]
-#[clap(name = "xtask", about = "fuel-core dev builder")]
+#[clap(name = "xtask", about = "fuel-core dev builder", version)]
 pub struct Opt {
     #[clap(subcommand)]
     command: Xtask,


### PR DESCRIPTION
Fixes #205 , mirror style and changes as much as possible of the commit which fixed this in Sway, but if any changes are needed just let me know and I can get that fixed!

Works with both `fuel-core --version` and `fuel-core -V`