### PR TITLE
Capitalize GQL field descriptions

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -77,11 +77,11 @@ type CoinEdge {
 }
 input CoinFilterInput {
 	"""
-	address of the owner
+	Address of the owner
 	"""
 	owner: Address!
 	"""
-	asset ID of the coins
+	Asset ID of the coins
 	"""
 	assetId: AssetId
 }
@@ -144,11 +144,11 @@ type Mutation {
 	reset(id: ID!): Boolean!
 	execute(id: ID!, op: String!): Boolean!
 	"""
-	dry-run the transaction using a fork of current state, no changes are committed.
+	Execute a dry-run of the transaction using a fork of current state, no changes are committed.
 	"""
 	dryRun(tx: HexString!): [Receipt!]!
 	"""
-	Submits transaction to the pool
+	Submits transaction to the txpool
 	"""
 	submit(tx: HexString!): Transaction!
 }
@@ -243,11 +243,11 @@ enum ReturnType {
 scalar Salt
 input SpendQueryElementInput {
 	"""
-	asset ID of the coins
+	Asset ID of the coins
 	"""
 	assetId: AssetId!
 	"""
-	address of the owner
+	Address of the owner
 	"""
 	amount: U64!
 }

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -64,8 +64,8 @@ impl BlockQuery {
     async fn block(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "id of the block")] id: Option<BlockId>,
-        #[graphql(desc = "height of the block")] height: Option<U64>,
+        #[graphql(desc = "Id of the block")] id: Option<BlockId>,
+        #[graphql(desc = "Height of the block")] height: Option<U64>,
     ) -> async_graphql::Result<Option<Block>> {
         let db = ctx.data_unchecked::<Database>();
         let id = match (id, height) {
@@ -83,10 +83,10 @@ impl BlockQuery {
                     ));
                 } else {
                     db.get_block_id(height.try_into()?)?
-                        .ok_or("block height non-existent")?
+                        .ok_or("Block height non-existent")?
                 }
             }
-            (None, None) => return Err(async_graphql::Error::new("missing either id or height")),
+            (None, None) => return Err(async_graphql::Error::new("Missing either id or height")),
         };
 
         let block = Storage::<fuel_types::Bytes32, FuelBlockDb>::get(db, &id)?

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -64,7 +64,7 @@ impl BlockQuery {
     async fn block(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "Id of the block")] id: Option<BlockId>,
+        #[graphql(desc = "ID of the block")] id: Option<BlockId>,
         #[graphql(desc = "Height of the block")] height: Option<U64>,
     ) -> async_graphql::Result<Option<Block>> {
         let db = ctx.data_unchecked::<Database>();

--- a/fuel-core/src/schema/coin.rs
+++ b/fuel-core/src/schema/coin.rs
@@ -69,7 +69,7 @@ impl CoinQuery {
     async fn coin(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "The utxo_id of the coin")] utxo_id: UtxoId,
+        #[graphql(desc = "The ID of the coin")] utxo_id: UtxoId,
     ) -> async_graphql::Result<Option<Coin>> {
         let utxo_id = utxo_id.0;
         let db = ctx.data_unchecked::<Database>().clone();

--- a/fuel-core/src/schema/coin.rs
+++ b/fuel-core/src/schema/coin.rs
@@ -47,17 +47,17 @@ impl Coin {
 
 #[derive(InputObject)]
 struct CoinFilterInput {
-    /// address of the owner
+    /// Address of the owner
     owner: Address,
-    /// asset ID of the coins
+    /// Asset ID of the coins
     asset_id: Option<AssetId>,
 }
 
 #[derive(InputObject)]
 struct SpendQueryElementInput {
-    /// asset ID of the coins
+    /// Asset ID of the coins
     asset_id: AssetId,
-    /// address of the owner
+    /// Address of the owner
     amount: U64,
 }
 
@@ -69,7 +69,7 @@ impl CoinQuery {
     async fn coin(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "utxo_id of the coin")] utxo_id: UtxoId,
+        #[graphql(desc = "The utxo_id of the coin")] utxo_id: UtxoId,
     ) -> async_graphql::Result<Option<Coin>> {
         let utxo_id = utxo_id.0;
         let db = ctx.data_unchecked::<Database>().clone();

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -37,7 +37,7 @@ impl TxQuery {
     async fn transaction(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "id of the transaction")] id: TransactionId,
+        #[graphql(desc = "The id of the transaction")] id: TransactionId,
     ) -> async_graphql::Result<Option<Transaction>> {
         let db = ctx.data_unchecked::<Database>();
         let key = id.0;
@@ -244,7 +244,7 @@ pub struct TxMutation;
 
 #[Object]
 impl TxMutation {
-    /// dry-run the transaction using a fork of current state, no changes are committed.
+    /// Execute a dry-run of the transaction using a fork of current state, no changes are committed.
     async fn dry_run(
         &self,
         ctx: &Context<'_>,
@@ -259,7 +259,7 @@ impl TxMutation {
         Ok(receipts.into_iter().map(Into::into).collect())
     }
 
-    /// Submits transaction to the pool
+    /// Submits transaction to the txpool
     async fn submit(&self, ctx: &Context<'_>, tx: HexString) -> async_graphql::Result<Transaction> {
         let tx_pool = ctx.data::<Arc<TxPool>>().unwrap();
         let tx = FuelTx::from_bytes(&tx.0)?;

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -37,7 +37,7 @@ impl TxQuery {
     async fn transaction(
         &self,
         ctx: &Context<'_>,
-        #[graphql(desc = "The id of the transaction")] id: TransactionId,
+        #[graphql(desc = "The ID of the transaction")] id: TransactionId,
     ) -> async_graphql::Result<Option<Transaction>> {
         let db = ctx.data_unchecked::<Database>();
         let key = id.0;


### PR DESCRIPTION
Done to fix #123  , I believe I regenerated the `schema.sdl` correctly but not too familiar so let me know if I missed a step. Went looking for fields of error in `fuel-core/schema/*` so its also possible I may have missed other GQL descriptions, I also tried to avoid capitalizing words which reference variables (like `utxo_id`) and instead added prefixes to those to fit in line with the new style while maintaining clarity. 