### PR TITLE
Add ability to set minimum required gas / byte fees on transactions

### DIFF
--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -84,7 +84,7 @@ spec:
             - "{{ .Values.app.min_gas_price }}"
             - "--min-byte-price"
             - "{{ .Values.app.min_byte_price }}"
-            - "--min-gas-per_byte"
+            - "--max-gas-per-byte-price"
             - "{{ .Values.app.min_gas_per_byte }}"
           resources: {}
           imagePullPolicy: {{ .Values.app.image.pullPolicy }}

--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -84,8 +84,6 @@ spec:
             - "{{ .Values.app.min_gas_price }}"
             - "--min-byte-price"
             - "{{ .Values.app.min_byte_price }}"
-            - "--max-gas-per-byte-price"
-            - "{{ .Values.app.min_gas_per_byte }}"
           resources: {}
           imagePullPolicy: {{ .Values.app.image.pullPolicy }}
           ports:

--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -80,6 +80,12 @@ spec:
           {{- if .Values.app.vm_backtrace }}
             - "--vm-backtrace"
           {{- end}}
+            - "--min-gas-price"
+            - "{{ .Values.app.min_gas_price }}"
+            - "--min-byte-price"
+            - "{{ .Values.app.min_byte_price }}"
+            - "--min-gas-per_byte"
+            - "{{ .Values.app.min_gas_per_byte }}"
           resources: {}
           imagePullPolicy: {{ .Values.app.image.pullPolicy }}
           ports:

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -13,7 +13,6 @@ app:
   vm_backtrace: ${fuel_core_vm_backtrace}
   min_gas_price: ${fuel_core_min_gas_price}
   min_byte_price: ${fuel_core_min_byte_price}
-  max_gas_per_byte_price: ${fuel_core_max_gas_per_byte_price}
   image:
     repository: ${fuel_core_image_repository}
     tag: ${fuel_core_image_tag}

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -13,7 +13,7 @@ app:
   vm_backtrace: ${fuel_core_vm_backtrace}
   min_gas_price: ${fuel_core_min_gas_price}
   min_byte_price: ${fuel_core_min_byte_price}
-  min_gas_per_byte: ${fuel_core_min_gas_per_byte}
+  max_gas_per_byte_price: ${fuel_core_max_gas_per_byte_price}
   image:
     repository: ${fuel_core_image_repository}
     tag: ${fuel_core_image_tag}

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -11,6 +11,9 @@ app:
   human_logging: ${fuel_core_human_logging}
   utxo_validation: ${fuel_core_utxo_validation}
   vm_backtrace: ${fuel_core_vm_backtrace}
+  min_gas_price: ${fuel_core_min_gas_price}
+  min_byte_price: ${fuel_core_min_byte_price}
+  min_gas_per_byte: ${fuel_core_min_gas_per_byte}
   image:
     repository: ${fuel_core_image_repository}
     tag: ${fuel_core_image_tag}

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -12,6 +12,9 @@ chain_spec_file="../test_chainspec.json"
 fuel_core_human_logging=false
 fuel_core_utxo_validation=true
 fuel_core_vm_backtrace=false
+fuel_core_min_gas_price=0
+fuel_core_min_byte_price=0
+fuel_core_min_gas_per_byte=0
 
 # Ingress Environment variables
 letsencrypt_email="helloworld@gmail.com"

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -14,7 +14,7 @@ fuel_core_utxo_validation=true
 fuel_core_vm_backtrace=false
 fuel_core_min_gas_price=0
 fuel_core_min_byte_price=0
-fuel_core_min_gas_per_byte=0
+fuel_core_max_gas_per_byte_price=0
 
 # Ingress Environment variables
 letsencrypt_email="helloworld@gmail.com"

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -14,7 +14,6 @@ fuel_core_utxo_validation=true
 fuel_core_vm_backtrace=false
 fuel_core_min_gas_price=0
 fuel_core_min_byte_price=0
