### PR TITLE
Fix contract output cleanup in txpool dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,6 +1593,7 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "fuel-core",
+ "fuel-crypto",
  "fuel-gql-client",
  "fuel-storage",
  "fuel-tx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/fuel-core/src/service.rs
+++ b/fuel-core/src/service.rs
@@ -5,8 +5,10 @@ use crate::tx_pool::TxPool;
 use fuel_storage::{MerkleStorage, Storage};
 use fuel_tx::UtxoId;
 use fuel_types::{AssetId, Bytes32, ContractId, Salt, Word};
+use fuel_vm::consts::WORD_SIZE;
 use fuel_vm::prelude::Contract;
 pub use graph_api::start_server;
+use itertools::Itertools;
 #[cfg(feature = "rocksdb")]
 use std::io::ErrorKind;
 use std::{
@@ -140,15 +142,24 @@ impl FuelService {
     /// initialize coins
     fn init_coin_state(db: &mut Database, state: &StateConfig) -> Result<(), std::io::Error> {
         // TODO: Store merkle sum tree root over coins with unspecified utxo ids.
-        let mut generated_output_index = 0;
+        let mut generated_output_index: u64 = 0;
         if let Some(coins) = &state.coins {
             for coin in coins {
                 let utxo_id = UtxoId::new(
-                    coin.tx_id.unwrap_or_default(),
-                    // TODO: come up with utxo id scheme if there are > 255 coins with default tx id
+                    // generated transaction id([0..[out_index/255]])
+                    coin.tx_id.unwrap_or_else(|| {
+                        Bytes32::try_from(
+                            (0..(Bytes32::LEN - WORD_SIZE))
+                                .map(|_| 0u8)
+                                .chain((generated_output_index / 255).to_be_bytes().into_iter())
+                                .collect_vec()
+                                .as_slice(),
+                        )
+                        .expect("Incorrect genesis transaction id byte length")
+                    }),
                     coin.output_index.map(|i| i as u8).unwrap_or_else(|| {
                         generated_output_index += 1;
-                        generated_output_index
+                        (generated_output_index % 255) as u8
                     }),
                 );
 
@@ -186,8 +197,22 @@ impl FuelService {
                 let _ = Storage::<ContractId, UtxoId>::insert(
                     db,
                     &contract_id,
-                    // TODO: come up with utxo id scheme if there are > 255 genesis contracts
-                    &UtxoId::new(Default::default(), generated_output_index as u8),
+                    &UtxoId::new(
+                        // generated transaction id([0..[out_index/255]])
+                        Bytes32::try_from(
+                            (0..(Bytes32::LEN - WORD_SIZE))
+                                .map(|_| 0u8)
+                                .chain(
+                                    (generated_output_index as u64 / 255)
+                                        .to_be_bytes()
+                                        .into_iter(),
+                                )
+                                .collect_vec()
+                                .as_slice(),
+                        )
+                        .expect("Incorrect genesis transaction id byte length"),
+                        generated_output_index as u8,
+                    ),
                 )?;
                 Self::init_contract_state(db, &contract_id, contract_config)?;
                 Self::init_contract_balance(db, &contract_id, contract_config)?;

--- a/fuel-core/src/service.rs
+++ b/fuel-core/src/service.rs
@@ -169,6 +169,7 @@ impl FuelService {
     fn init_contracts(db: &mut Database, state: &StateConfig) -> Result<(), std::io::Error> {
         // initialize contract state
         if let Some(contracts) = &state.contracts {
+            let mut generated_output_index = 0;
             for contract_config in contracts {
                 let contract = Contract::from(contract_config.code.as_slice());
                 let salt = contract_config.salt;
@@ -182,6 +183,12 @@ impl FuelService {
                     &contract_id,
                     &(salt, root),
                 )?;
+                let _ = Storage::<ContractId, UtxoId>::insert(
+                    db,
+                    &contract_id,
+                    &UtxoId::new(Default::default(), generated_output_index),
+                )?;
+                generated_output_index += 1;
                 Self::init_contract_state(db, &contract_id, contract_config)?;
                 Self::init_contract_balance(db, &contract_id, contract_config)?;
             }

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -19,9 +19,10 @@ harness = true
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 fuel-core = { path = "../fuel-core", features = ["test-helpers"], default-features = false }
+fuel-crypto = { version = "0.4", features = ["random"] }
 fuel-gql-client = { path = "../fuel-client", features = ["test-helpers"] }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.9", features = ["serde-types"] }
+fuel-tx = { version = "0.9", features = ["serde-types", "builder", "internals"] }
 fuel-types = { version = "0.3", features = ["serde-types"] }
 fuel-vm = { version = "0.8", features = ["serde-types", "random","test-helpers"] }
 insta = "1.8"

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -143,34 +143,37 @@ async fn submit_utxo_verified_tx() {
         .into_iter()
         .map(|i| {
             let secret = SecretKey::random(&mut rng);
-            TransactionBuilder::script(vec![Opcode::RET(REG_ONE)].iter().copied().collect(), vec![])
-                .gas_limit(100)
-                .add_unsigned_coin_input(
-                    rng.gen(),
-                    &secret,
-                    100 + i,
-                    Default::default(),
-                    0,
-                    vec![],
-                    vec![],
-                )
-                .add_input(Input::Contract {
-                    utxo_id: Default::default(),
-                    balance_root: Default::default(),
-                    state_root: Default::default(),
-                    contract_id: contract_id.clone(),
-                })
-                .add_output(Output::Change {
-                    amount: 0,
-                    asset_id: Default::default(),
-                    to: rng.gen(),
-                })
-                .add_output(Output::Contract {
-                    input_index: 1,
-                    balance_root: Default::default(),
-                    state_root: Default::default(),
-                })
-                .finalize()
+            TransactionBuilder::script(
+                Opcode::RET(REG_ONE).to_bytes().into_iter().collect(),
+                vec![],
+            )
+            .gas_limit(100)
+            .add_unsigned_coin_input(
+                rng.gen(),
+                &secret,
+                100 + i,
+                Default::default(),
+                0,
+                vec![],
+                vec![],
+            )
+            .add_input(Input::Contract {
+                utxo_id: Default::default(),
+                balance_root: Default::default(),
+                state_root: Default::default(),
+                contract_id,
+            })
+            .add_output(Output::Change {
+                amount: 0,
+                asset_id: Default::default(),
+                to: rng.gen(),
+            })
+            .add_output(Output::Contract {
+                input_index: 1,
+                balance_root: Default::default(),
+                state_root: Default::default(),
+            })
+            .finalize()
         })
         .collect_vec();
 

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use fuel_core::chain_config::{ChainConfig, CoinConfig, ContractConfig, StateConfig};
 use fuel_core::executor::ExecutionMode;
 use fuel_core::model::{FuelBlock, FuelBlockHeader};
 use fuel_core::{
@@ -6,9 +7,10 @@ use fuel_core::{
     executor::Executor,
     service::{Config, FuelService},
 };
+use fuel_crypto::SecretKey;
 use fuel_gql_client::client::types::TransactionStatus;
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
-use fuel_vm::util::test_helpers::TestBuilder as TxBuilder;
+use fuel_tx::TransactionBuilder;
 use fuel_vm::{consts::*, prelude::*};
 use itertools::Itertools;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -124,18 +126,102 @@ async fn submit() {
 
 #[tokio::test]
 async fn submit_utxo_verified_tx() {
+    let mut rng = StdRng::seed_from_u64(2322);
+
+    let test_contract_code = vec![];
+    let test_contract = Contract::from(test_contract_code.clone());
+    let root = test_contract.root();
+    let test_contract_salt: Salt = rng.gen();
+    let contract_id = test_contract.id(
+        &test_contract_salt.clone(),
+        &root,
+        &Contract::default_state_root(),
+    );
+
+    // initialize transactions
+    let transactions = (1..10 + 1)
+        .into_iter()
+        .map(|i| {
+            let secret = SecretKey::random(&mut rng);
+            TransactionBuilder::script(vec![Opcode::RET(REG_ONE)].iter().copied().collect(), vec![])
+                .gas_limit(100)
+                .add_unsigned_coin_input(
+                    rng.gen(),
+                    &secret,
+                    100 + i,
+                    Default::default(),
+                    0,
+                    vec![],
+                    vec![],
+                )
+                .add_input(Input::Contract {
+                    utxo_id: Default::default(),
+                    balance_root: Default::default(),
+                    state_root: Default::default(),
+                    contract_id: contract_id.clone(),
+                })
+                .add_output(Output::Change {
+                    amount: 0,
+                    asset_id: Default::default(),
+                    to: rng.gen(),
+                })
+                .add_output(Output::Contract {
+                    input_index: 1,
+                    balance_root: Default::default(),
+                    state_root: Default::default(),
+                })
+                .finalize()
+        })
+        .collect_vec();
+
+    // setup genesis block with coins that transactions can spend
+    let genesis_coins = transactions
+        .iter()
+        .flat_map(|t| t.inputs())
+        .filter_map(|input| {
+            if let Input::Coin {
+                amount,
+                owner,
+                asset_id,
+                utxo_id,
+                ..
+            } = input
+            {
+                Some(CoinConfig {
+                    tx_id: Some(*utxo_id.tx_id()),
+                    output_index: Some(utxo_id.output_index() as u64),
+                    block_created: None,
+                    maturity: None,
+                    owner: *owner,
+                    amount: *amount,
+                    asset_id: *asset_id,
+                })
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+
     let config = Config {
         utxo_validation: true,
+        chain_conf: ChainConfig {
+            initial_state: Some(StateConfig {
+                coins: Some(genesis_coins),
+                contracts: Some(vec![ContractConfig {
+                    code: test_contract_code,
+                    salt: test_contract_salt,
+                    state: None,
+                    balances: None,
+                }]),
+                ..StateConfig::default()
+            }),
+            ..ChainConfig::local_testnet()
+        },
         ..Config::local_node()
     };
 
     let srv = FuelService::new_node(config).await.unwrap();
     let client = FuelClient::from(srv.bound_address);
-
-    let transactions = (1..10 + 1)
-        .into_iter()
-        .map(|i| TxBuilder::new(2322u64).gas_limit(i * 1000).build())
-        .collect_vec();
 
     for tx in transactions {
         let id = client.submit(&tx).await.unwrap();

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3"
 parking_lot = "0.11"
 thiserror = "1.0"
 tokio = { version = "1.14", default-features = false, features = ["sync"] }
+tracing = "0.1"
 
 [dev-dependencies]
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.2", features = [

--- a/fuel-txpool/src/containers/dependency.rs
+++ b/fuel-txpool/src/containers/dependency.rs
@@ -473,7 +473,7 @@ impl Dependency {
                 }
                 Output::ContractCreated { contract_id, .. } => {
                     // remove any other pending txs that depend on our yet to be created contract
-                    if let Some(contract) = self.contracts.remove(&contract_id) {
+                    if let Some(contract) = self.contracts.remove(contract_id) {
                         for spend_by in contract
                             .used_by
                             .into_iter()

--- a/fuel-txpool/src/containers/dependency.rs
+++ b/fuel-txpool/src/containers/dependency.rs
@@ -6,6 +6,7 @@ use fuel_core_interfaces::{
 };
 use fuel_tx::{Input, Output, UtxoId};
 use std::collections::{HashMap, HashSet};
+use tracing::warn;
 
 /// Check and hold dependency between inputs and outputs. Be mindful
 /// about depth of connection
@@ -50,7 +51,7 @@ impl Dependency {
 
     /// find all dependent Transactions that are inside txpool.
     /// Does not check db. They can be sorted by gasPrice to get order of dependency
-    pub fn find_dependent(
+    pub(crate) fn find_dependent(
         &self,
         tx: ArcTx,
         seen: &mut HashMap<TxId, ArcTx>,
@@ -246,6 +247,8 @@ impl Dependency {
                                 .expect("Tx should be always present in txpool");
                             // compare if tx has better price
                             if txpool_tx.gas_price() > tx.gas_price() {
+                                // TODO: should we consider the value of all dependant txs to avoid
+                                //       large graphs being cancellable by single tx with a slightly higher gas price?
                                 return Err(Error::NotInsertedCollision(*spend_by, *utxo_id).into());
                             } else {
                                 if state.depth == 0 {
@@ -341,8 +344,8 @@ impl Dependency {
                     }
                     // if we are prices more, mark current contract origin for removal.
                     let origin = contract.origin.expect(
-                            "Only contract without origin are the ones that are inside DB. And we check depth for that, so we are okay to just unwrap
-                        ");
+                        "Only contract without origin are the ones that are inside DB. And we check depth for that, so we are okay to just unwrap"
+                        );
                     collided.push(*origin.tx_id());
                 }
             }
@@ -351,9 +354,10 @@ impl Dependency {
 
         Ok((max_depth, db_coins, db_contracts, collided))
     }
+
     /// insert tx inside dependency
     /// return list of transactions that are removed from txpool
-    pub async fn insert<'a>(
+    pub(crate) async fn insert<'a>(
         &'a mut self,
         txs: &'a HashMap<TxId, TxInfo>,
         db: &dyn TxPoolDb,
@@ -435,75 +439,72 @@ impl Dependency {
         Ok(removed_tx)
     }
 
-    pub fn recursively_remove_all_dependencies<'a>(
+    /// Remove all pending txs that depend on the outputs of the provided tx
+    pub(crate) fn recursively_remove_all_dependencies<'a>(
         &'a mut self,
         txs: &'a HashMap<TxId, TxInfo>,
         tx: ArcTx,
     ) -> Vec<ArcTx> {
-        let mut removed_tx = vec![tx.clone()];
+        let mut removed_transactions = vec![tx.clone()];
+        let id = tx.id();
 
-        // for all outputs recursivly call removal
+        // recursively remove all transactions dependant on the outputs of the current tx
         for (index, output) in tx.outputs().iter().enumerate() {
-            // get contract_id or none if it is coin
-            let is_contract = match output {
-                Output::Coin { .. }
-                | Output::Withdrawal { .. }
-                | Output::Change { .. }
-                | Output::Variable { .. } => None,
-                Output::Contract { input_index, .. } => {
-                    if let Input::Contract { contract_id, .. } = tx.inputs()[*input_index as usize]
-                    {
-                        Some(contract_id)
+            match output {
+                Output::Withdrawal { .. } | Output::Contract { .. } => {
+                    // no other transactions can depend on these types of outputs
+                }
+                Output::Coin { .. } | Output::Change { .. } | Output::Variable { .. } => {
+                    // remove transactions that depend on this coin output
+                    let utxo = UtxoId::new(tx.id(), index as u8);
+                    if let Some(state) = self.coins.remove(&utxo).map(|c| c.is_spend_by) {
+                        // there may or may not be any dependents for this coin output
+                        if let Some(spend_by) = state {
+                            let rem_tx = txs.get(&spend_by).expect("Tx should be present in txs");
+                            removed_transactions.extend(
+                                self.recursively_remove_all_dependencies(txs, rem_tx.tx().clone()),
+                            );
+                        }
                     } else {
-                        panic!("InputIndex for contract should be always correct");
+                        // this shouldn't happen since the output belongs to this unique transaction,
+                        // no other resources should remove this coin state except this transaction.
+                        warn!("expected a coin state to be associated with {:?}", &utxo);
                     }
                 }
-                Output::ContractCreated { contract_id, .. } => Some(*contract_id),
+                Output::ContractCreated { contract_id, .. } => {
+                    // remove any other pending txs that depend on our yet to be created contract
+                    if let Some(contract) = self.contracts.remove(&contract_id) {
+                        for spend_by in contract
+                            .used_by
+                            .into_iter()
+                            // skip the current tx
+                            .filter(|used_by| used_by != &id)
+                        {
+                            let rem_tx = txs.get(&spend_by).expect("Tx should be present in txs");
+                            removed_transactions.extend(
+                                self.recursively_remove_all_dependencies(txs, rem_tx.tx().clone()),
+                            );
+                        }
+                    }
+                }
             };
-            // remove contract childrens.
-            if let Some(ref contract_id) = is_contract {
-                let state = self.contracts.get(contract_id).cloned();
-                if let Some(state) = state {
-                    // call removal on every tx;
-                    for rem_tx in state.used_by.iter() {
-                        let rem_tx = txs.get(rem_tx).expect("Tx should be present in txs");
-                        removed_tx.extend(
-                            self.recursively_remove_all_dependencies(txs, rem_tx.tx().clone()),
-                        );
-                    }
-                } else {
-                    panic!("Contract state should be present when removing child");
-                }
-                // remove it from dependency
-                self.contracts.remove(contract_id);
-            } else {
-                // remove user of this coin.
-                let utxo = UtxoId::new(tx.id(), index as u8);
-                // call childrens.
-                if let Some(spend_by) = self
-                    .coins
-                    .get(&utxo)
-                    .expect("Coin should be present when removing child")
-                    .is_spend_by
-                {
-                    let rem_tx = txs.get(&spend_by).expect("Tx should be present in txs");
-                    removed_tx
-                        .extend(self.recursively_remove_all_dependencies(txs, rem_tx.tx().clone()));
-                }
-                // remove it from dependency
-                self.coins.remove(&utxo);
-            }
         }
 
-        // set all inputs as unspend.
+        // remove this transaction as a dependency of its' inputs.
         for input in tx.inputs() {
             match input {
                 Input::Coin { utxo_id, .. } => {
+                    // Input coin cases
+                    // 1. coin state was already removed if parent tx was also removed, no cleanup required.
+                    // 2. coin state spent_by needs to be freed from this tx if parent tx isn't being removed
+                    // 3. coin state can be removed if this is a database coin, as no other txs are involved.
                     let mut rem_coin = false;
-                    {
-                        let state = self.coins.get_mut(utxo_id).expect("Coin should be present");
-                        state.is_spend_by = None;
-                        if state.depth == 0 {
+                    if let Some(state) = self.coins.get_mut(utxo_id) {
+                        if state.depth != 0 {
+                            // case 2
+                            state.is_spend_by = None;
+                        } else {
+                            // case 3
                             rem_coin = true;
                         }
                     }
@@ -512,15 +513,15 @@ impl Dependency {
                     }
                 }
                 Input::Contract { contract_id, .. } => {
-                    // remove from contract
+                    // Input contract cases
+                    // 1. contract state no longer exists because the parent tx that created the
+                    //    contract was already removed from the graph
+                    // 2. contract state exists and this tx needs to be removed as a user of it.
+                    // 2.a. contract state can be removed if this is the last tx to use it.
                     let mut rem_contract = false;
-                    {
-                        let state = self
-                            .contracts
-                            .get_mut(contract_id)
-                            .expect("Contract should be present");
+                    if let Some(state) = self.contracts.get_mut(contract_id) {
                         state.used_by.remove(&tx.id());
-                        // if contract list is empty, remove contract from dependency.
+                        // if contract list is empty, flag contract state for removal.
                         if state.used_by.is_empty() {
                             rem_contract = true;
                         }
@@ -532,7 +533,7 @@ impl Dependency {
             }
         }
 
-        removed_tx
+        removed_transactions
     }
 }
 


### PR DESCRIPTION
When removing a transaction from the txpool that had a contract output, it was recursing on itself after it was already removed from the dependencies causing an unexpected failure. This fix makes it so that only contract created outputs will cause any sort of recursive cleanup, and ensures the tx can't recurse on itself. I've also replaced several panics with warns for now.