### PR TITLE
0.6.2 release bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-interfaces"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gql-client"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-p2p"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1620,7 +1620,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-txpool"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-core
 description: Fuel Core Helm Chart
 type: application
-appVersion: "0.6.1"
+appVersion: "0.6.2"
 version: 0.1.0

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-gql-client"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-interfaces"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -35,14 +35,14 @@ derive_more = { version = "0.99" }
 dirs = "3.0"
 env_logger = "0.9"
 fuel-asm = { version = "0.4", features = ["serde-types"] }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.1", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.2", features = [
     "serde-types",
 ] }
 fuel-crypto = { version = "0.4", features = ["random"] }
 fuel-merkle = "0.1"
 fuel-storage = { version = "0.1" }
 fuel-tx = { version = "0.9", features = ["serde-types"] }
-fuel-txpool = { path = "../fuel-txpool", version = "0.6.1" }
+fuel-txpool = { path = "../fuel-txpool", version = "0.6.2" }
 fuel-types = { version = "0.3", features = ["serde-types"] }
 fuel-vm = { version = "0.8", features = ["serde-types"] }
 futures = "0.3"

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-p2p"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 edition = "2021"

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-txpool"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -14,7 +14,7 @@ description = "Transaction pool"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.2" }
 fuel-tx = { version = "0.9", features = ["serde-types"] }
 fuel-types = { version = "0.3", features = ["serde-types"] }
 futures = "0.3"
@@ -23,6 +23,6 @@ thiserror = "1.0"
 tokio = { version = "1.14", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.1", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.2", features = [
     "test_helpers",
 ] }


### PR DESCRIPTION
includes fix to url parsing for fuel-client, and chainspec deployment updates for fuel-core