### PR TITLE
Update fuel core to latest deps (fuel-tx 0.10, fuel-vm 0.9, fuel-crypto 0.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -525,6 +525,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -977,6 +986,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1977,10 +1995,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuel-asm"
-version = "0.4.0"
+name = "fuchsia-cprng"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad9b05ccc6a243e54e86880e0b2a328da580f5aed5d44ff569d42f1f5f72471"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "fuel-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee63d1f54705db47d3cfa15f48b320c04a98252226adff0a46a88a9fbb08c489"
 dependencies = [
  "fuel-types",
  "serde",
@@ -2059,12 +2083,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e0f5a52d0dc3ac1e3cb57ef85955d5e87225b95a6b4718e4c81ae0423609c9"
+checksum = "8af1477833b63cf956b71a63a67a7af0e7477bd2f774536556fe0338f909542e"
 dependencies = [
  "borrown",
  "fuel-types",
+ "lazy_static",
  "rand 0.8.5",
  "secp256k1",
  "serde",
@@ -2183,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c62513f723eeed70c806581d40d93856654e13bb9858dc8cb3fe4b49518be9"
+checksum = "8fedf61251332608a32115e0910611e35938e8b7cf056766fbead42bc787a68c"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -2214,20 +2239,19 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3c8b8c3248c201495fab4e8a570840ab14fc33e3da8353e2bdb6a42314f9bf"
+checksum = "0b253058fc10bdc066f22d33df764de72601558b61efd1769475b21311332a15"
 dependencies = [
  "rand 0.8.5",
  "serde",
- "serde-big-array",
 ]
 
 [[package]]
 name = "fuel-vm"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fc8370f862046b8c3e81a97be12f29581406eb4ed81dabf5df90b105312316"
+checksum = "62bfa4ac84af427a2840a2c48cd340858cd35b66f9b7e6ddb17bf2f96faa6b64"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -2825,7 +2849,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown",
 ]
 
@@ -3504,7 +3528,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -3536,7 +3560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -3765,7 +3789,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -3775,7 +3799,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -4324,6 +4348,25 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -4332,7 +4375,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -4344,6 +4387,16 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4368,6 +4421,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -4386,11 +4454,82 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4768,6 +4907,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
 dependencies = [
+ "rand 0.6.5",
  "secp256k1-sys",
 ]
 
@@ -4827,16 +4967,6 @@ checksum = "93abf9799c576f004252b2a05168d58527fb7c54de12e94b4d12fe3475ffad24"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b20e7752957bbe9661cff4e0bb04d183d0948cdab2ea58cdb9df36a61dfe62"
-dependencies = [
- "serde",
- "serde_derive",
 ]
 
 [[package]]

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -21,9 +21,9 @@ clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "0.14", features = ["surf"] }
 derive_more = { version = "0.99" }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.9", features = ["serde-types"] }
-fuel-types = { version = "0.3", features = ["serde-types"] }
-fuel-vm = { version = "0.8", features = ["serde-types"] }
+fuel-tx = { version = "0.10", features = ["serde"] }
+fuel-types = { version = "0.5", features = ["serde"] }
+fuel-vm = { version = "0.9", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
 itertools = "0.10"

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -313,6 +313,7 @@ type Transaction {
 	script: HexString
 	scriptData: HexString
 	bytecodeWitnessIndex: Int
+	bytecodeLength: U64
 	salt: Salt
 	staticContracts: [Contract!]
 	storageSlots: [HexString!]

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -1,6 +1,8 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
+assertion_line: 273
 expression: operation.query
+
 ---
 query Query($_0: TransactionId!) {
   transaction(id: $_0) {
@@ -135,6 +137,7 @@ query Query($_0: TransactionId!) {
     }
     storageSlots
     bytecodeWitnessIndex
+    bytecodeLength
   }
 }
 

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -69,6 +69,7 @@ pub struct Transaction {
     pub static_contracts: Option<Vec<ContractIdFragment>>,
     pub storage_slots: Option<Vec<HexString>>,
     pub bytecode_witness_index: Option<i32>,
+    pub bytecode_length: Option<U64>,
 }
 
 impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
@@ -111,6 +112,10 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
                 gas_limit: tx.gas_limit.into(),
                 byte_price: tx.byte_price.into(),
                 maturity: tx.maturity.into(),
+                bytecode_length: tx
+                    .bytecode_length
+                    .ok_or_else(|| ConversionError::MissingField("bytecode_length".to_string()))?
+                    .into(),
                 bytecode_witness_index: tx
                     .bytecode_witness_index
                     .ok_or_else(|| {

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -15,12 +15,12 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
 derive_more = { version = "0.99" }
-fuel-asm = "0.4"
-fuel-crypto = { version = "0.4", default-features = false }
+fuel-asm = "0.5"
+fuel-crypto = { version = "0.5", default-features = false }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.9", default-features = false }
-fuel-types = { version = "0.3", default-features = false }
-fuel-vm = { version = "0.8", default-features = false }
+fuel-tx = { version = "0.10", default-features = false }
+fuel-types = { version = "0.5", default-features = false }
+fuel-vm = { version = "0.9", default-features = false }
 futures = "0.3"
 lazy_static = "1.4"
 parking_lot = "0.12"
@@ -32,4 +32,4 @@ tokio = { version = "1.14", features = ["full"] }
 
 [features]
 test_helpers = []
-serde-types = ["serde", "fuel-tx/serde-types", "fuel-types/serde-types", "fuel-vm/serde-types"]
+serde = ["dep:serde", "fuel-tx/serde", "fuel-types/serde", "fuel-vm/serde"]

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -4,7 +4,7 @@ use fuel_crypto::Hasher;
 use fuel_tx::{Address, Bytes32, Transaction};
 
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FuelBlockHeader {
     /// Fuel block height.
     pub height: BlockHeight,
@@ -57,7 +57,7 @@ impl Default for FuelBlockHeader {
 
 /// The compact representation of a block used in the database
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FuelBlockDb {
     pub headers: FuelBlockHeader,
     pub transactions: Vec<Bytes32>,
@@ -71,7 +71,7 @@ impl FuelBlockDb {
 
 /// Fuel block with all transaction data included
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FuelBlock {
     pub header: FuelBlockHeader,
     pub transactions: Vec<Transaction>,

--- a/fuel-core-interfaces/src/model/block_height.rs
+++ b/fuel-core-interfaces/src/model/block_height.rs
@@ -4,7 +4,7 @@ use std::{
     convert::{TryFrom, TryInto},
 };
 
-#[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd, Add, Display, Into, From)]
 pub struct BlockHeight(u32);
 

--- a/fuel-core-interfaces/src/model/coin.rs
+++ b/fuel-core-interfaces/src/model/coin.rs
@@ -5,7 +5,7 @@ use async_graphql::Enum;
 use fuel_asm::Word;
 use fuel_tx::{Address, AssetId};
 
-#[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Coin {
     pub owner: Address,
@@ -16,7 +16,7 @@ pub struct Coin {
     pub block_created: BlockHeight,
 }
 
-#[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Copy, Clone, Eq, PartialOrd, PartialEq)]
 pub enum CoinStatus {
     Unspent,

--- a/fuel-core-interfaces/src/relayer.rs
+++ b/fuel-core-interfaces/src/relayer.rs
@@ -5,7 +5,7 @@ use fuel_storage::Storage;
 use fuel_types::{Address, AssetId, Bytes32, Word};
 use tokio::sync::oneshot;
 
-#[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub struct DepositCoin {
     pub owner: Address,

--- a/fuel-core-interfaces/src/txpool.rs
+++ b/fuel-core-interfaces/src/txpool.rs
@@ -99,25 +99,25 @@ pub enum Error {
     #[error("Transaction is not inserted. The byte price is too low.")]
     NotInsertedBytePriceTooLow,
     #[error(
-        "Transaction is not inserted. More priced tx {0:?} already spend this UTXO output: {1:?}"
+        "Transaction is not inserted. More priced tx {0:#x} already spend this UTXO output: {1:#x}"
     )]
     NotInsertedCollision(TxId, UtxoId),
     #[error(
-        "Transaction is not inserted. More priced tx has created contract with ContractId {0:?}"
+        "Transaction is not inserted. More priced tx has created contract with ContractId {0:#x}"
     )]
     NotInsertedCollisionContractId(ContractId),
-    #[error("Transaction is not inserted. Dependent UTXO output is not existing: {0:?}")]
+    #[error("Transaction is not inserted. Dependent UTXO output is not existing: {0:#x}")]
     NotInsertedOutputNotExisting(UtxoId),
-    #[error("Transaction is not inserted. UTXO input contract is not existing: {0:?}")]
+    #[error("Transaction is not inserted. UTXO input contract is not existing: {0:#x}")]
     NotInsertedInputContractNotExisting(ContractId),
-    #[error("Transaction is not inserted. ContractId is already taken {0:?}")]
+    #[error("Transaction is not inserted. ContractId is already taken {0:#x}")]
     NotInsertedContractIdAlreadyTaken(ContractId),
-    #[error("Transaction is not inserted. UTXO is not existing: {0:?}")]
+    #[error("Transaction is not inserted. UTXO is not existing: {0:#x}")]
     NotInsertedInputUtxoIdNotExisting(UtxoId),
-    #[error("Transaction is not inserted. UTXO is spent: {0:?}")]
+    #[error("Transaction is not inserted. UTXO is spent: {0:#x}")]
     NotInsertedInputUtxoIdSpent(UtxoId),
     #[error(
-        "Transaction is not inserted. UTXO requires Contract input {0:?} that is priced lower"
+        "Transaction is not inserted. UTXO requires Contract input {0:#x} that is priced lower"
     )]
     NotInsertedContractPricedLower(ContractId),
     #[error("Transaction is not inserted. Input output mismatch. Coin owner is different from expected input")]

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -35,17 +35,17 @@ clap = { version = "3.1", features = ["env", "derive"] }
 derive_more = { version = "0.99" }
 dirs = "3.0"
 env_logger = "0.9"
-fuel-asm = { version = "0.4", features = ["serde-types"] }
+fuel-asm = { version = "0.5", features = ["serde"] }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.4", features = [
-    "serde-types",
+    "serde",
 ] }
-fuel-crypto = { version = "0.4", features = ["random"] }
+fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-merkle = "0.1"
 fuel-storage = { version = "0.1" }
-fuel-tx = { version = "0.9", features = ["serde-types"] }
+fuel-tx = { version = "0.10", features = ["serde"] }
 fuel-txpool = { path = "../fuel-txpool", version = "0.6.4" }
-fuel-types = { version = "0.3", features = ["serde-types"] }
-fuel-vm = { version = "0.8", features = ["serde-types"] }
+fuel-types = { version = "0.5", features = ["serde"] }
+fuel-vm = { version = "0.9", features = ["serde"] }
 futures = "0.3"
 graphql-parser = "0.3.0"
 hex = { version = "0.4", features = ["serde"] }
@@ -73,13 +73,13 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-fuel-tx = { version = "0.9", features = [
-    "serde-types",
+fuel-tx = { version = "0.10", features = [
+    "serde",
     "builder",
     "internals",
 ] }
-fuel-vm = { version = "0.8", features = [
-    "serde-types",
+fuel-vm = { version = "0.9", features = [
+    "serde",
     "random",
     "test-helpers",
 ] }

--- a/fuel-core/src/schema/tx/types.rs
+++ b/fuel-core/src/schema/tx/types.rs
@@ -1,12 +1,14 @@
-use super::input::Input;
-use super::output::Output;
-use super::receipt::Receipt;
-use crate::model::FuelBlockDb;
-use crate::schema::contract::Contract;
-use crate::schema::scalars::{AssetId, Bytes32, HexString, Salt, TransactionId, U64};
-use crate::tx_pool::TransactionStatus as TxStatus;
-use crate::tx_pool::TxPool;
-use crate::{database::Database, schema::block::Block};
+use super::{input::Input, output::Output, receipt::Receipt};
+use crate::{
+    database::Database,
+    model::FuelBlockDb,
+    schema::{
+        block::Block,
+        contract::Contract,
+        scalars::{AssetId, Bytes32, HexString, Salt, TransactionId, U64},
+    },
+    tx_pool::{TransactionStatus as TxStatus, TxPool},
+};
 use async_graphql::{Context, Enum, Object, Union};
 use chrono::{DateTime, Utc};
 use fuel_core_interfaces::db::KvStoreError;
@@ -260,6 +262,15 @@ impl Transaction {
                 bytecode_witness_index,
                 ..
             } => Some(bytecode_witness_index),
+        }
+    }
+
+    async fn bytecode_length(&self) -> Option<U64> {
+        match self.0 {
+            fuel_tx::Transaction::Script { .. } => None,
+            fuel_tx::Transaction::Create {
+                bytecode_length, ..
+            } => Some(bytecode_length.into()),
         }
     }
 

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -20,8 +20,8 @@ ethers-providers = { git = "https://github.com/rakita/ethers-rs.git", branch = "
 ] }
 features = "0.10"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.6.4" }
-fuel-tx = { version = "0.9", features = ["serde-types"] }
-fuel-types = { version = "0.3", features = ["serde-types"] }
+fuel-tx = { version = "0.10", features = ["serde"] }
+fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
 lazy_static = "1.4"
 parking_lot = "0.12"
@@ -36,7 +36,7 @@ tracing-subscriber = "0.3.9"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.6.4", features = [
     "test_helpers",
 ] }
-fuel-types = { version = "0.3", features = ["serde-types", "random"] }
+fuel-types = { version = "0.5", features = ["serde", "random"] }
 rand = "0.8"
 tracing-subscriber = "0.3"
 

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -19,13 +19,13 @@ harness = true
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 fuel-core = { path = "../fuel-core", features = ["test-helpers"], default-features = false }
-fuel-crypto = { version = "0.4", features = ["random"] }
+fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-gql-client = { path = "../fuel-client", features = ["test-helpers"] }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.9", features = ["serde-types", "builder", "internals"] }
+fuel-tx = { version = "0.10", features = ["serde", "builder", "internals"] }
 fuel-txpool = { path = "../fuel-txpool" }
-fuel-types = { version = "0.3", features = ["serde-types"] }
-fuel-vm = { version = "0.8", features = ["serde-types", "random","test-helpers"] }
+fuel-types = { version = "0.5", features = ["serde"] }
+fuel-vm = { version = "0.9", features = ["serde", "random","test-helpers"] }
 insta = "1.8"
 itertools = "0.10"
 rand = "0.8"

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -15,8 +15,8 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.6.4" }
-fuel-tx = { version = "0.9", features = ["serde-types"] }
-fuel-types = { version = "0.3", features = ["serde-types"] }
+fuel-tx = { version = "0.10", features = ["serde"] }
+fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
 parking_lot = "0.11"
 thiserror = "1.0"

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -212,7 +212,7 @@ pub mod tests {
         assert!(out.is_ok(), "Tx1 should be OK, get err:{:?}", out);
         let out = txpool.insert(tx2, &db).await;
         assert!(out.is_err(), "Tx2 should be error");
-        assert_eq!(out.err().unwrap().to_string(),"Transaction is not inserted. UTXO is not existing: UtxoId { tx_id: 0x0000000000000000000000000000000000000000000000000000000000000010, output_index: 0 }");
+        assert_eq!(out.err().unwrap().to_string(),"Transaction is not inserted. UTXO is not existing: 0x000000000000000000000000000000000000000000000000000000000000001000");
     }
 
     #[tokio::test]
@@ -247,7 +247,7 @@ pub mod tests {
 
         let out = txpool.insert(tx2, &db).await;
         assert!(out.is_err(), "Tx2 should be error");
-        assert_eq!(out.err().unwrap().to_string(),"Transaction is not inserted. UTXO is not existing: UtxoId { tx_id: 0x0000000000000000000000000000000000000000000000000000000000000010, output_index: 0 }",);
+        assert_eq!(out.err().unwrap().to_string(),"Transaction is not inserted. UTXO is not existing: 0x000000000000000000000000000000000000000000000000000000000000001000",);
     }
 
     #[tokio::test]
@@ -270,7 +270,7 @@ pub mod tests {
 
         let out = txpool.insert(tx1, &db).await;
         assert!(out.is_err(), "Tx1 should be error");
-        assert_eq!(out.err().unwrap().to_string(),"Transaction is not inserted. UTXO is spent: UtxoId { tx_id: 0x0000000000000000000000000000000000000000000000000000000000000000, output_index: 0 }",);
+        assert_eq!(out.err().unwrap().to_string(),"Transaction is not inserted. UTXO is spent: 0x000000000000000000000000000000000000000000000000000000000000000000",);
     }
 
     #[tokio::test]
@@ -312,7 +312,7 @@ pub mod tests {
         let out = txpool.insert(tx1, &db).await;
         assert!(out.is_err(), "Tx1 should be ERR");
         let err = out.err().unwrap();
-        assert_eq!(err.to_string(),"Transaction is not inserted. More priced tx 0x0000000000000000000000000000000000000000000000000000000000000012 already spend this UTXO output: UtxoId { tx_id: 0x0000000000000000000000000000000000000000000000000000000000000000, output_index: 0 }", "Tx1 should not be included:{:?}",err);
+        assert_eq!(err.to_string(),"Transaction is not inserted. More priced tx 0x0000000000000000000000000000000000000000000000000000000000000012 already spend this UTXO output: 0x000000000000000000000000000000000000000000000000000000000000000000", "Tx1 should not be included:{:?}",err);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Updates fuel-core to the latest available fuel-* dependencies. This includes the following changes:

- Hex-string based serde serialization for primitive fuel types
- Fix bytecode_length in fuel-tx signature validation
- fixes to next_page / previous_page when paginating transactions
- new feature flag format using weak deps (no more serde-types-minimal etc)

Also had to update some of the expected error messages in the txpool due to formatting changes in our types.