### PR TITLE
Improve p2p tests

### DIFF
--- a/fuel-p2p/src/behavior.rs
+++ b/fuel-p2p/src/behavior.rs
@@ -113,7 +113,7 @@ impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
             discovery_config
         };
 
-        let peer_info = PeerInfoBehaviour::new(local_public_key);
+        let peer_info = PeerInfoBehaviour::new(local_public_key, p2p_config);
 
         let req_res_protocol =
             std::iter::once((codec.get_req_res_protocol(), ProtocolSupport::Full));

--- a/fuel-p2p/src/config.rs
+++ b/fuel-p2p/src/config.rs
@@ -36,10 +36,10 @@ pub struct P2PConfig {
     // `PeerInfo` fields
     /// The interval at which identification requests are sent to
     /// the remote on established connections after the first request
-    pub identify_interval: Duration,
+    pub identify_interval: Option<Duration>,
     /// The duration between the last successful outbound or inbound ping
     /// and the next outbound ping
-    pub info_interval: Duration,
+    pub info_interval: Option<Duration>,
 
     // `Gossipsub` related fields
     pub topics: Vec<String>,

--- a/fuel-p2p/src/config.rs
+++ b/fuel-p2p/src/config.rs
@@ -28,7 +28,7 @@ pub struct P2PConfig {
     // `DiscoveryBehaviour` related fields
     pub bootstrap_nodes: Vec<(PeerId, Multiaddr)>,
     pub enable_mdns: bool,
-    pub max_peers_connected: u64,
+    pub max_peers_connected: usize,
     pub allow_private_addresses: bool,
     pub enable_random_walk: bool,
     pub connection_idle_timeout: Option<Duration>,

--- a/fuel-p2p/src/config.rs
+++ b/fuel-p2p/src/config.rs
@@ -33,6 +33,14 @@ pub struct P2PConfig {
     pub enable_random_walk: bool,
     pub connection_idle_timeout: Option<Duration>,
 
+    // `PeerInfo` fields
+    /// The interval at which identification requests are sent to
+    /// the remote on established connections after the first request
+    pub identify_interval: Duration,
+    /// The duration between the last successful outbound or inbound ping
+    /// and the next outbound ping
+    pub info_interval: Duration,
+
     // `Gossipsub` related fields
     pub topics: Vec<String>,
     pub ideal_mesh_size: usize,

--- a/fuel-p2p/src/discovery/discovery_config.rs
+++ b/fuel-p2p/src/discovery/discovery_config.rs
@@ -4,7 +4,10 @@ use libp2p::{
     kad::{store::MemoryStore, Kademlia, KademliaConfig},
     Multiaddr, PeerId,
 };
-use std::{collections::VecDeque, time::Duration};
+use std::{
+    collections::{HashSet, VecDeque},
+    time::Duration,
+};
 use tracing::warn;
 
 #[derive(Clone, Debug)]
@@ -15,7 +18,7 @@ pub struct DiscoveryConfig {
     with_random_walk: bool,
     allow_private_addresses: bool,
     network_name: String,
-    max_peers_connected: u64,
+    max_peers_connected: usize,
     connection_idle_timeout: Duration,
 }
 
@@ -24,7 +27,7 @@ impl DiscoveryConfig {
         Self {
             local_peer_id,
             bootstrap_nodes: vec![],
-            max_peers_connected: std::u64::MAX,
+            max_peers_connected: std::usize::MAX,
             allow_private_addresses: false,
             with_mdns: false,
             network_name,
@@ -34,7 +37,7 @@ impl DiscoveryConfig {
     }
 
     /// limit the number of connected nodes
-    pub fn discovery_limit(&mut self, limit: u64) -> &mut Self {
+    pub fn discovery_limit(&mut self, limit: usize) -> &mut Self {
         self.max_peers_connected = limit;
         self
     }
@@ -112,11 +115,11 @@ impl DiscoveryConfig {
 
         DiscoveryBehaviour {
             bootstrap_nodes,
+            connected_peers: HashSet::new(),
             events: VecDeque::new(),
             kademlia,
             next_kad_random_walk,
             duration_to_next_kad: Duration::from_secs(1),
-            connected_peers_count: 0,
             max_peers_connected,
             mdns,
             allow_private_addresses,

--- a/fuel-p2p/src/peer_info.rs
+++ b/fuel-p2p/src/peer_info.rs
@@ -75,7 +75,7 @@ impl PeerInfoBehaviour {
 
         let ping = {
             let ping_config = PingConfig::new();
-            if let Some(interval) = config.identify_interval {
+            if let Some(interval) = config.info_interval {
                 Ping::new(ping_config.with_interval(interval))
             } else {
                 Ping::new(ping_config)

--- a/fuel-p2p/src/peer_info.rs
+++ b/fuel-p2p/src/peer_info.rs
@@ -1,3 +1,4 @@
+use crate::config::P2PConfig;
 use libp2p::{
     core::{
         connection::{ConnectionId, ListenerId},
@@ -44,11 +45,11 @@ pub struct PeerInfo {
 }
 
 impl PeerInfo {
-    pub fn new(conencted_point: ConnectedPoint) -> Self {
+    pub fn new(connected_point: ConnectedPoint) -> Self {
         Self {
             peer_addresses: HashSet::default(),
             client_version: None,
-            connected_point: conencted_point,
+            connected_point,
             latest_ping: None,
         }
     }
@@ -62,14 +63,21 @@ pub struct PeerInfoBehaviour {
 }
 
 impl PeerInfoBehaviour {
-    pub fn new(local_public_key: PublicKey) -> Self {
+    pub fn new(local_public_key: PublicKey, config: &P2PConfig) -> Self {
         let identify = {
-            let cfg = IdentifyConfig::new("/fuel/1.0".to_string(), local_public_key);
-            Identify::new(cfg)
+            let identify_config = IdentifyConfig::new("/fuel/1.0".to_string(), local_public_key);
+            let identify_config = identify_config.with_interval(config.identify_interval);
+            Identify::new(identify_config)
+        };
+
+        let ping = {
+            let ping_config = PingConfig::new();
+            let ping_config = ping_config.with_interval(config.info_interval);
+            Ping::new(ping_config)
         };
 
         Self {
-            ping: Ping::new(PingConfig::new()),
+            ping,
             identify,
             peers: HashMap::default(),
         }

--- a/fuel-p2p/src/peer_info.rs
+++ b/fuel-p2p/src/peer_info.rs
@@ -66,14 +66,20 @@ impl PeerInfoBehaviour {
     pub fn new(local_public_key: PublicKey, config: &P2PConfig) -> Self {
         let identify = {
             let identify_config = IdentifyConfig::new("/fuel/1.0".to_string(), local_public_key);
-            let identify_config = identify_config.with_interval(config.identify_interval);
-            Identify::new(identify_config)
+            if let Some(interval) = config.identify_interval {
+                Identify::new(identify_config.with_interval(interval))
+            } else {
+                Identify::new(identify_config)
+            }
         };
 
         let ping = {
             let ping_config = PingConfig::new();
-            let ping_config = ping_config.with_interval(config.info_interval);
-            Ping::new(ping_config)
+            if let Some(interval) = config.identify_interval {
+                Ping::new(ping_config.with_interval(interval))
+            } else {
+                Ping::new(ping_config)
+            }
         };
 
         Self {

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -192,8 +192,8 @@ mod tests {
             ideal_mesh_size: 6,
             set_request_timeout: None,
             set_connection_keep_alive: None,
-            info_interval: Duration::from_secs(3),
-            identify_interval: Duration::from_secs(5),
+            info_interval: Some(Duration::from_secs(3)),
+            identify_interval: Some(Duration::from_secs(5)),
         }
     }
 


### PR DESCRIPTION
Closes #324 

After creating a small local p2p network and testing it out here are some findings and respective changes:

**Reconnect is guaranteed**
As long as Kademlia's random walk is enabled in the config (as is in the tests), the node will try to reconnect to another node if they disconnected previously. It will try to do that every 60 seconds, which is the max interval currently set in random walk.

Random walk tries to discover a random peer + it gets closest peers it already knows and tries to connect to them if not already connected.

_Changes:_ 
- Removed the sanity reconnect test, since it is not needed and is buggy (more on it in the next section)

**Multiple notifications for a single event might've caused issues with logic in the tests**
I have noticed some events like `PeerConnected` or `PeerDisconnected` appear multiple times from `libp2p` and consequently are propagated to our p2p service. Some tests that relied on those events, like now removed `peer_reconnects_after_disconnect()` potentially got their flow messed up because of it and they ended up stalling.

While debugging this I have also found a flaw in our logic when it comes to counting connected peers, since I would just increment a counter on each established connection, since some events were propagated multiple times for the same event, we would end up incrementing the `connected_peers` count multiple times for a single peer!

_Changes:_
- removed connected_peers count in favor of a `HashSet<PeerId>`, this way each original connect/disconnect is counted only once
- only propagate unique  Connect/Disconnect events once to the p2p service by utilizing newly added HashSet<PeerId> where we track connected peers

**Peer Info intervals can be customized**
Up until now we depended on default values for how often would a peer get identified and/or pinged.
I have added 2 more config field options in order to customize these intervals, giving us more flexibility.

Using smaller intervals for our tests should in theory drive tests faster to completion.

**Other changes**
Our tests were ran concurrently and all of them had the same network name - which could cause some interference.
While we already moved to executing tests synchronously - I have changed the name of each test's network name to match the name of the test itself.

**Does this mean there won't be any stalling tests like EVER?**
Unfortunately no, we cannot guarantee that at this point. What we've done here is removed most of the possible causes.
It's hard to detect from the CI did the connection break between the peers or there was some bug in the test flow.
Hence we should run some cron jobs with tracing enabled in order to discover possible issues.
