### PR TITLE
release 0.7.1 to make utxo-validation dry-run override available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-interfaces"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gql-client"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-p2p"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-txpool"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-core
 description: Fuel Core Helm Chart
 type: application
-appVersion: "0.7.0"
+appVersion: "0.7.1"
 version: 0.1.0

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-gql-client"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-interfaces"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -36,14 +36,14 @@ derive_more = { version = "0.99" }
 dirs = "3.0"
 env_logger = "0.9"
 fuel-asm = { version = "0.5", features = ["serde"] }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.0", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.1", features = [
     "serde",
 ] }
 fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-merkle = "0.1"
 fuel-storage = { version = "0.1" }
 fuel-tx = { version = "0.10", features = ["serde"] }
-fuel-txpool = { path = "../fuel-txpool", version = "0.7.0" }
+fuel-txpool = { path = "../fuel-txpool", version = "0.7.1" }
 fuel-types = { version = "0.5", features = ["serde"] }
 fuel-vm = { version = "0.9", features = ["serde"] }
 futures = "0.3"

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-p2p"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 edition = "2021"

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -19,7 +19,7 @@ ethers-providers = { git = "https://github.com/rakita/ethers-rs.git", branch = "
     "rustls",
 ] }
 features = "0.10"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.7.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.7.1" }
 fuel-tx = { version = "0.10", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
@@ -33,7 +33,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3.9"
 
 [dev-dependencies]
-fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.7.0", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.7.1", features = [
     "test_helpers",
 ] }
 fuel-types = { version = "0.5", features = ["serde", "random"] }

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-txpool"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -14,7 +14,7 @@ description = "Transaction pool"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.1" }
 fuel-tx = { version = "0.10", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
@@ -24,6 +24,6 @@ tokio = { version = "1.14", default-features = false, features = ["sync"] }
 tracing = "0.1"
 
 [dev-dependencies]
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.0", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.1", features = [
     "test_helpers",
 ] }


### PR DESCRIPTION
Small release to enable more user-friendly dry_run functionality in utxo-validated environments: https://github.com/FuelLabs/fuel-core/pull/347