### PR TITLE
fix mac os action again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,7 +369,7 @@ jobs:
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v1
         # need to find a work-around to be able to run this action on mac
-        if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag') && matrix.job.os != 'mac-os'
+        if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag') && matrix.job.os != 'macos-latest'
         with:
           status: ${{ job.status }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
used the wrong value to check against macos when trying to prevent the slack action from running.