### PR TITLE
fix logging env var name

### DIFF
--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -73,7 +73,7 @@ spec:
             - name: {{ .Values.app.volume.pvname }}
               mountPath: "{{ .Values.app.volume.mountPath }}"
           env:
-            - name: human_logging
+            - name: HUMAN_LOGGING
               value: {{ .Values.app.human_logging | quote }}
       volumes:
         - name: {{ .Values.app.volume.pvname }}


### PR DESCRIPTION
The human logging env var should be uppercase.