### PR TITLE
FuelClient can be converted from an Option

### DIFF
--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -35,17 +35,25 @@ impl FromStr for FuelClient {
     }
 }
 
-impl<S> From<S> for FuelClient
-where
-    S: Into<net::SocketAddr>,
+impl From<net::SocketAddr> for FuelClient
 {
-    fn from(socket: S) -> Self {
-        let url = format!("http://{}/graphql", socket.into())
+    fn from(socket: net::SocketAddr) -> Self {
+        let url = format!("http://{}/graphql", socket)
             .as_str()
             .parse()
             .unwrap();
 
         Self { url }
+    }
+}
+
+impl From<Option<net::SocketAddr>> for FuelClient
+{
+    fn from(option: Option<net::SocketAddr>) -> Self {
+        match option {
+            Some(url) => return FuelClient::from(url),
+            None => panic!("Url is missing!")
+        }
     }
 }
 

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -35,8 +35,7 @@ impl FromStr for FuelClient {
     }
 }
 
-impl From<net::SocketAddr> for FuelClient
-{
+impl From<net::SocketAddr> for FuelClient {
     fn from(socket: net::SocketAddr) -> Self {
         let url = format!("http://{}/graphql", socket)
             .as_str()
@@ -47,12 +46,11 @@ impl From<net::SocketAddr> for FuelClient
     }
 }
 
-impl From<Option<net::SocketAddr>> for FuelClient
-{
+impl From<Option<net::SocketAddr>> for FuelClient {
     fn from(option: Option<net::SocketAddr>) -> Self {
         match option {
             Some(url) => return FuelClient::from(url),
-            None => panic!("Url is missing!")
+            None => panic!("Url is missing!"),
         }
     }
 }

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -48,10 +48,11 @@ impl From<net::SocketAddr> for FuelClient {
 
 impl From<Option<net::SocketAddr>> for FuelClient {
     fn from(option: Option<net::SocketAddr>) -> Self {
-        match option {
-            Some(url) => return FuelClient::from(url),
+        let client = match option {
+            Some(url) => FuelClient::from(url),
             None => panic!("Url is missing!"),
-        }
+        };
+        client
     }
 }
 

--- a/fuel-tests/tests/dap.rs
+++ b/fuel-tests/tests/dap.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 #[tokio::test]
 async fn start_session() {
     let srv = FuelService::new_node(Config::local_node()).await.unwrap();
-    let client = FuelClient::from(srv.bound_address);
+    let client = FuelClient::from(Some(srv.bound_address));
 
     let session = client.start_session().await.unwrap();
     let session_p = client.start_session().await.unwrap();


### PR DESCRIPTION
Tried my hand at #206

Keeping the generic `From` impl and having another one that takes an `Option` doesn't seem doable to me, at least not without [this](https://github.com/rust-lang/rust/issues/35121) and [this](https://github.com/rust-lang/rust/issues/35121) rfc merged.... or maybe with macros that expand to generic-like code but allow for overwriting (?)... or maybe I'm missing something obvious.

The one (dumb) solution I came upon is noticing that `FuleClient` was always converted from `net::SocketAddr` ... so I just removed the generic behavior to allow for the `Option` instead. However, it's unclear from the issue what the desired behavior for `None` is (currently it just panics).

80% sure I'm missing the point of the issue, in which case I'd love to hear it, then I could also test it properly (currently just added a random `Some` in another unittest to check if it works in principle)








