### PR TITLE
Integrate predicate execution into fuel-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,16 +191,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      # enable docker layer caching for non-release builds
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          # Key is named differently to avoid collision
-          key: ${{ runner.os }}-multi-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-multi-buildx
-
       - name: Log in to the ghcr.io registry
         uses: docker/login-action@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,7 +2111,6 @@ dependencies = [
  "clap",
  "cynic",
  "derive_more",
- "fuel-storage",
  "fuel-tx",
  "fuel-types",
  "fuel-vm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,7 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.11.0"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a70dffe9faeb81f9d9d202eb26af4742980f884fa3109c169819ac6b2c51d3"
 dependencies = [
  "dyn-clone",
  "fuel-asm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,9 +2008,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuel-asm"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee63d1f54705db47d3cfa15f48b320c04a98252226adff0a46a88a9fbb08c489"
+checksum = "16628e172a06a411c57972c55a67404f1684118be3bbca79148bf5a00fff48f0"
 dependencies = [
  "fuel-types",
  "serde",
@@ -2035,8 +2035,8 @@ dependencies = [
  "fuel-asm",
  "fuel-core-interfaces",
  "fuel-crypto",
- "fuel-merkle",
- "fuel-storage",
+ "fuel-merkle 0.1.1",
+ "fuel-storage 0.1.0",
  "fuel-tx",
  "fuel-txpool",
  "fuel-types",
@@ -2075,7 +2075,7 @@ dependencies = [
  "derive_more",
  "fuel-asm",
  "fuel-crypto",
- "fuel-storage",
+ "fuel-storage 0.1.0",
  "fuel-tx",
  "fuel-types",
  "fuel-vm",
@@ -2133,11 +2133,24 @@ checksum = "8148b67b9ca99755b8c73fbc5bad7710590e1d7e245680ffd351289915258851"
 dependencies = [
  "bytes",
  "digest 0.9.0",
- "fuel-storage",
+ "fuel-storage 0.1.0",
  "generic-array 0.14.5",
  "hex",
  "lazy_static",
  "sha2 0.9.9",
+ "thiserror",
+]
+
+[[package]]
+name = "fuel-merkle"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab10247f9eababf72a64120da05cfef57fbf811ebd2c93dbbbbeccddcce5f11"
+dependencies = [
+ "digest 0.10.3",
+ "fuel-storage 0.2.0",
+ "hex",
+ "sha2 0.10.2",
  "thiserror",
 ]
 
@@ -2193,6 +2206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f97a6a68c3378e486d645a47026bcd7139500345ef214653811ea4f016f142ce"
 
 [[package]]
+name = "fuel-storage"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b9161e86d434a93088409530a4f71f42e074b3bbcbb7a27bfe666583f92fd7"
+
+[[package]]
 name = "fuel-tests"
 version = "0.0.0"
 dependencies = [
@@ -2200,7 +2219,7 @@ dependencies = [
  "fuel-core",
  "fuel-crypto",
  "fuel-gql-client",
- "fuel-storage",
+ "fuel-storage 0.1.0",
  "fuel-tx",
  "fuel-txpool",
  "fuel-types",
@@ -2214,12 +2233,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b6bb7bef3d281f50670288505987b41653e4a513d75482e19775564b91e05e"
+checksum = "8f76a720b4e32c6a51f39f609a472b9dcae35bc20a4ce9569601f3c24718b3ae"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
+ "fuel-merkle 0.2.0",
  "fuel-types",
  "itertools",
  "rand 0.8.5",
@@ -2255,15 +2275,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bb539c6cb5a8e1963b4c4ecbf238df4dd863e672d2773f32d08d59afb50a8"
+version = "0.11.0"
 dependencies = [
  "dyn-clone",
  "fuel-asm",
  "fuel-crypto",
- "fuel-merkle",
- "fuel-storage",
+ "fuel-merkle 0.1.1",
+ "fuel-storage 0.1.0",
  "fuel-tx",
  "fuel-types",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ members = [
 codegen-units = 1
 lto = "fat"
 panic = "abort"
+
+[patch.crates-io]
+fuel-vm = { path = "../fuel-vm" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ members = [
 codegen-units = 1
 lto = "fat"
 panic = "abort"
-
-[patch.crates-io]
-fuel-vm = { path = "../fuel-vm" }

--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -80,6 +80,9 @@ spec:
           {{- if .Values.app.vm_backtrace }}
             - "--vm-backtrace"
           {{- end}}
+          {{- if .Values.app.predicates }}
+            - "--predicates"
+          {{- end}}
             - "--min-gas-price"
             - "{{ .Values.app.min_gas_price }}"
             - "--min-byte-price"

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -13,6 +13,7 @@ app:
   vm_backtrace: ${fuel_core_vm_backtrace}
   min_gas_price: ${fuel_core_min_gas_price}
   min_byte_price: ${fuel_core_min_byte_price}
+  predicates: ${fuel_core_predicates}
   image:
     repository: ${fuel_core_image_repository}
     tag: ${fuel_core_image_tag}

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -14,6 +14,7 @@ fuel_core_utxo_validation=true
 fuel_core_vm_backtrace=false
 fuel_core_min_gas_price=0
 fuel_core_min_byte_price=0
+fuel_core_predicates=false
 
 # Ingress Environment variables
 letsencrypt_email="helloworld@gmail.com"

--- a/deployment/test_chainspec.json
+++ b/deployment/test_chainspec.json
@@ -12,5 +12,18 @@
         "asset_id": "0x0000000000000000000000000000000000000000000000000000000000000000"
       }
     ]
+  },
+  "transaction_parameters": {
+    "contract_max_size": 16777216,
+    "max_inputs": 255,
+    "max_outputs": 255,
+    "max_witnesses": 255,
+    "max_gas_per_tx": 100000000,
+    "max_script_length": 1048576,
+    "max_script_data_length": 1048576,
+    "max_static_contracts": 255,
+    "max_storage_slots": 255,
+    "max_predicate_length": 1048576,
+    "max_predicate_data_length": 1048576
   }
 }

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -20,9 +20,9 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "1.0", features = ["surf"] }
 derive_more = { version = "0.99" }
-fuel-tx = { version = "0.11", features = ["serde"] }
+fuel-tx = { version = "0.12", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.10", features = ["serde"] }
+fuel-vm = { version = "0.11", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
 itertools = "0.10"

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -20,7 +20,6 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "1.0", features = ["surf"] }
 derive_more = { version = "0.99" }
-fuel-storage = "0.1"
 fuel-tx = { version = "0.11", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
 fuel-vm = { version = "0.10", features = ["serde"] }

--- a/fuel-client/src/lib.rs
+++ b/fuel-client/src/lib.rs
@@ -1,2 +1,10 @@
 pub mod client;
 pub mod schema;
+
+// re-exports
+#[doc(no_inline)]
+pub use fuel_tx;
+#[doc(no_inline)]
+pub use fuel_types;
+#[doc(no_inline)]
+pub use fuel_vm;

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -18,9 +18,9 @@ derive_more = { version = "0.99" }
 fuel-asm = "0.5"
 fuel-crypto = { version = "0.5", default-features = false }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.11", default-features = false }
+fuel-tx = { version = "0.12", default-features = false }
 fuel-types = { version = "0.5", default-features = false }
-fuel-vm = { version = "0.10", default-features = false }
+fuel-vm = { version = "0.11", default-features = false }
 futures = "0.3"
 lazy_static = "1.4"
 parking_lot = "0.12"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -42,10 +42,10 @@ fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.1", fe
 fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-merkle = "0.1"
 fuel-storage = { version = "0.1" }
-fuel-tx = { version = "0.11", features = ["serde"] }
+fuel-tx = { version = "0.12", features = ["serde"] }
 fuel-txpool = { path = "../fuel-txpool", version = "0.7.1" }
 fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.10", features = ["serde", "profile-coverage"] }
+fuel-vm = { version = "0.11", features = ["serde", "profile-coverage"] }
 futures = "0.3"
 graphql-parser = "0.3.0"
 hex = { version = "0.4", features = ["serde"] }
@@ -73,12 +73,12 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-fuel-tx = { version = "0.11", features = [
+fuel-tx = { version = "0.12", features = [
     "serde",
     "builder",
     "internals",
 ] }
-fuel-vm = { version = "0.10", features = [
+fuel-vm = { version = "0.11", features = [
     "serde",
     "random",
     "test-helpers",

--- a/fuel-core/src/chain_config.rs
+++ b/fuel-core/src/chain_config.rs
@@ -1,5 +1,6 @@
 use self::serialization::{HexNumber, HexType};
 use crate::model::BlockHeight;
+use fuel_tx::ConsensusParameters;
 use fuel_types::{Address, AssetId, Bytes32, Salt};
 use itertools::Itertools;
 use rand::rngs::StdRng;
@@ -21,6 +22,7 @@ pub struct ChainConfig {
     pub parent_network: BaseChainConfig,
     #[serde(default)]
     pub initial_state: Option<StateConfig>,
+    pub transaction_parameters: ConsensusParameters,
 }
 
 impl ChainConfig {
@@ -58,6 +60,7 @@ impl ChainConfig {
                 coins: Some(initial_coins),
                 ..StateConfig::default()
             }),
+            transaction_parameters: ConsensusParameters::default(),
         }
     }
 }

--- a/fuel-core/src/coin_query.rs
+++ b/fuel-core/src/coin_query.rs
@@ -38,7 +38,7 @@ pub type SpendQueryElement = (Address, AssetId, u64);
 pub fn largest_first(
     db: &Database,
     spend_query: &SpendQuery,
-    max_inputs: u8,
+    max_inputs: u64,
     excluded_ids: Option<&Vec<UtxoId>>,
 ) -> Result<Vec<(UtxoId, Coin)>, CoinQueryError> {
     // Merge elements with the same (owner, asset_id)
@@ -117,7 +117,7 @@ pub fn largest_first(
 pub fn random_improve(
     db: &Database,
     spend_query: &SpendQuery,
-    max_inputs: u8,
+    max_inputs: u64,
     excluded_ids: Option<&Vec<UtxoId>>,
 ) -> Result<Vec<(UtxoId, Coin)>, CoinQueryError> {
     // Merge elements with the same (owner, asset_id)
@@ -281,7 +281,7 @@ mod tests {
             db.make_coin(owner, (i + 1) as Word, asset_ids[1]);
         });
         let query = |spend_query: &[SpendQueryElement],
-                     max_inputs: u8|
+                     max_inputs: u64|
          -> Result<Vec<(AssetId, u64)>, CoinQueryError> {
             let coins = largest_first(db.as_ref(), spend_query, max_inputs, None);
 
@@ -296,7 +296,7 @@ mod tests {
 
         // Query some amounts, including higher than the owner's balance
         for amount in 0..20 {
-            let coins = query(&[(owner, asset_ids[0], amount)], u8::MAX);
+            let coins = query(&[(owner, asset_ids[0], amount)], u8::MAX as u64);
 
             // Transform result for convenience
             let coins = coins.map(|coins| {
@@ -332,14 +332,14 @@ mod tests {
         // Query multiple asset IDs
         let coins = query(
             &[(owner, asset_ids[0], 3), (owner, asset_ids[1], 6)],
-            u8::MAX,
+            u8::MAX as u64,
         );
         assert_matches!(coins, Ok(coins) if coins == vec![(asset_ids[0], 5), (asset_ids[1], 5), (asset_ids[1], 4)]);
 
         // Query with duplicate (owner, asset_id)
         let coins = query(
             &[(owner, asset_ids[0], 3), (owner, asset_ids[0], 3)],
-            u8::MAX,
+            u8::MAX as u64,
         );
         assert_matches!(coins, Ok(coins) if coins == vec![(asset_ids[0], 5),  (asset_ids[0], 4)]);
 
@@ -359,7 +359,7 @@ mod tests {
             db.make_coin(owner, (i + 1) as Word, asset_ids[1]);
         });
         let query = |spend_query: &[SpendQueryElement],
-                     max_inputs: u8|
+                     max_inputs: u64|
          -> Result<Vec<(AssetId, u64)>, CoinQueryError> {
             let coins = random_improve(db.as_ref(), spend_query, max_inputs, None);
 
@@ -380,7 +380,7 @@ mod tests {
 
         // Query some amounts, including higher than the owner's balance
         for amount in 0..20 {
-            let coins = query(&[(owner, asset_ids[0], amount)], u8::MAX);
+            let coins = query(&[(owner, asset_ids[0], amount)], u8::MAX as u64);
 
             // Transform result for convenience
             let coins = coins.map(|coins| {
@@ -436,7 +436,7 @@ mod tests {
         // Query with duplicate (owner, asset_id)
         let coins = query(
             &[(owner, asset_ids[0], 3), (owner, asset_ids[0], 3)],
-            u8::MAX,
+            u8::MAX as u64,
         );
         assert_matches!(coins, Ok(coins) if coins
             .iter()
@@ -461,7 +461,7 @@ mod tests {
             db.make_coin(owner, (i + 1) as Word, asset_ids[1]);
         });
         let query = |spend_query: &[SpendQueryElement],
-                     max_inputs: u8,
+                     max_inputs: u64,
                      excluded_ids: Option<&Vec<UtxoId>>|
          -> Result<Vec<(AssetId, u64)>, CoinQueryError> {
             let coins = random_improve(db.as_ref(), spend_query, max_inputs, excluded_ids);
@@ -493,7 +493,7 @@ mod tests {
         for amount in 0..20 {
             let coins = query(
                 &[(owner, asset_ids[0], amount)],
-                u8::MAX,
+                u8::MAX as u64,
                 Some(&excluded_ids),
             );
 

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -95,7 +95,10 @@ impl Executor {
             let mut sub_block_db_commit = block_db_transaction.transaction();
             let sub_db_view = sub_block_db_commit.deref_mut();
             // execution vm
-            let mut vm = Interpreter::with_storage(sub_db_view.clone());
+            let mut vm = Interpreter::with_storage(
+                sub_db_view.clone(),
+                self.config.chain_conf.transaction_parameters,
+            );
             let vm_result = vm
                 .transact(tx.clone())
                 .map_err(|error| Error::VmExecution {
@@ -708,7 +711,7 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use fuel_asm::Opcode;
     use fuel_crypto::SecretKey;
-    use fuel_tx::consts::MAX_GAS_PER_TX;
+    use fuel_tx::default_parameters::MAX_GAS_PER_TX;
     use fuel_tx::TransactionBuilder;
     use fuel_types::{ContractId, Immediate12, Salt};
     use fuel_vm::consts::{REG_CGAS, REG_FP, REG_ONE, REG_ZERO};
@@ -740,9 +743,9 @@ mod tests {
 
     fn create_contract<R: Rng>(contract_code: Vec<u8>, rng: &mut R) -> (Transaction, ContractId) {
         let salt: Salt = rng.gen();
-        let contract = fuel_vm::contract::Contract::from(contract_code.clone());
+        let contract = fuel_tx::Contract::from(contract_code.clone());
         let root = contract.root();
-        let state_root = fuel_vm::contract::Contract::default_state_root();
+        let state_root = fuel_tx::Contract::default_state_root();
         let contract_id = contract.id(&salt, &root, &state_root);
 
         let tx = Transaction::create(

--- a/fuel-core/src/service.rs
+++ b/fuel-core/src/service.rs
@@ -89,7 +89,7 @@ impl FuelService {
     async fn init_service(database: Database, config: Config) -> Result<Self, AnyError> {
         // check predicates flag
         if config.predicates {
-            warn!("Predicates are not supported yet!");
+            warn!("Predicates are currently an unstable feature!");
         }
 
         // initialize state

--- a/fuel-core/src/service/graph_api.rs
+++ b/fuel-core/src/service/graph_api.rs
@@ -35,8 +35,9 @@ pub async fn start_server(
     tx_pool: Arc<TxPool>,
 ) -> Result<(SocketAddr, JoinHandle<Result<()>>)> {
     let network_addr = config.addr;
+    let params = config.chain_conf.transaction_parameters;
     let schema = build_schema().data(db).data(tx_pool).data(config);
-    let schema = dap::init(schema).extension(Tracing).finish();
+    let schema = dap::init(schema, params).extension(Tracing).finish();
 
     let router = Router::new()
         .route("/playground", get(graphql_playground))

--- a/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_configurable_block_height.snap
+++ b/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_configurable_block_height.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/chain_config.rs
+assertion_line: 214
 expression: json
 
 ---
@@ -11,5 +12,18 @@ expression: json
   },
   "initial_state": {
     "height": "0x0000000014c8be1f"
+  },
+  "transaction_parameters": {
+    "contract_max_size": 16777216,
+    "max_inputs": 255,
+    "max_outputs": 255,
+    "max_witnesses": 255,
+    "max_gas_per_tx": 100000000,
+    "max_script_length": 1048576,
+    "max_script_data_length": 1048576,
+    "max_static_contracts": 255,
+    "max_storage_slots": 255,
+    "max_predicate_length": 1048576,
+    "max_predicate_data_length": 1048576
   }
 }

--- a/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_contract_with_balances.snap
+++ b/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_contract_with_balances.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/chain_config.rs
+assertion_line: 266
 expression: json
 
 ---
@@ -22,5 +23,18 @@ expression: json
         ]
       }
     ]
+  },
+  "transaction_parameters": {
+    "contract_max_size": 16777216,
+    "max_inputs": 255,
+    "max_outputs": 255,
+    "max_witnesses": 255,
+    "max_gas_per_tx": 100000000,
+    "max_script_length": 1048576,
+    "max_script_data_length": 1048576,
+    "max_static_contracts": 255,
+    "max_storage_slots": 255,
+    "max_predicate_length": 1048576,
+    "max_predicate_data_length": 1048576
   }
 }

--- a/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_contract_with_state.snap
+++ b/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_contract_with_state.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/chain_config.rs
+assertion_line: 251
 expression: json
 
 ---
@@ -22,5 +23,18 @@ expression: json
         ]
       }
     ]
+  },
+  "transaction_parameters": {
+    "contract_max_size": 16777216,
+    "max_inputs": 255,
+    "max_outputs": 255,
+    "max_witnesses": 255,
+    "max_gas_per_tx": 100000000,
+    "max_script_length": 1048576,
+    "max_script_data_length": 1048576,
+    "max_static_contracts": 255,
+    "max_storage_slots": 255,
+    "max_predicate_length": 1048576,
+    "max_predicate_data_length": 1048576
   }
 }

--- a/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_local_testnet_config.snap
+++ b/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_local_testnet_config.snap
@@ -1,6 +1,6 @@
 ---
 source: fuel-core/src/chain_config.rs
-assertion_line: 189
+assertion_line: 192
 expression: json
 
 ---
@@ -38,5 +38,18 @@ expression: json
         "asset_id": "0x0000000000000000000000000000000000000000000000000000000000000000"
       }
     ]
+  },
+  "transaction_parameters": {
+    "contract_max_size": 16777216,
+    "max_inputs": 255,
+    "max_outputs": 255,
+    "max_witnesses": 255,
+    "max_gas_per_tx": 100000000,
+    "max_script_length": 1048576,
+    "max_script_data_length": 1048576,
+    "max_static_contracts": 255,
+    "max_storage_slots": 255,
+    "max_predicate_length": 1048576,
+    "max_predicate_data_length": 1048576
   }
 }

--- a/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_simple_coin_state.snap
+++ b/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_simple_coin_state.snap
@@ -1,6 +1,6 @@
 ---
 source: fuel-core/src/chain_config.rs
-assertion_line: 257
+assertion_line: 281
 expression: json
 
 ---
@@ -22,5 +22,18 @@ expression: json
         "asset_id": "0x0d053242a9719dca480b4f4910fa60671f2068086498c72e30fc8b969e083932"
       }
     ]
+  },
+  "transaction_parameters": {
+    "contract_max_size": 16777216,
+    "max_inputs": 255,
+    "max_outputs": 255,
+    "max_witnesses": 255,
+    "max_gas_per_tx": 100000000,
+    "max_script_length": 1048576,
+    "max_script_data_length": 1048576,
+    "max_static_contracts": 255,
+    "max_storage_slots": 255,
+    "max_predicate_length": 1048576,
+    "max_predicate_data_length": 1048576
   }
 }

--- a/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_simple_contract.snap
+++ b/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_simple_contract.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/chain_config.rs
+assertion_line: 236
 expression: json
 
 ---
@@ -16,5 +17,18 @@ expression: json
         "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
       }
     ]
+  },
+  "transaction_parameters": {
+    "contract_max_size": 16777216,
+    "max_inputs": 255,
+    "max_outputs": 255,
+    "max_witnesses": 255,
+    "max_gas_per_tx": 100000000,
+    "max_script_length": 1048576,
+    "max_script_data_length": 1048576,
+    "max_static_contracts": 255,
+    "max_storage_slots": 255,
+    "max_predicate_length": 1048576,
+    "max_predicate_data_length": 1048576
   }
 }

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -20,7 +20,7 @@ ethers-providers = { git = "https://github.com/rakita/ethers-rs.git", branch = "
 ] }
 features = "0.10"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.7.1" }
-fuel-tx = { version = "0.11", features = ["serde"] }
+fuel-tx = { version = "0.12", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
 lazy_static = "1.4"

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -22,10 +22,10 @@ fuel-core = { path = "../fuel-core", features = ["test-helpers"], default-featur
 fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-gql-client = { path = "../fuel-client", features = ["test-helpers"] }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.11", features = ["serde", "builder", "internals"] }
+fuel-tx = { version = "0.12", features = ["serde", "builder", "internals"] }
 fuel-txpool = { path = "../fuel-txpool" }
 fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.10", features = ["serde", "random", "test-helpers"] }
+fuel-vm = { version = "0.11", features = ["serde", "random", "test-helpers"] }
 insta = "1.8"
 itertools = "0.10"
 rand = "0.8"

--- a/fuel-tests/tests/tx/predicates.rs
+++ b/fuel-tests/tests/tx/predicates.rs
@@ -1,7 +1,6 @@
 // Tests related to the predicate execution feature
 
 use crate::helpers::TestSetupBuilder;
-use fuel_crypto::Hasher;
 use fuel_tx::{Input, Output, TransactionBuilder};
 use fuel_vm::{consts::REG_ONE, prelude::Opcode};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -45,7 +44,7 @@ async fn transaction_with_predicates_is_allowed_when_feature_enabled() {
     // setup tx with a predicate input
     let asset_id = rng.gen();
     let predicate = Opcode::RET(REG_ONE).to_bytes().to_vec();
-    let owner = (*Hasher::hash(predicate.as_slice())).into();
+    let owner = Input::predicate_owner(&predicate);
     let predicate_tx = TransactionBuilder::script(Default::default(), Default::default())
         .add_input(Input::coin_predicate(
             rng.gen(),

--- a/fuel-tests/tests/tx/predicates.rs
+++ b/fuel-tests/tests/tx/predicates.rs
@@ -2,6 +2,7 @@
 
 use crate::helpers::TestSetupBuilder;
 use fuel_tx::{Input, Output, TransactionBuilder};
+use fuel_vm::consts::REG_ZERO;
 use fuel_vm::{consts::REG_ONE, prelude::Opcode};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
@@ -38,21 +39,70 @@ async fn transaction_with_predicates_is_rejected_when_feature_disabled() {
 }
 
 #[tokio::test]
-async fn transaction_with_predicates_is_allowed_when_feature_enabled() {
+async fn transaction_with_predicate_is_executed_when_feature_enabled() {
     let mut rng = StdRng::seed_from_u64(2322);
 
     // setup tx with a predicate input
+    let amount = 500;
     let asset_id = rng.gen();
+    // make predicate return 1 which mean valid
     let predicate = Opcode::RET(REG_ONE).to_bytes().to_vec();
     let owner = Input::predicate_owner(&predicate);
     let predicate_tx = TransactionBuilder::script(Default::default(), Default::default())
         .add_input(Input::coin_predicate(
             rng.gen(),
             owner,
-            500,
+            amount,
             asset_id,
             0,
-            // TODO: make this a valid predicate once predicate execution is enabled in the VM.
+            predicate,
+            vec![],
+        ))
+        .add_output(Output::change(rng.gen(), 0, asset_id))
+        .finalize();
+
+    // create test context with predicates disabled
+    let context = TestSetupBuilder {
+        predicates: true,
+        ..Default::default()
+    }
+    .config_coin_inputs_from_transactions(&[&predicate_tx])
+    .finalize()
+    .await;
+
+    let transaction_id = context.client.submit(&predicate_tx).await.unwrap();
+
+    // check transaction change amount to see if predicate was spent
+    let transaction = context
+        .client
+        .transaction(&transaction_id.to_string())
+        .await
+        .unwrap()
+        .unwrap()
+        .transaction;
+
+    assert!(
+        matches!(transaction.outputs()[0], Output::Change { amount: change_amount, .. } if change_amount == amount)
+    )
+}
+
+#[tokio::test]
+async fn transaction_with_invalid_predicate_is_rejected_when_feature_is_enabled() {
+    let mut rng = StdRng::seed_from_u64(2322);
+
+    // setup tx with a predicate input
+    let amount = 500;
+    let asset_id = rng.gen();
+    // make predicate return 0 which means invalid
+    let predicate = Opcode::RET(REG_ZERO).to_bytes().to_vec();
+    let owner = Input::predicate_owner(&predicate);
+    let predicate_tx = TransactionBuilder::script(Default::default(), Default::default())
+        .add_input(Input::coin_predicate(
+            rng.gen(),
+            owner,
+            amount,
+            asset_id,
+            0,
             predicate,
             vec![],
         ))
@@ -69,6 +119,6 @@ async fn transaction_with_predicates_is_allowed_when_feature_enabled() {
     .await;
 
     let result = context.client.submit(&predicate_tx).await;
-    // for now, only ensure no errors occurred
-    assert!(result.is_ok());
+
+    assert!(result.is_err())
 }

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.7.1" }
-fuel-tx = { version = "0.11", features = ["serde"] }
+fuel-tx = { version = "0.12", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
 parking_lot = "0.11"


### PR DESCRIPTION
- Enables predicate execution by utilizing https://github.com/FuelLabs/fuel-vm/pull/129
- Adds configurable parameters for transaction validation in the chainspec
- Re-export fuel-deps from fuel-gql-client, so SDK or other downstream users won't have to worry about aligning the versions on their end for fuel-vm, fuel-tx, and fuel-types.