### PR TITLE
CI fix: mac-os -> macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
           /target/aarch64-unknown-linux-musl/release/fuel-core
 
       - name: Strip release binary mac
-        if: matrix.job.os == 'mac-os'
+        if: matrix.job.os == 'macos-latest'
         run: strip -x "target/${{ matrix.job.target }}/release/fuel-core"
 
       - name: Prepare Binary Artifact


### PR DESCRIPTION
Was using `ci.yml` from this repo as reference for `fuelup`, and @Voxelot pointed this out in a [review](https://github.com/FuelLabs/fuelup/pull/9#discussion_r881252477)