### PR TITLE
async-graphql upgrade to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
 name = "asn1_der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "2.9.15"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640d9d3f3d2ee7df7d64f1ce752877bfbcccfd146a4291a7eca69bcc89ffc17"
+checksum = "19bc50aa64e3bc176fe1530a270d5efccd79bde469d6957629c590fe47558689"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -243,12 +249,14 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
+ "fast_chemail",
  "fnv",
  "futures-util",
  "http",
  "indexmap",
  "mime",
  "multer",
+ "num-traits",
  "once_cell",
  "pin-project-lite 0.2.8",
  "regex",
@@ -263,13 +271,13 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "2.9.15"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b146a2869ab23a711721ae7e1d6f08013298f2f7814f5a21431134feed18f31"
+checksum = "77c3836e72f564e4d502f9ed70ef67d9ef29163901027774fec7970f2785ef27"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling 0.12.4",
+ "darling",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -279,24 +287,24 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "2.9.15"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c9faa27abf0cc9969874a48ff6e439d46cbc6e19d36a73b1b88702ce06b7af"
+checksum = "09c540cdcb24755edf53571ac4228b8288b0cdc1eb6c7f9af333ed185bb8e0ed"
 dependencies = [
  "async-graphql-value",
  "pest",
- "pest_derive",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "async-graphql-value"
-version = "2.9.15"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d59b43a2116d78557d224d86da65b7b05f9bcbb8b2744bd6c50d18b3b69e29"
+checksum = "f7484b68c290bbf97e961003ffc2e781c0210e342c849bac43b5a5636101926e"
 dependencies = [
  "bytes",
+ "indexmap",
  "serde",
  "serde_json",
 ]
@@ -921,12 +929,24 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+checksum = "58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552"
 dependencies = [
  "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+dependencies = [
  "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -1352,7 +1372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd9f0852fe3d3637d4dccb4b69e5a8f881214fc38907a528385ff71cd7b15c3e"
 dependencies = [
  "Inflector",
- "darling 0.13.1",
+ "darling",
  "graphql-parser",
  "lazy_static",
  "proc-macro2",
@@ -1373,36 +1393,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core 0.12.4",
- "darling_macro 0.12.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
- "darling_core 0.13.1",
- "darling_macro 0.13.1",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1421,22 +1417,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core 0.12.4",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
- "darling_core 0.13.1",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1924,6 +1909,15 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
+]
 
 [[package]]
 name = "fastrand"
@@ -2878,6 +2872,7 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -3511,12 +3506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4016,40 +4005,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest_derive"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
-dependencies = [
- "maplit",
- "pest",
- "sha-1 0.8.2",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,6 +4022,45 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+ "uncased",
 ]
 
 [[package]]
@@ -4580,9 +4574,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4600,9 +4594,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -5058,7 +5052,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
- "darling 0.13.1",
+ "darling",
  "proc-macro2",
  "quote",
  "syn",
@@ -5074,18 +5068,6 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -5234,6 +5216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5285,7 +5273,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha-1",
 ]
 
 [[package]]
@@ -5909,7 +5897,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustls 0.20.4",
- "sha-1 0.9.8",
+ "sha-1",
  "thiserror",
  "url",
  "utf-8",
@@ -5938,6 +5926,15 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -1,10 +1,13 @@
 scalar Address
+
 scalar AssetId
+
 type Balance {
 	owner: Address!
 	amount: U64!
 	assetId: AssetId!
 }
+
 type BalanceConnection {
 	"""
 	Information to aid in pagination.
@@ -13,27 +16,30 @@ type BalanceConnection {
 	"""
 	A list of edges.
 	"""
-	edges: [BalanceEdge]
+	edges: [BalanceEdge!]!
 }
+
 """
 An edge in a connection.
 """
 type BalanceEdge {
 	"""
-	The item at the end of the edge
-	"""
-	node: Balance!
-	"""
 	A cursor for use in pagination
 	"""
 	cursor: String!
+	"""
+	"The item at the end of the edge
+	"""
+	node: Balance!
 }
+
 input BalanceFilterInput {
 	"""
 	Filter coins based on the `owner` field
 	"""
 	owner: Address!
 }
+
 type Block {
 	id: BlockId!
 	height: U64!
@@ -41,6 +47,7 @@ type Block {
 	time: DateTime!
 	producer: Address!
 }
+
 type BlockConnection {
 	"""
 	Information to aid in pagination.
@@ -49,38 +56,46 @@ type BlockConnection {
 	"""
 	A list of edges.
 	"""
-	edges: [BlockEdge]
+	edges: [BlockEdge!]!
 }
+
 """
 An edge in a connection.
 """
 type BlockEdge {
 	"""
-	The item at the end of the edge
-	"""
-	node: Block!
-	"""
 	A cursor for use in pagination
 	"""
 	cursor: String!
+	"""
+	"The item at the end of the edge
+	"""
+	node: Block!
 }
+
 scalar BlockId
+
+
 input Breakpoint {
 	contract: ContractId!
 	pc: U64!
 }
+
 scalar Bytes32
+
 type ChainInfo {
 	name: String!
 	latestBlock: Block!
 	baseChainHeight: U64!
 	peerCount: Int!
 }
+
 type ChangeOutput {
 	to: Address!
 	amount: U64!
 	assetId: AssetId!
 }
+
 type Coin {
 	utxoId: UtxoId!
 	owner: Address!
@@ -90,6 +105,7 @@ type Coin {
 	status: CoinStatus!
 	blockCreated: U64!
 }
+
 type CoinConnection {
 	"""
 	Information to aid in pagination.
@@ -98,21 +114,23 @@ type CoinConnection {
 	"""
 	A list of edges.
 	"""
-	edges: [CoinEdge]
+	edges: [CoinEdge!]!
 }
+
 """
 An edge in a connection.
 """
 type CoinEdge {
 	"""
-	The item at the end of the edge
-	"""
-	node: Coin!
-	"""
 	A cursor for use in pagination
 	"""
 	cursor: String!
+	"""
+	"The item at the end of the edge
+	"""
+	node: Coin!
 }
+
 input CoinFilterInput {
 	"""
 	Address of the owner
@@ -123,49 +141,63 @@ input CoinFilterInput {
 	"""
 	assetId: AssetId
 }
+
 type CoinOutput {
 	to: Address!
 	amount: U64!
 	assetId: AssetId!
 }
+
 enum CoinStatus {
 	UNSPENT
 	SPENT
 }
+
 type Contract {
 	id: ContractId!
 	bytecode: HexString!
 	salt: Salt!
 }
+
 type ContractBalance {
 	contract: ContractId!
 	amount: U64!
 	assetId: AssetId!
 }
+
 type ContractCreated {
 	contract: Contract!
 	stateRoot: Bytes32!
 }
+
 scalar ContractId
+
 type ContractOutput {
 	inputIndex: Int!
 	balanceRoot: Bytes32!
 	stateRoot: Bytes32!
 }
+
 """
 Implement the DateTime<Utc> scalar
 
 The input/output is a string in RFC3339 format.
 """
 scalar DateTime
+
 type FailureStatus {
 	block: Block!
 	time: DateTime!
 	reason: String!
 	programState: ProgramState
 }
+
+
 scalar HexString
+
+
 union Input = | InputCoin | InputContract
+
 type InputCoin {
 	utxoId: UtxoId!
 	owner: Address!
@@ -176,12 +208,15 @@ type InputCoin {
 	predicate: HexString!
 	predicateData: HexString!
 }
+
 type InputContract {
 	utxoId: UtxoId!
 	balanceRoot: Bytes32!
 	stateRoot: Bytes32!
 	contract: Contract!
 }
+
+
 type Mutation {
 	startSession: ID!
 	endSession(id: ID!): Boolean!
@@ -200,7 +235,9 @@ type Mutation {
 	"""
 	submit(tx: HexString!): Transaction!
 }
+
 union Output = | CoinOutput | ContractOutput | WithdrawalOutput | ChangeOutput | VariableOutput | ContractCreated
+
 """
 A separate `Breakpoint` type to be used as an output, as a single
 type cannot act as both input and output type in async-graphql
@@ -209,6 +246,7 @@ type OutputBreakpoint {
 	contract: ContractId!
 	pc: U64!
 }
+
 """
 Information about pagination in a connection
 """
@@ -230,10 +268,12 @@ type PageInfo {
 	"""
 	endCursor: String
 }
+
 type ProgramState {
 	returnType: ReturnType!
 	data: HexString!
 }
+
 type Query {
 	register(id: ID!, register: U64!): U64!
 	memory(id: ID!, start: U64!, size: U64!): String!
@@ -256,6 +296,7 @@ type Query {
 	contract(id: ContractId!): Contract
 	contractBalance(contract: ContractId!, asset: AssetId!): ContractBalance!
 }
+
 type Receipt {
 	contract: Contract
 	pc: U64
@@ -282,6 +323,7 @@ type Receipt {
 	gasUsed: U64
 	data: HexString
 }
+
 enum ReceiptType {
 	CALL
 	RETURN
@@ -294,20 +336,25 @@ enum ReceiptType {
 	TRANSFER_OUT
 	SCRIPT_RESULT
 }
+
 enum ReturnType {
 	RETURN
 	RETURN_DATA
 	REVERT
 }
+
 type RunResult {
 	state: RunState!
 	breakpoint: OutputBreakpoint
 }
+
 enum RunState {
 	COMPLETED
 	BREAKPOINT
 }
+
 scalar Salt
+
 input SpendQueryElementInput {
 	"""
 	Asset ID of the coins
@@ -318,14 +365,18 @@ input SpendQueryElementInput {
 	"""
 	amount: U64!
 }
+
+
 type SubmittedStatus {
 	time: DateTime!
 }
+
 type SuccessStatus {
 	block: Block!
 	time: DateTime!
 	programState: ProgramState!
 }
+
 type Transaction {
 	id: TransactionId!
 	inputAssetIds: [AssetId!]!
@@ -353,6 +404,7 @@ type Transaction {
 	"""
 	rawPayload: HexString!
 }
+
 type TransactionConnection {
 	"""
 	Information to aid in pagination.
@@ -361,35 +413,43 @@ type TransactionConnection {
 	"""
 	A list of edges.
 	"""
-	edges: [TransactionEdge]
+	edges: [TransactionEdge!]!
 }
+
 """
 An edge in a connection.
 """
 type TransactionEdge {
 	"""
-	The item at the end of the edge
-	"""
-	node: Transaction!
-	"""
 	A cursor for use in pagination
 	"""
 	cursor: String!
+	"""
+	"The item at the end of the edge
+	"""
+	node: Transaction!
 }
+
 scalar TransactionId
+
 union TransactionStatus = | SubmittedStatus | SuccessStatus | FailureStatus
+
 scalar U64
+
 scalar UtxoId
+
 type VariableOutput {
 	to: Address!
 	amount: U64!
 	assetId: AssetId!
 }
+
 type WithdrawalOutput {
 	to: Address!
 	amount: U64!
 	assetId: AssetId!
 }
+
 schema {
 	query: Query
 	mutation: Mutation

--- a/fuel-client/src/client/schema/balance.rs
+++ b/fuel-client/src/client/schema/balance.rs
@@ -75,7 +75,7 @@ pub struct BalancesQuery {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct BalanceConnection {
-    pub edges: Option<Vec<Option<BalanceEdge>>>,
+    pub edges: Vec<BalanceEdge>,
     pub page_info: PageInfo,
 }
 
@@ -85,12 +85,7 @@ impl From<BalanceConnection> for PaginatedResult<Balance, String> {
             has_next_page: conn.page_info.has_next_page,
             has_previous_page: conn.page_info.has_previous_page,
             cursor: conn.page_info.end_cursor,
-            results: conn
-                .edges
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|e| e.map(|e| e.node))
-                .collect(),
+            results: conn.edges.into_iter().map(|e| e.node).collect(),
         }
     }
 }

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -35,7 +35,7 @@ pub struct BlocksQuery {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct BlockConnection {
-    pub edges: Option<Vec<Option<BlockEdge>>>,
+    pub edges: Vec<BlockEdge>,
     pub page_info: PageInfo,
 }
 
@@ -45,12 +45,7 @@ impl From<BlockConnection> for PaginatedResult<Block, String> {
             cursor: conn.page_info.end_cursor,
             has_next_page: conn.page_info.has_next_page,
             has_previous_page: conn.page_info.has_previous_page,
-            results: conn
-                .edges
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|e| e.map(|e| e.node))
-                .collect(),
+            results: conn.edges.into_iter().map(|e| e.node).collect(),
         }
     }
 }

--- a/fuel-client/src/client/schema/coin.rs
+++ b/fuel-client/src/client/schema/coin.rs
@@ -82,7 +82,7 @@ pub struct CoinsQuery {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct CoinConnection {
-    pub edges: Option<Vec<Option<CoinEdge>>>,
+    pub edges: Vec<CoinEdge>,
     pub page_info: PageInfo,
 }
 
@@ -92,12 +92,7 @@ impl From<CoinConnection> for PaginatedResult<Coin, String> {
             cursor: conn.page_info.end_cursor,
             has_next_page: conn.page_info.has_next_page,
             has_previous_page: conn.page_info.has_previous_page,
-            results: conn
-                .edges
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|e| e.map(|e| e.node))
-                .collect(),
+            results: conn.edges.into_iter().map(|e| e.node).collect(),
         }
     }
 }

--- a/fuel-client/src/client/schema/tx.rs
+++ b/fuel-client/src/client/schema/tx.rs
@@ -39,7 +39,7 @@ pub struct TransactionsQuery {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct TransactionConnection {
-    pub edges: Option<Vec<Option<TransactionEdge>>>,
+    pub edges: Vec<TransactionEdge>,
     pub page_info: PageInfo,
 }
 
@@ -47,12 +47,8 @@ impl TryFrom<TransactionConnection> for PaginatedResult<TransactionResponse, Str
     type Error = ConversionError;
 
     fn try_from(conn: TransactionConnection) -> Result<Self, Self::Error> {
-        let results: Result<Vec<TransactionResponse>, Self::Error> = conn
-            .edges
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|e| e.map(|e| e.node.try_into()))
-            .collect();
+        let results: Result<Vec<TransactionResponse>, Self::Error> =
+            conn.edges.into_iter().map(|e| e.node.try_into()).collect();
 
         Ok(PaginatedResult {
             cursor: conn.page_info.end_cursor,

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -35,7 +35,7 @@ pub struct TransactionsQuery {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct TransactionConnection {
-    pub edges: Option<Vec<Option<TransactionEdge>>>,
+    pub edges: Vec<TransactionEdge>,
     pub page_info: PageInfo,
 }
 

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -21,7 +21,7 @@ test = false
 anyhow = "1.0"
 # This needs to be pinned as newer versions are incompatible with fuel-core.
 # We're waiting for the following resolution: https://github.com/FuelLabs/fuel-core/pull/260#issuecomment-1102435692
-async-graphql = { version = "=2.9", features = [
+async-graphql = { version = "4.0", features = [
     "chrono",
     "chrono-tz",
     "tracing",

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -651,7 +651,7 @@ pub enum TransactionValidityError {
     #[error("Transaction validity: {0:#?}")]
     Validation(#[from] ValidationError),
     #[error("Datastore error occurred")]
-    DataStoreError(Box<dyn std::error::Error>),
+    DataStoreError(Box<dyn StdError + Send + Sync>),
 }
 
 impl From<KvStoreError> for TransactionValidityError {
@@ -674,7 +674,7 @@ pub enum Error {
     #[error("Invalid transaction: {0}")]
     TransactionValidity(#[from] TransactionValidityError),
     #[error("corrupted block state")]
-    CorruptedBlockState(Box<dyn StdError>),
+    CorruptedBlockState(Box<dyn StdError + Send + Sync>),
     #[error("missing transaction data for tx {transaction_id:#x} in block {block_id:#x}")]
     MissingTransactionData {
         block_id: Bytes32,

--- a/fuel-core/src/schema.rs
+++ b/fuel-core/src/schema.rs
@@ -33,9 +33,10 @@ pub struct Mutation(dap::DapMutation, tx::TxMutation);
 pub type CoreSchema = Schema<Query, Mutation, EmptySubscription>;
 
 pub fn build_schema() -> SchemaBuilder<Query, Mutation, EmptySubscription> {
-    Schema::build(
+    Schema::build_with_ignore_name_conflicts(
         Query::default(),
         Mutation::default(),
         EmptySubscription::default(),
+        ["TransactionConnection"],
     )
 }

--- a/fuel-core/src/schema/balance.rs
+++ b/fuel-core/src/schema/balance.rs
@@ -192,12 +192,14 @@ impl BalanceQuery {
 
                 let mut connection =
                     Connection::new(started.is_some(), records_to_fetch <= balances.len());
-                connection.append(
+
+                connection.edges.extend(
                     balances
                         .into_iter()
                         .map(|item| Edge::new(item.asset_id.into(), item)),
                 );
-                Ok(connection)
+
+                Ok::<Connection<AssetId, Balance>, KvStoreError>(connection)
             },
         )
         .await

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -164,15 +164,14 @@ impl BlockQuery {
 
                 let mut connection =
                     Connection::new(started.is_some(), records_to_fetch <= blocks.len());
-                connection.append(
-                    blocks
-                        .into_iter()
-                        .map(|item| Edge::new(item.headers.height.to_usize(), item.into_owned())),
-                );
-                Ok(connection)
+
+                connection.edges.extend(blocks.into_iter().map(|item| {
+                    Edge::new(item.headers.height.to_usize(), Block(item.into_owned()))
+                }));
+
+                Ok::<Connection<usize, Block>, KvStoreError>(connection)
             },
         )
         .await
-        .map(|conn| conn.map_node(Block))
     }
 }

--- a/fuel-core/src/schema/coin.rs
+++ b/fuel-core/src/schema/coin.rs
@@ -171,12 +171,13 @@ impl CoinQuery {
 
                 let mut connection =
                     Connection::new(started.is_some(), records_to_fetch <= coins.len());
-                connection.append(
+                connection.edges.extend(
                     coins
                         .into_iter()
                         .map(|item| Edge::new(UtxoId::from(item.0), item)),
                 );
-                Ok(connection)
+
+                Ok::<Connection<UtxoId, Coin>, KvStoreError>(connection)
             },
         )
         .await

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -151,17 +151,17 @@ impl TxQuery {
                 let mut connection =
                     Connection::new(started.is_some(), records_to_fetch < tx_ids.len());
 
-                connection.append(txs.into_iter().map(|(tx, block_height)| {
+                connection.edges.extend(txs.into_iter().map(|(tx, block_height)| {
                     Edge::new(
                         SortedTxCursor::new(*block_height, Bytes32::from(tx.id())),
-                        tx.into_owned(),
+                        Transaction(tx.into_owned()),
                     )
                 }));
-                Ok(connection)
+
+                Ok::<Connection<SortedTxCursor, Transaction>, KvStoreError>(connection)
             },
         )
         .await
-        .map(|conn| conn.map_node(Transaction))
     }
 
     async fn transactions_by_owner(
@@ -238,11 +238,12 @@ impl TxQuery {
 
                 let mut connection =
                     Connection::new(started.is_some(), records_to_fetch <= txs.len());
-                connection.append(
+                connection.edges.extend(
                     txs.into_iter()
                         .map(|item| Edge::new(HexString::from(item.0), Transaction(item.1))),
                 );
-                Ok(connection)
+
+                Ok::<Connection<HexString, Transaction>, KvStoreError>(connection)
             },
         )
         .await

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -35,7 +35,7 @@ pub enum TransactionStatus {
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("unexpected database error {0:?}")]
-    Database(Box<dyn StdError>),
+    Database(Box<dyn StdError + Send + Sync>),
     #[error("unexpected block execution error {0:?}")]
     Execution(#[from] crate::executor::Error),
     #[error("Tx is invalid, insertion failed {0:?}")]


### PR DESCRIPTION
Closes #310 

I updated `async-graphql` to v4

In this latest version they removed `append()` method from `Connection` so I had to extend the edges with
`conn.edges.extend()` directly

Our other problem was that our Errors weren't constrained to Send + Sync, so I added those constraints and now it compiles