### PR TITLE
Add Docker image building to standard CI flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     needs:
       - lint-toml-files
       - cargo-verifications
-      - publish
+      - publish-crates
 
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v1
+        with:
+          key: "${{ matrix.command }} ${{ matrix.args }}"
       - name: ${{ matrix.command }} ${{ matrix.args }}
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
           RUSTFLAGS: -D warnings
 
-  publish:
+  publish-crates:
     # Only do this job if publishing a release
     needs:
       - lint-toml-files
@@ -142,20 +142,28 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
-  build-publish-master-image:
+  publish-docker-image:
     needs:
       - lint-toml-files
       - cargo-verifications
-    if: github.ref == 'refs/heads/master'
+      - publish
+
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
+      # This is a way to make this job run after publish-crates even if it's skipped on master or pr branches
+      # https://stackoverflow.com/a/69252812/680811
+      - name: fail if any dependent jobs failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v2
-            
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -166,6 +174,7 @@ jobs:
             type=sha
             type=ref,event=branch
             type=ref,event=tag
+            type=semver,pattern={{raw}}
           flavor: |
             latest=${{ github.ref == 'refs/heads/master' }}
 
@@ -198,63 +207,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max  
-      
-      - name: Notify if Job Fails
-        uses: ravsamhq/notify-slack-action@v1
-        if: always()
-        with:
-          status: ${{ job.status }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          notification_title: '{workflow} has {status_message}'
-          message_format: '{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>'
-          footer: ''
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
-      
-  build-publish-release-image:
-    # Build & Publish Docker Image Per Fuel-Core Release
-    needs: publish
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-            
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            ghcr.io/fuellabs/fuel-core
-          tags: |
-            type=semver,pattern={{raw}}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      
-      - name: Log in to the ghcr.io registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-    
-      - name: Build and push the image to ghcr.io
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: deployment/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
           cache-to: type=gha,mode=max
-      
+
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v1
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
             args: --all-targets --all-features
           - command: test
             args: --all-targets --no-default-features
+    # disallow any job that takes longer than 30 minutes
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -46,6 +46,8 @@ test-helpers = ["fuel-core-interfaces/test_helpers"]
 # Example of customizing binaries in Cargo.toml.
 [[bin]]
 name = "testrun"
+# path needs to be specified (even though this is the default path) due
+# to a bug in cargo-chef https://github.com/LukeMathWalker/cargo-chef/issues/128
 path = "src/bin/testrun.rs"
 test = true
 bench = false

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -46,6 +46,7 @@ test-helpers = ["fuel-core-interfaces/test_helpers"]
 # Example of customizing binaries in Cargo.toml.
 [[bin]]
 name = "testrun"
+path = "src/bin/testrun.rs"
 test = true
 bench = false
 required-features = ["test-helpers"]


### PR DESCRIPTION
- Fixes a docker image building issue due to a [bug](https://github.com/LukeMathWalker/cargo-chef/issues/128) in cargo-chef that was triggered by the addition of the relayer
- Make docker image building a standard part of CI, so that these issues will be caught earlier. This will also open up the possibility of us having similar capabilities to GitLab [review apps](https://about.gitlab.com/blog/2016/11/22/introducing-review-apps/) from a feature branch of fuel-core (e.g. spin up a hosted env with predicates enabled)
- Also found a bug with the way our rust caching action was interacting with the new matrix style builds. The matrix commands need to be included in the cache key, otherwise the cache will be corrupted by other jobs using different feature flags. This drops our cached build times by 50% in some cases.
- Add timeout to cargo-verifications to prevent stalled jobs from running for hours.