### PR TITLE
ScriptExecutionResult + Call Receipt Updates (fuel-tx 0.8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,13 +1961,13 @@ dependencies = [
  "env_logger",
  "fuel-asm 0.3.0",
  "fuel-core-interfaces",
- "fuel-crypto 0.3.0",
+ "fuel-crypto",
  "fuel-merkle",
  "fuel-storage",
- "fuel-tx 0.7.0",
+ "fuel-tx 0.8.0",
  "fuel-txpool",
  "fuel-types 0.3.0",
- "fuel-vm 0.6.0",
+ "fuel-vm 0.7.0",
  "futures",
  "graphql-parser",
  "hex",
@@ -2001,11 +2001,11 @@ dependencies = [
  "chrono",
  "derive_more",
  "fuel-asm 0.3.0",
- "fuel-crypto 0.4.2",
+ "fuel-crypto",
  "fuel-storage",
- "fuel-tx 0.7.0",
+ "fuel-tx 0.8.0",
  "fuel-types 0.3.0",
- "fuel-vm 0.6.0",
+ "fuel-vm 0.7.0",
  "futures",
  "lazy_static",
  "parking_lot 0.12.0",
@@ -2016,26 +2016,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb541e22388f3e21d416128e5ec2a33b80bb8976124a79587fe1328d7d04e149"
-dependencies = [
- "borrown",
- "fuel-types 0.3.0",
- "rand 0.8.5",
- "secp256k1",
- "serde",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "fuel-crypto"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e0f5a52d0dc3ac1e3cb57ef85955d5e87225b95a6b4718e4c81ae0423609c9"
 dependencies = [
  "borrown",
  "fuel-types 0.3.0",
+ "rand 0.8.5",
+ "secp256k1",
+ "serde",
  "sha2 0.9.9",
 ]
 
@@ -2072,9 +2061,9 @@ dependencies = [
  "cynic",
  "derive_more",
  "fuel-storage",
- "fuel-tx 0.7.0",
+ "fuel-tx 0.8.0",
  "fuel-types 0.3.0",
- "fuel-vm 0.6.0",
+ "fuel-vm 0.7.0",
  "futures",
  "hex",
  "insta",
@@ -2114,7 +2103,7 @@ name = "fuel-indexer-schema"
 version = "0.0.0"
 dependencies = [
  "diesel",
- "fuel-tx 0.7.0",
+ "fuel-tx 0.8.0",
  "fuel-types 0.3.0",
  "graphql-parser",
  "insta",
@@ -2216,9 +2205,9 @@ dependencies = [
  "fuel-core 0.5.0",
  "fuel-gql-client 0.5.0",
  "fuel-storage",
- "fuel-tx 0.7.0",
+ "fuel-tx 0.8.0",
  "fuel-types 0.3.0",
- "fuel-vm 0.6.0",
+ "fuel-vm 0.7.0",
  "insta",
  "itertools",
  "rand 0.8.5",
@@ -2253,12 +2242,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1669a4c16c1d55bca2e93915ee92983e65a281950f3d4a157b2e51f4d0a66e7c"
+checksum = "89be16332174017b5273ebab5cb6b97d1bd2fd309305456f2bbccf9fc12d8ef3"
 dependencies = [
  "fuel-asm 0.3.0",
- "fuel-crypto 0.3.0",
+ "fuel-crypto",
  "fuel-types 0.3.0",
  "itertools",
  "rand 0.8.5",
@@ -2272,7 +2261,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-interfaces",
- "fuel-tx 0.7.0",
+ "fuel-tx 0.8.0",
  "fuel-types 0.3.0",
  "futures",
  "parking_lot 0.11.2",
@@ -2320,15 +2309,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c48bfd8fb29f5f91ac4b73e2cdfd5aa7c194d4696552d1b536ff629bbfde817"
+checksum = "f76eee6ab193e99a85176e468b78f28496fd724ab22b803f15d492b3310faa39"
 dependencies = [
  "fuel-asm 0.3.0",
- "fuel-crypto 0.3.0",
+ "fuel-crypto",
  "fuel-merkle",
  "fuel-storage",
- "fuel-tx 0.7.0",
+ "fuel-tx 0.8.0",
  "fuel-types 0.3.0",
  "itertools",
  "rand 0.8.5",

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -21,9 +21,9 @@ clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "0.14", features = ["surf"] }
 derive_more = { version = "0.99" }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.7", features = ["serde-types"] }
+fuel-tx = { version = "0.8", features = ["serde-types"] }
 fuel-types = { version = "0.3", features = ["serde-types"] }
-fuel-vm = { version = "0.6", features = ["serde-types"] }
+fuel-vm = { version = "0.7", features = ["serde-types"] }
 futures = "0.3"
 hex = "0.4"
 itertools = "0.10"

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -242,8 +242,8 @@ type Receipt {
 	amount: U64
 	assetId: AssetId
 	gas: U64
-	a: U64
-	b: U64
+	param1: U64
+	param2: U64
 	val: U64
 	ptr: U64
 	digest: Bytes32

--- a/fuel-client/src/client/schema/primitives.rs
+++ b/fuel-client/src/client/schema/primitives.rs
@@ -3,6 +3,7 @@ use crate::client::schema::ConversionError;
 use crate::client::schema::ConversionError::HexStringPrefixError;
 use core::fmt;
 use cynic::impl_scalar;
+use fuel_tx::InstructionResult;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Debug, Display, Formatter, LowerHex};
@@ -193,5 +194,11 @@ impl<'de> Deserialize<'de> for U64 {
 impl From<usize> for U64 {
     fn from(i: usize) -> Self {
         U64(i as u64)
+    }
+}
+
+impl From<U64> for InstructionResult {
+    fn from(s: U64) -> Self {
+        s.0.into()
     }
 }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -1,8 +1,6 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
-assertion_line: 271
 expression: operation.query
-
 ---
 query Query($_0: TransactionId!) {
   transaction(id: $_0) {
@@ -101,8 +99,8 @@ query Query($_0: TransactionId!) {
     }
     witnesses
     receipts {
-      a
-      b
+      param1
+      param2
       amount
       assetId
       gas

--- a/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
@@ -7,8 +7,8 @@ use fuel_types::Word;
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Receipt {
-    pub a: Option<U64>,
-    pub b: Option<U64>,
+    pub param1: Option<U64>,
+    pub param2: Option<U64>,
     pub amount: Option<U64>,
     pub asset_id: Option<AssetId>,
     pub gas: Option<U64>,
@@ -75,13 +75,13 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
                     .gas
                     .ok_or_else(|| MissingField("gas".to_string()))?
                     .into(),
-                a: schema
-                    .a
-                    .ok_or_else(|| MissingField("a".to_string()))?
+                param1: schema
+                    .param1
+                    .ok_or_else(|| MissingField("param1".to_string()))?
                     .into(),
-                b: schema
-                    .b
-                    .ok_or_else(|| MissingField("b".to_string()))?
+                param2: schema
+                    .param2
+                    .ok_or_else(|| MissingField("param2".to_string()))?
                     .into(),
                 pc: schema
                     .pc

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -18,9 +18,9 @@ derive_more = { version = "0.99" }
 fuel-asm = "0.3"
 fuel-crypto = { version = "0.4", default-features = false }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.7", default-features = false }
+fuel-tx = { version = "0.8", default-features = false }
 fuel-types = { version = "0.3", default-features = false }
-fuel-vm = { version = "0.6", default-features = false }
+fuel-vm = { version = "0.7", default-features = false }
 futures = "0.3"
 lazy_static = "1.4"
 parking_lot = "0.12"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -36,13 +36,13 @@ fuel-asm = { version = "0.3", features = ["serde-types"] }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.5.0", features = [
     "serde-types",
 ] }
-fuel-crypto = { version = "0.3" }
+fuel-crypto = { version = "0.4" }
 fuel-merkle = "0.1"
 fuel-storage = { version = "0.1" }
-fuel-tx = { version = "0.7", features = ["serde-types"] }
+fuel-tx = { version = "0.8", features = ["serde-types"] }
 fuel-txpool = { path = "../fuel-txpool", version = "0.5.0" }
 fuel-types = { version = "0.3", features = ["serde-types"] }
-fuel-vm = { version = "0.6", features = ["serde-types"] }
+fuel-vm = { version = "0.7", features = ["serde-types"] }
 futures = "0.3"
 graphql-parser = "0.3.0"
 hex = { version = "0.4", features = ["serde"] }
@@ -70,12 +70,12 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-fuel-tx = { version = "0.7", features = [
+fuel-tx = { version = "0.8", features = [
     "serde-types",
     "builder",
     "internals",
 ] }
-fuel-vm = { version = "0.6", features = [
+fuel-vm = { version = "0.7", features = [
     "serde-types",
     "random",
     "test-helpers",

--- a/fuel-core/src/schema/tx/receipt.rs
+++ b/fuel-core/src/schema/tx/receipt.rs
@@ -66,11 +66,11 @@ impl Receipt {
     async fn gas(&self) -> Option<U64> {
         self.0.gas().map(Into::into)
     }
-    async fn a(&self) -> Option<U64> {
-        self.0.a().map(Into::into)
+    async fn param1(&self) -> Option<U64> {
+        self.0.param1().map(Into::into)
     }
-    async fn b(&self) -> Option<U64> {
-        self.0.b().map(Into::into)
+    async fn param2(&self) -> Option<U64> {
+        self.0.param2().map(Into::into)
     }
     async fn val(&self) -> Option<U64> {
         self.0.val().map(Into::into)
@@ -82,7 +82,7 @@ impl Receipt {
         self.0.digest().copied().map(Into::into)
     }
     async fn reason(&self) -> Option<U64> {
-        self.0.reason().map(Into::into)
+        self.0.reason().map(|r| U64(r.into()))
     }
     async fn ra(&self) -> Option<U64> {
         self.0.ra().map(Into::into)

--- a/fuel-indexer/schema/Cargo.toml
+++ b/fuel-indexer/schema/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 diesel = { version = "1.4", optional = true, features = ["postgres", "serde_json"] }
-fuel-tx = { version = "0.7", default-features = false }
+fuel-tx = { version = "0.8", default-features = false }
 fuel-types = { version = "0.3", default-features = false }
 graphql-parser = "0.3"
 itertools = { version = "0.10", optional = true }

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -21,9 +21,9 @@ chrono = { version = "0.4", features = ["serde"] }
 fuel-core = { path = "../fuel-core", features = ["test-helpers"], default-features = false }
 fuel-gql-client = { path = "../fuel-client", features = ["test-helpers"] }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.7", features = ["serde-types"] }
+fuel-tx = { version = "0.8", features = ["serde-types"] }
 fuel-types = { version = "0.3", features = ["serde-types"] }
-fuel-vm = { version = "0.6", features = ["serde-types", "random","test-helpers"] }
+fuel-vm = { version = "0.7", features = ["serde-types", "random","test-helpers"] }
 insta = "1.8"
 itertools = "0.10"
 rand = "0.8"

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -14,7 +14,7 @@ description = "Transaction pool"
 anyhow = "1.0"
 async-trait = "0.1"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.5.0" }
-fuel-tx = { version = "0.7", features = ["serde-types"] }
+fuel-tx = { version = "0.8", features = ["serde-types"] }
 fuel-types = { version = "0.3", features = ["serde-types"] }
 futures = "0.3"
 parking_lot = "0.11"


### PR DESCRIPTION
Handle updated ScriptResult receipt, which shows reverts as an error in addition to panics and remove unintuitive `RESERV00` error messages.