### PR TITLE
fix: has next page

### DIFF
--- a/fuel-client/src/client/schema.rs
+++ b/fuel-client/src/client/schema.rs
@@ -175,6 +175,8 @@ impl<T: Into<String>> From<PaginationRequest<T>> for ConnectionArgs {
 pub struct PaginatedResult<T, C> {
     pub cursor: Option<C>,
     pub results: Vec<T>,
+    pub has_next_page: bool,
+    pub has_previous_page: bool,
 }
 
 #[derive(Error, Debug)]

--- a/fuel-client/src/client/schema/balance.rs
+++ b/fuel-client/src/client/schema/balance.rs
@@ -82,6 +82,8 @@ pub struct BalanceConnection {
 impl From<BalanceConnection> for PaginatedResult<Balance, String> {
     fn from(conn: BalanceConnection) -> Self {
         PaginatedResult {
+            has_next_page: conn.page_info.has_next_page,
+            has_previous_page: conn.page_info.has_previous_page,
             cursor: conn.page_info.end_cursor,
             results: conn
                 .edges

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -43,6 +43,8 @@ impl From<BlockConnection> for PaginatedResult<Block, String> {
     fn from(conn: BlockConnection) -> Self {
         PaginatedResult {
             cursor: conn.page_info.end_cursor,
+            has_next_page: conn.page_info.has_next_page,
+            has_previous_page: conn.page_info.has_previous_page,
             results: conn
                 .edges
                 .unwrap_or_default()

--- a/fuel-client/src/client/schema/coin.rs
+++ b/fuel-client/src/client/schema/coin.rs
@@ -90,6 +90,8 @@ impl From<CoinConnection> for PaginatedResult<Coin, String> {
     fn from(conn: CoinConnection) -> Self {
         PaginatedResult {
             cursor: conn.page_info.end_cursor,
+            has_next_page: conn.page_info.has_next_page,
+            has_previous_page: conn.page_info.has_previous_page,
             results: conn
                 .edges
                 .unwrap_or_default()

--- a/fuel-client/src/client/schema/tx.rs
+++ b/fuel-client/src/client/schema/tx.rs
@@ -56,6 +56,8 @@ impl TryFrom<TransactionConnection> for PaginatedResult<TransactionResponse, Str
 
         Ok(PaginatedResult {
             cursor: conn.page_info.end_cursor,
+            has_next_page: conn.page_info.has_next_page,
+            has_previous_page: conn.page_info.has_previous_page,
             results: results?,
         })
     }

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -258,6 +258,9 @@ async fn get_transactions() {
         .map(|tx| tx.transaction.id())
         .collect_vec();
     assert_eq!(transactions, &[tx1, tx2]);
+    // Check pagination state to query or not next/previous
+    assert_eq!(response.has_next_page, false);
+    assert_eq!(response.has_previous_page, true);
 
     let response = client.transactions(page_request_forwards).await.unwrap();
     let transactions = &response
@@ -266,6 +269,8 @@ async fn get_transactions() {
         .map(|tx| tx.transaction.id())
         .collect_vec();
     assert_eq!(transactions, &[tx4, tx5, tx6]);
+    assert_eq!(response.has_next_page, false);
+    assert_eq!(response.has_previous_page, true);
 }
 
 #[tokio::test]

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -259,8 +259,8 @@ async fn get_transactions() {
         .collect_vec();
     assert_eq!(transactions, &[tx1, tx2]);
     // Check pagination state to query or not next/previous
-    assert_eq!(response.has_next_page, false);
-    assert_eq!(response.has_previous_page, true);
+    assert!(!response.has_next_page);
+    assert!(response.has_previous_page);
 
     let response = client.transactions(page_request_forwards).await.unwrap();
     let transactions = &response
@@ -269,8 +269,8 @@ async fn get_transactions() {
         .map(|tx| tx.transaction.id())
         .collect_vec();
     assert_eq!(transactions, &[tx4, tx5, tx6]);
-    assert_eq!(response.has_next_page, false);
-    assert_eq!(response.has_previous_page, true);
+    assert!(!response.has_next_page);
+    assert!(response.has_previous_page);
 }
 
 #[tokio::test]

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -236,6 +236,16 @@ async fn get_transactions() {
         .map(|tx| tx.transaction.id())
         .collect_vec();
     assert_eq!(transactions, &[tx1, tx2, tx3]);
+    // Check pagination state for first page
+    assert!(response.has_next_page);
+    assert!(!response.has_previous_page);
+
+    // Query for second page 2 with last given cursor: [4,5]
+    let page_request_middle_page = PaginationRequest {
+        cursor: response.cursor.clone(),
+        results: 2,
+        direction: PageDirection::Forward,
+    };
 
     // Query backwards from last given cursor [3]: [1,2]
     let page_request_backwards = PaginationRequest {
@@ -251,6 +261,18 @@ async fn get_transactions() {
         direction: PageDirection::Forward,
     };
 
+    let response = client.transactions(page_request_middle_page).await.unwrap();
+    let transactions = &response
+        .results
+        .iter()
+        .map(|tx| tx.transaction.id())
+        .collect_vec();
+    assert_eq!(transactions, &[tx4, tx5]);
+    // Check pagination state for middle page
+    // it should have next and previous page
+    assert!(response.has_next_page);
+    assert!(response.has_previous_page);
+
     let response = client.transactions(page_request_backwards).await.unwrap();
     let transactions = &response
         .results
@@ -258,7 +280,7 @@ async fn get_transactions() {
         .map(|tx| tx.transaction.id())
         .collect_vec();
     assert_eq!(transactions, &[tx1, tx2]);
-    // Check pagination state to query or not next/previous
+    // Check pagination state for last page
     assert!(!response.has_next_page);
     assert!(response.has_previous_page);
 
@@ -269,6 +291,7 @@ async fn get_transactions() {
         .map(|tx| tx.transaction.id())
         .collect_vec();
     assert_eq!(transactions, &[tx4, tx5, tx6]);
+    // Check pagination state for last page
     assert!(!response.has_next_page);
     assert!(response.has_previous_page);
 }


### PR DESCRIPTION
This PR fixes an issue on `hasPreviousPage` and `hasNextPage`;

## Use case
To navigate from the first page to the last page, being the first page `the latest transactions`.

### Page 1
To do that we query transactions using;

`transactions(last: 5) {....`

###  Next -> Page 2
To go to the next page we use the `startCursor` returned from the previous query and pass it as a cursor;

`transactions(last: 5, before: "<startCursor>") {....`


### Previous -> Page 1
Now navigate to the previous page we use the `endCursor` returned from the previous query;

`transactions(first: 5, after: "<endCursor>") {....`

This returns `hasPreviousPage` and `hasNextPage` as `true`. But it should return `hasNextPage` as `false`. 


