### PR TITLE
split p2p into separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,11 @@ jobs:
           - command: check
             args: --all-targets --all-features
           - command: test
-            args: --all-targets --all-features
+            args: --all-targets --all-features --workspace --exclude fuel-p2p
           - command: test
-            args: --all-targets --no-default-features
+            args: --all-targets --no-default-features --workspace --exclude fuel-p2p
+          - command: test
+            args: --all-targets --all-features -p fuel-p2p -- --test-threads=1
     # disallow any job that takes longer than 30 minutes
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
             args: --all-targets --all-features --workspace --exclude fuel-p2p
           - command: test
             args: --all-targets --no-default-features --workspace --exclude fuel-p2p
+          # Split p2p into its own job so that it can use a single threaded runner
           - command: test
             args: --all-targets --all-features -p fuel-p2p -- --test-threads=1
     # disallow any job that takes longer than 30 minutes


### PR DESCRIPTION
move p2p tests into a separate job with a single-threaded runner.

example pipeline here: https://github.com/FuelLabs/fuel-core/actions/runs/2315033407