### PR TITLE
evict reverted pending block commitments [relayer]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote",
  "syn",
@@ -4586,9 +4586,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4606,9 +4606,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -5779,9 +5779,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -35,7 +35,7 @@ pub struct FinalizationQueue {
 pub struct DaBlockDiff {
     /// da block height
     pub da_height: DaBlockHeight,
-    /// Validator stake deposit and withdrawel.
+    /// Validator stake deposit and withdrawal.
     pub validators: HashMap<Address, Option<Address>>,
     // Delegation diff contains new delegation list, if we did just withdrawal option will be None.
     pub delegations: HashMap<Address, Option<HashMap<Address, u64>>>,

--- a/fuel-relayer/src/pending_blocks.rs
+++ b/fuel-relayer/src/pending_blocks.rs
@@ -389,7 +389,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore("Because chain_height is hardcoded to 10")]
+    #[ignore = "Because chain_height is hardcoded to 10"]
     fn reverted_blocks_causes_rollback_of_best_chain_height() {
         let mut rng = StdRng::seed_from_u64(59);
 


### PR DESCRIPTION
Attempt to simplify the pending_blocks structure a lot by simply removing reverted pending blocks since they aren't used by anything. It's hard to say if everything works as intended because the test coverage for handling revert logic in the finalization_queue module isn't implemented.