### PR TITLE
feat: add `Query.{balance,balances}` to GraphQL schema

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -1,5 +1,39 @@
 scalar Address
 scalar AssetId
+type Balance {
+	owner: Address!
+	amount: U64!
+	assetId: AssetId!
+}
+type BalanceConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [BalanceEdge]
+}
+"""
+An edge in a connection.
+"""
+type BalanceEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Balance!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+input BalanceFilterInput {
+	"""
+	Filter coins based on the `owner` field
+	"""
+	owner: Address!
+}
 type Block {
 	id: BlockId!
 	height: U64!
@@ -181,6 +215,8 @@ type ProgramState {
 type Query {
 	register(id: ID!, register: U64!): U64!
 	memory(id: ID!, start: U64!, size: U64!): String!
+	balance(owner: Address!, assetId: AssetId!): Balance!
+	balances(filter: BalanceFilterInput!, first: Int, after: String, last: Int, before: String): BalanceConnection!
 	block(id: BlockId, height: U64): Block
 	blocks(first: Int, after: String, last: Int, before: String): BlockConnection!
 	chain: ChainInfo!

--- a/fuel-client/src/client/schema.rs
+++ b/fuel-client/src/client/schema.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 
 pub use primitives::*;
 
+pub mod balance;
 pub mod block;
 pub mod chain;
 pub mod coin;

--- a/fuel-client/src/client/schema/balance.rs
+++ b/fuel-client/src/client/schema/balance.rs
@@ -1,0 +1,139 @@
+use crate::client::schema::{schema, Address, AssetId, PageInfo, U64};
+use crate::client::{PageDirection, PaginatedResult, PaginationRequest};
+
+#[derive(cynic::FragmentArguments, Debug)]
+pub struct BalanceArgs {
+    pub owner: Address,
+    pub asset_id: AssetId,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    argument_struct = "BalanceArgs"
+)]
+pub struct BalanceQuery {
+    #[arguments(owner = &args.owner, asset_id = &args.asset_id)]
+    pub balance: Balance,
+}
+
+#[derive(cynic::InputObject, Clone, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct BalanceFilterInput {
+    /// Filter coins based on the `owner` field
+    pub owner: Address,
+}
+
+#[derive(cynic::FragmentArguments, Debug)]
+pub struct BalancesConnectionArgs {
+    /// Filter coins based on a filter
+    filter: BalanceFilterInput,
+    /// Skip until coin id (forward pagination)
+    pub after: Option<String>,
+    /// Skip until coin id (backward pagination)
+    pub before: Option<String>,
+    /// Retrieve the first n coins in order (forward pagination)
+    pub first: Option<i32>,
+    /// Retrieve the last n coins in order (backward pagination).
+    /// Can't be used at the same time as `first`.
+    pub last: Option<i32>,
+}
+
+impl From<(Address, PaginationRequest<String>)> for BalancesConnectionArgs {
+    fn from(r: (Address, PaginationRequest<String>)) -> Self {
+        match r.1.direction {
+            PageDirection::Forward => BalancesConnectionArgs {
+                filter: BalanceFilterInput { owner: r.0 },
+                after: r.1.cursor,
+                before: None,
+                first: Some(r.1.results as i32),
+                last: None,
+            },
+            PageDirection::Backward => BalancesConnectionArgs {
+                filter: BalanceFilterInput { owner: r.0 },
+                after: None,
+                before: r.1.cursor,
+                first: None,
+                last: Some(r.1.results as i32),
+            },
+        }
+    }
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    argument_struct = "BalancesConnectionArgs"
+)]
+pub struct BalancesQuery {
+    #[arguments(filter = &args.filter, after = &args.after, before = &args.before, first = &args.first, last = &args.last)]
+    pub balances: BalanceConnection,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct BalanceConnection {
+    pub edges: Option<Vec<Option<BalanceEdge>>>,
+    pub page_info: PageInfo,
+}
+
+impl From<BalanceConnection> for PaginatedResult<Balance, String> {
+    fn from(conn: BalanceConnection) -> Self {
+        PaginatedResult {
+            cursor: conn.page_info.end_cursor,
+            results: conn
+                .edges
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|e| e.map(|e| e.node))
+                .collect(),
+        }
+    }
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct BalanceEdge {
+    pub cursor: String,
+    pub node: Balance,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct Balance {
+    pub owner: Address,
+    pub amount: U64,
+    pub asset_id: AssetId,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn balance_query_gql_output() {
+        use cynic::QueryBuilder;
+        let operation = BalanceQuery::build(BalanceArgs {
+            owner: Address::default(),
+            asset_id: AssetId::default(),
+        });
+        insta::assert_snapshot!(operation.query)
+    }
+
+    #[test]
+    fn balances_connection_query_gql_output() {
+        use cynic::QueryBuilder;
+        let operation = BalancesQuery::build(BalancesConnectionArgs {
+            filter: BalanceFilterInput {
+                owner: Address::default(),
+            },
+            after: None,
+            before: None,
+            first: None,
+            last: None,
+        });
+        insta::assert_snapshot!(operation.query)
+    }
+}

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__balance__tests__balance_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__balance__tests__balance_query_gql_output.snap
@@ -1,0 +1,14 @@
+---
+source: fuel-client/src/client/schema/balance.rs
+assertion_line: 122
+expression: operation.query
+
+---
+query Query($_0: Address!, $_1: AssetId!) {
+  balance(owner: $_0, assetId: $_1) {
+    owner
+    amount
+    assetId
+  }
+}
+

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__balance__tests__balances_connection_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__balance__tests__balances_connection_query_gql_output.snap
@@ -1,0 +1,25 @@
+---
+source: fuel-client/src/client/schema/balance.rs
+assertion_line: 137
+expression: operation.query
+
+---
+query Query($_0: BalanceFilterInput!, $_1: Int, $_2: String, $_3: Int, $_4: String) {
+  balances(filter: $_0, first: $_1, after: $_2, last: $_3, before: $_4) {
+    edges {
+      cursor
+      node {
+        owner
+        amount
+        assetId
+      }
+    }
+    pageInfo {
+      endCursor
+      hasNextPage
+      hasPreviousPage
+      startCursor
+    }
+  }
+}
+

--- a/fuel-core/src/schema.rs
+++ b/fuel-core/src/schema.rs
@@ -1,5 +1,6 @@
 use async_graphql::{EmptySubscription, MergedObject, Schema, SchemaBuilder};
 
+pub mod balance;
 pub mod block;
 pub mod chain;
 pub mod coin;
@@ -12,6 +13,7 @@ pub mod tx;
 #[derive(MergedObject, Default)]
 pub struct Query(
     dap::DapQuery,
+    balance::BalanceQuery,
     block::BlockQuery,
     chain::ChainQuery,
     tx::TxQuery,

--- a/fuel-core/src/schema/balance.rs
+++ b/fuel-core/src/schema/balance.rs
@@ -1,0 +1,192 @@
+use crate::database::{Database, KvStoreError};
+use crate::model::coin::{Coin as CoinModel, CoinStatus};
+use crate::schema::scalars::{Address, AssetId, U64};
+use crate::state::IterDirection;
+use async_graphql::InputObject;
+use async_graphql::{
+    connection::{query, Connection, Edge, EmptyFields},
+    Context, Object,
+};
+use fuel_storage::Storage;
+use itertools::Itertools;
+
+pub struct Balance {
+    owner: fuel_types::Address,
+    amount: u64,
+    asset_id: fuel_types::AssetId,
+}
+
+#[Object]
+impl Balance {
+    async fn owner(&self) -> Address {
+        self.owner.into()
+    }
+
+    async fn amount(&self) -> U64 {
+        self.amount.into()
+    }
+
+    async fn asset_id(&self) -> AssetId {
+        self.asset_id.into()
+    }
+}
+
+#[derive(InputObject)]
+struct BalanceFilterInput {
+    /// Filter coins based on the `owner` field
+    owner: Address,
+}
+
+#[derive(Default)]
+pub struct BalanceQuery;
+
+#[Object]
+impl BalanceQuery {
+    async fn balance(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(desc = "address of the owner")] owner: Address,
+        #[graphql(desc = "asset_id of the coin")] asset_id: AssetId,
+    ) -> async_graphql::Result<Balance> {
+        let db = ctx.data_unchecked::<Database>();
+
+        let coin_ids: Vec<fuel_tx::UtxoId> =
+            db.owned_coins(owner.into(), None, None).try_collect()?;
+        let mut coins: Vec<(fuel_tx::UtxoId, CoinModel)> = coin_ids
+            .into_iter()
+            .map(|id| {
+                Storage::<fuel_tx::UtxoId, CoinModel>::get(db, &id)
+                    .transpose()
+                    .ok_or(KvStoreError::NotFound)?
+                    .map(|coin| (id, coin.into_owned()))
+            })
+            .try_collect()?;
+        coins.retain(|(_, coin)| coin.status == CoinStatus::Unspent);
+
+        let sum_amount = coins
+            .iter()
+            .filter(|(_, coin)| coin.asset_id == asset_id.into())
+            .map(|(_, coin)| coin.amount)
+            .sum();
+
+        Ok(Balance {
+            owner: owner.into(),
+            amount: sum_amount,
+            asset_id: asset_id.into(),
+        })
+    }
+
+    async fn balances(
+        &self,
+        ctx: &Context<'_>,
+        filter: BalanceFilterInput,
+        first: Option<i32>,
+        after: Option<String>,
+        last: Option<i32>,
+        before: Option<String>,
+    ) -> async_graphql::Result<Connection<AssetId, Balance, EmptyFields, EmptyFields>> {
+        let db = ctx.data_unchecked::<Database>();
+
+        let coin_ids: Vec<fuel_tx::UtxoId> = db
+            .owned_coins(filter.owner.into(), None, None)
+            .try_collect()?;
+        let mut coins: Vec<(fuel_tx::UtxoId, CoinModel)> = coin_ids
+            .into_iter()
+            .map(|id| {
+                Storage::<fuel_tx::UtxoId, CoinModel>::get(db, &id)
+                    .transpose()
+                    .ok_or(KvStoreError::NotFound)?
+                    .map(|coin| (id, coin.into_owned()))
+            })
+            .try_collect()?;
+        coins.retain(|(_, coin)| coin.status == CoinStatus::Unspent);
+
+        let balances = coins
+            .iter()
+            .group_by(|(_, coin)| coin.asset_id)
+            .into_iter()
+            .map(|(asset_id, coins)| {
+                let sum_amount = coins.map(|(_, coin)| coin.amount).sum();
+
+                Balance {
+                    owner: filter.owner.into(),
+                    amount: sum_amount,
+                    asset_id,
+                }
+            })
+            .collect::<Vec<Balance>>();
+
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after: Option<AssetId>, before: Option<AssetId>, first, last| async move {
+                let (records_to_fetch, direction) = if let Some(first) = first {
+                    (first, IterDirection::Forward)
+                } else if let Some(last) = last {
+                    (last, IterDirection::Reverse)
+                } else {
+                    (0, IterDirection::Forward)
+                };
+
+                let after = after.map(fuel_tx::AssetId::from);
+                let before = before.map(fuel_tx::AssetId::from);
+
+                let start;
+                let end;
+
+                if direction == IterDirection::Forward {
+                    start = after;
+                    end = before;
+                } else {
+                    start = before;
+                    end = after;
+                }
+
+                let mut balances = balances.into_iter();
+                if direction == IterDirection::Reverse {
+                    balances = balances.rev().collect::<Vec<Balance>>().into_iter();
+                }
+                if let Some(start) = start {
+                    balances = balances
+                        .skip_while(|balance| balance.asset_id == start)
+                        .collect::<Vec<Balance>>()
+                        .into_iter();
+                }
+                let mut started = None;
+                if start.is_some() {
+                    // skip initial result
+                    started = balances.next();
+                }
+
+                // take desired amount of results
+                let balances = balances
+                    .take_while(|balance| {
+                        // take until we've reached the end
+                        if let Some(end) = end.as_ref() {
+                            if balance.asset_id == *end {
+                                return false;
+                            }
+                        }
+                        true
+                    })
+                    .take(records_to_fetch);
+                let mut balances: Vec<Balance> = balances.collect();
+                if direction == IterDirection::Reverse {
+                    balances.reverse();
+                }
+
+                let mut connection =
+                    Connection::new(started.is_some(), records_to_fetch <= balances.len());
+                connection.append(
+                    balances
+                        .into_iter()
+                        .map(|item| Edge::new(item.asset_id.into(), item)),
+                );
+                Ok(connection)
+            },
+        )
+        .await
+    }
+}

--- a/fuel-tests/tests/balances.rs
+++ b/fuel-tests/tests/balances.rs
@@ -1,0 +1,110 @@
+use fuel_core::{
+    chain_config::{CoinConfig, StateConfig},
+    service::{Config, FuelService},
+};
+use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
+use fuel_tx::AssetId;
+use fuel_vm::prelude::Address;
+
+#[tokio::test]
+async fn balance() {
+    let owner = Address::default();
+    let asset_id = AssetId::new([1u8; 32]);
+
+    // setup config
+    let mut config = Config::local_node();
+    config.chain_conf.initial_state = Some(StateConfig {
+        height: None,
+        contracts: None,
+        coins: Some(
+            vec![
+                (owner, 50, asset_id),
+                (owner, 100, asset_id),
+                (owner, 150, asset_id),
+            ]
+            .into_iter()
+            .map(|(owner, amount, asset_id)| CoinConfig {
+                tx_id: None,
+                output_index: None,
+                block_created: None,
+                maturity: None,
+                owner,
+                amount,
+                asset_id,
+            })
+            .collect(),
+        ),
+    });
+
+    // setup server & client
+    let srv = FuelService::new_node(config).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    // run test
+    let balance = client
+        .balance(
+            format!("{:#x}", owner).as_str(),
+            Some(format!("{:#x}", asset_id).as_str()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(balance, 300);
+}
+
+#[tokio::test]
+async fn first_5_balances() {
+    let owner = Address::default();
+    let asset_ids = (1..=6u8)
+        .map(|i| AssetId::new([i; 32]))
+        .collect::<Vec<AssetId>>();
+
+    // setup config
+    let mut config = Config::local_node();
+    config.chain_conf.initial_state = Some(StateConfig {
+        height: None,
+        contracts: None,
+        coins: Some(
+            asset_ids
+                .clone()
+                .into_iter()
+                .flat_map(|asset_id| {
+                    vec![
+                        (owner, 50, asset_id),
+                        (owner, 100, asset_id),
+                        (owner, 150, asset_id),
+                    ]
+                })
+                .map(|(owner, amount, asset_id)| CoinConfig {
+                    tx_id: None,
+                    output_index: None,
+                    block_created: None,
+                    maturity: None,
+                    owner,
+                    amount,
+                    asset_id,
+                })
+                .collect(),
+        ),
+    });
+
+    // setup server & client
+    let srv = FuelService::new_node(config).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    // run test
+    let balances = client
+        .balances(
+            format!("{:#x}", owner).as_str(),
+            PaginationRequest {
+                cursor: None,
+                results: 5,
+                direction: PageDirection::Forward,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!balances.results.is_empty());
+    assert_eq!(balances.results.len(), 5);
+    assert_eq!(balances.results[0].asset_id.0 .0, asset_ids[0]);
+    assert_eq!(balances.results[0].amount.0, 300);
+}

--- a/fuel-tests/tests/lib.rs
+++ b/fuel-tests/tests/lib.rs
@@ -1,3 +1,4 @@
+mod balances;
 mod blocks;
 mod coin;
 mod contract;


### PR DESCRIPTION
Adds appropriate fields to our GQL schema to query the total amount of assets an address has.

It works by fetching all coins and adding their amounts together which definitely is not what peak performance looks like. While this is very useful in the short term, I'd say these sums should be indexed somewhere in the future.