### PR TITLE
Updating AWS envs to be more specific

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -126,15 +126,15 @@ You will need to customize the following environment variables as needed (for va
 | grafana_ingress_dns            |  fuel-core-ingress-deploy | the custom dns address for the grafana ingress                                                    | 
 | pvc_storage_class              |  fuel-core-deploy         | Storage class for the persistent volume                                                           | 
 | pvc_storage_requests           |  fuel-core-deploy         | Th size of the request for the persistent volume                                                  |
-| TF_VAR_environment             |  create-k8s (all)         | environment name                                                                                  |
-| TF_VAR_region                  |  create-k8s (aws)         | AWS region where you plan to deploy your EKS cluster e.g. us-east-1                               |
-| TF_VAR_account_id              |  create-k8s (aws)         | AWS account id                                                                                    |
-| TF_state_bucket                |  create-k8s (aws)         | the s3 bucket to store the deployed terraform state                                               |
-| TF_state_bucket_key            |  create-k8s (aws)         | the s3 key to save the deployed terraform state.tf                                                |
-| TF_VAR_vpc_cidr_block          |  create-k8s (aws)         | AWS vpc cidr block                                                                                |
-| TF_VAR_azs                     |  create-k8s (aws)         | A list of regional availability zones for the AWS vpc subnets                                     |
-| TF_VAR_public_subnets          |  create-k8s (aws)         | A list of cidr blocks for AWS public subnets                                                      |
-| TF_VAR_private_subnets         |  create-k8s (aws)         | A list of cidr blocks for AWS private subnets                                                     | 
+| TF_VAR_aws_environment         |  create-k8s (all)         | environment name                                                                                  |
+| TF_VAR_aws_region              |  create-k8s (aws)         | AWS region where you plan to deploy your EKS cluster e.g. us-east-1                               |
+| TF_VAR_aws_account_id          |  create-k8s (aws)         | AWS account id                                                                                    |
+| TF_state_s3_bucket             |  create-k8s (aws)         | the s3 bucket to store the deployed terraform state                                               |
+| TF_state_s3_bucket_key         |  create-k8s (aws)         | the s3 key to save the deployed terraform state.tf                                                |
+| TF_VAR_aws_vpc_cidr_block      |  create-k8s (aws)         | AWS vpc cidr block                                                                                |
+| TF_VAR_aws_azs                 |  create-k8s (aws)         | A list of regional availability zones for the AWS vpc subnets                                     |
+| TF_VAR_aws_public_subnets      |  create-k8s (aws)         | A list of cidr blocks for AWS public subnets                                                      |
+| TF_VAR_aws_private_subnets     |  create-k8s (aws)         | A list of cidr blocks for AWS private subnets                                                     | 
 | TF_VAR_eks_cluster_name        |  create-k8s (aws)         | EKS cluster name                                                                                  |
 | TF_VAR_eks_cluster_version     |  create-k8s (aws)         | EKS cluster version, possible options: 1.18.16, 1.19.8, 1.20.7, 1.21.2                            |
 | TF_VAR_eks_node_groupname      |  create-k8s (aws)         | EKS worker node group name                                                                        |

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -1,5 +1,5 @@
 # Kubernetes Provider Enviromment Variables
-k8s_provider="eks"
+k8s_provider="eks" # choices are eks | other
 
 # Helm Environment Values
 k8s_namespace="fuel-core"
@@ -18,15 +18,15 @@ fuel_core_ingress_http_port="80"
 grafana_ingress_dns="monitoring.example.com"
 
 # AWS Environment variables 
-TF_VAR_environment="fuel-core"
-TF_VAR_region="us-east-1"
-TF_VAR_account_id="123456789012"
-TF_state_bucket="example-bucket"
-TF_state_bucket_key="example-bucket-key"
-TF_VAR_vpc_cidr_block="10.128.0.0/20"
-TF_VAR_azs='["us-east-1a", "us-east-1b", "us-east-1c"]'
-TF_VAR_public_subnets='["10.128.0.0/24", "10.128.1.0/24", "10.128.2.0/24"]'
-TF_VAR_private_subnets='["10.128.4.0/24", "10.128.5.0/24", "10.128.6.0/24"]'
+TF_VAR_aws_environment="fuel-core"
+TF_VAR_aws_region="us-east-1"
+TF_VAR_aws_account_id="123456789012"
+TF_state_s3_bucket="example-bucket"
+TF_state_s3_bucket_key="example-bucket-key"
+TF_VAR_aws_vpc_cidr_block="10.128.0.0/20"
+TF_VAR_aws_azs='["us-east-1a", "us-east-1b", "us-east-1c"]'
+TF_VAR_aws_public_subnets='["10.128.0.0/24", "10.128.1.0/24", "10.128.2.0/24"]'
+TF_VAR_aws_private_subnets='["10.128.4.0/24", "10.128.5.0/24", "10.128.6.0/24"]'
 TF_VAR_eks_cluster_name="fuel-core-deploy"
 TF_VAR_eks_cluster_version="1.21"
 TF_VAR_eks_node_groupname="nodes"

--- a/deployment/terraform/environments/eks/main.tf
+++ b/deployment/terraform/environments/eks/main.tf
@@ -1,17 +1,17 @@
-# General
-variable "environment" {
+# AWS General
+variable "aws_environment" {
   type = string
 }
 
-variable "account_id" {
+variable "aws_account_id" {
   type = string
 }
 
-variable "region" {
+variable "aws_region" {
   type = string
 }
 
-# EKS
+# AWS EKS
 variable "eks_cluster_name" {
   type = string
 }
@@ -52,19 +52,19 @@ variable "eks_capacity_type" {
   type = string
 }
 
-variable "azs" {
+variable "aws_azs" {
   type = list(string)
 }
 
-variable "private_subnets" {
+variable "aws_private_subnets" {
   type = list(string)
 }
 
-variable "public_subnets" {
+variable "aws_public_subnets" {
   type = list(string)
 }
 
-variable "vpc_cidr_block" {
+variable "aws_vpc_cidr_block" {
   type = string
 }
 
@@ -76,19 +76,16 @@ variable "ec2_ssh_key" {
 module "fuel-core-aws-deploy" {
   source = "../../modules/eks"
 
-    # Environment
-  
-  environment = var.environment
-
   # AWS
-  region              = var.region
-  account_id          = var.account_id
+  aws_environment             = var.aws_environment
+  aws_region                  = var.aws_region
+  aws_account_id              = var.aws_account_id
 
   # Networking
-  vpc_cidr_block      = var.vpc_cidr_block  
-  azs                 = var.azs
-  public_subnets      = var.public_subnets
-  private_subnets     = var.private_subnets
+  aws_vpc_cidr_block          = var.aws_vpc_cidr_block  
+  aws_azs                     = var.aws_azs
+  aws_public_subnets          = var.aws_public_subnets
+  aws_private_subnets         = var.aws_private_subnets
 
   # EKS
   eks_cluster_name          = var.eks_cluster_name 

--- a/deployment/terraform/environments/eks/state.tf
+++ b/deployment/terraform/environments/eks/state.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    bucket = "${TF_state_bucket}"
-    key    = "${TF_state_bucket_key}"
-    region = "${TF_VAR_region}"
+    bucket = "${TF_state_s3_bucket}"
+    key    = "${TF_state_s3_bucket_key}"
+    region = "${TF_VAR_aws_region}"
   }
 }

--- a/deployment/terraform/modules/eks/aws.tf
+++ b/deployment/terraform/modules/eks/aws.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  region  = var.region
+  region  = var.aws_region
 }
 

--- a/deployment/terraform/modules/eks/variables.tf
+++ b/deployment/terraform/modules/eks/variables.tf
@@ -1,17 +1,17 @@
-# General
-variable "environment" {
+# AWS General
+variable "aws_environment" {
   type = string
 }
 
-variable "account_id" {
+variable "aws_account_id" {
   type = string
 }
 
-variable "region" {
+variable "aws_region" {
   type = string
 }
 
-# EKS
+# AWS EKS
 variable "eks_cluster_name" {
   type = string
 }
@@ -52,19 +52,19 @@ variable "eks_capacity_type" {
   type = string
 }
 
-variable "azs" {
+variable "aws_azs" {
   type = list(string)
 }
 
-variable "private_subnets" {
+variable "aws_private_subnets" {
   type = list(string)
 }
 
-variable "public_subnets" {
+variable "aws_public_subnets" {
   type = list(string)
 }
 
-variable "vpc_cidr_block" {
+variable "aws_vpc_cidr_block" {
   type = string
 }
 

--- a/deployment/terraform/modules/eks/vpc.tf
+++ b/deployment/terraform/modules/eks/vpc.tf
@@ -10,7 +10,7 @@ locals {
     "kubernetes.io/role/elb" = "1"
   }
   environment_tag = {
-    Environment = var.environment
+    Environment = var.aws_environment
   }
 }
 
@@ -18,13 +18,13 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.11.0"
 
-  name = var.environment
-  cidr = var.vpc_cidr_block
+  name = var.aws_environment
+  cidr = var.aws_vpc_cidr_block
 
-  azs                 = var.azs
-  public_subnets      = var.public_subnets
+  azs                 = var.aws_azs
+  public_subnets      = var.aws_public_subnets
   public_subnet_tags  = local.public_subnet_eks_tag
-  private_subnets     = var.private_subnets
+  private_subnets     = var.aws_private_subnets
   private_subnet_tags = local.private_subnet_eks_tag
 
   enable_nat_gateway = true


### PR DESCRIPTION
To accommodate future k8s cluster types e.g. azure, gcp, and others, want to make the AWS envs more aws specific. 