### PR TITLE
Disable slack notifications for mac os binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,7 +367,8 @@ jobs:
 
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v1
-        if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
+        # need to find a work-around to be able to run this action on mac
+        if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag') && matrix.job.os != 'mac-os'
         with:
           status: ${{ job.status }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
disable slack notifications for mac builds since the action is incompatible with osx

https://github.com/FuelLabs/fuel-core/runs/6516776368?check_suite_focus=true#step:16:22