### PR TITLE
0.4.2 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1929,7 +1929,7 @@ dependencies = [
  "fuel-tx 0.6.0",
  "fuel-txpool",
  "fuel-types 0.3.0",
- "fuel-vm 0.5.0",
+ "fuel-vm 0.5.1",
  "futures",
  "graphql-parser",
  "hex",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-interfaces"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1964,7 +1964,7 @@ dependencies = [
  "fuel-storage",
  "fuel-tx 0.6.0",
  "fuel-types 0.3.0",
- "fuel-vm 0.5.0",
+ "fuel-vm 0.5.1",
  "futures",
  "lazy_static",
  "parking_lot 0.11.2",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gql-client"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "clap 3.1.2",
@@ -2020,7 +2020,7 @@ dependencies = [
  "fuel-storage",
  "fuel-tx 0.6.0",
  "fuel-types 0.3.0",
- "fuel-vm 0.5.0",
+ "fuel-vm 0.5.1",
  "futures",
  "hex",
  "insta",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-p2p"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "env_logger",
  "futures",
@@ -2156,12 +2156,12 @@ name = "fuel-tests"
 version = "0.0.0"
 dependencies = [
  "chrono",
- "fuel-core 0.4.1",
- "fuel-gql-client 0.4.1",
+ "fuel-core 0.4.2",
+ "fuel-gql-client 0.4.2",
  "fuel-storage",
  "fuel-tx 0.6.0",
  "fuel-types 0.3.0",
- "fuel-vm 0.5.0",
+ "fuel-vm 0.5.1",
  "insta",
  "itertools",
  "rand 0.8.5",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-txpool"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2263,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec55ff935848e476dbcfca3931723252b5c33ad90d126f49a886600a8a731a3"
+checksum = "56258326db96b0aeddecbe9657a1f8fce2236423f4ca22d2754b346fb1ce70d9"
 dependencies = [
  "fuel-asm 0.2.0",
  "fuel-crypto",
@@ -7367,7 +7367,7 @@ name = "xtask"
 version = "0.0.0"
 dependencies = [
  "clap 3.1.2",
- "fuel-core 0.4.1",
+ "fuel-core 0.4.2",
 ]
 
 [[package]]

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-core
 description: Fuel Core Helm Chart
 type: application
-appVersion: "0.4.1"
+appVersion: "0.4.2"
 version: 0.1.0

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-gql-client"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-interfaces"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -29,12 +29,12 @@ derive_more = { version = "0.99" }
 dirs = "3.0"
 env_logger = "0.9"
 fuel-asm = { version = "0.2", features = ["serde-types"] }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.4.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.4.2" }
 fuel-crypto = { version = "0.3" }
 fuel-merkle = "0.1"
 fuel-storage = { version = "0.1" }
 fuel-tx = { version = "0.6", features = ["serde-types"] }
-fuel-txpool = { path = "../fuel-txpool", version = "0.4.1" }
+fuel-txpool = { path = "../fuel-txpool", version = "0.4.2" }
 fuel-types = { version = "0.3", features = ["serde-types"] }
 fuel-vm = { version = "0.5", features = ["serde-types"] }
 futures = "0.3"

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-p2p"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 edition = "2021"

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-txpool"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -13,7 +13,7 @@ description = "Transaction pool"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.4.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.4.2" }
 fuel-tx = { version = "0.6", features = ["serde-types"] }
 fuel-types = { version = "0.3", features = ["serde-types"] }
 futures = "0.3"
@@ -22,6 +22,6 @@ thiserror = "1.0"
 tokio = { version = "1.14", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.4.1", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.4.2", features = [
     "test_helpers",
 ] }


### PR DESCRIPTION
includes newer version of fuel-vm with call opcode fixes. This version bump is required for deploying the newer VM to k8s.