-fuel_core_max_gas_per_byte_price=0
 
 # Ingress Environment variables
 letsencrypt_email="helloworld@gmail.com"

--- a/fuel-core-interfaces/src/db.rs
+++ b/fuel-core-interfaces/src/db.rs
@@ -67,6 +67,8 @@ pub mod helpers {
     use lazy_static::lazy_static;
 
     // constants
+    pub const TX1_GAS_PRICE: u64 = 10u64;
+    pub const TX1_BYTE_PRICE: u64 = 5u64;
     lazy_static! {
         pub static ref TX_ID_DB1: TxId =
             TxId::from_str("0x0000000000000000000000000000000000000000000000000000000000000000")
@@ -146,9 +148,9 @@ pub mod helpers {
 
             let script = Opcode::RET(0x10).to_bytes().to_vec();
             let tx1 = Transaction::Script {
-                gas_price: 10,
+                gas_price: TX1_GAS_PRICE,
                 gas_limit: 1_000_000,
-                byte_price: 10,
+                byte_price: TX1_BYTE_PRICE,
                 maturity: 0,
                 receipts_root: Default::default(),
                 script,

--- a/fuel-core-interfaces/src/txpool.rs
+++ b/fuel-core-interfaces/src/txpool.rs
@@ -86,6 +86,7 @@ pub trait TxPool: Send + Sync {
 }
 
 #[derive(Error, Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Transaction is not inserted. Hash is already known")]
     NotInsertedTxKnown,
@@ -93,6 +94,10 @@ pub enum Error {
     NotInsertedLimitHit,
     #[error("TxPool required that transaction contains metadata")]
     NoMetadata,
+    #[error("Transaction is not inserted. The gas price is too low.")]
+    NotInsertedGasPriceTooLow,
+    #[error("Transaction is not inserted. The byte price is too low.")]
+    NotInsertedBytePriceTooLow,
     #[error(
         "Transaction is not inserted. More priced tx {0:?} already spend this UTXO output: {1:?}"
     )]

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -56,13 +56,6 @@ pub struct Opt {
     /// The minimum allowed byte price
     #[clap(long = "min-byte-price", default_value = "0")]
     pub min_byte_price: u64,
-    /// If non-zero, the tx pool will require the byte price to be
-    /// at least this fraction of the gas price, `byte_price >= gas_price / max_gas_per_byte`.
-    /// This protects against front-runners from manipulating priority using gas prices on
-    /// transactions that don't incur any execution costs, since the tx pool only
-    /// prioritizes gas prices.
-    #[clap(long = "max-gas-per-byte-price", default_value = "0")]
-    pub max_gas_per_byte_price: u64,
 }
 
 impl Opt {
@@ -111,7 +104,6 @@ impl Opt {
             utxo_validation,
             min_gas_price,
             min_byte_price,
-            max_gas_per_byte_price,
         } = self;
 
         let addr = net::SocketAddr::new(ip, port);
@@ -128,7 +120,6 @@ impl Opt {
             tx_pool_config: fuel_txpool::Config {
                 min_gas_price,
                 min_byte_price,
-                max_gas_per_byte_price,
                 ..Default::default()
             },
         })

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -51,17 +51,17 @@ pub struct Opt {
     pub utxo_validation: bool,
 
     /// The minimum allowed gas price
-    #[clap(long = "min-gas-price")]
+    #[clap(long = "min-gas-price", default_value = "0")]
     pub min_gas_price: u64,
     /// The minimum allowed byte price
-    #[clap(long = "min-byte-price")]
+    #[clap(long = "min-byte-price", default_value = "0")]
     pub min_byte_price: u64,
     /// If non-zero, the tx pool will require the byte price to be
     /// at least this fraction of the gas price, `byte_price >= gas_price / gas_per_byte`.
     /// This protects against front-runners attempting to manipulating a high gas price on
     /// transactions that don't incur any execution costs, since the tx pool only
     /// prioritizes gas prices.
-    #[clap(long = "min-gas-per-byte")]
+    #[clap(long = "min-gas-per-byte", default_value = "0")]
     pub min_gas_per_byte: u64,
 }
 

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -57,12 +57,12 @@ pub struct Opt {
     #[clap(long = "min-byte-price", default_value = "0")]
     pub min_byte_price: u64,
     /// If non-zero, the tx pool will require the byte price to be
-    /// at least this fraction of the gas price, `byte_price >= gas_price / gas_per_byte`.
+    /// at least this fraction of the gas price, `byte_price >= gas_price / max_gas_per_byte`.
     /// This protects against front-runners attempting to manipulating a high gas price on
     /// transactions that don't incur any execution costs, since the tx pool only
     /// prioritizes gas prices.
-    #[clap(long = "min-gas-per-byte", default_value = "0")]
-    pub min_gas_per_byte: u64,
+    #[clap(long = "max-gas-per-byte-price", default_value = "0")]
+    pub max_gas_per_byte_price: u64,
 }
 
 impl Opt {
@@ -111,7 +111,7 @@ impl Opt {
             utxo_validation,
             min_gas_price,
             min_byte_price,
-            min_gas_per_byte,
+            max_gas_per_byte_price,
         } = self;
 
         let addr = net::SocketAddr::new(ip, port);
@@ -128,7 +128,7 @@ impl Opt {
             tx_pool_config: fuel_txpool::Config {
                 min_gas_price,
                 min_byte_price,
-                min_gas_per_byte,
+                max_gas_per_byte_price,
                 ..Default::default()
             },
         })

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -58,7 +58,7 @@ pub struct Opt {
     pub min_byte_price: u64,
     /// If non-zero, the tx pool will require the byte price to be
     /// at least this fraction of the gas price, `byte_price >= gas_price / max_gas_per_byte`.
-    /// This protects against front-runners attempting to manipulating a high gas price on
+    /// This protects against front-runners from manipulating priority using gas prices on
     /// transactions that don't incur any execution costs, since the tx pool only
     /// prioritizes gas prices.
     #[clap(long = "max-gas-per-byte-price", default_value = "0")]

--- a/fuel-core/src/main.rs
+++ b/fuel-core/src/main.rs
@@ -1,15 +1,17 @@
 use clap::Parser;
 use fuel_core::service::FuelService;
 use std::io;
-use tracing::trace;
+use tracing::{info, trace};
 
 mod args;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    trace!("Initializing in TRACE mode.");
     // load configuration
     let config = args::Opt::parse().exec()?;
+    // log fuel-core version
+    info!("Fuel Core version v{}", env!("CARGO_PKG_VERSION"));
+    trace!("Initializing in TRACE mode.");
     // initialize the server
     let server = FuelService::new_node(config).await?;
     // pause the main task while service is running

--- a/fuel-core/src/service.rs
+++ b/fuel-core/src/service.rs
@@ -32,6 +32,7 @@ pub struct Config {
     // default to false until downstream consumers stabilize
     pub utxo_validation: bool,
     pub vm: VMConfig,
+    pub tx_pool_config: fuel_txpool::Config,
 }
 
 impl Config {
@@ -43,6 +44,7 @@ impl Config {
             chain_conf: ChainConfig::local_testnet(),
             vm: Default::default(),
             utxo_validation: false,
+            tx_pool_config: Default::default(),
         }
     }
 }

--- a/fuel-txpool/src/config.rs
+++ b/fuel-txpool/src/config.rs
@@ -1,9 +1,19 @@
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// Maximum number of transaction inside pool
+    /// Maximum number of transactions inside the pool
     pub max_tx: usize,
     /// max depth of connected UTXO excluding contracts
     pub max_depth: usize,
+    /// The minimum allowed gas price
+    pub min_gas_price: u64,
+    /// The minimum allowed byte price
+    pub min_byte_price: u64,
+    /// If non-zero, the tx pool will require the byte price to be
+    /// _at least_ this fraction of the gas price, `byte_price >= gas_price / gas_per_byte`.
+    /// This protects against front-runners attempting to manipulating a high gas price on
+    /// transactions that don't incur any execution costs, since the tx pool only
+    /// prioritizes gas prices.
+    pub min_gas_per_byte: u64,
 }
 
 impl Default for Config {
@@ -11,6 +21,9 @@ impl Default for Config {
         Self {
             max_tx: 4064,
             max_depth: 10,
+            min_gas_price: 0,
+            min_byte_price: 0,
+            min_gas_per_byte: 0,
         }
     }
 }

--- a/fuel-txpool/src/config.rs
+++ b/fuel-txpool/src/config.rs
@@ -9,11 +9,11 @@ pub struct Config {
     /// The minimum allowed byte price
     pub min_byte_price: u64,
     /// If non-zero, the tx pool will require the byte price to be
-    /// _at least_ this fraction of the gas price, `byte_price >= gas_price / gas_per_byte`.
+    /// _at least_ this fraction of the gas price, `byte_price >= gas_price / max_gas_per_byte`.
     /// This protects against front-runners attempting to manipulating a high gas price on
     /// transactions that don't incur any execution costs, since the tx pool only
     /// prioritizes gas prices.
-    pub min_gas_per_byte: u64,
+    pub max_gas_per_byte_price: u64,
 }
 
 impl Default for Config {
@@ -23,7 +23,7 @@ impl Default for Config {
             max_depth: 10,
             min_gas_price: 0,
             min_byte_price: 0,
-            min_gas_per_byte: 0,
+            max_gas_per_byte_price: 0,
         }
     }
 }

--- a/fuel-txpool/src/config.rs
+++ b/fuel-txpool/src/config.rs
@@ -10,7 +10,7 @@ pub struct Config {
     pub min_byte_price: u64,
     /// If non-zero, the tx pool will require the byte price to be
     /// _at least_ this fraction of the gas price, `byte_price >= gas_price / max_gas_per_byte`.
-    /// This protects against front-runners attempting to manipulating a high gas price on
+    /// This protects against front-runners from manipulating priority using gas prices on
     /// transactions that don't incur any execution costs, since the tx pool only
     /// prioritizes gas prices.
     pub max_gas_per_byte_price: u64,

--- a/fuel-txpool/src/config.rs
+++ b/fuel-txpool/src/config.rs
@@ -8,12 +8,6 @@ pub struct Config {
     pub min_gas_price: u64,
     /// The minimum allowed byte price
     pub min_byte_price: u64,
-    /// If non-zero, the tx pool will require the byte price to be
-    /// _at least_ this fraction of the gas price, `byte_price >= gas_price / max_gas_per_byte`.
-    /// This protects against front-runners from manipulating priority using gas prices on
-    /// transactions that don't incur any execution costs, since the tx pool only
-    /// prioritizes gas prices.
-    pub max_gas_per_byte_price: u64,
 }
 
 impl Default for Config {
@@ -23,7 +17,6 @@ impl Default for Config {
             max_depth: 10,
             min_gas_price: 0,
             min_byte_price: 0,
-            max_gas_per_byte_price: 0,
         }
     }
 }

--- a/fuel-txpool/src/service.rs
+++ b/fuel-txpool/src/service.rs
@@ -16,7 +16,7 @@ pub struct TxPoolService {
 }
 
 impl TxPoolService {
-    pub fn new(db: Box<dyn TxPoolDb>, config: Arc<Config>) -> Self {
+    pub fn new(db: Box<dyn TxPoolDb>, config: Config) -> Self {
         Self {
             txpool: RwLock::new(TxPoolImpl::new(config)),
             db,
@@ -136,7 +136,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_filter_by_negative() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = Box::new(DummyDB::filled());
 
         let tx1_hash = *TX_ID1;
@@ -158,7 +158,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_find() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = Box::new(DummyDB::filled());
 
         let tx1_hash = *TX_ID1;
@@ -183,7 +183,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn simple_insert_removal_subscription() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = Box::new(DummyDB::filled());
 
         struct Subs {

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -1,27 +1,30 @@
-use crate::containers::dependency::Dependency;
-use crate::Error;
-use crate::{containers::price_sort::PriceSort, types::*, Config};
-use fuel_core_interfaces::model::{ArcTx, TxInfo};
-use fuel_core_interfaces::txpool::TxPoolDb;
+use crate::{
+    containers::{dependency::Dependency, price_sort::PriceSort},
+    types::*,
+    Config, Error,
+};
+use fuel_core_interfaces::{
+    model::{ArcTx, TxInfo},
+    txpool::TxPoolDb,
+};
 use std::collections::HashMap;
-use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TxPool {
     by_hash: HashMap<TxId, TxInfo>,
     by_gas_price: PriceSort,
     by_dependency: Dependency,
-    config: Arc<Config>,
+    config: Config,
 }
 
 impl TxPool {
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Config) -> Self {
         let max_depth = config.max_depth;
         Self {
             by_hash: HashMap::new(),
             by_gas_price: PriceSort::default(),
-            config,
             by_dependency: Dependency::new(max_depth),
+            config,
         }
     }
     pub fn txs(&self) -> &HashMap<TxId, TxInfo> {
@@ -37,6 +40,13 @@ impl TxPool {
         if tx.metadata().is_none() {
             return Err(Error::NoMetadata.into());
         }
+
+        // verify gas price is at least the minimum
+        self.verify_tx_min_gas_price(&tx)?;
+        // verify byte price is at least the minimum
+        self.verify_tx_min_byte_price(&tx)?;
+        // verify the byte price is at least some configured multiple of the gas price
+        self.verify_tx_min_byte_price_ratio(&tx)?;
 
         if self.by_hash.contains_key(&tx.id()) {
             return Err(Error::NotInsertedTxKnown.into());
@@ -110,6 +120,30 @@ impl TxPool {
         }
         Vec::new()
     }
+
+    fn verify_tx_min_gas_price(&mut self, tx: &Transaction) -> Result<(), Error> {
+        if tx.gas_price() < self.config.min_gas_price {
+            return Err(Error::NotInsertedGasPriceTooLow);
+        }
+        Ok(())
+    }
+
+    fn verify_tx_min_byte_price(&mut self, tx: &Transaction) -> Result<(), Error> {
+        if tx.byte_price() < self.config.min_byte_price {
+            return Err(Error::NotInsertedBytePriceTooLow);
+        }
+        Ok(())
+    }
+
+    fn verify_tx_min_byte_price_ratio(&mut self, tx: &Transaction) -> Result<(), Error> {
+        if self.config.min_gas_per_byte > 0
+            && tx.byte_price() * self.config.min_gas_per_byte < tx.gas_price()
+        {
+            return Err(Error::NotInsertedBytePriceTooLow);
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -119,10 +153,11 @@ pub mod tests {
     use fuel_core_interfaces::{db::helpers::*, model::CoinStatus};
     use fuel_tx::UtxoId;
     use std::cmp::Reverse;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn simple_insertion() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -135,7 +170,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn simple_dependency_tx1_tx2() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -153,7 +188,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn faulty_t2_collided_on_contract_id_from_tx1() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -174,7 +209,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn fails_to_insert_tx2_with_missing_utxo_dependency_on_faulty_tx1() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_faulty_hash = *TX_ID_FAULTY1;
@@ -194,7 +229,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn not_inserted_known_tx() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1 = *TX_ID1;
@@ -214,7 +249,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn try_to_insert_tx2_missing_utxo() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx2_hash = *TX_ID2;
@@ -229,7 +264,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn tx1_try_to_use_spend_coin() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let mut db = DummyDB::filled();
 
         // mark utxo as spend
@@ -250,7 +285,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn more_priced_tx3_removes_tx1() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -272,7 +307,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn underpriced_tx1_not_included_coin_colision() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -292,7 +327,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn overpriced_tx5_contract_input_not_inserted() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -315,7 +350,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn dependent_tx5_contract_input_inserted() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -332,7 +367,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn more_priced_tx3_removes_tx1_and_dependent_tx2() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -358,10 +393,11 @@ pub mod tests {
 
     #[tokio::test]
     async fn tx_limit_hit() {
-        let config = Arc::new(Config {
+        let config = Config {
             max_tx: 1,
             max_depth: 10,
-        });
+            ..Default::default()
+        };
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -379,10 +415,11 @@ pub mod tests {
 
     #[tokio::test]
     async fn tx2_depth_hit() {
-        let config = Arc::new(Config {
+        let config = Config {
             max_tx: 10,
             max_depth: 1,
-        });
+            ..Default::default()
+        };
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -400,7 +437,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn sorted_out_tx1_2_4() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -428,7 +465,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn find_dependent_tx1_tx2() {
-        let config = Arc::new(Config::default());
+        let config = Config::default();
         let db = DummyDB::filled();
 
         let tx1_hash = *TX_ID1;
@@ -451,5 +488,118 @@ pub mod tests {
         assert_eq!(list.len(), 2, "We should have two items");
         assert_eq!(list[0].id(), tx1_hash, "Tx1 should be first.");
         assert_eq!(list[1].id(), tx2_hash, "Tx2 should be second.");
+    }
+
+    #[tokio::test]
+    async fn tx_at_least_min_gas_price_is_insertable() {
+        let config = Config {
+            min_gas_price: TX1_GAS_PRICE,
+            ..Config::default()
+        };
+        let db = DummyDB::filled();
+
+        let tx1_hash = *TX_ID1;
+        let tx1 = Arc::new(DummyDB::dummy_tx(tx1_hash));
+
+        let mut txpool = TxPool::new(config);
+
+        let out = txpool.insert(tx1, &db).await;
+        assert!(out.is_ok(), "Tx1 should be OK, get err:{:?}", out);
+    }
+
+    #[tokio::test]
+    async fn tx_below_min_gas_price_is_not_insertable() {
+        let config = Config {
+            min_gas_price: TX1_GAS_PRICE + 1,
+            ..Config::default()
+        };
+        let db = DummyDB::filled();
+
+        let tx1_hash = *TX_ID1;
+        let tx1 = Arc::new(DummyDB::dummy_tx(tx1_hash));
+
+        let mut txpool = TxPool::new(config);
+
+        let err = txpool.insert(tx1, &db).await.err().unwrap();
+        assert!(matches!(
+            err.root_cause().downcast_ref::<Error>().unwrap(),
+            Error::NotInsertedGasPriceTooLow
+        ));
+    }
+
+    #[tokio::test]
+    async fn tx_above_min_byte_price_is_insertable() {
+        let config = Config {
+            min_byte_price: TX1_BYTE_PRICE,
+            ..Config::default()
+        };
+        let db = DummyDB::filled();
+
+        let tx1_hash = *TX_ID1;
+        let tx1 = Arc::new(DummyDB::dummy_tx(tx1_hash));
+
+        let mut txpool = TxPool::new(config);
+
+        let out = txpool.insert(tx1, &db).await;
+        assert!(out.is_ok(), "Tx1 should be OK, get err:{:?}", out);
+    }
+
+    #[tokio::test]
+    async fn tx_below_min_byte_price_is_not_insertable() {
+        let config = Config {
+            min_byte_price: TX1_BYTE_PRICE + 1,
+            ..Config::default()
+        };
+        let db = DummyDB::filled();
+
+        let tx1_hash = *TX_ID1;
+        let tx1 = Arc::new(DummyDB::dummy_tx(tx1_hash));
+
+        let mut txpool = TxPool::new(config);
+
+        let err = txpool.insert(tx1, &db).await.err().unwrap();
+        assert!(matches!(
+            err.root_cause().downcast_ref::<Error>().unwrap(),
+            Error::NotInsertedBytePriceTooLow
+        ));
+    }
+
+    #[tokio::test]
+    async fn tx_byte_price_above_min_gas_per_byte_ratio_is_insertable() {
+        let config = Config {
+            min_gas_per_byte: 2,
+            ..Config::default()
+        };
+        let db = DummyDB::filled();
+
+        let tx1_hash = *TX_ID1;
+        let tx1 = Arc::new(DummyDB::dummy_tx(tx1_hash));
+
+        let mut txpool = TxPool::new(config);
+
+        let out = txpool.insert(tx1, &db).await;
+        assert!(out.is_ok(), "Tx1 should be OK, get err:{:?}", out);
+    }
+
+    #[tokio::test]
+    async fn tx_byte_price_below_min_gas_per_byte_ratio_is_not_insertable() {
+        // require byte_price >= gas_price
+        // since tx1 byte_price is 5, and gas_price is 10, this will return a BytePriceTooLow error
+        let config = Config {
+            min_gas_per_byte: 1,
+            ..Config::default()
+        };
+        let db = DummyDB::filled();
+
+        let tx1_hash = *TX_ID1;
+        let tx1 = Arc::new(DummyDB::dummy_tx(tx1_hash));
+
+        let mut txpool = TxPool::new(config);
+
+        let err = txpool.insert(tx1, &db).await.err().unwrap();
+        assert!(matches!(
+            err.root_cause().downcast_ref::<Error>().unwrap(),
+            Error::NotInsertedBytePriceTooLow
+        ));
     }
 }

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -136,8 +136,8 @@ impl TxPool {
     }
 
     fn verify_tx_min_byte_price_ratio(&mut self, tx: &Transaction) -> Result<(), Error> {
-        if self.config.min_gas_per_byte > 0
-            && tx.byte_price() * self.config.min_gas_per_byte < tx.gas_price()
+        if self.config.max_gas_per_byte_price > 0
+            && tx.byte_price() * self.config.max_gas_per_byte_price < tx.gas_price()
         {
             return Err(Error::NotInsertedBytePriceTooLow);
         }
@@ -565,9 +565,9 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn tx_byte_price_above_min_gas_per_byte_ratio_is_insertable() {
+    async fn tx_byte_price_above_max_gas_per_byte_ratio_is_insertable() {
         let config = Config {
-            min_gas_per_byte: 2,
+            max_gas_per_byte_price: 2,
             ..Config::default()
         };
         let db = DummyDB::filled();
@@ -582,11 +582,11 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn tx_byte_price_below_min_gas_per_byte_ratio_is_not_insertable() {
+    async fn tx_byte_price_below_max_gas_per_byte_ratio_is_not_insertable() {
         // require byte_price >= gas_price
         // since tx1 byte_price is 5, and gas_price is 10, this will return a BytePriceTooLow error
         let config = Config {
-            min_gas_per_byte: 1,
+            max_gas_per_byte_price: 1,
             ..Config::default()
         };
         let db = DummyDB::filled();


### PR DESCRIPTION
Adds the following transaction pool configuration parameters to fuel-core:

- minimum gas price
- minimum byte price

```rust
/// The minimum allowed gas price
pub min_gas_price: u64,

/// The minimum allowed byte price
pub min_byte_price: u64,
```

These are enforced in the transaction pool rather than the consensus rules, since fee market management isn't the job of consensus. 

It also does some miscellaneous cleanup of unneeded Arcs.