### PR TITLE
Support split of Input::Coin in to CoinSignature & CoinPredicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fedf61251332608a32115e0910611e35938e8b7cf056766fbead42bc787a68c"
+checksum = "b4b6bb7bef3d281f50670288505987b41653e4a513d75482e19775564b91e05e"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -2256,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c2dc53d77a9f3d815231efe6bed2688ec7435c36870453defebb43e60bbdcb"
+checksum = "e42bb539c6cb5a8e1963b4c4ecbf238df4dd863e672d2773f32d08d59afb50a8"
 dependencies = [
  "dyn-clone",
  "fuel-asm",

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -21,9 +21,9 @@ clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "1.0", features = ["surf"] }
 derive_more = { version = "0.99" }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.10", features = ["serde"] }
+fuel-tx = { version = "0.11", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.9", features = ["serde"] }
+fuel-vm = { version = "0.10", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
 itertools = "0.10"

--- a/fuel-client/src/client/schema.rs
+++ b/fuel-client/src/client/schema.rs
@@ -267,6 +267,7 @@ pub struct PaginatedResult<T, C> {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum ConversionError {
     #[error("Field is required from the GraphQL response {0}")]
     MissingField(String),

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -202,16 +202,28 @@ impl TryFrom<Input> for fuel_tx::Input {
 
     fn try_from(input: Input) -> Result<fuel_tx::Input, Self::Error> {
         Ok(match input {
-            Input::InputCoin(coin) => fuel_tx::Input::Coin {
-                utxo_id: coin.utxo_id.into(),
-                owner: coin.owner.into(),
-                amount: coin.amount.into(),
-                asset_id: coin.asset_id.into(),
-                witness_index: coin.witness_index.try_into()?,
-                maturity: coin.maturity.into(),
-                predicate: coin.predicate.into(),
-                predicate_data: coin.predicate_data.into(),
-            },
+            Input::InputCoin(coin) => {
+                if coin.predicate.0 .0.is_empty() {
+                    fuel_tx::Input::CoinSigned {
+                        utxo_id: coin.utxo_id.into(),
+                        owner: coin.owner.into(),
+                        amount: coin.amount.into(),
+                        asset_id: coin.asset_id.into(),
+                        witness_index: coin.witness_index.try_into()?,
+                        maturity: coin.maturity.into(),
+                    }
+                } else {
+                    fuel_tx::Input::CoinPredicate {
+                        utxo_id: coin.utxo_id.into(),
+                        owner: coin.owner.into(),
+                        amount: coin.amount.into(),
+                        asset_id: coin.asset_id.into(),
+                        maturity: coin.maturity.into(),
+                        predicate: coin.predicate.into(),
+                        predicate_data: coin.predicate_data.into(),
+                    }
+                }
+            }
             Input::InputContract(contract) => fuel_tx::Input::Contract {
                 utxo_id: contract.utxo_id.into(),
                 balance_root: contract.balance_root.into(),

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -18,9 +18,9 @@ derive_more = { version = "0.99" }
 fuel-asm = "0.5"
 fuel-crypto = { version = "0.5", default-features = false }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.10", default-features = false }
+fuel-tx = { version = "0.11", default-features = false }
 fuel-types = { version = "0.5", default-features = false }
-fuel-vm = { version = "0.9", default-features = false }
+fuel-vm = { version = "0.10", default-features = false }
 futures = "0.3"
 lazy_static = "1.4"
 parking_lot = "0.12"

--- a/fuel-core-interfaces/src/db.rs
+++ b/fuel-core-interfaces/src/db.rs
@@ -4,6 +4,7 @@ use fuel_vm::prelude::InterpreterError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     #[error("error performing binary serialization")]
     Codec,
@@ -180,15 +181,13 @@ pub mod helpers {
                 receipts_root: Default::default(),
                 script,
                 script_data: vec![],
-                inputs: vec![Input::Coin {
+                inputs: vec![Input::CoinSigned {
                     utxo_id: UtxoId::new(*TX_ID_DB1, 0),
                     owner: Address::default(),
                     amount: 100,
                     asset_id: Default::default(),
                     witness_index: 0,
                     maturity: 0,
-                    predicate: vec![],
-                    predicate_data: vec![],
                 }],
                 outputs: vec![
                     Output::Coin {
@@ -221,15 +220,13 @@ pub mod helpers {
                 receipts_root: Default::default(),
                 script,
                 script_data: vec![],
-                inputs: vec![Input::Coin {
+                inputs: vec![Input::CoinSigned {
                     utxo_id: UtxoId::new(*TX_ID_DB1, 0),
                     owner: Address::default(),
                     amount: 100,
                     asset_id: Default::default(),
                     witness_index: 0,
                     maturity: 0,
-                    predicate: vec![],
-                    predicate_data: vec![],
                 }],
                 outputs: vec![Output::ContractCreated {
                     contract_id: *CONTRACT_ID1,
@@ -255,15 +252,13 @@ pub mod helpers {
                 receipts_root: Default::default(),
                 script,
                 script_data: vec![],
-                inputs: vec![Input::Coin {
+                inputs: vec![Input::CoinSigned {
                     utxo_id: UtxoId::new(*TX_ID1, 0),
                     owner: Address::default(),
                     amount: 100,
                     asset_id: Default::default(),
                     witness_index: 0,
                     maturity: 0,
-                    predicate: vec![],
-                    predicate_data: vec![],
                 }],
                 outputs: vec![Output::Coin {
                     amount: 100,
@@ -290,15 +285,13 @@ pub mod helpers {
                 receipts_root: Default::default(),
                 script,
                 script_data: vec![],
-                inputs: vec![Input::Coin {
+                inputs: vec![Input::CoinSigned {
                     utxo_id: UtxoId::new(*TX_ID1, 0),
                     owner: Address::default(),
                     amount: 100,
                     asset_id: Default::default(),
                     witness_index: 0,
                     maturity: 0,
-                    predicate: vec![],
-                    predicate_data: vec![],
                 }],
                 outputs: vec![
                     Output::Coin {
@@ -332,15 +325,13 @@ pub mod helpers {
                 receipts_root: Default::default(),
                 script,
                 script_data: vec![],
-                inputs: vec![Input::Coin {
+                inputs: vec![Input::CoinSigned {
                     utxo_id: UtxoId::new(*TX_ID_DB1, 0),
                     owner: Address::default(),
                     amount: 100,
                     asset_id: Default::default(),
                     witness_index: 0,
                     maturity: 0,
-                    predicate: vec![],
-                    predicate_data: vec![],
                 }],
                 outputs: vec![Output::Coin {
                     amount: 100,
@@ -368,15 +359,13 @@ pub mod helpers {
                 receipts_root: Default::default(),
                 script,
                 script_data: vec![],
-                inputs: vec![Input::Coin {
+                inputs: vec![Input::CoinSigned {
                     utxo_id: UtxoId::new(*TX_ID_DB2, 0),
                     owner: Address::default(),
                     amount: 200,
                     asset_id: Default::default(),
                     witness_index: 0,
                     maturity: 0,
-                    predicate: vec![],
-                    predicate_data: vec![],
                 }],
                 outputs: vec![Output::Coin {
                     amount: 100,

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -42,10 +42,10 @@ fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.1", fe
 fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-merkle = "0.1"
 fuel-storage = { version = "0.1" }
-fuel-tx = { version = "0.10", features = ["serde"] }
+fuel-tx = { version = "0.11", features = ["serde"] }
 fuel-txpool = { path = "../fuel-txpool", version = "0.7.1" }
 fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.9", features = ["serde", "profile-coverage"] }
+fuel-vm = { version = "0.10", features = ["serde", "profile-coverage"] }
 futures = "0.3"
 graphql-parser = "0.3.0"
 hex = { version = "0.4", features = ["serde"] }
@@ -63,7 +63,7 @@ serde_with = "1.11"
 strum = "0.21"
 strum_macros = "0.21"
 tempfile = "3.3"
-thiserror = "1.0.26"
+thiserror = "1.0"
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.2.1", features = ["set-header", "trace"] }
 tower-layer = "0.3"
@@ -73,12 +73,12 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-fuel-tx = { version = "0.10", features = [
+fuel-tx = { version = "0.11", features = [
     "serde",
     "builder",
     "internals",
 ] }
-fuel-vm = { version = "0.9", features = [
+fuel-vm = { version = "0.10", features = [
     "serde",
     "random",
     "test-helpers",

--- a/fuel-core/src/args.rs
+++ b/fuel-core/src/args.rs
@@ -53,9 +53,15 @@ pub struct Opt {
     /// The minimum allowed gas price
     #[clap(long = "min-gas-price", default_value = "0")]
     pub min_gas_price: u64,
+
     /// The minimum allowed byte price
     #[clap(long = "min-byte-price", default_value = "0")]
     pub min_byte_price: u64,
+
+    /// Enable predicate execution on transaction inputs.
+    /// Will reject any transactions with predicates if set to false.
+    #[clap(long = "predicates")]
+    pub predicates: bool,
 }
 
 impl Opt {
@@ -104,6 +110,7 @@ impl Opt {
             utxo_validation,
             min_gas_price,
             min_byte_price,
+            predicates,
         } = self;
 
         let addr = net::SocketAddr::new(ip, port);
@@ -122,6 +129,7 @@ impl Opt {
                 min_byte_price,
                 ..Default::default()
             },
+            predicates,
         })
     }
 }

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -64,6 +64,8 @@ impl Executor {
                 return Err(Error::TransactionIdCollision(tx_id));
             }
 
+            self.verify_tx_predicates(tx)?;
+
             if self.config.utxo_validation {
                 // validate transaction has at least one coin
                 self.verify_tx_has_at_least_one_coin(tx)?;
@@ -249,7 +251,7 @@ impl Executor {
     ) -> Result<(), TransactionValidityError> {
         for input in transaction.inputs() {
             match input {
-                Input::Coin { utxo_id, .. } => {
+                Input::CoinSigned { utxo_id, .. } | Input::CoinPredicate { utxo_id, .. } => {
                     if let Some(coin) = Storage::<UtxoId, Coin>::get(db, utxo_id)? {
                         if coin.status == CoinStatus::Spent {
                             return Err(TransactionValidityError::CoinAlreadySpent(*utxo_id));
@@ -268,6 +270,25 @@ impl Executor {
         Ok(())
     }
 
+    /// Verify all the predicates of a tx.
+    pub fn verify_tx_predicates(&self, tx: &Transaction) -> Result<(), Error> {
+        // fail if tx contains any predicates when predicates are disabled
+        if !self.config.predicates {
+            let has_predicate = tx
+                .inputs()
+                .iter()
+                .find(|input| input.is_coin_predicate())
+                .is_some();
+            if has_predicate {
+                return Err(Error::TransactionValidity(
+                    TransactionValidityError::PredicateExecutionDisabled(tx.id()),
+                ));
+            }
+        }
+        // otherwise, allow execution to continue for now.
+        return Ok(());
+    }
+
     /// Verify the transaction has at least one coin.
     ///
     /// TODO: This verification really belongs in fuel-tx, and can be removed once
@@ -283,7 +304,15 @@ impl Executor {
     /// Mark inputs as spent
     fn spend_inputs(&self, tx: &Transaction, db: &mut Database) -> Result<(), Error> {
         for input in tx.inputs() {
-            if let Input::Coin {
+            if let Input::CoinSigned {
+                utxo_id,
+                owner,
+                amount,
+                asset_id,
+                maturity,
+                ..
+            }
+            | Input::CoinPredicate {
                 utxo_id,
                 owner,
                 amount,
@@ -327,7 +356,9 @@ impl Executor {
                 .inputs()
                 .iter()
                 .filter_map(|input| {
-                    if let Input::Coin { amount, .. } = input {
+                    if let Input::CoinSigned { amount, .. } | Input::CoinPredicate { amount, .. } =
+                        input
+                    {
                         Some(*amount)
                     } else {
                         None
@@ -540,7 +571,7 @@ impl Executor {
     ) -> Result<(), Error> {
         let mut owners = vec![];
         for input in tx.inputs() {
-            if let Input::Coin { owner, .. } = input {
+            if let Input::CoinSigned { owner, .. } | Input::CoinPredicate { owner, .. } = input {
                 owners.push(owner);
             }
         }
@@ -603,14 +634,16 @@ pub enum TransactionValidityError {
     InvalidContractInputIndex(UtxoId),
     #[error("The transaction must have at least one coin input type: {0:#x}")]
     NoCoinInput(TxId),
+    #[error("The transaction contains predicate inputs which aren't enabled")]
+    PredicateExecutionDisabled(TxId),
     #[error("Transaction validity: {0:#?}")]
     Validation(#[from] ValidationError),
     #[error("Datastore error occurred")]
     DataStoreError(Box<dyn std::error::Error>),
 }
 
-impl From<crate::database::KvStoreError> for TransactionValidityError {
-    fn from(e: crate::database::KvStoreError) -> Self {
+impl From<KvStoreError> for TransactionValidityError {
+    fn from(e: KvStoreError) -> Self {
         Self::DataStoreError(Box::new(e))
     }
 }
@@ -660,7 +693,7 @@ impl From<FuelBacktrace> for Error {
     }
 }
 
-impl From<crate::database::KvStoreError> for Error {
+impl From<KvStoreError> for Error {
     fn from(e: KvStoreError) -> Self {
         Error::CorruptedBlockState(Box::new(e))
     }
@@ -880,7 +913,7 @@ mod tests {
         Storage::<UtxoId, Coin>::insert(&mut db, &spent_utxo_id, &coin).unwrap();
 
         // create an input referring to a coin that is already spent
-        let input = Input::coin(spent_utxo_id, owner, amount, asset_id, 0, 0, vec![], vec![]);
+        let input = Input::coin_signed(spent_utxo_id, owner, amount, asset_id, 0, 0);
         let output = Output::Change {
             to: owner,
             amount: 0,
@@ -953,8 +986,6 @@ mod tests {
                     10,
                     Default::default(),
                     0,
-                    vec![],
-                    vec![],
                 )
                 .add_output(Output::Change {
                     to: Default::default(),
@@ -1173,8 +1204,6 @@ mod tests {
                     100,
                     Default::default(),
                     0,
-                    vec![],
-                    vec![],
                 )
                 .add_output(Output::Change {
                     to: Default::default(),
@@ -1185,7 +1214,14 @@ mod tests {
         let mut db = Database::default();
 
         // insert coin into state
-        if let Input::Coin {
+        if let Input::CoinSigned {
+            utxo_id,
+            owner,
+            amount,
+            asset_id,
+            ..
+        }
+        | Input::CoinPredicate {
             utxo_id,
             owner,
             amount,

--- a/fuel-core/src/schema/tx/input.rs
+++ b/fuel-core/src/schema/tx/input.rs
@@ -27,6 +27,7 @@ impl InputCoin {
     async fn utxo_id(&self) -> UtxoId {
         self.utxo_id
     }
+
     async fn owner(&self) -> Address {
         self.owner
     }
@@ -85,12 +86,28 @@ impl InputContract {
 impl From<&fuel_tx::Input> for Input {
     fn from(input: &fuel_tx::Input) -> Self {
         match input {
-            fuel_tx::Input::Coin {
+            fuel_tx::Input::CoinSigned {
                 utxo_id,
                 owner,
                 amount,
                 asset_id,
                 witness_index,
+                maturity,
+            } => Input::Coin(InputCoin {
+                utxo_id: UtxoId(*utxo_id),
+                owner: Address(*owner),
+                amount: *amount,
+                asset_id: AssetId(*asset_id),
+                witness_index: *witness_index,
+                maturity: *maturity,
+                predicate: HexString(Default::default()),
+                predicate_data: HexString(Default::default()),
+            }),
+            fuel_tx::Input::CoinPredicate {
+                utxo_id,
+                owner,
+                amount,
+                asset_id,
                 maturity,
                 predicate,
                 predicate_data,
@@ -99,7 +116,7 @@ impl From<&fuel_tx::Input> for Input {
                 owner: Address(*owner),
                 amount: *amount,
                 asset_id: AssetId(*asset_id),
-                witness_index: *witness_index,
+                witness_index: Default::default(),
                 maturity: *maturity,
                 predicate: HexString(predicate.clone()),
                 predicate_data: HexString(predicate_data.clone()),

--- a/fuel-core/src/service.rs
+++ b/fuel-core/src/service.rs
@@ -1,18 +1,7 @@
-use crate::chain_config::{ChainConfig, ContractConfig, StateConfig};
-use crate::database::Database;
-use crate::model::{Coin, CoinStatus};
-use crate::tx_pool::TxPool;
-use fuel_storage::{MerkleStorage, Storage};
-use fuel_tx::UtxoId;
-use fuel_types::{AssetId, Bytes32, ContractId, Salt, Word};
-use fuel_vm::consts::WORD_SIZE;
-use fuel_vm::prelude::Contract;
-pub use graph_api::start_server;
-use itertools::Itertools;
-#[cfg(feature = "rocksdb")]
-use std::io::ErrorKind;
+use crate::{chain_config::ChainConfig, database::Database, tx_pool::TxPool};
+use anyhow::Error as AnyError;
 use std::{
-    net::{self, Ipv4Addr, SocketAddr},
+    net::{Ipv4Addr, SocketAddr},
     panic,
     path::PathBuf,
     sync::Arc,
@@ -20,17 +9,23 @@ use std::{
 use strum_macros::{Display, EnumString, EnumVariantNames};
 use thiserror::Error;
 use tokio::task::JoinHandle;
+use tracing::log::warn;
 
+pub use graph_api::start_server;
+
+pub(crate) mod genesis;
 pub mod graph_api;
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub addr: net::SocketAddr,
+    pub addr: SocketAddr,
     pub database_path: PathBuf,
     pub database_type: DbType,
     pub chain_conf: ChainConfig,
     // default to false until downstream consumers stabilize
     pub utxo_validation: bool,
+    // default to false until predicates have fully stabilized
+    pub predicates: bool,
     pub vm: VMConfig,
     pub tx_pool_config: fuel_txpool::Config,
 }
@@ -44,6 +39,7 @@ impl Config {
             chain_conf: ChainConfig::local_testnet(),
             vm: Default::default(),
             utxo_validation: false,
+            predicates: false,
             tx_pool_config: Default::default(),
         }
     }
@@ -62,7 +58,7 @@ pub enum DbType {
 }
 
 pub struct FuelService {
-    tasks: Vec<JoinHandle<Result<(), Error>>>,
+    tasks: Vec<JoinHandle<Result<(), AnyError>>>,
     /// The address bound by the system for serving the API
     pub bound_address: SocketAddr,
 }
@@ -70,12 +66,11 @@ pub struct FuelService {
 impl FuelService {
     /// Create a fuel node instance from service config
     #[tracing::instrument(skip(config))]
-    pub async fn new_node(config: Config) -> Result<Self, std::io::Error> {
+    pub async fn new_node(config: Config) -> Result<Self, AnyError> {
         // initialize database
         let database = match config.database_type {
             #[cfg(feature = "rocksdb")]
-            DbType::RocksDb => Database::open(&config.database_path)
-                .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?,
+            DbType::RocksDb => Database::open(&config.database_path)?,
             DbType::InMemory => Database::in_memory(),
             #[cfg(not(feature = "rocksdb"))]
             _ => Database::in_memory(),
@@ -86,12 +81,17 @@ impl FuelService {
 
     #[cfg(any(test, feature = "test-helpers"))]
     /// Used to initialize a service with a pre-existing database
-    pub async fn from_database(database: Database, config: Config) -> Result<Self, std::io::Error> {
+    pub async fn from_database(database: Database, config: Config) -> Result<Self, AnyError> {
         Self::init_service(database, config).await
     }
 
     /// Private inner method for initializing the fuel service
-    async fn init_service(database: Database, config: Config) -> Result<Self, std::io::Error> {
+    async fn init_service(database: Database, config: Config) -> Result<Self, AnyError> {
+        // check predicates flag
+        if config.predicates {
+            warn!("Predicates are not supported yet!");
+        }
+
         // initialize state
         Self::import_state(&config.chain_conf, &database)?;
         // initialize transaction pool
@@ -99,156 +99,13 @@ impl FuelService {
 
         // start background tasks
         let mut tasks = vec![];
-        let (bound_address, api_server) =
-            graph_api::start_server(config, database, tx_pool).await?;
+        let (bound_address, api_server) = start_server(config, database, tx_pool).await?;
         tasks.push(api_server);
 
         Ok(FuelService {
             tasks,
             bound_address,
         })
-    }
-
-    /// Loads state from the chain config into database
-    fn import_state(config: &ChainConfig, database: &Database) -> Result<(), std::io::Error> {
-        // start a db transaction for bulk-writing
-        let mut import_tx = database.transaction();
-        let database = import_tx.as_mut();
-
-        // check if chain is initialized
-        if database.get_chain_name()?.is_none() {
-            // initialize the chain id
-            database.init_chain_name(config.chain_name.clone())?;
-
-            if let Some(initial_state) = &config.initial_state {
-                Self::init_block_height(database, initial_state)?;
-                Self::init_coin_state(database, initial_state)?;
-                Self::init_contracts(database, initial_state)?;
-            }
-        }
-
-        // Write transaction to db
-        import_tx.commit()?;
-
-        Ok(())
-    }
-
-    /// initialize starting block height if set
-    fn init_block_height(db: &Database, state: &StateConfig) -> Result<(), std::io::Error> {
-        if let Some(height) = state.height {
-            db.init_chain_height(height)?;
-        }
-        Ok(())
-    }
-
-    /// initialize coins
-    fn init_coin_state(db: &mut Database, state: &StateConfig) -> Result<(), std::io::Error> {
-        // TODO: Store merkle sum tree root over coins with unspecified utxo ids.
-        let mut generated_output_index: u64 = 0;
-        if let Some(coins) = &state.coins {
-            for coin in coins {
-                let utxo_id = UtxoId::new(
-                    // generated transaction id([0..[out_index/255]])
-                    coin.tx_id.unwrap_or_else(|| {
-                        Bytes32::try_from(
-                            (0..(Bytes32::LEN - WORD_SIZE))
-                                .map(|_| 0u8)
-                                .chain((generated_output_index / 255).to_be_bytes().into_iter())
-                                .collect_vec()
-                                .as_slice(),
-                        )
-                        .expect("Incorrect genesis transaction id byte length")
-                    }),
-                    coin.output_index.map(|i| i as u8).unwrap_or_else(|| {
-                        generated_output_index += 1;
-                        (generated_output_index % 255) as u8
-                    }),
-                );
-
-                let coin = Coin {
-                    owner: coin.owner,
-                    amount: coin.amount,
-                    asset_id: coin.asset_id,
-                    maturity: coin.maturity.unwrap_or_default(),
-                    status: CoinStatus::Unspent,
-                    block_created: coin.block_created.unwrap_or_default(),
-                };
-
-                let _ = Storage::<UtxoId, Coin>::insert(db, &utxo_id, &coin)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn init_contracts(db: &mut Database, state: &StateConfig) -> Result<(), std::io::Error> {
-        // initialize contract state
-        if let Some(contracts) = &state.contracts {
-            for (generated_output_index, contract_config) in contracts.iter().enumerate() {
-                let contract = Contract::from(contract_config.code.as_slice());
-                let salt = contract_config.salt;
-                let root = contract.root();
-                let contract_id = contract.id(&salt, &root, &Contract::default_state_root());
-                // insert contract code
-                let _ = Storage::<ContractId, Contract>::insert(db, &contract_id, &contract)?;
-                // insert contract root
-                let _ = Storage::<ContractId, (Salt, Bytes32)>::insert(
-                    db,
-                    &contract_id,
-                    &(salt, root),
-                )?;
-                let _ = Storage::<ContractId, UtxoId>::insert(
-                    db,
-                    &contract_id,
-                    &UtxoId::new(
-                        // generated transaction id([0..[out_index/255]])
-                        Bytes32::try_from(
-                            (0..(Bytes32::LEN - WORD_SIZE))
-                                .map(|_| 0u8)
-                                .chain(
-                                    (generated_output_index as u64 / 255)
-                                        .to_be_bytes()
-                                        .into_iter(),
-                                )
-                                .collect_vec()
-                                .as_slice(),
-                        )
-                        .expect("Incorrect genesis transaction id byte length"),
-                        generated_output_index as u8,
-                    ),
-                )?;
-                Self::init_contract_state(db, &contract_id, contract_config)?;
-                Self::init_contract_balance(db, &contract_id, contract_config)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn init_contract_state(
-        db: &mut Database,
-        contract_id: &ContractId,
-        contract: &ContractConfig,
-    ) -> Result<(), std::io::Error> {
-        // insert state related to contract
-        if let Some(contract_state) = &contract.state {
-            for (key, value) in contract_state {
-                MerkleStorage::<ContractId, Bytes32, Bytes32>::insert(db, contract_id, key, value)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn init_contract_balance(
-        db: &mut Database,
-        contract_id: &ContractId,
-        contract: &ContractConfig,
-    ) -> Result<(), std::io::Error> {
-        // insert balances related to contract
-        if let Some(balances) = &contract.balances {
-            for (key, value) in balances {
-                MerkleStorage::<ContractId, AssetId, Word>::insert(db, contract_id, key, value)?;
-            }
-        }
-        Ok(())
     }
 
     /// Awaits for the completion of any server background tasks
@@ -281,257 +138,4 @@ impl FuelService {
 pub enum Error {
     #[error("An api server error occurred {0}")]
     ApiServer(#[from] hyper::Error),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::chain_config::{CoinConfig, ContractConfig, StateConfig};
-    use crate::model::BlockHeight;
-    use fuel_asm::Opcode;
-    use fuel_types::{Address, AssetId, Word};
-    use itertools::Itertools;
-    use rand::rngs::StdRng;
-    use rand::{Rng, RngCore, SeedableRng};
-
-    #[tokio::test]
-    async fn config_initializes_chain_name() {
-        let test_name = "test_net_123".to_string();
-        let service_config = Config {
-            chain_conf: ChainConfig {
-                chain_name: test_name.clone(),
-                ..ChainConfig::local_testnet()
-            },
-            ..Config::local_node()
-        };
-
-        let db = Database::default();
-        FuelService::from_database(db.clone(), service_config)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            test_name,
-            db.get_chain_name()
-                .unwrap()
-                .expect("Expected a chain name to be set")
-        )
-    }
-
-    #[tokio::test]
-    async fn config_initializes_block_height() {
-        let test_height = BlockHeight::from(99u32);
-        let service_config = Config {
-            chain_conf: ChainConfig {
-                initial_state: Some(StateConfig {
-                    height: Some(test_height),
-                    ..Default::default()
-                }),
-                ..ChainConfig::local_testnet()
-            },
-            ..Config::local_node()
-        };
-
-        let db = Database::default();
-        FuelService::from_database(db.clone(), service_config)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            test_height,
-            db.get_block_height()
-                .unwrap()
-                .expect("Expected a block height to be set")
-        )
-    }
-
-    #[tokio::test]
-    async fn config_state_initializes_multiple_coins_with_different_owners_and_asset_ids() {
-        let mut rng = StdRng::seed_from_u64(10);
-
-        // a coin with all options set
-        let alice: Address = rng.gen();
-        let asset_id_alice: AssetId = rng.gen();
-        let alice_value = rng.gen();
-        let alice_maturity = Some(rng.next_u32().into());
-        let alice_block_created = Some(rng.next_u32().into());
-        let alice_tx_id = Some(rng.gen());
-        let alice_output_index = Some(rng.gen());
-        let alice_utxo_id = UtxoId::new(alice_tx_id.unwrap(), alice_output_index.unwrap());
-
-        // a coin with minimal options set
-        let bob: Address = rng.gen();
-        let asset_id_bob: AssetId = rng.gen();
-        let bob_value = rng.gen();
-
-        let service_config = Config {
-            chain_conf: ChainConfig {
-                initial_state: Some(StateConfig {
-                    coins: Some(vec![
-                        CoinConfig {
-                            tx_id: alice_tx_id,
-                            output_index: alice_output_index.map(|i| i as u64),
-                            block_created: alice_block_created,
-                            maturity: alice_maturity,
-                            owner: alice,
-                            amount: alice_value,
-                            asset_id: asset_id_alice,
-                        },
-                        CoinConfig {
-                            tx_id: None,
-                            output_index: None,
-                            block_created: None,
-                            maturity: None,
-                            owner: bob,
-                            amount: bob_value,
-                            asset_id: asset_id_bob,
-                        },
-                    ]),
-                    height: alice_block_created.map(|h| {
-                        let mut h: u32 = h.into();
-                        // set starting height to something higher than alice's coin
-                        h = h.saturating_add(rng.next_u32());
-                        h.into()
-                    }),
-                    ..Default::default()
-                }),
-                ..ChainConfig::local_testnet()
-            },
-            ..Config::local_node()
-        };
-
-        let db = Database::default();
-        FuelService::from_database(db.clone(), service_config)
-            .await
-            .unwrap();
-
-        let alice_coins = get_coins(&db, alice);
-        let bob_coins = get_coins(&db, bob)
-            .into_iter()
-            .map(|(_, coin)| coin)
-            .collect_vec();
-
-        assert!(matches!(
-            alice_coins.as_slice(),
-            &[(utxo_id, Coin {
-                owner,
-                amount,
-                asset_id,
-                block_created,
-                maturity,
-                ..
-            })] if utxo_id == alice_utxo_id
-            && owner == alice
-            && amount == alice_value
-            && asset_id == asset_id_alice
-            && block_created == alice_block_created.unwrap()
-            && maturity == alice_maturity.unwrap(),
-        ));
-        assert!(matches!(
-            bob_coins.as_slice(),
-            &[Coin {
-                owner,
-                amount,
-                asset_id,
-                ..
-            }] if owner == bob
-            && amount == bob_value
-            && asset_id == asset_id_bob
-        ));
-    }
-
-    #[tokio::test]
-    async fn config_state_initializes_contract_state() {
-        let mut rng = StdRng::seed_from_u64(10);
-
-        let test_key: Bytes32 = rng.gen();
-        let test_value: Bytes32 = rng.gen();
-        let state = vec![(test_key, test_value)];
-        let salt: Salt = rng.gen();
-        let contract = Contract::from(Opcode::RET(0x10).to_bytes().to_vec());
-        let root = contract.root();
-        let id = contract.id(&salt, &root, &Contract::default_state_root());
-
-        let service_config = Config {
-            chain_conf: ChainConfig {
-                initial_state: Some(StateConfig {
-                    contracts: Some(vec![ContractConfig {
-                        code: contract.into(),
-                        salt,
-                        state: Some(state),
-                        balances: None,
-                    }]),
-                    ..Default::default()
-                }),
-                ..ChainConfig::local_testnet()
-            },
-            ..Config::local_node()
-        };
-
-        let db = Database::default();
-        FuelService::from_database(db.clone(), service_config)
-            .await
-            .unwrap();
-
-        let ret = MerkleStorage::<ContractId, Bytes32, Bytes32>::get(&db, &id, &test_key)
-            .unwrap()
-            .expect("Expect a state entry to exist with test_key")
-            .into_owned();
-
-        assert_eq!(test_value, ret)
-    }
-
-    #[tokio::test]
-    async fn config_state_initializes_contract_balance() {
-        let mut rng = StdRng::seed_from_u64(10);
-
-        let test_asset_id: AssetId = rng.gen();
-        let test_balance: u64 = rng.next_u64();
-        let balances = vec![(test_asset_id, test_balance)];
-        let salt: Salt = rng.gen();
-        let contract = Contract::from(Opcode::RET(0x10).to_bytes().to_vec());
-        let root = contract.root();
-        let id = contract.id(&salt, &root, &Contract::default_state_root());
-
-        let service_config = Config {
-            chain_conf: ChainConfig {
-                initial_state: Some(StateConfig {
-                    contracts: Some(vec![ContractConfig {
-                        code: contract.into(),
-                        salt,
-                        state: None,
-                        balances: Some(balances),
-                    }]),
-                    ..Default::default()
-                }),
-                ..ChainConfig::local_testnet()
-            },
-            ..Config::local_node()
-        };
-
-        let db = Database::default();
-        FuelService::from_database(db.clone(), service_config)
-            .await
-            .unwrap();
-
-        let ret = MerkleStorage::<ContractId, AssetId, Word>::get(&db, &id, &test_asset_id)
-            .unwrap()
-            .expect("Expected a balance to be present")
-            .into_owned();
-
-        assert_eq!(test_balance, ret)
-    }
-
-    fn get_coins(db: &Database, owner: Address) -> Vec<(UtxoId, Coin)> {
-        db.owned_coins(owner, None, None)
-            .map(|r| {
-                r.and_then(|coin_id| {
-                    Storage::<UtxoId, Coin>::get(db, &coin_id)
-                        .map_err(Into::into)
-                        .map(|v| (coin_id, v.unwrap().into_owned()))
-                })
-            })
-            .try_collect()
-            .unwrap()
-    }
 }

--- a/fuel-core/src/service/genesis.rs
+++ b/fuel-core/src/service/genesis.rs
@@ -1,0 +1,410 @@
+use crate::{
+    chain_config::{ChainConfig, ContractConfig, StateConfig},
+    database::Database,
+    service::FuelService,
+};
+use anyhow::Result;
+use fuel_core_interfaces::model::{Coin, CoinStatus};
+use fuel_storage::{MerkleStorage, Storage};
+use fuel_tx::UtxoId;
+use fuel_types::{bytes::WORD_SIZE, AssetId, Bytes32, ContractId, Salt, Word};
+use fuel_vm::prelude::Contract;
+use itertools::Itertools;
+
+impl FuelService {
+    /// Loads state from the chain config into database
+    pub(crate) fn import_state(config: &ChainConfig, database: &Database) -> Result<()> {
+        // start a db transaction for bulk-writing
+        let mut import_tx = database.transaction();
+        let database = import_tx.as_mut();
+
+        // check if chain is initialized
+        if database.get_chain_name()?.is_none() {
+            // initialize the chain id
+            database.init_chain_name(config.chain_name.clone())?;
+
+            if let Some(initial_state) = &config.initial_state {
+                Self::init_block_height(database, initial_state)?;
+                Self::init_coin_state(database, initial_state)?;
+                Self::init_contracts(database, initial_state)?;
+            }
+        }
+
+        // Write transaction to db
+        import_tx.commit()?;
+
+        Ok(())
+    }
+
+    /// initialize starting block height if set
+    fn init_block_height(db: &Database, state: &StateConfig) -> Result<()> {
+        if let Some(height) = state.height {
+            db.init_chain_height(height)?;
+        }
+        Ok(())
+    }
+
+    /// initialize coins
+    fn init_coin_state(db: &mut Database, state: &StateConfig) -> Result<()> {
+        // TODO: Store merkle sum tree root over coins with unspecified utxo ids.
+        let mut generated_output_index: u64 = 0;
+        if let Some(coins) = &state.coins {
+            for coin in coins {
+                let utxo_id = UtxoId::new(
+                    // generated transaction id([0..[out_index/255]])
+                    coin.tx_id.unwrap_or_else(|| {
+                        Bytes32::try_from(
+                            (0..(Bytes32::LEN - WORD_SIZE))
+                                .map(|_| 0u8)
+                                .chain((generated_output_index / 255).to_be_bytes().into_iter())
+                                .collect_vec()
+                                .as_slice(),
+                        )
+                        .expect("Incorrect genesis transaction id byte length")
+                    }),
+                    coin.output_index.map(|i| i as u8).unwrap_or_else(|| {
+                        generated_output_index += 1;
+                        (generated_output_index % 255) as u8
+                    }),
+                );
+
+                let coin = Coin {
+                    owner: coin.owner,
+                    amount: coin.amount,
+                    asset_id: coin.asset_id,
+                    maturity: coin.maturity.unwrap_or_default(),
+                    status: CoinStatus::Unspent,
+                    block_created: coin.block_created.unwrap_or_default(),
+                };
+
+                let _ = Storage::<UtxoId, Coin>::insert(db, &utxo_id, &coin)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn init_contracts(db: &mut Database, state: &StateConfig) -> Result<()> {
+        // initialize contract state
+        if let Some(contracts) = &state.contracts {
+            for (generated_output_index, contract_config) in contracts.iter().enumerate() {
+                let contract = Contract::from(contract_config.code.as_slice());
+                let salt = contract_config.salt;
+                let root = contract.root();
+                let contract_id = contract.id(&salt, &root, &Contract::default_state_root());
+                // insert contract code
+                let _ = Storage::<ContractId, Contract>::insert(db, &contract_id, &contract)?;
+                // insert contract root
+                let _ = Storage::<ContractId, (Salt, Bytes32)>::insert(
+                    db,
+                    &contract_id,
+                    &(salt, root),
+                )?;
+                let _ = Storage::<ContractId, UtxoId>::insert(
+                    db,
+                    &contract_id,
+                    &UtxoId::new(
+                        // generated transaction id([0..[out_index/255]])
+                        Bytes32::try_from(
+                            (0..(Bytes32::LEN - WORD_SIZE))
+                                .map(|_| 0u8)
+                                .chain(
+                                    (generated_output_index as u64 / 255)
+                                        .to_be_bytes()
+                                        .into_iter(),
+                                )
+                                .collect_vec()
+                                .as_slice(),
+                        )
+                        .expect("Incorrect genesis transaction id byte length"),
+                        generated_output_index as u8,
+                    ),
+                )?;
+                Self::init_contract_state(db, &contract_id, contract_config)?;
+                Self::init_contract_balance(db, &contract_id, contract_config)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn init_contract_state(
+        db: &mut Database,
+        contract_id: &ContractId,
+        contract: &ContractConfig,
+    ) -> Result<()> {
+        // insert state related to contract
+        if let Some(contract_state) = &contract.state {
+            for (key, value) in contract_state {
+                MerkleStorage::<ContractId, Bytes32, Bytes32>::insert(db, contract_id, key, value)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn init_contract_balance(
+        db: &mut Database,
+        contract_id: &ContractId,
+        contract: &ContractConfig,
+    ) -> Result<()> {
+        // insert balances related to contract
+        if let Some(balances) = &contract.balances {
+            for (key, value) in balances {
+                MerkleStorage::<ContractId, AssetId, Word>::insert(db, contract_id, key, value)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chain_config::{CoinConfig, ContractConfig, StateConfig};
+    use crate::model::BlockHeight;
+    use crate::service::Config;
+    use fuel_asm::Opcode;
+    use fuel_types::{Address, AssetId, Word};
+    use itertools::Itertools;
+    use rand::rngs::StdRng;
+    use rand::{Rng, RngCore, SeedableRng};
+
+    #[tokio::test]
+    async fn config_initializes_chain_name() {
+        let test_name = "test_net_123".to_string();
+        let service_config = Config {
+            chain_conf: ChainConfig {
+                chain_name: test_name.clone(),
+                ..ChainConfig::local_testnet()
+            },
+            ..Config::local_node()
+        };
+
+        let db = Database::default();
+        FuelService::from_database(db.clone(), service_config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            test_name,
+            db.get_chain_name()
+                .unwrap()
+                .expect("Expected a chain name to be set")
+        )
+    }
+
+    #[tokio::test]
+    async fn config_initializes_block_height() {
+        let test_height = BlockHeight::from(99u32);
+        let service_config = Config {
+            chain_conf: ChainConfig {
+                initial_state: Some(StateConfig {
+                    height: Some(test_height),
+                    ..Default::default()
+                }),
+                ..ChainConfig::local_testnet()
+            },
+            ..Config::local_node()
+        };
+
+        let db = Database::default();
+        FuelService::from_database(db.clone(), service_config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            test_height,
+            db.get_block_height()
+                .unwrap()
+                .expect("Expected a block height to be set")
+        )
+    }
+
+    #[tokio::test]
+    async fn config_state_initializes_multiple_coins_with_different_owners_and_asset_ids() {
+        let mut rng = StdRng::seed_from_u64(10);
+
+        // a coin with all options set
+        let alice: Address = rng.gen();
+        let asset_id_alice: AssetId = rng.gen();
+        let alice_value = rng.gen();
+        let alice_maturity = Some(rng.next_u32().into());
+        let alice_block_created = Some(rng.next_u32().into());
+        let alice_tx_id = Some(rng.gen());
+        let alice_output_index = Some(rng.gen());
+        let alice_utxo_id = UtxoId::new(alice_tx_id.unwrap(), alice_output_index.unwrap());
+
+        // a coin with minimal options set
+        let bob: Address = rng.gen();
+        let asset_id_bob: AssetId = rng.gen();
+        let bob_value = rng.gen();
+
+        let service_config = Config {
+            chain_conf: ChainConfig {
+                initial_state: Some(StateConfig {
+                    coins: Some(vec![
+                        CoinConfig {
+                            tx_id: alice_tx_id,
+                            output_index: alice_output_index.map(|i| i as u64),
+                            block_created: alice_block_created,
+                            maturity: alice_maturity,
+                            owner: alice,
+                            amount: alice_value,
+                            asset_id: asset_id_alice,
+                        },
+                        CoinConfig {
+                            tx_id: None,
+                            output_index: None,
+                            block_created: None,
+                            maturity: None,
+                            owner: bob,
+                            amount: bob_value,
+                            asset_id: asset_id_bob,
+                        },
+                    ]),
+                    height: alice_block_created.map(|h| {
+                        let mut h: u32 = h.into();
+                        // set starting height to something higher than alice's coin
+                        h = h.saturating_add(rng.next_u32());
+                        h.into()
+                    }),
+                    ..Default::default()
+                }),
+                ..ChainConfig::local_testnet()
+            },
+            ..Config::local_node()
+        };
+
+        let db = Database::default();
+        FuelService::from_database(db.clone(), service_config)
+            .await
+            .unwrap();
+
+        let alice_coins = get_coins(&db, alice);
+        let bob_coins = get_coins(&db, bob)
+            .into_iter()
+            .map(|(_, coin)| coin)
+            .collect_vec();
+
+        assert!(matches!(
+            alice_coins.as_slice(),
+            &[(utxo_id, Coin {
+                owner,
+                amount,
+                asset_id,
+                block_created,
+                maturity,
+                ..
+            })] if utxo_id == alice_utxo_id
+            && owner == alice
+            && amount == alice_value
+            && asset_id == asset_id_alice
+            && block_created == alice_block_created.unwrap()
+            && maturity == alice_maturity.unwrap(),
+        ));
+        assert!(matches!(
+            bob_coins.as_slice(),
+            &[Coin {
+                owner,
+                amount,
+                asset_id,
+                ..
+            }] if owner == bob
+            && amount == bob_value
+            && asset_id == asset_id_bob
+        ));
+    }
+
+    #[tokio::test]
+    async fn config_state_initializes_contract_state() {
+        let mut rng = StdRng::seed_from_u64(10);
+
+        let test_key: Bytes32 = rng.gen();
+        let test_value: Bytes32 = rng.gen();
+        let state = vec![(test_key, test_value)];
+        let salt: Salt = rng.gen();
+        let contract = Contract::from(Opcode::RET(0x10).to_bytes().to_vec());
+        let root = contract.root();
+        let id = contract.id(&salt, &root, &Contract::default_state_root());
+
+        let service_config = Config {
+            chain_conf: ChainConfig {
+                initial_state: Some(StateConfig {
+                    contracts: Some(vec![ContractConfig {
+                        code: contract.into(),
+                        salt,
+                        state: Some(state),
+                        balances: None,
+                    }]),
+                    ..Default::default()
+                }),
+                ..ChainConfig::local_testnet()
+            },
+            ..Config::local_node()
+        };
+
+        let db = Database::default();
+        FuelService::from_database(db.clone(), service_config)
+            .await
+            .unwrap();
+
+        let ret = MerkleStorage::<ContractId, Bytes32, Bytes32>::get(&db, &id, &test_key)
+            .unwrap()
+            .expect("Expect a state entry to exist with test_key")
+            .into_owned();
+
+        assert_eq!(test_value, ret)
+    }
+
+    #[tokio::test]
+    async fn config_state_initializes_contract_balance() {
+        let mut rng = StdRng::seed_from_u64(10);
+
+        let test_asset_id: AssetId = rng.gen();
+        let test_balance: u64 = rng.next_u64();
+        let balances = vec![(test_asset_id, test_balance)];
+        let salt: Salt = rng.gen();
+        let contract = Contract::from(Opcode::RET(0x10).to_bytes().to_vec());
+        let root = contract.root();
+        let id = contract.id(&salt, &root, &Contract::default_state_root());
+
+        let service_config = Config {
+            chain_conf: ChainConfig {
+                initial_state: Some(StateConfig {
+                    contracts: Some(vec![ContractConfig {
+                        code: contract.into(),
+                        salt,
+                        state: None,
+                        balances: Some(balances),
+                    }]),
+                    ..Default::default()
+                }),
+                ..ChainConfig::local_testnet()
+            },
+            ..Config::local_node()
+        };
+
+        let db = Database::default();
+        FuelService::from_database(db.clone(), service_config)
+            .await
+            .unwrap();
+
+        let ret = MerkleStorage::<ContractId, AssetId, Word>::get(&db, &id, &test_asset_id)
+            .unwrap()
+            .expect("Expected a balance to be present")
+            .into_owned();
+
+        assert_eq!(test_balance, ret)
+    }
+
+    fn get_coins(db: &Database, owner: Address) -> Vec<(UtxoId, Coin)> {
+        db.owned_coins(owner, None, None)
+            .map(|r| {
+                r.and_then(|coin_id| {
+                    Storage::<UtxoId, Coin>::get(db, &coin_id)
+                        .map_err(Into::into)
+                        .map(|v| (coin_id, v.unwrap().into_owned()))
+                })
+            })
+            .try_collect()
+            .unwrap()
+    }
+}

--- a/fuel-core/src/service/graph_api.rs
+++ b/fuel-core/src/service/graph_api.rs
@@ -2,10 +2,10 @@ use crate::database::Database;
 use crate::schema::{build_schema, dap, CoreSchema};
 use crate::service::Config;
 use crate::tx_pool::TxPool;
+use anyhow::Result;
 use async_graphql::{
     extensions::Tracing, http::playground_source, http::GraphQLPlaygroundConfig, Request, Response,
 };
-use axum::routing::{get, post};
 use axum::{
     extract::Extension,
     http::{
@@ -16,6 +16,7 @@ use axum::{
     },
     response::Html,
     response::IntoResponse,
+    routing::{get, post},
     Json, Router,
 };
 use serde_json::json;
@@ -32,7 +33,7 @@ pub async fn start_server(
     config: Config,
     db: Database,
     tx_pool: Arc<TxPool>,
-) -> Result<(SocketAddr, JoinHandle<Result<(), crate::service::Error>>), std::io::Error> {
+) -> Result<(SocketAddr, JoinHandle<Result<()>>)> {
     let network_addr = config.addr;
     let schema = build_schema().data(db).data(tx_pool).data(config);
     let schema = dap::init(schema).extension(Tracing).finish();

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -20,7 +20,7 @@ ethers-providers = { git = "https://github.com/rakita/ethers-rs.git", branch = "
 ] }
 features = "0.10"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.7.1" }
-fuel-tx = { version = "0.10", features = ["serde"] }
+fuel-tx = { version = "0.11", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
 lazy_static = "1.4"

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -22,10 +22,10 @@ fuel-core = { path = "../fuel-core", features = ["test-helpers"], default-featur
 fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-gql-client = { path = "../fuel-client", features = ["test-helpers"] }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.10", features = ["serde", "builder", "internals"] }
+fuel-tx = { version = "0.11", features = ["serde", "builder", "internals"] }
 fuel-txpool = { path = "../fuel-txpool" }
 fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.9", features = ["serde", "random", "test-helpers"] }
+fuel-vm = { version = "0.10", features = ["serde", "random", "test-helpers"] }
 insta = "1.8"
 itertools = "0.10"
 rand = "0.8"

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -474,15 +474,13 @@ impl TestContext {
             receipts_root: Default::default(),
             script,
             script_data: vec![],
-            inputs: vec![Input::Coin {
+            inputs: vec![Input::CoinSigned {
                 utxo_id: self.rng.gen(),
                 owner: from,
                 amount,
                 asset_id: Default::default(),
                 witness_index: 0,
                 maturity: 0,
-                predicate: vec![],
-                predicate_data: vec![],
             }],
             outputs: vec![Output::Coin {
                 amount,

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -11,9 +11,10 @@ use fuel_gql_client::client::types::TransactionStatus;
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
 use fuel_vm::{consts::*, prelude::*};
 use itertools::Itertools;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::Rng;
 use std::io;
 
+mod predicates;
 mod utxo_validation;
 
 #[test]
@@ -457,13 +458,6 @@ async fn get_owned_transactions() {
 }
 
 impl TestContext {
-    async fn new(seed: u64) -> Self {
-        let rng = StdRng::seed_from_u64(seed);
-        let srv = FuelService::new_node(Config::local_node()).await.unwrap();
-        let client = FuelClient::from(srv.bound_address);
-        Self { rng, client }
-    }
-
     async fn transfer(&mut self, from: Address, to: Address, amount: u64) -> io::Result<Bytes32> {
         let script = Opcode::RET(0x10).to_bytes().to_vec();
         let tx = Transaction::Script {

--- a/fuel-tests/tests/tx/predicates.rs
+++ b/fuel-tests/tests/tx/predicates.rs
@@ -1,0 +1,76 @@
+// Tests related to the predicate execution feature
+
+use crate::helpers::TestSetupBuilder;
+use fuel_crypto::Hasher;
+use fuel_tx::{Input, Output, TransactionBuilder};
+use fuel_vm::consts::REG_ONE;
+use fuel_vm::prelude::Opcode;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+
+#[tokio::test]
+async fn transaction_with_predicates_is_rejected_when_feature_disabled() {
+    let mut rng = StdRng::seed_from_u64(2322);
+
+    // setup tx with a predicate input
+    let asset_id = rng.gen();
+    let predicate_tx = TransactionBuilder::script(Default::default(), Default::default())
+        .add_input(Input::coin_predicate(
+            rng.gen(),
+            rng.gen(),
+            500,
+            asset_id,
+            0,
+            rng.gen::<[u8; 32]>().to_vec(),
+            rng.gen::<[u8; 32]>().to_vec(),
+        ))
+        .add_output(Output::change(rng.gen(), 0, asset_id))
+        .finalize();
+
+    // create test context with predicates disabled
+    let context = TestSetupBuilder {
+        predicates: false,
+        ..Default::default()
+    }
+    .config_coin_inputs_from_transactions(&[&predicate_tx])
+    .finalize()
+    .await;
+
+    let result = context.client.submit(&predicate_tx).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn transaction_with_predicates_is_allowed_when_feature_enabled() {
+    let mut rng = StdRng::seed_from_u64(2322);
+
+    // setup tx with a predicate input
+    let asset_id = rng.gen();
+    let predicate = Opcode::RET(REG_ONE).to_bytes().to_vec();
+    let owner = (*Hasher::hash(predicate.as_slice())).into();
+    let predicate_tx = TransactionBuilder::script(Default::default(), Default::default())
+        .add_input(Input::coin_predicate(
+            rng.gen(),
+            owner,
+            500,
+            asset_id,
+            0,
+            // TODO: make this a valid predicate once predicate execution is enabled in the VM.
+            predicate,
+            vec![],
+        ))
+        .add_output(Output::change(rng.gen(), 0, asset_id))
+        .finalize();
+
+    // create test context with predicates disabled
+    let context = TestSetupBuilder {
+        predicates: true,
+        ..Default::default()
+    }
+    .config_coin_inputs_from_transactions(&[&predicate_tx])
+    .finalize()
+    .await;
+
+    let result = context.client.submit(&predicate_tx).await;
+    // for now, only ensure no errors occurred
+    assert!(result.is_ok());
+}

--- a/fuel-tests/tests/tx/predicates.rs
+++ b/fuel-tests/tests/tx/predicates.rs
@@ -3,8 +3,7 @@
 use crate::helpers::TestSetupBuilder;
 use fuel_crypto::Hasher;
 use fuel_tx::{Input, Output, TransactionBuilder};
-use fuel_vm::consts::REG_ONE;
-use fuel_vm::prelude::Opcode;
+use fuel_vm::{consts::REG_ONE, prelude::Opcode};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 #[tokio::test]

--- a/fuel-tests/tests/tx/utxo_validation.rs
+++ b/fuel-tests/tests/tx/utxo_validation.rs
@@ -24,15 +24,7 @@ async fn submit_utxo_verified_tx_with_min_gas_price() {
             .gas_limit(100)
             .gas_price(1)
             .byte_price(1)
-            .add_unsigned_coin_input(
-                rng.gen(),
-                &secret,
-                1000 + i,
-                Default::default(),
-                0,
-                vec![],
-                vec![],
-            )
+            .add_unsigned_coin_input(rng.gen(), &secret, 1000 + i, Default::default(), 0)
             .add_input(Input::Contract {
                 utxo_id: Default::default(),
                 balance_root: Default::default(),
@@ -129,24 +121,20 @@ async fn dry_run_override_utxo_validation() {
         vec![],
     )
     .gas_limit(1000)
-    .add_input(Input::coin(
+    .add_input(Input::coin_signed(
         rng.gen(),
         rng.gen(),
         1000,
         AssetId::default(),
         0,
         Default::default(),
-        Default::default(),
-        Default::default(),
     ))
-    .add_input(Input::coin(
+    .add_input(Input::coin_signed(
         rng.gen(),
         rng.gen(),
         rng.gen(),
         asset_id,
         0,
-        Default::default(),
-        Default::default(),
         Default::default(),
     ))
     .add_output(Output::change(rng.gen(), 0, asset_id))
@@ -176,24 +164,20 @@ async fn dry_run_no_utxo_validation_override() {
         vec![],
     )
     .gas_limit(1000)
-    .add_input(Input::coin(
+    .add_input(Input::coin_signed(
         rng.gen(),
         rng.gen(),
         1000,
         AssetId::default(),
         0,
         Default::default(),
-        Default::default(),
-        Default::default(),
     ))
-    .add_input(Input::coin(
+    .add_input(Input::coin_signed(
         rng.gen(),
         rng.gen(),
         rng.gen(),
         asset_id,
         0,
-        Default::default(),
-        Default::default(),
         Default::default(),
     ))
     .add_output(Output::change(rng.gen(), 0, asset_id))

--- a/fuel-tests/tests/tx/utxo_validation.rs
+++ b/fuel-tests/tests/tx/utxo_validation.rs
@@ -46,7 +46,7 @@ async fn submit_utxo_verified_tx_with_min_gas_price() {
         .collect_vec();
 
     // setup genesis block with coins that transactions can spend
-    test_builder.config_coin_inputs_from_transactions(&transactions);
+    test_builder.config_coin_inputs_from_transactions(&transactions.iter().collect_vec());
 
     // spin up node
     let TestContext { client, .. } = test_builder.finalize().await;

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.1" }
-fuel-tx = { version = "0.10", features = ["serde"] }
+fuel-tx = { version = "0.11", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
 parking_lot = "0.11"


### PR DESCRIPTION
Adds support for the new Input type `CoinPredicate`. This will only break Rust dependents, graphql and ts consumers won't be affected.

This also adds a feature flag called `predicates` to the fuel-core service config which allows the node to reject tx's with predicates until they are stabilized.