### PR TITLE
[Txpool] Add insert_tx and check mempool when finding tx's

### DIFF
--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -11,6 +11,7 @@ use async_graphql::{
 use fuel_storage::Storage;
 use fuel_tx::Transaction as FuelTx;
 use fuel_vm::prelude::Deserializable;
+use futures::FutureExt;
 use itertools::Itertools;
 use std::borrow::Cow;
 use std::iter;
@@ -42,9 +43,9 @@ impl TxQuery {
         let db = ctx.data_unchecked::<Database>();
         let key = id.0;
 
-        //let tx_pool = ctx.data::<Arc<TxPool>>().unwrap();
+        let tx_pool = ctx.data::<Arc<TxPool>>().unwrap();
 
-        //let _tx_from_mem = tx_pool.pool().find(&[key]).deref();
+        let tx_from_mem = tx_pool.pool().find(&[key]).await.get(0).unwrap();
         
         Ok(Storage::<fuel_types::Bytes32, FuelTx>::get(db, &key)?
             .map(|tx| Transaction(tx.into_owned())))

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -49,11 +49,15 @@ impl TxQuery {
         
         let tx_from_mem = found_tx.get(0).unwrap();
 
-        let rewrapped_tx = Arc::try_unwrap(tx_from_mem.as_ref().unwrap().clone()).ok();
+        let rewrapped_tx = Some(Transaction(Arc::try_unwrap(tx_from_mem.as_ref().unwrap().clone()).ok().unwrap()));
 
-        Ok(Storage::<fuel_types::Bytes32, FuelTx>::get(db, &key)?
-        .map(|tx| Transaction(tx.into_owned())))
-        
+        let tx_from_storage = Storage::<fuel_types::Bytes32, FuelTx>::get(db, &key)?
+        .map(|tx| Transaction(tx.into_owned()));
+
+        let return_transaction =if rewrapped_tx.is_some() {rewrapped_tx} else {tx_from_storage};
+
+        Ok(return_transaction)
+
         }
 
     async fn transactions(

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -45,10 +45,15 @@ impl TxQuery {
 
         let tx_pool = ctx.data::<Arc<TxPool>>().unwrap();
 
-        let tx_from_mem = tx_pool.pool().find(&[key]).await.get(0).unwrap();
+        let found_tx = tx_pool.pool().find(&[key]).await.clone();
         
+        let tx_from_mem = found_tx.get(0).unwrap();
+
+        let rewrapped_tx = Arc::try_unwrap(tx_from_mem.as_ref().unwrap().clone()).ok();
+
         Ok(Storage::<fuel_types::Bytes32, FuelTx>::get(db, &key)?
-            .map(|tx| Transaction(tx.into_owned())))
+        .map(|tx| Transaction(tx.into_owned())))
+        
         }
 
     async fn transactions(

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -42,9 +42,9 @@ impl TxQuery {
         let db = ctx.data_unchecked::<Database>();
         let key = id.0;
 
-        let tx_pool = ctx.data::<Arc<TxPool>>().unwrap();
+        //let tx_pool = ctx.data::<Arc<TxPool>>().unwrap();
 
-        let _tx_from_mem = tx_pool.pool().find(&[key]).deref();
+        //let _tx_from_mem = tx_pool.pool().find(&[key]).deref();
         
         Ok(Storage::<fuel_types::Bytes32, FuelTx>::get(db, &key)?
             .map(|tx| Transaction(tx.into_owned())))

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -41,9 +41,14 @@ impl TxQuery {
     ) -> async_graphql::Result<Option<Transaction>> {
         let db = ctx.data_unchecked::<Database>();
         let key = id.0;
+
+        let tx_pool = ctx.data::<Arc<TxPool>>().unwrap();
+
+        let _tx_from_mem = tx_pool.pool().find(&[key]).deref();
+        
         Ok(Storage::<fuel_types::Bytes32, FuelTx>::get(db, &key)?
             .map(|tx| Transaction(tx.into_owned())))
-    }
+        }
 
     async fn transactions(
         &self,

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -100,7 +100,7 @@ pub async fn submit_tx(&self, tx: Transaction) -> Result<Bytes32, Error> {
         let new_block_height = current_height + 1u32.into();
 
         // Next fetch the tx from mempool
-        let arc_txs_to_include  = self.fuel_txpool.includable().await.iter().map(|arc| Transaction::clone(&*arc)).collect();;
+        let arc_txs_to_include  = self.fuel_txpool.includable().await.iter().map(|arc| Transaction::clone(&*arc)).collect();
 
         let mut block = FuelBlock {
             header: FuelBlockHeader {

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -84,6 +84,11 @@ impl TxPool {
     pub async fn submit_tx(&self, tx: Transaction) -> Result<Bytes32, Error> {
         let db = self.db.clone();
         let tx_id = tx.id();
+        let copy_tx = tx.clone();
+        let tx_arc = std::sync::Arc::new(copy_tx);
+        let mut tx_vec = Vec::new();
+        tx_vec.push(tx_arc);
+        self.fuel_txpool.insert(tx_vec).await;
         // set status to submitted
         db.update_tx_status(&tx_id, TransactionStatus::Submitted { time: Utc::now() })?;
 

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -87,8 +87,7 @@ impl TxPool {
 
         let copy_tx = tx.clone();
         let tx_arc = std::sync::Arc::new(copy_tx);
-        let mut tx_vec = Vec::new();
-        tx_vec.push(tx_arc);
+        let tx_vec = vec![tx_arc];
 
         self.fuel_txpool.insert(tx_vec).await;
 
@@ -98,7 +97,13 @@ impl TxPool {
         let new_block_height = current_height + 1u32.into();
 
         // Next fetch the tx from mempool
-        let txs_to_mine = self.fuel_txpool.includable().await.iter().map(|arc| Transaction::clone(&*arc)).collect();
+        let txs_to_mine = self
+            .fuel_txpool
+            .includable()
+            .await
+            .iter()
+            .map(|arc| Transaction::clone(&*arc))
+            .collect();
 
         println!("{:?}", txs_to_mine);
         let mut block = FuelBlock {

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -105,7 +105,6 @@ impl TxPool {
             .map(|arc| Transaction::clone(&*arc))
             .collect();
 
-        println!("{:?}", txs_to_mine);
         let mut block = FuelBlock {
             header: FuelBlockHeader {
                 height: new_block_height,


### PR DESCRIPTION
I made 2 main changes with this to fix #152 

- Check the mempool for a transaction if it's not found in the database with find_tx
- Utilize new mempool in submit tx under the hood to start using that code in lieu of the present dummy tx pool

Still used to writing this level of rust code though so feel free to let me know if I missed some best practices or did something wrong. Tests are passing for me, but as most of the functionality added is under the hood I may have missed something