### PR TITLE
tx consensus parameters

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -88,6 +88,7 @@ type ChainInfo {
 	latestBlock: Block!
 	baseChainHeight: U64!
 	peerCount: Int!
+	transactionParameters: ConsensusParameters!
 }
 
 type ChangeOutput {
@@ -151,6 +152,20 @@ type CoinOutput {
 enum CoinStatus {
 	UNSPENT
 	SPENT
+}
+
+type ConsensusParameters {
+	contractMaxSize: U64!
+	maxInputs: U64!
+	maxOutputs: U64!
+	maxWitnesses: U64!
+	maxGasPerTx: U64!
+	maxScriptLength: U64!
+	maxScriptDataLength: U64!
+	maxStaticContracts: U64!
+	maxStorageSlots: U64!
+	maxPredicateLength: U64!
+	maxPredicateDataLength: U64!
 }
 
 type Contract {

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -88,7 +88,7 @@ type ChainInfo {
 	latestBlock: Block!
 	baseChainHeight: U64!
 	peerCount: Int!
-	transactionParameters: ConsensusParameters!
+	consensusParameters: ConsensusParameters!
 }
 
 type ChangeOutput {

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -91,6 +91,11 @@ impl FuelClient {
         self.query(query).await.map(|r| r.node_info)
     }
 
+    pub async fn chain_info(&self) -> io::Result<schema::chain::ChainInfo> {
+        let query = schema::chain::ChainQuery::build(());
+        self.query(query).await.map(|r| r.chain)
+    }
+
     /// Default dry run, matching the exact configuration as the node
     pub async fn dry_run(&self, tx: &Transaction) -> io::Result<Vec<Receipt>> {
         self.dry_run_opt(tx, None).await

--- a/fuel-client/src/client/schema/chain.rs
+++ b/fuel-client/src/client/schema/chain.rs
@@ -29,7 +29,7 @@ pub struct ChainInfo {
     pub name: String,
     pub peer_count: i32,
     pub latest_block: Block,
-    pub transaction_parameters: ConsensusParameters,
+    pub consensus_parameters: ConsensusParameters,
 }
 
 #[cfg(test)]

--- a/fuel-client/src/client/schema/chain.rs
+++ b/fuel-client/src/client/schema/chain.rs
@@ -1,4 +1,5 @@
 use crate::client::schema::{block::Block, schema, U64};
+use fuel_tx::ConsensusParameters as TxConsensusParameters;
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
@@ -14,6 +15,24 @@ pub struct ConsensusParameters {
     pub max_storage_slots: U64,
     pub max_predicate_length: U64,
     pub max_predicate_data_length: U64,
+}
+
+impl From<ConsensusParameters> for TxConsensusParameters {
+    fn from(params: ConsensusParameters) -> Self {
+        Self {
+            contract_max_size: params.contract_max_size.into(),
+            max_inputs: params.max_inputs.into(),
+            max_outputs: params.max_outputs.into(),
+            max_witnesses: params.max_witnesses.into(),
+            max_gas_per_tx: params.max_gas_per_tx.into(),
+            max_script_length: params.max_script_length.into(),
+            max_script_data_length: params.max_script_data_length.into(),
+            max_static_contracts: params.max_static_contracts.into(),
+            max_storage_slots: params.max_storage_slots.into(),
+            max_predicate_length: params.max_predicate_length.into(),
+            max_predicate_data_length: params.max_predicate_data_length.into(),
+        }
+    }
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/fuel-client/src/client/schema/chain.rs
+++ b/fuel-client/src/client/schema/chain.rs
@@ -1,6 +1,22 @@
 use crate::client::schema::{block::Block, schema, U64};
 
 #[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct ConsensusParameters {
+    pub contract_max_size: U64,
+    pub max_inputs: U64,
+    pub max_outputs: U64,
+    pub max_witnesses: U64,
+    pub max_gas_per_tx: U64,
+    pub max_script_length: U64,
+    pub max_script_data_length: U64,
+    pub max_static_contracts: U64,
+    pub max_storage_slots: U64,
+    pub max_predicate_length: U64,
+    pub max_predicate_data_length: U64,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Query")]
 pub struct ChainQuery {
     pub chain: ChainInfo,
@@ -13,6 +29,7 @@ pub struct ChainInfo {
     pub name: String,
     pub peer_count: i32,
     pub latest_block: Block,
+    pub transaction_parameters: ConsensusParameters,
 }
 
 #[cfg(test)]

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -1,8 +1,6 @@
 ---
 source: fuel-client/src/client/schema/chain.rs
-assertion_line: 26
 expression: operation.query
-
 ---
 query Query {
   chain {
@@ -17,6 +15,19 @@ query Query {
       transactions {
         id
       }
+    }
+    transactionParameters {
+      contractMaxSize
+      maxInputs
+      maxOutputs
+      maxWitnesses
+      maxGasPerTx
+      maxScriptLength
+      maxScriptDataLength
+      maxStaticContracts
+      maxStorageSlots
+      maxPredicateLength
+      maxPredicateDataLength
     }
   }
 }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -16,7 +16,7 @@ query Query {
         id
       }
     }
-    transactionParameters {
+    consensusParameters {
       contractMaxSize
       maxInputs
       maxOutputs

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__node_info__tests__node_settings_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__node_info__tests__node_settings_query_gql_output.snap
@@ -1,0 +1,8 @@
+---
+source: fuel-client/src/client/schema/node_info.rs
+expression: operation.query
+---
+query Query {
+  nodeVersion
+}
+

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__node_info__tests__node_settings_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__node_info__tests__node_settings_query_gql_output.snap
@@ -1,8 +1,0 @@
----
-source: fuel-client/src/client/schema/node_info.rs
-expression: operation.query
----
-query Query {
-  nodeVersion
-}
-

--- a/fuel-core/src/schema/chain.rs
+++ b/fuel-core/src/schema/chain.rs
@@ -1,13 +1,62 @@
-use crate::database::Database;
 use crate::model::FuelBlockDb;
 use crate::schema::block::Block;
 use crate::schema::scalars::U64;
+use crate::{database::Database, service::Config};
 use async_graphql::{Context, Object};
 use fuel_storage::Storage;
 
 pub const DEFAULT_NAME: &str = "Fuel.testnet";
 
 pub struct ChainInfo;
+
+pub struct ConsensusParameters(fuel_tx::ConsensusParameters);
+
+#[Object]
+impl ConsensusParameters {
+    async fn contract_max_size(&self) -> U64 {
+        self.0.contract_max_size.into()
+    }
+
+    async fn max_inputs(&self) -> U64 {
+        self.0.max_inputs.into()
+    }
+
+    async fn max_outputs(&self) -> U64 {
+        self.0.max_outputs.into()
+    }
+
+    async fn max_witnesses(&self) -> U64 {
+        self.0.max_witnesses.into()
+    }
+
+    async fn max_gas_per_tx(&self) -> U64 {
+        self.0.max_gas_per_tx.into()
+    }
+
+    async fn max_script_length(&self) -> U64 {
+        self.0.max_script_length.into()
+    }
+
+    async fn max_script_data_length(&self) -> U64 {
+        self.0.max_script_data_length.into()
+    }
+
+    async fn max_static_contracts(&self) -> U64 {
+        self.0.max_static_contracts.into()
+    }
+
+    async fn max_storage_slots(&self) -> U64 {
+        self.0.max_storage_slots.into()
+    }
+
+    async fn max_predicate_length(&self) -> U64 {
+        self.0.max_predicate_length.into()
+    }
+
+    async fn max_predicate_data_length(&self) -> U64 {
+        self.0.max_predicate_data_length.into()
+    }
+}
 
 #[Object]
 impl ChainInfo {
@@ -33,6 +82,17 @@ impl ChainInfo {
 
     async fn peer_count(&self) -> u16 {
         0
+    }
+
+    async fn transaction_parameters(
+        &self,
+        ctx: &Context<'_>,
+    ) -> async_graphql::Result<ConsensusParameters> {
+        let config = ctx.data_unchecked::<Config>();
+
+        Ok(ConsensusParameters(
+            config.chain_conf.transaction_parameters,
+        ))
     }
 }
 

--- a/fuel-core/src/schema/chain.rs
+++ b/fuel-core/src/schema/chain.rs
@@ -84,7 +84,7 @@ impl ChainInfo {
         0
     }
 
-    async fn transaction_parameters(
+    async fn consensus_parameters(
         &self,
         ctx: &Context<'_>,
     ) -> async_graphql::Result<ConsensusParameters> {

--- a/fuel-tests/tests/chain.rs
+++ b/fuel-tests/tests/chain.rs
@@ -1,0 +1,17 @@
+use fuel_core::service::{Config, FuelService};
+use fuel_gql_client::client::FuelClient;
+
+#[tokio::test]
+async fn chain_info() {
+    let node_config = Config::local_node();
+    let srv = FuelService::new_node(node_config.clone()).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    let chain_info = client.chain_info().await.unwrap();
+
+    assert_eq!(node_config.chain_conf.chain_name, chain_info.name);
+    assert_eq!(
+        node_config.chain_conf.transaction_parameters,
+        chain_info.consensus_parameters.into()
+    );
+}

--- a/fuel-tests/tests/lib.rs
+++ b/fuel-tests/tests/lib.rs
@@ -1,5 +1,6 @@
 mod balances;
 mod blocks;
+mod chain;
 mod coin;
 mod contract;
 mod dap;


### PR DESCRIPTION
closes #362 

Created `ConsensusParameters` struct with all the necessary fields, and made it part of the `ChainInfo` query - that is, gave it its own queryable method `consensus_parameters`.