### PR TITLE
Configurable service vars

### DIFF
--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -8,9 +8,9 @@ app:
   httpport: 80
   httpsport: 443
   targetport: 4000
-  human_logging: false
-  utxo_validation: true
-  vm_backtrace: true
+  human_logging: ${fuel_core_human_logging}
+  utxo_validation: ${fuel_core_utxo_validation}
+  vm_backtrace: ${fuel_core_vm_backtrace}
   image:
     repository: ${fuel_core_image_repository}
     tag: ${fuel_core_image_tag}

--- a/deployment/overlay/example/kustomization.yaml
+++ b/deployment/overlay/example/kustomization.yaml
@@ -1,8 +1,0 @@
-bases:
-- ../../base
-namePrefix: example-
-images:
-- name: fuel-core
-  # change the path to the image
-  newName: fuel-core
-  

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -9,6 +9,9 @@ fuel_core_pod_replicas="1"
 pvc_storage_class="gp2"
 pvc_storage_requests="3Gi"
 chain_spec_file="../test_chainspec.json"
+fuel_core_human_logging=false
+fuel_core_utxo_validation=true
+fuel_core_vm_backtrace=false
 
 # Ingress Environment variables
 letsencrypt_email="helloworld@gmail.com"


### PR DESCRIPTION
The following parameters were exposed but not fully adjustable on a per-env basis. This PR makes it so that the following vars can be configured and modified on a per deployment basis via .env files:

- human_logging
- utxo_validation
- vm_backtrace