### PR TITLE
fuel-gql-client support for "https://"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,6 +2051,7 @@ dependencies = [
 name = "fuel-gql-client"
 version = "0.5.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap 3.1.2",
  "cynic",

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -15,6 +15,7 @@ name = "fuel-gql-cli"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "0.14", features = ["surf"] }

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -37,7 +37,7 @@ impl FromStr for FuelClient {
             Err(anyhow!("Url is missing /graphql path".to_string()))
         } else {
             Ok(Self {
-                url: surf::Url::parse(&str)?,
+                url: surf::Url::parse(str)?,
             })
         }
     }

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -10,6 +10,7 @@ use std::{
 pub mod schema;
 pub mod types;
 
+use anyhow::anyhow;
 use schema::{
     balance::BalanceArgs,
     block::BlockByIdArgs,
@@ -28,10 +29,17 @@ pub struct FuelClient {
 }
 
 impl FromStr for FuelClient {
-    type Err = net::AddrParseError;
+    type Err = anyhow::Error;
 
     fn from_str(str: &str) -> Result<Self, Self::Err> {
-        str.parse().map(|s: net::SocketAddr| s.into())
+        // lightweight url verification
+        if !str.contains("/graphql") {
+            Err(anyhow!("Url is missing /graphql path".to_string()))
+        } else {
+            Ok(Self {
+                url: surf::Url::parse(&str)?,
+            })
+        }
     }
 }
 
@@ -50,7 +58,7 @@ where
 }
 
 impl FuelClient {
-    pub fn new(url: impl AsRef<str>) -> Result<Self, net::AddrParseError> {
+    pub fn new(url: impl AsRef<str>) -> Result<Self, anyhow::Error> {
         Self::from_str(url.as_ref())
     }
 


### PR DESCRIPTION
Fuel gql client accepted a string for instantiation but always parsed it as a socket addr so that it could be formatted in a way that is guaranteed to be the correct route for the fuel node. The problem with this approach is that it always assumes the client URL will be on `http`. This change allows the string to be directly passed in and parsed as the URL of the fuel-core graphql endpoint, allowing users to set `https` in the prefix if needed.