### PR TITLE
Unique tls secrets for ingress

### DIFF
--- a/deployment/ingress/eks/fuel-core-ingress.yaml
+++ b/deployment/ingress/eks/fuel-core-ingress.yaml
@@ -24,4 +24,4 @@ spec:
   tls:
     - hosts:
         - ${fuel_core_ingress_dns}
-      secretName: letsencrypt-prod
+      secretName: ${fuel_core_ingress_secret}

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -19,6 +19,7 @@ fuel_core_min_byte_price=0
 letsencrypt_email="helloworld@gmail.com"
 fuel_core_ingress_dns="node.example.com"
 fuel_core_ingress_http_port="80"
+fuel_core_ingress_secret="node-example-com"
 
 # Monitoring Environment variables
 grafana_ingress_dns="monitoring.example.com"

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -18,8 +18,8 @@ fuel_core_min_byte_price=0
 # Ingress Environment variables
 letsencrypt_email="helloworld@gmail.com"
 fuel_core_ingress_dns="node.example.com"
-fuel_core_ingress_http_port="80"
 fuel_core_ingress_secret="node-example-com"
+fuel_core_ingress_http_port="80"
 
 # Monitoring Environment variables
 grafana_ingress_dns="monitoring.example.com"

--- a/deployment/scripts/fuel-core-ingress-delete.sh
+++ b/deployment/scripts/fuel-core-ingress-delete.sh
@@ -10,6 +10,9 @@ if [ "${k8s_provider}" == "eks" ]; then
     aws eks update-kubeconfig --name ${TF_VAR_eks_cluster_name}
     cd ../ingress/${k8s_provider}
     echo "Deleting fuel-core ingress on ${TF_VAR_eks_cluster_name} ...."
+    mv fuel-core-ingress.yaml fuel-core-ingress.template
+    envsubst < fuel-core-ingress.template > fuel-core-ingress.yaml
+    rm fuel-core-ingress.template
     kubectl delete -f fuel-core-ingress.yaml
 else
    echo "You have inputted a non-supported kubernetes provider in your .env"


### PR DESCRIPTION
I was having issue obtaining certs from the fuel-core ingress when deploying new environments. Making the secret unique to each ingress controller seems to fix this issue and allows the certs to be issued very quickly <1m.

also fixed the ingress deletion script as it wasn't working properly.