### PR TITLE
Adjust to fuel-core-service to match helm templates

### DIFF
--- a/deployment/ingress/eks/ingress.yaml
+++ b/deployment/ingress/eks/ingress.yaml
@@ -18,7 +18,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: ${k8s_namespace}-service
+                name: fuel-core-service
                 port:
                   number: ${ingress_http_port}
   tls:


### PR DESCRIPTION
Not so much a typo or error, just continuation of the service name per se the helm charts service definition