### PR TITLE
Update docker to rust 1.60 & productionalize

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,22 @@
 [alias]
 xtask = "run --package xtask --"
+
+# On Windows
+# ```
+# cargo install -f cargo-binutils
+# rustup component add llvm-tools-preview
+# ```
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+[target.x86_64-pc-windows-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+# On Linux:
+# - Ubuntu, `sudo apt-get install lld clang`
+# - Arch, `sudo pacman -S lld clang`
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
+# On MacOS, `brew install michaeleisel/zld/zld`
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,25 +1,33 @@
 # Stage 1: Build
-FROM rust:1.59.0 as builder
-
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-
+FROM lukemathwalker/cargo-chef:latest-rust-1.60 as chef
+WORKDIR /build/
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+    lld \
     clang \
     libclang-dev \
     libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /build/
-
+FROM chef as planner
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
+FROM chef as builder
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+COPY --from=planner /build/recipe.json recipe.json
+# Build our project dependecies, not our application!
+RUN cargo chef cook --release -p fuel-core --recipe-path recipe.json
+# Up to this point, if our dependency tree stays the same,
+# all layers should be cached.
+COPY . .
 RUN cargo build --release -p fuel-core
 
 # Stage 2: Run
-FROM ubuntu:20.04 as run
+FROM debian:bullseye-slim as run
 
 ARG IP=0.0.0.0
 ARG PORT=4000
@@ -29,21 +37,21 @@ ENV IP="${IP}"
 ENV PORT="${PORT}"
 ENV DB_PATH="${DB_PATH}"
 
-# hadolint ignore=DL3008
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /root/
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/fuel-core .
 COPY --from=builder /build/target/release/fuel-core.d .
+
+EXPOSE ${PORT}
 
 # https://stackoverflow.com/a/44671685
 # https://stackoverflow.com/a/40454758
 # hadolint ignore=DL3025
 CMD exec ./fuel-core --ip ${IP} --port ${PORT} --db-path ${DB_PATH}
-
-EXPOSE ${PORT}

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 RUN cargo build --release -p fuel-core
 
 # Stage 2: Run
-FROM debian:bullseye-slim as run
+FROM ubuntu:22.04 as run
 
 ARG IP=0.0.0.0
 ARG PORT=4000


### PR DESCRIPTION
- Use latest stable rust
- Update to latest ubuntu LTS (22.04)
- Cargo chef to cache cargo dependencies as layers

Caching will greatly improve the developer workflow for external development environments such as swayswap.