### PR TITLE
p2p messages with dummy consensus Vote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,8 @@ dependencies = [
  "async-trait",
  "bincode",
  "ctor",
+ "fuel-core-interfaces",
+ "fuel-tx",
  "futures",
  "futures-timer",
  "ip_network",

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -13,7 +13,7 @@ description = "Fuel core interfaces"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"]}
 derive_more = { version = "0.99" }
 fuel-asm = "0.5"
 fuel-crypto = { version = "0.5", default-features = false }

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -13,7 +13,7 @@ description = "Fuel core interfaces"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-chrono = { version = "0.4", features = ["serde"]}
+chrono = { version = "0.4", features = ["serde"] }
 derive_more = { version = "0.99" }
 fuel-asm = "0.5"
 fuel-crypto = { version = "0.5", default-features = false }

--- a/fuel-core-interfaces/src/model.rs
+++ b/fuel-core-interfaces/src/model.rs
@@ -2,10 +2,12 @@ mod block;
 mod block_height;
 mod coin;
 mod txpool;
+mod vote;
 
 pub use block::{FuelBlock, FuelBlockDb, FuelBlockHeader};
 pub use block_height::BlockHeight;
 pub use coin::{Coin, CoinStatus};
 pub use txpool::{ArcTx, TxInfo};
+pub use vote::Vote;
 
 pub type DaBlockHeight = u64;

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -1,5 +1,5 @@
 pub use super::BlockHeight;
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{serde::ts_seconds, DateTime, TimeZone, Utc};
 use fuel_crypto::Hasher;
 use fuel_tx::{Address, Bytes32, Transaction};
 
@@ -22,6 +22,7 @@ pub struct FuelBlockHeader {
     /// Merkle root of transactions.
     pub transactions_root: Bytes32,
     /// The block producer time
+    #[serde(with = "ts_seconds")]
     pub time: DateTime<Utc>,
     /// The block producer public key
     pub producer: Address,

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -21,7 +21,7 @@ pub struct FuelBlockHeader {
     pub prev_root: Bytes32,
     /// Merkle root of transactions.
     pub transactions_root: Bytes32,
-    /// The block producer time    
+    /// The block producer time
     pub time: DateTime<Utc>,
     /// The block producer public key
     pub producer: Address,

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -1,5 +1,5 @@
 pub use super::BlockHeight;
-use chrono::{serde::ts_seconds, DateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use fuel_crypto::Hasher;
 use fuel_tx::{Address, Bytes32, Transaction};
 
@@ -21,8 +21,7 @@ pub struct FuelBlockHeader {
     pub prev_root: Bytes32,
     /// Merkle root of transactions.
     pub transactions_root: Bytes32,
-    /// The block producer time
-    #[serde(with = "ts_seconds")]
+    /// The block producer time    
     pub time: DateTime<Utc>,
     /// The block producer public key
     pub producer: Address,

--- a/fuel-core-interfaces/src/model/vote.rs
+++ b/fuel-core-interfaces/src/model/vote.rs
@@ -1,0 +1,16 @@
+use fuel_crypto::{PublicKey, Signature};
+use fuel_types::Bytes32;
+
+/// A vote from a validator.
+///
+/// This is a dummy placeholder for the Vote Struct in fuel-bft
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Vote {
+    block_id: Bytes32,
+    height: u64,
+    round: u64,
+    signature: Signature,
+    //step: Step,
+    validator: PublicKey,
+}

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -14,6 +14,8 @@ description = "Fuel client networking"
 [dependencies]
 async-trait = "0.1.52"
 bincode = "1.3"
+fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["serde"], version = "0.8.0" }
+fuel-tx = { version = "0.12.1", features = ["serde"] }
 futures = "0.3"
 futures-timer = "3.0"
 ip_network = "0.4"

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -15,7 +15,7 @@ description = "Fuel client networking"
 async-trait = "0.1.52"
 bincode = "1.3"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["serde"], version = "0.8.0" }
-fuel-tx = { version = "0.12.1", features = ["serde"] }
+fuel-tx = { version = "0.12", features = ["serde"] }
 futures = "0.3"
 futures-timer = "3.0"
 ip_network = "0.4"

--- a/fuel-p2p/src/behavior.rs
+++ b/fuel-p2p/src/behavior.rs
@@ -31,6 +31,7 @@ use std::{
 use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum FuelBehaviourEvent {
     PeerConnected(PeerId),

--- a/fuel-p2p/src/config.rs
+++ b/fuel-p2p/src/config.rs
@@ -25,6 +25,9 @@ pub struct P2PConfig {
     /// The TCP port that Swarm listens on
     pub tcp_port: u16,
 
+    /// Max Size of a FuelBlock in bytes
+    pub max_block_size: usize,
+
     // `DiscoveryBehaviour` related fields
     pub bootstrap_nodes: Vec<(PeerId, Multiaddr)>,
     pub enable_mdns: bool,

--- a/fuel-p2p/src/gossipsub/messages.rs
+++ b/fuel-p2p/src/gossipsub/messages.rs
@@ -1,7 +1,10 @@
+use fuel_core_interfaces::model::{FuelBlock, Vote};
+use fuel_tx::Transaction;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum GossipsubMessage {
-    BroadcastNewTx,
-    BroadcastNewBlock,
+    BroadcastNewTx(Transaction),
+    BroadcastNewBlock(FuelBlock),
+    BroadcastConensusVote(Vote),
 }

--- a/fuel-p2p/src/gossipsub/messages.rs
+++ b/fuel-p2p/src/gossipsub/messages.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum GossipsubMessage {
-    BroadcastNewTx(Transaction),
-    BroadcastNewBlock(FuelBlock),
-    BroadcastConensusVote(Vote),
+    NewTx(Transaction),
+    NewBlock(FuelBlock),
+    ConensusVote(Vote),
 }

--- a/fuel-p2p/src/request_response/messages.rs
+++ b/fuel-p2p/src/request_response/messages.rs
@@ -1,21 +1,21 @@
+use fuel_core_interfaces::model::{BlockHeight, FuelBlock};
 use libp2p::request_response::OutboundFailure;
 use serde::{Deserialize, Serialize};
 
 pub(crate) const REQUEST_RESPONSE_PROTOCOL_ID: &[u8] = b"/fuel/req_res/0.0.1";
-/// Max Size in Bytes of the messages
-// todo: this will be defined once Request & Response Messages are clearly defined
-// it should be the biggest field of respective enum
-pub(crate) const MAX_REQUEST_SIZE: usize = 100;
-pub(crate) const MAX_RESPONSE_SIZE: usize = 100;
+
+/// Max Size in Bytes of the Request Message
+/// Currently the only and the biggest message is RequestBlock(BlockHeight)
+pub(crate) const MAX_REQUEST_SIZE: usize = 8;
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
 pub enum RequestMessage {
-    RequestBlock,
+    RequestBlock(BlockHeight),
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum ResponseMessage {
-    ResponseBlock,
+    ResponseBlock(FuelBlock),
 }
 
 #[derive(Debug)]

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -33,6 +33,7 @@ pub struct FuelP2PService {
     swarm: Swarm<FuelBehaviour<BincodeCodec>>,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum FuelP2PEvent {
     Behaviour(FuelBehaviourEvent),
@@ -406,7 +407,7 @@ mod tests {
                             // verifies that we've got at least a single peer address to send message to
                             if !peer_addresses.is_empty() && !message_sent  {
                                 message_sent = true;
-                                let default_tx = FuelGossipsubMessage::BroadcastNewTx(Transaction::default());
+                                let default_tx = FuelGossipsubMessage::NewTx(Transaction::default());
                                 node_a.publish_message(selected_topic.clone(), default_tx).unwrap();
                             }
                         }
@@ -421,9 +422,9 @@ mod tests {
                             panic!("Wrong Topic");
                         }
 
-                        if let FuelGossipsubMessage::BroadcastNewTx(message) = message {
+                        if let FuelGossipsubMessage::NewTx(message) = message {
                             if message != Transaction::default() {
-                                tracing::error!("Wrong p2p message, expected: {:?} - actual: {:?}", FuelGossipsubMessage::BroadcastNewTx(Transaction::default()), message);
+                                tracing::error!("Wrong p2p message, expected: {:?} - actual: {:?}", FuelGossipsubMessage::NewTx(Transaction::default()), message);
                                 panic!("Wrong Message")
 
                             }

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -47,7 +47,11 @@ impl FuelP2PService {
 
         // configure and build P2P Serivce
         let transport = build_transport(local_keypair.clone()).await;
-        let behaviour = FuelBehaviour::new(local_keypair, &config, BincodeCodec);
+        let behaviour = FuelBehaviour::new(
+            local_keypair,
+            &config,
+            BincodeCodec::new(config.max_block_size),
+        );
         let mut swarm = Swarm::new(transport, behaviour, local_peer_id);
 
         // set up node's address to listen on
@@ -184,6 +188,7 @@ mod tests {
             network_name: network_name.into(),
             address: IpAddr::V4(Ipv4Addr::from([0, 0, 0, 0])),
             tcp_port: 4000,
+            max_block_size: 100_000,
             bootstrap_nodes: vec![],
             enable_mdns: false,
             max_peers_connected: 50,
@@ -442,6 +447,9 @@ mod tests {
     #[tokio::test]
     #[instrument]
     async fn request_response_works() {
+        use fuel_core_interfaces::model::{FuelBlock, FuelBlockHeader};
+        use fuel_tx::Transaction;
+
         let mut p2p_config = build_p2p_config("request_response_works");
 
         // Node A
@@ -460,27 +468,40 @@ mod tests {
 
         let (tx_test_end, mut rx_test_end) = mpsc::channel(1);
 
+        let mut request_sent = false;
+
         loop {
             tokio::select! {
                 message_sent = rx_test_end.recv() => {
                     // we received a signal to end the test
-                    assert_eq!(message_sent, Some(true), "Message not received successfully!");
+                    assert_eq!(message_sent, Some(true), "Received wrong block height!");
                     break;
                 }
                 node_a_event = node_a.next_event() => {
                     if let FuelP2PEvent::Behaviour(FuelBehaviourEvent::PeerInfoUpdated(peer_id)) = node_a_event {
                         if let Some(PeerInfo { peer_addresses, .. }) = node_a.swarm.behaviour().get_peer_info(&peer_id) {
                             // 0. verifies that we've got at least a single peer address to request messsage from
-                            if !peer_addresses.is_empty() {
+                            if !peer_addresses.is_empty() && !request_sent {
+                                request_sent = true;
+
                                 // 1. Simulating Oneshot channel from the NetworkOrchestrator
                                 let (tx_orchestrator, rx_orchestrator) = oneshot::channel();
-                                assert!(node_a.send_request_msg(None, RequestMessage::RequestBlock, tx_orchestrator).is_ok());
+
+                                let requested_block_height = RequestMessage::RequestBlock(0_u64.into());
+                                assert!(node_a.send_request_msg(None, requested_block_height, tx_orchestrator).is_ok());
 
                                 let tx_test_end = tx_test_end.clone();
                                 tokio::spawn(async move {
                                     // 4. Simulating NetworkOrchestrator receving a message from Node B
-                                    let message_sent = matches!(rx_orchestrator.await, Ok(Ok(_)));
-                                    tx_test_end.send(message_sent).await
+                                    let response_message = rx_orchestrator.await;
+
+                                    if let Ok(Ok(ResponseMessage::ResponseBlock(block))) = response_message {
+                                        let _ = tx_test_end.send(block.header.height == 0_u64.into()).await;
+                                    } else {
+                                        tracing::error!("Orchestrator failed to receive a message: {:?}", response_message);
+                                        panic!("Message not received successfully!")
+                                    }
+
                                 });
                             }
                         }
@@ -491,7 +512,12 @@ mod tests {
                 node_b_event = node_b.next_event() => {
                     // 2. Node B recieves the RequestMessage from Node A initiated by the NetworkOrchestrator
                     if let FuelP2PEvent::Behaviour(FuelBehaviourEvent::RequestMessage{ request_id, .. }) = node_b_event {
-                        let _ = node_b.send_response_msg(request_id, ResponseMessage::ResponseBlock);
+                        let block = FuelBlock {
+                            header: FuelBlockHeader::default(),
+                            transactions: vec![Transaction::default(), Transaction::default(), Transaction::default(), Transaction::default(), Transaction::default()],
+                        };
+
+                        let _ = node_b.send_response_msg(request_id, ResponseMessage::ResponseBlock(block));
                     }
 
                     tracing::info!("Node B Event: {:?}", node_b_event);
@@ -542,7 +568,8 @@ mod tests {
                                 assert_eq!(node_a.swarm.behaviour().get_outbound_requests_table().len(), 0);
 
                                 // Request successfully sent
-                                assert!(node_a.send_request_msg(None, RequestMessage::RequestBlock, tx_orchestrator).is_ok());
+                                let requested_block_height = RequestMessage::RequestBlock(0_u64.into());
+                                assert!(node_a.send_request_msg(None, requested_block_height, tx_orchestrator).is_ok());
 
                                 // 2b. there should be ONE pending outbound requests in the table
                                 assert_eq!(node_a.swarm.behaviour().get_outbound_requests_table().len(), 1);


### PR DESCRIPTION
This in favor of #313 

I have defined:
- Gossipsub Messages
- Request/Response Messages

In order to unblock myself I have added a placeholder for Vote struct from FuelLabs/fuel-bft#9
in `fuel-core-interfaces` .

In this PR I also fixed a bug in `serde` feature in `fuel-core-interfaces` where `time` field of `FuelBlockHeader` is not properly serialized, by importing `serde` feature from `chrono` dep.

I have added a `max_response_size` field to `BincodeCodec` since max FuelBlock size is configurable and we need to configure max size of both Request and Response messages. Max request size is pretty straightforward but response message size depends on max block size.