### PR TITLE
Debugger API: Return new receipts when execution is paused

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -411,6 +411,7 @@ enum ReturnType {
 type RunResult {
 	state: RunState!
 	breakpoint: OutputBreakpoint
+	jsonReceipts: [String!]!
 }
 
 enum RunState {

--- a/fuel-client/src/client/schema.rs
+++ b/fuel-client/src/client/schema.rs
@@ -6,7 +6,7 @@ pub mod schema {
 
 use hex::FromHexError;
 use std::array::TryFromSliceError;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::io::ErrorKind;
 use std::num::TryFromIntError;
 use thiserror::Error;
@@ -191,6 +191,25 @@ pub struct ContinueTx {
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct RunResult {
     pub breakpoint: Option<OutputBreakpoint>,
+    pub json_receipts: Vec<String>,
+}
+
+impl RunResult {
+    pub fn receipts(&self) -> impl Iterator<Item = fuel_tx::Receipt> + '_ {
+        self.json_receipts.iter().map(|r| {
+            serde_json::from_str::<fuel_tx::Receipt>(r).expect("JSON deserialization failed")
+        })
+    }
+}
+
+impl fmt::Display for RunResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let receipts: Vec<fuel_tx::Receipt> = self.receipts().collect();
+        f.debug_struct("RunResult")
+            .field("breakpoint", &self.breakpoint)
+            .field("receipts", &receipts)
+            .finish()
+    }
 }
 
 #[derive(cynic::QueryFragment, Debug)]


### PR DESCRIPTION
Currently the GraphQL debugger API doesn't make receipts availble. This PR adds receipts to `RunResult` responses, so that they are communicated to the caller every time a breakpoint is hit and when the transaction terminates.