### PR TITLE
Add Contract Balances API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +395,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
 dependencies = [
+ "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",
@@ -2234,6 +2245,7 @@ dependencies = [
  "insta",
  "itertools",
  "rand 0.8.5",
+ "rstest",
  "serde_json",
  "tokio",
 ]
@@ -4743,6 +4755,32 @@ checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rstest"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b939295f93cb1d12bc1a83cf9ee963199b133fb8a79832dd51b68bb9f59a04dc"
+dependencies = [
+ "async-std",
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78aba848123782ba59340928ec7d876ebe745aa0365d6af8a630f19a5c16116"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn",
 ]
 
 [[package]]

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -142,6 +142,35 @@ type ContractBalance {
 	amount: U64!
 	assetId: AssetId!
 }
+type ContractBalanceConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ContractBalanceEdge]
+}
+"""
+An edge in a connection.
+"""
+type ContractBalanceEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ContractBalance!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+input ContractBalanceFilterInput {
+	"""
+	Filter assets based on the `contractId` field
+	"""
+	contract: ContractId!
+}
 type ContractCreated {
 	contract: Contract!
 	stateRoot: Bytes32!
@@ -255,6 +284,7 @@ type Query {
 	coinsToSpend(owner: Address!, spendQuery: [SpendQueryElementInput!]!, maxInputs: Int, excludedIds: [UtxoId!]): [Coin!]!
 	contract(id: ContractId!): Contract
 	contractBalance(contract: ContractId!, asset: AssetId!): ContractBalance!
+	contractBalances(filter: ContractBalanceFilterInput!, first: Int, after: String, last: Int, before: String): ContractBalanceConnection!
 }
 type Receipt {
 	contract: Contract

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -164,6 +164,7 @@ type ContractBalance {
 	amount: U64!
 	assetId: AssetId!
 }
+
 type ContractBalanceConnection {
 	"""
 	Information to aid in pagination.
@@ -172,27 +173,30 @@ type ContractBalanceConnection {
 	"""
 	A list of edges.
 	"""
-	edges: [ContractBalanceEdge]
+	edges: [ContractBalanceEdge!]!
 }
+
 """
 An edge in a connection.
 """
 type ContractBalanceEdge {
 	"""
-	The item at the end of the edge
-	"""
-	node: ContractBalance!
-	"""
 	A cursor for use in pagination
 	"""
 	cursor: String!
+	"""
+	"The item at the end of the edge
+	"""
+	node: ContractBalance!
 }
+
 input ContractBalanceFilterInput {
 	"""
 	Filter assets based on the `contractId` field
 	"""
 	contract: ContractId!
 }
+
 type ContractCreated {
 	contract: Contract!
 	stateRoot: Bytes32!

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -404,6 +404,19 @@ impl FuelClient {
         let balances = self.query(query).await?.balances.into();
         Ok(balances)
     }
+
+    pub async fn contract_balances(
+        &self,
+        contract: &str,
+        request: PaginationRequest<String>,
+    ) -> io::Result<PaginatedResult<schema::contract::ContractBalance, String>> {
+        let contract_id: schema::ContractId = contract.parse()?;
+        let query = schema::contract::ContractBalancesQuery::build(&(contract_id, request).into());
+
+        let balances = self.query(query).await?.contract_balances.into();
+        
+        Ok(balances)
+    }
 }
 
 #[cfg(any(test, feature = "test-helpers"))]

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -414,7 +414,7 @@ impl FuelClient {
         let query = schema::contract::ContractBalancesQuery::build(&(contract_id, request).into());
 
         let balances = self.query(query).await?.contract_balances.into();
-        
+
         Ok(balances)
     }
 }

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -88,7 +88,7 @@ pub struct ContractBalanceEdge {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractBalanceConnection {
-    pub edges: Option<Vec<Option<ContractBalanceEdge>>>,
+    pub edges: Vec<ContractBalanceEdge>,
     pub page_info: PageInfo,
 }
 
@@ -109,12 +109,7 @@ impl From<ContractBalanceConnection> for PaginatedResult<ContractBalance, String
             has_next_page: conn.page_info.has_next_page,
             has_previous_page: conn.page_info.has_previous_page,
             cursor: conn.page_info.end_cursor,
-            results: conn
-                .edges
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|e| e.map(|e| e.node))
-                .collect(),
+            results: conn.edges.into_iter().map(|e| e.node).collect(),
         }
     }
 }

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -1,4 +1,5 @@
-use crate::client::schema::{schema, AssetId, ContractId, HexString, Salt, U64};
+use crate::client::schema::{schema, AssetId, ContractId, PageInfo, HexString, Salt, U64};
+use crate::client::{PageDirection, PaginatedResult, PaginationRequest};
 
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct ContractByIdArgs {
@@ -53,6 +54,90 @@ pub struct Contract {
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Contract")]
 pub struct ContractIdFragment {
     pub id: ContractId,
+}
+
+#[derive(cynic::InputObject, Clone, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct ContractBalanceFilterInput {
+    /// Filter coins based on the `owner` field
+    pub contract: ContractId,
+}
+
+#[derive(cynic::FragmentArguments, Debug)]
+pub struct ContractBalancesConnectionArgs {
+    /// Filter coins based on a filter
+    filter: ContractBalanceFilterInput,
+    /// Skip until coin id (forward pagination)
+    pub after: Option<String>,
+    /// Skip until coin id (backward pagination)
+    pub before: Option<String>,
+    /// Retrieve the first n coins in order (forward pagination)
+    pub first: Option<i32>,
+    /// Retrieve the last n coins in order (backward pagination).
+    /// Can't be used at the same time as `first`.
+    pub last: Option<i32>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct ContractBalanceEdge {
+    pub cursor: String,
+    pub node: ContractBalance,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct ContractBalanceConnection {
+    pub edges: Option<Vec<Option<ContractBalanceEdge>>>,
+    pub page_info: PageInfo,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    argument_struct = "ContractBalancesConnectionArgs"
+)]
+pub struct ContractBalancesQuery {
+    #[arguments(filter = &args.filter, after = &args.after, before = &args.before, first = &args.first, last = &args.last)]
+    pub contract_balances: ContractBalanceConnection,
+}
+
+impl From<ContractBalanceConnection> for PaginatedResult<ContractBalance, String> {
+    fn from(conn: ContractBalanceConnection) -> Self {
+        PaginatedResult {
+            has_next_page: conn.page_info.has_next_page,
+            has_previous_page: conn.page_info.has_previous_page,
+            cursor: conn.page_info.end_cursor,
+            results: conn
+                .edges
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|e| e.map(|e| e.node))
+                .collect(),
+        }
+    }
+}
+
+impl From<(ContractId, PaginationRequest<String>)> for ContractBalancesConnectionArgs {
+    fn from(r: (ContractId, PaginationRequest<String>)) -> Self {
+        match r.1.direction {
+            PageDirection::Forward => ContractBalancesConnectionArgs {
+                filter: ContractBalanceFilterInput { contract: r.0 },
+                after: r.1.cursor,
+                before: None,
+                first: Some(r.1.results as i32),
+                last: None,
+            },
+            PageDirection::Backward => ContractBalancesConnectionArgs {
+                filter: ContractBalanceFilterInput { contract: r.0 },
+                after: None,
+                before: r.1.cursor,
+                first: None,
+                last: Some(r.1.results as i32),
+            },
+        }
+    }
 }
 
 #[cfg(test)]

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -67,7 +67,7 @@ pub struct ContractBalanceFilterInput {
 pub struct ContractBalancesConnectionArgs {
     /// Filter balances based on a filter
     filter: ContractBalanceFilterInput,
-    /// Skip until coin id (forward pagination)
+    /// Skip until asset id (forward pagination)
     pub after: Option<String>,
     /// Skip until coin id (backward pagination)
     pub before: Option<String>,

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -71,7 +71,7 @@ pub struct ContractBalancesConnectionArgs {
     pub after: Option<String>,
     /// Skip until asset id (backward pagination)
     pub before: Option<String>,
-    /// Retrieve the first n coins in order (forward pagination)
+    /// Retrieve the first n asset balances in order (forward pagination)
     pub first: Option<i32>,
     /// Retrieve the last n coins in order (backward pagination).
     /// Can't be used at the same time as `first`.

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -69,7 +69,7 @@ pub struct ContractBalancesConnectionArgs {
     filter: ContractBalanceFilterInput,
     /// Skip until asset id (forward pagination)
     pub after: Option<String>,
-    /// Skip until coin id (backward pagination)
+    /// Skip until asset id (backward pagination)
     pub before: Option<String>,
     /// Retrieve the first n coins in order (forward pagination)
     pub first: Option<i32>,

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -73,7 +73,7 @@ pub struct ContractBalancesConnectionArgs {
     pub before: Option<String>,
     /// Retrieve the first n asset balances in order (forward pagination)
     pub first: Option<i32>,
-    /// Retrieve the last n coins in order (backward pagination).
+    /// Retrieve the last n asset balances in order (backward pagination).
     /// Can't be used at the same time as `first`.
     pub last: Option<i32>,
 }

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -1,4 +1,4 @@
-use crate::client::schema::{schema, AssetId, ContractId, PageInfo, HexString, Salt, U64};
+use crate::client::schema::{schema, AssetId, ContractId, HexString, PageInfo, Salt, U64};
 use crate::client::{PageDirection, PaginatedResult, PaginationRequest};
 
 #[derive(cynic::FragmentArguments, Debug)]

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -65,7 +65,7 @@ pub struct ContractBalanceFilterInput {
 
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct ContractBalancesConnectionArgs {
-    /// Filter coins based on a filter
+    /// Filter balances based on a filter
     filter: ContractBalanceFilterInput,
     /// Skip until coin id (forward pagination)
     pub after: Option<String>,

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -59,7 +59,7 @@ pub struct ContractIdFragment {
 #[derive(cynic::InputObject, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractBalanceFilterInput {
-    /// Filter coins based on the `owner` field
+    /// Filter asset balances based on the `contract` field
     pub contract: ContractId,
 }
 

--- a/fuel-core/src/database/coin.rs
+++ b/fuel-core/src/database/coin.rs
@@ -19,6 +19,7 @@ fn owner_coin_id_key(owner: &Address, coin_id: &UtxoId) -> Vec<u8> {
         .copied()
         .collect()
 }
+
 // 32 Bytes for Tx_id + 1 byte for output_index
 const SIZE_OF_UTXO_ID: usize = 264;
 

--- a/fuel-core/src/database/coin.rs
+++ b/fuel-core/src/database/coin.rs
@@ -19,6 +19,7 @@ fn owner_coin_id_key(owner: &Address, coin_id: &UtxoId) -> Vec<u8> {
         .copied()
         .collect()
 }
+// 32 Bytes for Tx_id + 1 byte for output_index
 const SIZE_OF_UTXO_ID: usize = 264;
 
 fn utxo_id_to_bytes(utxo_id: &UtxoId) -> Vec<u8> {

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -18,10 +18,10 @@ fn contract_asset_id_id_key(contract: &ContractId, asset: &AssetId) -> Vec<u8> {
         .collect()
 }
 
-
 fn asset_id_to_bytes(asset_id: &AssetId) -> Vec<u8> {
     let mut out = Vec::with_capacity(256);
     out.extend(asset_id.as_ref().iter());
+    println!("{:?}", out);
     out
 }
 
@@ -79,7 +79,9 @@ impl Database {
             direction,
         )
         // Safety: key is always 64 bytes
-        .map(|res| res.map(|(key, _)| AssetId::new(key.try_into().unwrap())))
+        .map(|res| {
+            res.map(|(key, _)| AssetId::new(key.try_into().expect("Failed on line 82 here")))
+        })
     }
 }
 

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -18,11 +18,9 @@ fn contract_asset_id_id_key(contract: &ContractId, asset: &AssetId) -> Vec<u8> {
         .collect()
 }
 
-// Flat 32 bytes
-const SIZE_OF_ASSET_ID: usize = 256;
 
 fn asset_id_to_bytes(asset_id: &AssetId) -> Vec<u8> {
-    let mut out = Vec::with_capacity(SIZE_OF_ASSET_ID);
+    let mut out = Vec::with_capacity(256);
     out.extend(asset_id.as_ref().iter());
     out
 }

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -22,7 +22,6 @@ fn contract_asset_id_id_key(contract: &ContractId, asset: &AssetId) -> Vec<u8> {
 fn asset_id_to_bytes(asset_id: &AssetId) -> Vec<u8> {
     let mut out = Vec::with_capacity(256);
     out.extend(asset_id.as_ref().iter());
-    println!("{:?}", out);
     out
 }
 

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     state::{Error, IterDirection},
 };
-use fuel_tx::{Bytes32, UtxoId};
+use fuel_tx::UtxoId;
 use fuel_vm::prelude::{AssetId, Contract, ContractId, Storage};
 use std::borrow::Cow;
 

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -56,14 +56,14 @@ impl Database {
         contract: ContractId,
         start_asset: Option<AssetId>,
         direction: Option<IterDirection>,
-    ) -> impl Iterator<Item = Result<AssetId, Error>> + '_ {
+    ) -> impl Iterator<Item = Result<(AssetId, Word), Error>> + '_ {
         self.iter_all::<Vec<u8>, Word>(
             BALANCES,
             Some(contract.as_ref().to_vec()),
             start_asset.map(|asset_id| MultiKey::new((&contract, &asset_id)).as_ref().to_vec()),
             direction,
         )
-        .map(|res| res.map(|(key, _)| AssetId::new(key[32..].try_into().unwrap())))
+        .map(|res| res.map(|(key, balance)| (AssetId::new(key[32..].try_into().unwrap()), balance)))
     }
 }
 

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -60,7 +60,7 @@ impl Database {
         self.iter_all::<Vec<u8>, Word>(
             BALANCES,
             Some(contract.as_ref().to_vec()),
-            start_asset.map(|b| MultiKey::new((&contract, &b)).as_ref().to_vec()),
+            start_asset.map(|asset_id| MultiKey::new((&contract, &asset_id)).as_ref().to_vec()),
             direction,
         )
         .map(|res| res.map(|(key, _)| AssetId::new(key[32..].try_into().unwrap())))

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -6,6 +6,7 @@ use crate::{
     state::{Error, IterDirection},
 };
 use fuel_tx::UtxoId;
+use fuel_types::Word;
 use fuel_vm::prelude::{AssetId, Contract, ContractId, Storage};
 use std::borrow::Cow;
 
@@ -72,16 +73,13 @@ impl Database {
         start_asset: Option<AssetId>,
         direction: Option<IterDirection>,
     ) -> impl Iterator<Item = Result<AssetId, Error>> + '_ {
-        self.iter_all::<Vec<u8>, bool>(
+        self.iter_all::<Vec<u8>, Word>(
             BALANCES,
             Some(contract.as_ref().to_vec()),
             start_asset.map(|b| contract_asset_id_id_key(&contract, &b)),
             direction,
         )
-        // Safety: key is always 64 bytes
-        .map(|res| {
-            res.map(|(key, _)| AssetId::new(key.try_into().expect("Failed on line 82 here")))
-        })
+        .map(|res| res.map(|(key, _)| AssetId::new(key[32..].try_into().unwrap())))
     }
 }
 

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -151,7 +151,10 @@ impl ContractBalanceQuery {
                     (0, IterDirection::Forward)
                 };
 
-                if (first.is_some() && before.is_some()) || (after.is_some() && before.is_some()) {
+                if (first.is_some() && before.is_some())
+                    || (after.is_some() && before.is_some())
+                    || (last.is_some() && after.is_some())
+                {
                     return Err(anyhow!("Wrong argument combination"));
                 }
 

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -163,7 +163,6 @@ impl ContractBalanceQuery {
                     start = before;
                     end = after;
                 }
-                // impl Iterator<Item = ContractBalance>
                 let mut balances = db
                     .contract_balances(filter.contract.into(), start, Some(IterDirection::Forward))
                     .map(|balance| -> ContractBalance {

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -1,8 +1,10 @@
 use crate::database::{Database, KvStoreError};
 use crate::schema::scalars::{AssetId, ContractId, HexString, Salt, U64};
 use crate::state::IterDirection;
-use async_graphql::connection::{query, Connection, Edge, EmptyFields};
-use async_graphql::{Context, InputObject, Object};
+use async_graphql::{
+    connection::{query, Connection, Edge, EmptyFields},
+    Context, InputObject, Object,
+};
 use fuel_storage::Storage;
 use fuel_vm::prelude::Contract as FuelVmContract;
 use std::iter::IntoIterator;

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -113,4 +113,12 @@ impl ContractBalanceQuery {
             asset_id,
         })
     }
+
+    async fn contract_balances(&self, ctx: &Context<'_>, contract : ContractId, start_asset : AssetId, ) -> async_graphql::Result<U64> {
+        let db = ctx.data_unchecked::<Database>().clone();
+
+        let balances = db.contract_balances(contract, start_asset, direction).map(|res| -> Result<_, Error> {})
+
+        Ok(U64::from(1))
+    }
 }

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -162,6 +162,8 @@ impl ContractBalanceQuery {
             })
             .collect();
 
+        println!("Got here!");
+
         query(
             after,
             before,

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -172,7 +172,7 @@ impl ContractBalanceQuery {
                     started = balances_iter.next();
                 }
 
-                let balances  = balances_iter
+                let balances = balances_iter
                     .take(records_to_fetch + 1)
                     .map(|balance| {
                         let balance = balance?;

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -8,6 +8,7 @@ use async_graphql::{
 use fuel_storage::Storage;
 use fuel_vm::prelude::Contract as FuelVmContract;
 use std::iter::IntoIterator;
+
 pub struct Contract(pub(crate) fuel_types::ContractId);
 
 impl From<fuel_types::ContractId> for Contract {

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -190,12 +190,6 @@ impl ContractBalanceQuery {
                 if direction == IterDirection::Reverse {
                     balances = balances.rev().collect::<Vec<ContractBalance>>().into_iter();
                 }
-                if let Some(start) = start {
-                    balances = balances
-                        .skip_while(|balance| balance.asset_id == start)
-                        .collect::<Vec<ContractBalance>>()
-                        .into_iter();
-                }
                 let mut started = None;
                 if start.is_some() {
                     // skip initial result

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -135,10 +135,6 @@ impl ContractBalanceQuery {
 
         let balances: Vec<ContractBalance> = db
             .contract_balances(filter.contract.into(), None, None)
-            .filter(|element| {
-                // Remove all Errors which occured when fetching balances
-                element.is_err()
-            })
             .map(|balance| -> ContractBalance {
                 let asset_id = balance.unwrap();
 
@@ -152,17 +148,13 @@ impl ContractBalanceQuery {
 
                 let amount = result.unwrap_or(0);
 
-                let contract_balance = ContractBalance {
+                ContractBalance {
                     contract: filter.contract.into(),
                     amount,
                     asset_id,
-                };
-
-                contract_balance
+                }
             })
             .collect();
-
-        println!("Got here!");
 
         query(
             after,

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -172,7 +172,7 @@ impl ContractBalanceQuery {
                     started = balances_iter.next();
                 }
 
-                let balances: Result<Vec<ContractBalance>, KvStoreError> = balances_iter
+                let balances  = balances_iter
                     .take(records_to_fetch + 1)
                     .map(|balance| {
                         let balance = balance?;
@@ -183,8 +183,7 @@ impl ContractBalanceQuery {
                             asset_id: balance.0,
                         })
                     })
-                    .collect();
-                let mut balances = balances?;
+                    .collect::<Result<Vec<ContractBalance>, KvStoreError>>()?;
 
                 let has_next_page = balances.len() > records_to_fetch;
 

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -219,12 +219,12 @@ impl ContractBalanceQuery {
 
                 let mut connection =
                     Connection::new(started.is_some(), records_to_fetch <= balances.len());
-                connection.append(
+                connection.edges.extend(
                     balances
                         .into_iter()
                         .map(|item| Edge::new(item.asset_id.into(), item)),
                 );
-                Ok(connection)
+                Ok::<Connection<AssetId, ContractBalance>, KvStoreError>(connection)
             },
         )
         .await

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -172,7 +172,7 @@ impl ContractBalanceQuery {
                     started = balances_iter.next();
                 }
 
-                let balances = balances_iter
+                let mut balances = balances_iter
                     .take(records_to_fetch + 1)
                     .map(|balance| {
                         let balance = balance?;

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -26,10 +26,10 @@ fuel-tx = { version = "0.12", features = ["serde", "builder", "internals"] }
 fuel-txpool = { path = "../fuel-txpool" }
 fuel-types = { version = "0.5", features = ["serde"] }
 fuel-vm = { version = "0.11", features = ["serde", "random", "test-helpers"] }
-rstest = { version = "0.13" }
 insta = "1.8"
 itertools = "0.10"
 rand = "0.8"
+rstest = { version = "0.13" }
 serde_json = "1.0"
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -26,6 +26,7 @@ fuel-tx = { version = "0.12", features = ["serde", "builder", "internals"] }
 fuel-txpool = { path = "../fuel-txpool" }
 fuel-types = { version = "0.5", features = ["serde"] }
 fuel-vm = { version = "0.11", features = ["serde", "random", "test-helpers"] }
+rstest = { version = "0.13" }
 insta = "1.8"
 itertools = "0.10"
 rand = "0.8"

--- a/fuel-tests/tests/contract.rs
+++ b/fuel-tests/tests/contract.rs
@@ -69,5 +69,7 @@ async fn test_first_5_contract_balances() {
         .await
         .unwrap();
 
+    println!("Weird");
+
     assert!(!contract_balances.results.is_empty());
 }

--- a/fuel-tests/tests/contract.rs
+++ b/fuel-tests/tests/contract.rs
@@ -1,4 +1,5 @@
 use crate::helpers::{TestContext, TestSetupBuilder};
+use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
 use fuel_vm::prelude::*;
 
 const SEED: u64 = 2322;
@@ -43,4 +44,30 @@ async fn test_contract_balance() {
 
         assert_eq!(balance, test_bal);
     }
+}
+
+#[tokio::test]
+async fn test_first_5_contract_balances() {
+    let mut test_builder = TestSetupBuilder::new(SEED);
+    let (_, contract_id) =
+        test_builder.setup_contract(vec![], Some(vec![(AssetId::new([1u8; 32]), 1000)]));
+
+    // spin up node
+    let TestContext { client, .. } = test_builder.finalize().await;
+
+    let asset_id = AssetId::new([1u8; 32]);
+
+    let contract_balances = client
+        .contract_balances(
+            format!("{:#x}", contract_id).as_str(),
+            PaginationRequest {
+                cursor: None,
+                results: 5,
+                direction: PageDirection::Forward,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(!contract_balances.results.is_empty());
 }

--- a/fuel-tests/tests/contract.rs
+++ b/fuel-tests/tests/contract.rs
@@ -65,7 +65,7 @@ async fn test_first_5_contract_balances() {
             format!("{:#x}", contract_id).as_str(),
             PaginationRequest {
                 cursor: None,
-                results: 5,
+                results: 3,
                 direction: PageDirection::Forward,
             },
         )

--- a/fuel-tests/tests/contract.rs
+++ b/fuel-tests/tests/contract.rs
@@ -1,5 +1,5 @@
 use crate::helpers::{TestContext, TestSetupBuilder};
-use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
+use fuel_gql_client::client::{PageDirection, PaginationRequest};
 use fuel_vm::prelude::*;
 
 const SEED: u64 = 2322;
@@ -72,7 +72,8 @@ async fn test_first_5_contract_balances() {
         .await
         .unwrap();
 
-    println!("Weird");
-
     assert!(!contract_balances.results.is_empty());
+    assert_eq!(contract_balances.results[0].amount.0, 1000);
+    assert_eq!(contract_balances.results[1].amount.0, 400);
+    assert_eq!(contract_balances.results[2].amount.0, 700);
 }

--- a/fuel-tests/tests/contract.rs
+++ b/fuel-tests/tests/contract.rs
@@ -1,7 +1,7 @@
 use crate::helpers::{TestContext, TestSetupBuilder};
 use fuel_gql_client::client::{PageDirection, PaginationRequest};
 use fuel_vm::prelude::*;
-
+use rstest::rstest;
 const SEED: u64 = 2322;
 
 #[tokio::test]
@@ -46,8 +46,11 @@ async fn test_contract_balance() {
     }
 }
 
+#[rstest]
+#[case(PageDirection::Forward)]
+#[case(PageDirection::Backward)]
 #[tokio::test]
-async fn test_first_5_contract_balances() {
+async fn test_first_5_contract_balances(#[case] direction: PageDirection) {
     let mut test_builder = TestSetupBuilder::new(SEED);
     let (_, contract_id) = test_builder.setup_contract(
         vec![],
@@ -66,7 +69,7 @@ async fn test_first_5_contract_balances() {
             PaginationRequest {
                 cursor: None,
                 results: 3,
-                direction: PageDirection::Forward,
+                direction,
             },
         )
         .await

--- a/fuel-tests/tests/contract.rs
+++ b/fuel-tests/tests/contract.rs
@@ -2,6 +2,7 @@ use crate::helpers::{TestContext, TestSetupBuilder};
 use fuel_gql_client::client::{PageDirection, PaginationRequest};
 use fuel_vm::prelude::*;
 use rstest::rstest;
+
 const SEED: u64 = 2322;
 
 #[tokio::test]

--- a/fuel-tests/tests/contract.rs
+++ b/fuel-tests/tests/contract.rs
@@ -49,13 +49,16 @@ async fn test_contract_balance() {
 #[tokio::test]
 async fn test_first_5_contract_balances() {
     let mut test_builder = TestSetupBuilder::new(SEED);
-    let (_, contract_id) =
-        test_builder.setup_contract(vec![], Some(vec![(AssetId::new([1u8; 32]), 1000)]));
+    let (_, contract_id) = test_builder.setup_contract(
+        vec![],
+        Some(vec![
+            (AssetId::new([1u8; 32]), 1000),
+            (AssetId::new([2u8; 32]), 400),
+            (AssetId::new([3u8; 32]), 700),
+        ]),
+    );
 
-    // spin up node
     let TestContext { client, .. } = test_builder.finalize().await;
-
-    let asset_id = AssetId::new([1u8; 32]);
 
     let contract_balances = client
         .contract_balances(


### PR DESCRIPTION
Should fix and mean everything in #71  has now been addressed, closing up on the contracts API.

Adds an endpoint for contract balances, using `iter_all` to fetch the balance for each asset, of all possible assets the contract has. This is my first time writing a query which requires a cursor and pages, so it's heavily based off of the existing balances endpoint. 

I also haven't been to close to the db yet, so safety of the db query is something I wasn't sure on.