### PR TITLE
Update client URL parsing

### DIFF
--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -32,14 +32,9 @@ impl FromStr for FuelClient {
     type Err = anyhow::Error;
 
     fn from_str(str: &str) -> Result<Self, Self::Err> {
-        // lightweight url verification
-        if !str.contains("/graphql") {
-            Err(anyhow!("Url is missing /graphql path".to_string()))
-        } else {
-            Ok(Self {
-                url: surf::Url::parse(str)?,
-            })
-        }
+        let mut url = surf::Url::parse(str)?;
+        url.set_path("/graphql");
+        Ok(Self { url })
     }
 }
 
@@ -48,12 +43,10 @@ where
     S: Into<net::SocketAddr>,
 {
     fn from(socket: S) -> Self {
-        let url = format!("http://{}/graphql", socket.into())
+        format!("http://{}", socket.into())
             .as_str()
             .parse()
-            .unwrap();
-
-        Self { url }
+            .unwrap()
     }
 }
 

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -1,16 +1,6 @@
 use cynic::{http::SurfExt, MutationBuilder, Operation, QueryBuilder};
 use fuel_vm::prelude::*;
 use itertools::Itertools;
-use std::{
-    convert::TryInto,
-    io, net,
-    str::{self, FromStr},
-};
-
-pub mod schema;
-pub mod types;
-
-use anyhow::anyhow;
 use schema::{
     balance::BalanceArgs,
     block::BlockByIdArgs,
@@ -19,9 +9,18 @@ use schema::{
     tx::{TxArg, TxIdArgs},
     Bytes, ConversionError, HexString, IdArg, MemoryArgs, RegisterArgs, TransactionId,
 };
-pub use schema::{PageDirection, PaginatedResult, PaginationRequest};
-use std::io::ErrorKind;
+use std::{
+    convert::TryInto,
+    io::{self, ErrorKind},
+    net,
+    str::{self, FromStr},
+};
 use types::{TransactionResponse, TransactionStatus};
+
+pub use schema::{PageDirection, PaginatedResult, PaginationRequest};
+
+pub mod schema;
+pub mod types;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FuelClient {


### PR DESCRIPTION
Before when creating the fuel-gql-client it was expecting the URL to also contain the expected endpoint `/graphql`. This PR allows users to just set a base URL for the node, and then the client will automatically set the correct path to the api.