### PR TITLE
Validators get

### DIFF
--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -7,11 +7,11 @@ use ethers_core::types::{Log, H160};
 use ethers_providers::Middleware;
 use fuel_core_interfaces::{
     model::{BlockHeight, DaBlockHeight, SealedFuelBlock},
-    relayer::{RelayerDb, StakingDiff},
+    relayer::{RelayerDb, StakingDiff, ValidatorDiff},
 };
 use fuel_tx::{Address, Bytes32};
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{hash_map::Entry, HashMap, VecDeque},
     sync::Arc,
 };
 use tracing::{debug, error, info, warn};
@@ -85,8 +85,9 @@ impl FinalizationQueue {
     pub async fn get_validators(
         &mut self,
         da_height: DaBlockHeight,
+        db: &mut dyn RelayerDb,
     ) -> Option<HashMap<Address, (u64, Option<Address>)>> {
-        self.validators.get(da_height).await
+        self.validators.get(da_height, db).await
     }
 
     pub fn clear(&mut self) {
@@ -265,17 +266,42 @@ impl FinalizationQueue {
         }
         self.remove_bundled_reverted_events();
 
+        //TODO to be paranoid, recheck every block and all events got from eth client.
+
+        let mut validators: HashMap<Address, Option<Address>> = HashMap::new();
         while let Some(diff) = self.pending.front_mut() {
             if diff.da_height > finalized_da_height {
                 break;
             }
             info!("flush eth log:{:?} diff:{:?}", diff.da_height, diff);
-            //TODO to be paranoid, recheck events got from eth client.
+
+            let validator_diff: HashMap<Address, ValidatorDiff> = diff
+                .validators
+                .iter()
+                .map(|(val, &new_consensus_key)| {
+                    let previous_consensus_key = match validators.entry(*val) {
+                        Entry::Occupied(mut entry) => {
+                            core::mem::replace(entry.get_mut(), new_consensus_key)
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(new_consensus_key);
+                            self.validators.set.get(val).and_then(|(_, i)| *i)
+                        }
+                    };
+                    (
+                        *val,
+                        ValidatorDiff {
+                            previous_consensus_key,
+                            new_consensus_key,
+                        },
+                    )
+                })
+                .collect();
 
             // apply staking diffs
             db.insert_staking_diff(
                 diff.da_height,
-                &StakingDiff::new(diff.validators.clone(), diff.delegations.clone()),
+                &StakingDiff::new(validator_diff, diff.delegations.clone()),
             )
             .await;
 
@@ -380,12 +406,12 @@ mod tests {
             BlockHeight::from(0u64),
         );
 
-        let v1_register = eth_log_validator_registration(0, v1, c1);
-        let v2_register = eth_log_validator_registration(0, v2, c2);
-        let v1_unregister = eth_log_validator_unregistration(1, v1);
-
         queue
-            .append_eth_logs(vec![v1_register, v2_register, v1_unregister])
+            .append_eth_logs(vec![
+                eth_log_validator_registration(0, v1, c1),
+                eth_log_validator_registration(0, v2, c2),
+                eth_log_validator_unregistration(1, v1),
+            ])
             .await;
 
         let diff1 = queue.pending[0].clone();
@@ -416,13 +442,13 @@ mod tests {
             BlockHeight::from(0u64),
         );
 
-        let v1_register = eth_log_validator_registration(1, v1, c1);
-        let v2_register = eth_log_validator_registration(2, v2, c2);
-        let deposit1 = eth_log_asset_deposit(2, acc1, token1, 1, 40, nonce1, 0);
-        let v1_unregister = eth_log_validator_unregistration(3, v1);
-
         queue
-            .append_eth_logs(vec![v1_register, v2_register, deposit1, v1_unregister])
+            .append_eth_logs(vec![
+                eth_log_validator_registration(1, v1, c1),
+                eth_log_validator_registration(2, v2, c2),
+                eth_log_asset_deposit(2, acc1, token1, 1, 40, nonce1, 0),
+                eth_log_validator_unregistration(3, v1),
+            ])
             .await;
 
         let mut db = DummyDb::filled();
@@ -469,13 +495,13 @@ mod tests {
         let s2 = rng.gen::<u16>() as u64;
         let s3 = rng.gen::<u16>() as u64;
 
-        let del1 = eth_log_delegation(1, delegator1, vec![v1, v2], vec![s1, s2]);
-        let v1_register = eth_log_validator_registration(2, v1, c1);
-        let del2 = eth_log_delegation(2, delegator2, vec![v1], vec![s3]);
-        let del_with = eth_log_withdrawal(3, delegator1, 7);
-
         queue
-            .append_eth_logs(vec![del1, del2, v1_register, del_with])
+            .append_eth_logs(vec![
+                eth_log_delegation(1, delegator1, vec![v1, v2], vec![s1, s2]),
+                eth_log_validator_registration(2, v1, c1),
+                eth_log_delegation(2, delegator2, vec![v1], vec![s3]),
+                eth_log_withdrawal(3, delegator1, 7),
+            ])
             .await;
         let mut db = DummyDb::filled();
 
@@ -518,15 +544,14 @@ mod tests {
         let s2 = rng.gen::<u16>() as u64;
         let s3 = rng.gen::<u16>() as u64;
 
-        let del1 = eth_log_delegation(1, delegator1, vec![v1, v2], vec![s1, s2]);
-        let del1_ret = eth_log_delegation(1, delegator1, vec![v1], vec![s1]);
-        let del2 = eth_log_delegation(1, delegator2, vec![v2], vec![s1]);
-
-        let del2_first = eth_log_delegation(2, delegator2, vec![v1], vec![s3]);
-        let del2_ret = eth_log_withdrawal(2, delegator2, 0); // amount does nothing
-
         queue
-            .append_eth_logs(vec![del1, del1_ret, del2, del2_first, del2_ret])
+            .append_eth_logs(vec![
+                eth_log_delegation(1, delegator1, vec![v1, v2], vec![s1, s2]),
+                eth_log_delegation(1, delegator1, vec![v1], vec![s1]),
+                eth_log_delegation(1, delegator2, vec![v2], vec![s1]),
+                eth_log_delegation(2, delegator2, vec![v1], vec![s3]),
+                eth_log_withdrawal(2, delegator2, 0), // amount does nothing
+            ])
             .await;
         let mut db = DummyDb::filled();
 
@@ -611,5 +636,84 @@ mod tests {
         queue.commit_diffs(&mut db, 1).await;
 
         assert_eq!(queue.pending.len(), 0)
+    }
+
+    #[tokio::test]
+    pub async fn simple_get_validator_set_down_drift() {
+        let mut rng = StdRng::seed_from_u64(3020);
+        let mut delegator1: Address = rng.gen();
+        let mut delegator2: Address = rng.gen();
+        let mut delegator3: Address = rng.gen();
+        delegator1.iter_mut().take(12).for_each(|i| *i = 0);
+        delegator2.iter_mut().take(12).for_each(|i| *i = 0);
+        delegator3.iter_mut().take(12).for_each(|i| *i = 0);
+        let mut v1: Address = rng.gen();
+        let mut v2: Address = rng.gen();
+        let cons1: Address = rng.gen();
+        let cons2: Address = rng.gen();
+        v1.iter_mut().take(12).for_each(|i| *i = 0);
+        v2.iter_mut().take(12).for_each(|i| *i = 0);
+
+        let mut queue = FinalizationQueue::new(
+            0,
+            H160::zero(),
+            &(hex::decode("79afbf7147841fca72b45a1978dd7669470ba67abbe5c220062924380c9c364b")
+                .unwrap()),
+            BlockHeight::from(0u64),
+            BlockHeight::from(0u64),
+        );
+
+        let s1 = rng.gen::<u16>() as u64;
+        let s2 = rng.gen::<u16>() as u64;
+        let s3 = rng.gen::<u16>() as u64;
+
+        queue
+            .append_eth_logs(vec![
+                eth_log_validator_registration(1, v1, cons1),
+                eth_log_validator_registration(1, v2, cons2),
+                eth_log_delegation(1, delegator1, vec![v1, v2], vec![s1, s2]),
+                eth_log_delegation(2, delegator1, vec![v1], vec![s1]),
+                eth_log_delegation(2, delegator2, vec![v2], vec![s1]),
+                eth_log_delegation(3, delegator2, vec![v1], vec![s3]),
+                eth_log_withdrawal(4, delegator2, 0),
+            ])
+            .await;
+        let mut db = DummyDb::filled();
+
+        // finalize all logs
+        queue.commit_diffs(&mut db, 5).await;
+
+        let set = queue.get_validators(6, &mut db).await;
+        assert_eq!(set, None);
+
+        let set = queue.get_validators(5, &mut db).await;
+        assert!(set.is_some(), "Should be some for 5");
+        let set = set.unwrap();
+        assert_eq!(set.get(&v1), Some(&(s1, Some(cons1))));
+        assert_eq!(set.get(&v2), None);
+
+        let set = queue.get_validators(4, &mut db).await;
+        assert!(set.is_some(), "Should be some for 4");
+        let set = set.unwrap();
+        assert_eq!(set.get(&v1), Some(&(s1, Some(cons1))));
+        assert_eq!(set.get(&v2), None);
+
+        let set = queue.get_validators(3, &mut db).await;
+        assert!(set.is_some(), "Should be some for 3");
+        let set = set.unwrap();
+        assert_eq!(set.get(&v1), Some(&(s1 + s3, Some(cons1))));
+        assert_eq!(set.get(&v2), None);
+
+        let set = queue.get_validators(2, &mut db).await;
+        assert!(set.is_some(), "Should be some for 2");
+        let set = set.unwrap();
+        assert_eq!(set.get(&v1), Some(&(s1, Some(cons1))));
+        assert_eq!(set.get(&v2), Some(&(s1, Some(cons2))));
+
+        let set = queue.get_validators(1, &mut db).await;
+        assert!(set.is_some(), "Should be some for 1");
+        let set = set.unwrap();
+        assert_eq!(set.get(&v1), Some(&(s1, Some(cons1))));
+        assert_eq!(set.get(&v2), Some(&(s2, Some(cons2))));
     }
 }

--- a/fuel-relayer/src/relayer.rs
+++ b/fuel-relayer/src/relayer.rs
@@ -332,7 +332,7 @@ impl Relayer {
                 da_height,
                 response_channel,
             } => {
-                let res = match self.queue.get_validators(da_height).await {
+                let res = match self.queue.get_validators(da_height, self.db.as_mut()).await {
                     Some(set) => Ok(set),
                     None => Err(RelayerError::ProviderError),
                 };

--- a/fuel-relayer/src/validators.rs
+++ b/fuel-relayer/src/validators.rs
@@ -1,6 +1,6 @@
 use fuel_core_interfaces::{
     model::{DaBlockHeight, ValidatorStake},
-    relayer::RelayerDb,
+    relayer::{RelayerDb, ValidatorDiff},
 };
 use fuel_tx::Address;
 use std::collections::{hash_map::Entry, HashMap};
@@ -26,16 +26,94 @@ impl Validators {
         self.set = db.get_validators().await;
     }
 
-    /// Get validator set
+    /// Get validator set for da_height.
     pub async fn get(
-        &mut self,
+        &self,
         da_height: DaBlockHeight,
+        db: &mut dyn RelayerDb,
     ) -> Option<HashMap<Address, (u64, Option<Address>)>> {
-        // TODO apply down drift https://github.com/FuelLabs/fuel-core/issues/365
-        if self.da_height == da_height {
-            return Some(self.set.clone());
+        match self.da_height.cmp(&da_height) {
+            std::cmp::Ordering::Less => {
+                // We request validator set that we still didnt finalized or know about.
+                // Probably there is eth client sync problem
+                error!(
+                    "current height {} is less then requested validator set height: {da_height}",
+                    self.da_height
+                );
+                return None;
+            }
+            std::cmp::Ordering::Equal => {
+                // unusual but do nothing
+                info!("Get last finalized set height: {da_height}");
+                let set = self
+                    .set
+                    .iter()
+                    .filter(|(_, (stake, consensus_key))| *stake != 0 && consensus_key.is_some())
+                    .map(|(k, v)| (*k, *v))
+                    .collect();
+                return Some(set);
+            }
+            std::cmp::Ordering::Greater => {
+                // slightly drift to past
+            }
         }
-        None
+
+        let mut validators = self.set.clone();
+        // get staking diffs to revert from our current set.
+        let diffs = db
+            .get_staking_diffs(da_height + 1, Some(self.da_height))
+            .await;
+
+        for (diff_height, diff) in diffs.into_iter().rev() {
+            // update consensus_key
+            for (
+                validator,
+                ValidatorDiff {
+                    previous_consensus_key,
+                    ..
+                },
+            ) in diff.validators
+            {
+                if let Some((_, consensus_key)) = validators.get_mut(&validator) {
+                    *consensus_key = previous_consensus_key;
+                } else {
+                    panic!("Validator should be present when reverting diff");
+                }
+            }
+
+            // for every delegates, cache it and if it is not in cache query db's delegates_index for earlier delegate set.
+            for (delegator, delegation) in diff.delegations.into_iter() {
+                // add new delegation stake.
+                if let Some(ref delegation) = delegation {
+                    for (validator, stake) in delegation {
+                        validators
+                            .entry(*validator)
+                            .or_insert_with(|| self.set.get(validator).cloned().unwrap_or_default())
+                            // remove stake
+                            .0 -= stake;
+                    }
+                }
+
+                // get older delegation to add again to validator stake
+                if let Some(delegations) = db
+                    .get_first_lesser_delegation(&delegator, diff_height)
+                    .await
+                {
+                    for (validator, stake) in delegations {
+                        validators
+                            .entry(validator)
+                            .or_insert_with(|| {
+                                self.set.get(&validator).cloned().unwrap_or_default()
+                            })
+                            // remove stake
+                            .0 += stake;
+                    }
+                };
+            }
+        }
+
+        validators.retain(|_, (stake, consensus_key)| *stake != 0 && consensus_key.is_some());
+        Some(validators)
     }
 
     /// Bump validator set to new high da_height.
@@ -70,11 +148,17 @@ impl Validators {
         let mut delegates_cached: HashMap<Address, Option<HashMap<Address, u64>>> = HashMap::new();
         for (diff_height, diff) in diffs.into_iter() {
             // update consensus_key
-            for (validator, consensus_key) in diff.validators {
+            for (
+                validator,
+                ValidatorDiff {
+                    new_consensus_key, ..
+                },
+            ) in diff.validators
+            {
                 validators
                     .entry(validator)
                     .or_insert_with(|| self.set.get(&validator).cloned().unwrap_or_default())
-                    .1 = consensus_key;
+                    .1 = new_consensus_key;
             }
 
             // for every delegates, cache it and if it is not in cache query db's delegates_index for earlier delegate set.
@@ -93,7 +177,9 @@ impl Validators {
                 // get old delegation
                 let old_delegation = match delegates_cached.entry(delegator) {
                     Entry::Vacant(entry) => {
-                        let old_delegation = db.get_last_delegation(&delegator, diff_height).await;
+                        let old_delegation = db
+                            .get_first_lesser_delegation(&delegator, diff_height)
+                            .await;
                         entry.insert(delegation);
                         old_delegation
                     }
@@ -111,7 +197,10 @@ impl Validators {
                         validators
                             .entry(validator)
                             .or_insert_with(|| {
-                                self.set.get(&validator).cloned().unwrap_or_default()
+                                self.set
+                                    .get(&validator)
+                                    .cloned()
+                                    .expect("Expect for validator to exists")
                             })
                             // decrease undelegated stake
                             .0 -= old_stake;
@@ -126,3 +215,5 @@ impl Validators {
         self.da_height = da_height;
     }
 }
+
+// testing for this mod is done inside finalization_queue.rs mod.

--- a/fuel-relayer/src/validators.rs
+++ b/fuel-relayer/src/validators.rs
@@ -4,7 +4,7 @@ use fuel_core_interfaces::{
 };
 use fuel_tx::Address;
 use std::collections::{hash_map::Entry, HashMap};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 /// It contains list of Validators and its stake and consensus public key.
 /// We dont expect big number of validators in that sense we are okey to have it all in memory
@@ -40,80 +40,83 @@ impl Validators {
                     "current height {} is less then requested validator set height: {da_height}",
                     self.da_height
                 );
-                return None;
+                None
             }
             std::cmp::Ordering::Equal => {
                 // unusual but do nothing
-                info!("Get last finalized set height: {da_height}");
+                debug!("Get last finalized set height: {da_height}");
                 let set = self
                     .set
                     .iter()
                     .filter(|(_, (stake, consensus_key))| *stake != 0 && consensus_key.is_some())
                     .map(|(k, v)| (*k, *v))
                     .collect();
-                return Some(set);
+                Some(set)
             }
             std::cmp::Ordering::Greater => {
                 // slightly drift to past
-            }
-        }
 
-        let mut validators = self.set.clone();
-        // get staking diffs to revert from our current set.
-        let diffs = db
-            .get_staking_diffs(da_height + 1, Some(self.da_height))
-            .await;
+                let mut validators = self.set.clone();
+                // get staking diffs to revert from our current set.
+                let diffs = db
+                    .get_staking_diffs(da_height + 1, Some(self.da_height))
+                    .await;
 
-        for (diff_height, diff) in diffs.into_iter().rev() {
-            // update consensus_key
-            for (
-                validator,
-                ValidatorDiff {
-                    previous_consensus_key,
-                    ..
-                },
-            ) in diff.validators
-            {
-                if let Some((_, consensus_key)) = validators.get_mut(&validator) {
-                    *consensus_key = previous_consensus_key;
-                } else {
-                    panic!("Validator should be present when reverting diff");
-                }
-            }
+                for (diff_height, diff) in diffs.into_iter().rev() {
+                    // update consensus_key
+                    for (
+                        validator,
+                        ValidatorDiff {
+                            previous_consensus_key,
+                            ..
+                        },
+                    ) in diff.validators
+                    {
+                        if let Some((_, consensus_key)) = validators.get_mut(&validator) {
+                            *consensus_key = previous_consensus_key;
+                        } else {
+                            panic!("Validator should be present when reverting diff");
+                        }
+                    }
 
-            // for every delegates, cache it and if it is not in cache query db's delegates_index for earlier delegate set.
-            for (delegator, delegation) in diff.delegations.into_iter() {
-                // add new delegation stake.
-                if let Some(ref delegation) = delegation {
-                    for (validator, stake) in delegation {
-                        validators
-                            .entry(*validator)
-                            .or_insert_with(|| self.set.get(validator).cloned().unwrap_or_default())
-                            // remove stake
-                            .0 -= stake;
+                    // for every delegates, cache it and if it is not in cache query db's delegates_index for earlier delegate set.
+                    for (delegator, delegation) in diff.delegations {
+                        // add new delegation stake.
+                        if let Some(ref delegation) = delegation {
+                            for (validator, stake) in delegation {
+                                validators
+                                    .entry(*validator)
+                                    .or_insert_with(|| {
+                                        self.set.get(validator).cloned().unwrap_or_default()
+                                    })
+                                    // remove stake
+                                    .0 -= stake;
+                            }
+                        }
+
+                        // get older delegation to add again to validator stake
+                        if let Some(delegations) = db
+                            .get_first_lesser_delegation(&delegator, diff_height)
+                            .await
+                        {
+                            for (validator, stake) in delegations {
+                                validators
+                                    .entry(validator)
+                                    .or_insert_with(|| {
+                                        self.set.get(&validator).cloned().unwrap_or_default()
+                                    })
+                                    // remove stake
+                                    .0 += stake;
+                            }
+                        };
                     }
                 }
 
-                // get older delegation to add again to validator stake
-                if let Some(delegations) = db
-                    .get_first_lesser_delegation(&delegator, diff_height)
-                    .await
-                {
-                    for (validator, stake) in delegations {
-                        validators
-                            .entry(validator)
-                            .or_insert_with(|| {
-                                self.set.get(&validator).cloned().unwrap_or_default()
-                            })
-                            // remove stake
-                            .0 += stake;
-                    }
-                };
+                validators
+                    .retain(|_, (stake, consensus_key)| *stake != 0 && consensus_key.is_some());
+                Some(validators)
             }
         }
-
-        validators.retain(|_, (stake, consensus_key)| *stake != 0 && consensus_key.is_some());
-        Some(validators)
     }
 
     /// Bump validator set to new high da_height.
@@ -162,7 +165,7 @@ impl Validators {
             }
 
             // for every delegates, cache it and if it is not in cache query db's delegates_index for earlier delegate set.
-            for (delegator, delegation) in diff.delegations.into_iter() {
+            for (delegator, delegation) in diff.delegations {
                 // add new delegation stake.
                 if let Some(ref delegation) = delegation {
                     for (validator, stake) in delegation {


### PR DESCRIPTION
Implemented `validator_get` function that can get validator set that is in past in regards to the current finalized set.

StakingDiff DB table is extended to contain both old and new validator `consensus_key`.