### PR TITLE
Allow dry-run to override utxo_validation setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
 
   publish-docker-image:
     needs:
+      - cancel-previous-runs
       - lint-toml-files
       - cargo-verifications
       - publish-crates

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -180,7 +180,7 @@ type Mutation {
 	"""
 	Execute a dry-run of the transaction using a fork of current state, no changes are committed.
 	"""
-	dryRun(tx: HexString!): [Receipt!]!
+	dryRun(tx: HexString!, utxoValidation: Boolean): [Receipt!]!
 	"""
 	Submits transaction to the txpool
 	"""

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__dry_run_tx_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__dry_run_tx_gql_output.snap
@@ -1,10 +1,11 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
+assertion_line: 324
 expression: query.query
 
 ---
-mutation Mutation($_0: HexString!) {
-  dryRun(tx: $_0) {
+mutation Mutation($_0: HexString!, $_1: Boolean) {
+  dryRun(tx: $_0, utxoValidation: $_1) {
     rawPayload
   }
 }

--- a/fuel-client/src/client/schema/tx.rs
+++ b/fuel-client/src/client/schema/tx.rs
@@ -233,14 +233,20 @@ pub struct TxArg {
     pub tx: HexString,
 }
 
+#[derive(cynic::FragmentArguments)]
+pub struct DryRunArg {
+    pub tx: HexString,
+    pub utxo_validation: Option<bool>,
+}
+
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
-    argument_struct = "TxArg"
+    argument_struct = "DryRunArg"
 )]
 pub struct DryRun {
-    #[arguments(tx = &args.tx)]
+    #[arguments(tx = &args.tx, utxo_validation = &args.utxo_validation)]
     pub dry_run: Vec<OpaqueReceipt>,
 }
 
@@ -311,8 +317,9 @@ pub mod tests {
     fn dry_run_tx_gql_output() {
         use cynic::MutationBuilder;
         let mut tx = fuel_tx::Transaction::default();
-        let query = DryRun::build(TxArg {
+        let query = DryRun::build(DryRunArg {
             tx: HexString(Bytes(tx.to_bytes())),
+            utxo_validation: None,
         });
         insta::assert_snapshot!(query.query)
     }

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -259,9 +259,16 @@ impl TxMutation {
         &self,
         ctx: &Context<'_>,
         tx: HexString,
+        // disable input utxo validation, allowing for non-existent inputs to be used
+        // without signature validation
+        utxo_validation: Option<bool>,
     ) -> async_graphql::Result<Vec<receipt::Receipt>> {
         let transaction = ctx.data_unchecked::<Database>().transaction();
-        let cfg = ctx.data_unchecked::<Config>();
+        let mut cfg = ctx.data_unchecked::<Config>().clone();
+        // disable utxo-validation
+        if let Some(utxo_validation) = utxo_validation {
+            cfg.utxo_validation = utxo_validation;
+        }
         let tx = FuelTx::from_bytes(&tx.0)?;
         // make virtual txpool from transactional view
         let tx_pool = TxPool::new(transaction.deref().clone(), cfg.clone());

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -259,13 +259,14 @@ impl TxMutation {
         &self,
         ctx: &Context<'_>,
         tx: HexString,
-        // disable input utxo validation, allowing for non-existent inputs to be used
-        // without signature validation
+        // If set to false, disable input utxo validation, overriding the configuration of the node.
+        // This allows for non-existent inputs to be used without signature validation
+        // for read-only calls.
         utxo_validation: Option<bool>,
     ) -> async_graphql::Result<Vec<receipt::Receipt>> {
         let transaction = ctx.data_unchecked::<Database>().transaction();
         let mut cfg = ctx.data_unchecked::<Config>().clone();
-        // disable utxo-validation
+        // override utxo_validation if set
         if let Some(utxo_validation) = utxo_validation {
             cfg.utxo_validation = utxo_validation;
         }


### PR DESCRIPTION
While ethereum has `.call` for querying read-only methods on contracts, our dry-run has the ability to fully simulate the end to end execution of a transaction including the txpool rules. While this is great for things like estimating gas costs and predicting result of a transaction execution which modifies state, it's inconvenient for simple read-only use-cases if simulated txs require real coin inputs and valid signatures. 

To improve the read-only `call`-style experience, this PR adds a new optional `utxo_validation` parameter to the dry run API. This allows the SDK to bypass coin and signature validation normally applied to a transaction. This was added in a non-breaking way, allowing for this to be a patch release to fuel-core.