### PR TITLE
ensure transactions have at least one coin input

### DIFF
--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -274,10 +274,10 @@ impl Executor {
     ///       https://github.com/FuelLabs/fuel-tx/issues/118 is resolved.
     fn verify_tx_has_at_least_one_coin(&self, tx: &Transaction) -> Result<(), Error> {
         if tx.inputs().iter().filter(|input| input.is_coin()).count() == 0 {
-            Err(TransactionValidityError::NoCoinInput(tx.id()))?;
+            Err(TransactionValidityError::NoCoinInput(tx.id()).into())
+        } else {
+            Ok(())
         }
-
-        Ok(())
     }
 
     /// Mark inputs as spent

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -613,6 +613,7 @@ impl From<crate::database::KvStoreError> for TransactionValidityError {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Transaction id was already used: {0:#x}")]
     TransactionIdCollision(Bytes32),


### PR DESCRIPTION
implements https://github.com/FuelLabs/fuel-tx/issues/118 in the validator node for now, while we wait for the fuel-tx rules to propagate.