### PR TITLE
Misc Deployment Enhancements

### DIFF
--- a/deployment/scripts/create-k8s.sh
+++ b/deployment/scripts/create-k8s.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit # abort on nonzero exitstatus
+set -o nounset # abort on unbound variable
+
 echo "This script is to create a new or update existing k8s cluster ...."
 
 set -o allexport && source .env && set +o allexport 

--- a/deployment/scripts/delete-k8s.sh
+++ b/deployment/scripts/delete-k8s.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit # abort on nonzero exitstatus
+set -o nounset # abort on unbound variable
+
 echo "This script is to delete existing k8s cluster"
 
 set -o allexport && source .env && set +o allexport 

--- a/deployment/scripts/fuel-core-delete.sh
+++ b/deployment/scripts/fuel-core-delete.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit # abort on nonzero exitstatus
+set -o nounset # abort on unbound variable
+
 set -o allexport && source .env && set +o allexport 
 
 if [ "${k8s_provider}" == "eks" ]; then

--- a/deployment/scripts/fuel-core-delete.sh
+++ b/deployment/scripts/fuel-core-delete.sh
@@ -9,7 +9,7 @@ if [ "${k8s_provider}" == "eks" ]; then
     echo "Updating your kube context locally ...."
     aws eks update-kubeconfig --name ${TF_VAR_eks_cluster_name}
     echo "Deleting fuel-core helm chart on ${TF_VAR_eks_cluster_name} ...."
-    helm delete fuel-core --namespace ${k8s_namespace}
+    helm delete fuel-core --namespace ${k8s_namespace} --wait
 else
    echo "You have inputted a non-supported kubernetes provider in your .env"
 fi

--- a/deployment/scripts/fuel-core-delete.sh
+++ b/deployment/scripts/fuel-core-delete.sh
@@ -9,7 +9,11 @@ if [ "${k8s_provider}" == "eks" ]; then
     echo "Updating your kube context locally ...."
     aws eks update-kubeconfig --name ${TF_VAR_eks_cluster_name}
     echo "Deleting fuel-core helm chart on ${TF_VAR_eks_cluster_name} ...."
-    helm delete fuel-core --namespace ${k8s_namespace} --wait
+    helm delete fuel-core \
+              --namespace ${k8s_namespace} \
+              --wait \
+              --timeout 8000s \
+              --debug
 else
    echo "You have inputted a non-supported kubernetes provider in your .env"
 fi

--- a/deployment/scripts/fuel-core-deploy.sh
+++ b/deployment/scripts/fuel-core-deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit # abort on nonzero exitstatus
+set -o nounset # abort on unbound variable
+
 set -o allexport && source .env && set +o allexport 
 
 if [ "${k8s_provider}" == "eks" ]; then

--- a/deployment/scripts/fuel-core-ingress-delete.sh
+++ b/deployment/scripts/fuel-core-ingress-delete.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit # abort on nonzero exitstatus
+set -o nounset # abort on unbound variable
+
 set -o allexport && source .env && set +o allexport 
 
 if [ "${k8s_provider}" == "eks" ]; then

--- a/deployment/scripts/fuel-core-ingress-deploy.sh
+++ b/deployment/scripts/fuel-core-ingress-deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit # abort on nonzero exitstatus
+set -o nounset # abort on unbound variable
+
 set -o allexport && source .env && set +o allexport 
 
 if [ "${k8s_provider}" == "eks" ]; then


### PR DESCRIPTION
- ensure deployment scripts won't silently continue after an error
- wait on all fuel-core resources to be deleted before continuing
  - I was running into issues when using "Flag to delete previous infrastructure on new deployments" because it was attempting to create the same PVC while the old one was still being deleted, leading to stalled pod deployments that never got assigned a volume.