### PR TITLE
Pin async-graphql 2.9 again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,39 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
+  cargo-publish-dry-run:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run fuel-core Cargo Publish dry-run
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: -p fuel-core --dry-run
+      - name: Run fuel-client Cargo Publish dry-run
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: -p fuel-gql-client --dry-run
+      - name: Notify if Job Fails
+        uses: ravsamhq/notify-slack-action@v1
+        if: always() && github.ref == 'refs/heads/master'
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: '{workflow} has {status_message}'
+          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>'
+          footer: ''
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+
   cargo-test:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,7 @@ jobs:
       - cargo-fmt-check
       - cargo-clippy
       - cargo-check
+      - cargo-publish-dry-run
       - cargo-test
       - cargo-test-no-default-features
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -281,6 +282,7 @@ jobs:
       - cargo-fmt-check
       - cargo-clippy
       - cargo-check
+      - cargo-publish-dry-run
       - cargo-test
       - cargo-test-no-default-features
     if: github.ref == 'refs/heads/master'

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -19,6 +19,8 @@ test = false
 
 [dependencies]
 anyhow = "1.0"
+# This needs to be pinned as newer versions are incompatible with fuel-core.
+# We're waiting for the following resolution: https://github.com/FuelLabs/fuel-core/pull/260#issuecomment-1102435692
 async-graphql = { version = "=2.9", features = [
     "chrono",
     "chrono-tz",

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -19,7 +19,7 @@ test = false
 
 [dependencies]
 anyhow = "1.0"
-async-graphql = { version = "2.9", features = [
+async-graphql = { version = "=2.9", features = [
     "chrono",
     "chrono-tz",
     "tracing",


### PR DESCRIPTION
don't use newer version of async-graphql until newer release is fixed