### PR TITLE
prevent slack notifications from PR branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
       # https://stackoverflow.com/a/69252812/680811
       - name: fail if any dependent jobs failed
         if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
+        run: exit 0
 
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v1
-        if: always()
+        if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
         with:
           status: ${{ job.status }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The PR fixes two issues with docker image publish job error reporting:

- The job was marked as a failure due to `exit 1` when an upstream job failed. Instead it should just skip/exit early in this case `exit 0`.
- Docker image publishing used to only run on master branch or release tags, so the slack notification action always ran every publish. This is no longer valid now that we publish docker images on PRs as well. So the `if` syntax for docker image slack notification step was updated to select only on master branch or tag events.