### PR TITLE
Use lld for linking

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,22 @@
 [alias]
 xtask = "run --package xtask --"
+
+# On Windows
+# ```
+# cargo install -f cargo-binutils
+# rustup component add llvm-tools-preview
+# ```
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+[target.x86_64-pc-windows-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+# On Linux:
+# - Ubuntu, `sudo apt-get install lld clang`
+# - Arch, `sudo pacman -S lld clang`
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
+# On MacOS, `brew install michaeleisel/zld/zld`
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]

--- a/README.md
+++ b/README.md
@@ -20,20 +20,24 @@ There are several system requirements including clang & llvm.
 ###### MacOS
 ```bash
 brew update
-brew install openssl cmake llvm
+brew install cmake llvm michaeleisel/zld/zld
 ```
 
 ###### Debian
 ```bash
 apt update
-apt install -y cmake pkg-config libssl-dev git gcc build-essential git clang libclang-dev llvm
+apt install -y cmake pkg-config git gcc build-essential git clang libclang-dev lld
 ```
 
 ###### Arch
 ```bash 
-pacman -Syu --needed --noconfirm cmake gcc openssl-1.0 pkgconf git clang llvm11 llvm11-libs
-export OPENSSL_LIB_DIR="/usr/lib/openssl-1.0";
-export OPENSSL_INCLUDE_DIR="/usr/include/openssl-1.0"
+pacman -Syu --needed --noconfirm cmake gcc pkgconf git clang lld
+```
+
+###### Windows
+```
+cargo install -f cargo-binutils
+rustup component add llvm-tools-preview
 ```
 
 ## Building 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are several system requirements including clang & llvm.
 ###### MacOS
 ```bash
 brew update
-brew install cmake llvm michaeleisel/zld/zld
+brew install cmake michaeleisel/zld/zld
 ```
 
 ###### Debian

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     clang \
     libclang-dev \
-    libssl-dev \
+    lld \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Setup the fuel-core project to use lld as the linker, which is roughly twice as fast as the default linker.

For fuel-core CI, this makes the build ~2 minutes faster.

before: https://github.com/FuelLabs/fuel-core/runs/6180962633?check_suite_focus=true
after: https://github.com/FuelLabs/fuel-core/pull/283/checks

also cleans up openssl related stuff, since it's no longer used.