### PR TITLE
add tracing to p2p tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
@@ -2142,7 +2152,7 @@ version = "0.7.0"
 dependencies = [
  "async-trait",
  "bincode",
- "env_logger",
+ "ctor",
  "futures",
  "futures-timer",
  "ip_network",
@@ -2152,6 +2162,9 @@ dependencies = [
  "sha2 0.9.9",
  "tokio",
  "tracing",
+ "tracing-appender",
+ "tracing-attributes",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3809,6 +3822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -5555,6 +5577,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+]
+
+[[package]]
 name = "time-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5745,10 +5778,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.19"
+name = "tracing-appender"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.9",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -28,6 +28,9 @@ tokio = { version = "1.17", features = ["sync"] }
 tracing = "0.1"
 
 [dev-dependencies]
-env_logger = "0.9"
+ctor = "0.1"
 rand = "0.8"
 tokio = { version = "1.17", features = ["full"] }
+tracing-appender = "0.2"
+tracing-attributes = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/fuel-p2p/src/behavior.rs
+++ b/fuel-p2p/src/behavior.rs
@@ -31,7 +31,7 @@ use std::{
 use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FuelBehaviourEvent {
     PeerConnected(PeerId),
     PeerDisconnected(PeerId),

--- a/fuel-p2p/src/discovery.rs
+++ b/fuel-p2p/src/discovery.rs
@@ -385,7 +385,6 @@ mod tests {
     // test completes after all swarms have connected to each other
     #[tokio::test]
     async fn discovery_works() {
-        env_logger::init();
         // Number of peers in the network
         let num_of_swarms = 25;
         let (first_swarm, first_peer_addr, first_peer_id) = build_fuel_discovery(vec![]);

--- a/fuel-p2p/src/gossipsub/messages.rs
+++ b/fuel-p2p/src/gossipsub/messages.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
 pub enum GossipsubMessage {
     BroadcastNewTx,
     BroadcastNewBlock,

--- a/fuel-p2p/src/request_response/messages.rs
+++ b/fuel-p2p/src/request_response/messages.rs
@@ -8,12 +8,12 @@ pub(crate) const REQUEST_RESPONSE_PROTOCOL_ID: &[u8] = b"/fuel/req_res/0.0.1";
 pub(crate) const MAX_REQUEST_SIZE: usize = 100;
 pub(crate) const MAX_RESPONSE_SIZE: usize = 100;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
 pub enum RequestMessage {
     RequestBlock,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
 pub enum ResponseMessage {
     ResponseBlock,
 }


### PR DESCRIPTION
I have added more log events to p2p tests,

I have also added [optional] logging for the tests, specifically for our cron jobs.

The logs will be written to `stderr` and to a log file.

Few other updates:
- renamed some variables in p2p tests
- added few default derive traits to few structs, like Clone, Copy etc


