### PR TITLE
readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This will run `cargo build` as well as any other custom build processes we have 
 The service can listen to an arbitrary socket, as specified in the help command:
 
 ```
-$ ./target/release/fuel-core --help
+$ ./target/debug/fuel-core --help
 fuel-core 0.1.0
 
 USAGE:


### PR DESCRIPTION
"cargo xtask build" command only runs "cargo build" command and "cargo run" build only for development. It only creates a debug directory. It doesn't create a release directory. To create a release directory or run it on production and optimized "cargo xtask build" should run "cargo build --release" command.