### PR TITLE
Dependency consolidation using fuel-core-interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,12 +1567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
-
-[[package]]
 name = "ecdsa"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,7 +2040,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
- "fuel-types",
  "tokio",
 ]
 
@@ -2056,7 +2049,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
- "fuel-types",
  "parking_lot 0.12.1",
  "tokio",
 ]
@@ -2067,7 +2059,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
- "fuel-types",
  "parking_lot 0.12.1",
  "tokio",
 ]
@@ -2088,20 +2079,13 @@ dependencies = [
  "derive_more",
  "dirs",
  "env_logger",
- "fuel-asm",
  "fuel-block-executor",
  "fuel-block-importer",
  "fuel-block-producer",
  "fuel-core-bft",
  "fuel-core-interfaces",
- "fuel-crypto",
- "fuel-merkle 0.1.1",
- "fuel-storage 0.1.0",
  "fuel-sync",
- "fuel-tx",
  "fuel-txpool",
- "fuel-types",
- "fuel-vm",
  "futures",
  "graphql-parser",
  "hex",
@@ -2132,7 +2116,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
- "fuel-types",
  "parking_lot 0.12.1",
  "tokio",
 ]
@@ -2147,6 +2130,7 @@ dependencies = [
  "derive_more",
  "fuel-asm",
  "fuel-crypto",
+ "fuel-merkle 0.2.0",
  "fuel-storage 0.1.0",
  "fuel-tx",
  "fuel-types",
@@ -2234,7 +2218,6 @@ dependencies = [
  "bincode",
  "ctor",
  "fuel-core-interfaces",
- "fuel-tx",
  "futures",
  "futures-timer",
  "ip_network",
@@ -2265,8 +2248,6 @@ dependencies = [
  "ethers-signers",
  "features",
  "fuel-core-interfaces",
- "fuel-tx",
- "fuel-types",
  "futures",
  "hex",
  "once_cell",
@@ -2301,7 +2282,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
- "fuel-types",
  "parking_lot 0.12.1",
  "tokio",
 ]
@@ -2312,13 +2292,10 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "fuel-core",
+ "fuel-core-interfaces",
  "fuel-crypto",
  "fuel-gql-client",
- "fuel-storage 0.1.0",
- "fuel-tx",
  "fuel-txpool",
- "fuel-types",
- "fuel-vm",
  "insta",
  "itertools",
  "rand 0.8.5",
@@ -2350,8 +2327,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "fuel-core-interfaces",
- "fuel-tx",
- "fuel-types",
  "futures",
  "parking_lot 0.11.2",
  "thiserror",
@@ -2375,7 +2350,6 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a70dffe9faeb81f9d9d202eb26af4742980f884fa3109c169819ac6b2c51d3"
 dependencies = [
- "dyn-clone",
  "fuel-asm",
  "fuel-crypto",
  "fuel-merkle 0.1.1",

--- a/fuel-block-executor/Cargo.toml
+++ b/fuel-block-executor/Cargo.toml
@@ -12,5 +12,4 @@ description = "Fuel Block Executor"
 [dependencies]
 anyhow = "1.0"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.8.0" }
-fuel-types = { version = "0.5", default-features = false }
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-block-importer/Cargo.toml
+++ b/fuel-block-importer/Cargo.toml
@@ -12,6 +12,5 @@ description = "Fuel Block Importer"
 [dependencies]
 anyhow = "1.0"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.8.0" }
-fuel-types = { version = "0.5", default-features = false }
 parking_lot = "0.12"
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-block-producer/Cargo.toml
+++ b/fuel-block-producer/Cargo.toml
@@ -12,6 +12,5 @@ description = "Fuel Block Producer"
 [dependencies]
 anyhow = "1.0"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.8.0" }
-fuel-types = { version = "0.5", default-features = false }
 parking_lot = "0.12"
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-core-bft/Cargo.toml
+++ b/fuel-core-bft/Cargo.toml
@@ -12,6 +12,5 @@ description = "Fuel Core BFT"
 [dependencies]
 anyhow = "1.0"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.8.0" }
-fuel-types = { version = "0.5", default-features = false }
 parking_lot = "0.12"
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -13,10 +13,11 @@ description = "Fuel core interfaces"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4" }
 derive_more = { version = "0.99" }
 fuel-asm = "0.5"
 fuel-crypto = { version = "0.5", default-features = false }
+fuel-merkle = { version = "0.2" }
 fuel-storage = "0.1"
 fuel-tx = { version = "0.12", default-features = false }
 fuel-types = { version = "0.5", default-features = false }
@@ -29,5 +30,9 @@ thiserror = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 
 [features]
-test_helpers = []
-serde = ["dep:serde", "fuel-tx/serde", "fuel-types/serde", "fuel-vm/serde"]
+test-helpers = [
+    "fuel-tx/internals", "fuel-tx/builder", "fuel-tx/random", "fuel-vm/random", "fuel-vm/test-helpers",
+    "fuel-crypto/random", "fuel-types/random"
+]
+serde = ["dep:serde", "fuel-vm/serde", "chrono/serde"]
+debug = ["fuel-vm/debug"]

--- a/fuel-core-interfaces/src/db.rs
+++ b/fuel-core-interfaces/src/db.rs
@@ -62,7 +62,7 @@ impl From<KvStoreError> for InterpreterError {
     }
 }
 
-#[cfg(any(test, feature = "test_helpers"))]
+#[cfg(any(test, feature = "test-helpers"))]
 pub mod helpers {
 
     use async_trait::async_trait;

--- a/fuel-core-interfaces/src/lib.rs
+++ b/fuel-core-interfaces/src/lib.rs
@@ -8,3 +8,20 @@ pub mod relayer;
 pub mod signer;
 pub mod sync;
 pub mod txpool;
+
+pub mod common {
+    #[doc(no_inline)]
+    pub use fuel_asm;
+    #[doc(no_inline)]
+    pub use fuel_crypto;
+    #[doc(no_inline)]
+    pub use fuel_merkle;
+    #[doc(no_inline)]
+    pub use fuel_storage;
+    #[doc(no_inline)]
+    pub use fuel_tx;
+    #[doc(no_inline)]
+    pub use fuel_types;
+    #[doc(no_inline)]
+    pub use fuel_vm;
+}

--- a/fuel-core-interfaces/src/signer.rs
+++ b/fuel-core-interfaces/src/signer.rs
@@ -15,7 +15,7 @@ pub enum SignerError {
     KeyNotLoaded,
 }
 
-#[cfg(any(test, feature = "test_helpers"))]
+#[cfg(any(test, feature = "test-helpers"))]
 pub mod helpers {
     use super::*;
 

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -35,7 +35,6 @@ clap = { version = "3.1", features = ["env", "derive"] }
 derive_more = { version = "0.99" }
 dirs = "3.0"
 env_logger = "0.9"
-fuel-asm = { version = "0.5", features = ["serde"] }
 fuel-block-executor = { path = "../fuel-block-executor", version = "0.8.0" }
 fuel-block-importer = { path = "../fuel-block-importer", version = "0.8.0" }
 fuel-block-producer = { path = "../fuel-block-producer", version = "0.8.0" }
@@ -43,14 +42,8 @@ fuel-core-bft = { path = "../fuel-core-bft", version = "0.8.0" }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.8.0", features = [
     "serde",
 ] }
-fuel-crypto = { version = "0.5", features = ["random"] }
-fuel-merkle = "0.1"
-fuel-storage = { version = "0.1" }
 fuel-sync = { path = "../fuel-sync", version = "0.8.0" }
-fuel-tx = { version = "0.12", features = ["serde"] }
 fuel-txpool = { path = "../fuel-txpool", version = "0.8.0" }
-fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.11", features = ["serde", "profile-coverage"] }
 futures = "0.3"
 graphql-parser = "0.3.0"
 hex = { version = "0.4", features = ["serde"] }
@@ -82,11 +75,10 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-fuel-tx = { version = "0.12", features = ["serde", "builder", "internals"] }
-fuel-vm = { version = "0.11", features = ["serde", "random", "test-helpers"] }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["serde", "test-helpers"] }
 insta = "1.8"
 
 [features]
 default = ["rocksdb", "debug"]
-debug = ["fuel-vm/debug"]
+debug = ["fuel-core-interfaces/debug"]
 test-helpers = []

--- a/fuel-core/src/chain_config.rs
+++ b/fuel-core/src/chain_config.rs
@@ -1,7 +1,9 @@
 use self::serialization::{HexNumber, HexType};
 use crate::model::BlockHeight;
-use fuel_tx::ConsensusParameters;
-use fuel_types::{Address, AssetId, Bytes32, Salt};
+use fuel_core_interfaces::common::{
+    fuel_tx::ConsensusParameters,
+    fuel_types::{Address, AssetId, Bytes32, Salt},
+};
 use itertools::Itertools;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -32,7 +34,7 @@ impl ChainConfig {
         let mut rng = StdRng::seed_from_u64(10);
         let initial_coins = (0..5)
             .map(|_| {
-                let secret = fuel_crypto::SecretKey::random(&mut rng);
+                let secret = fuel_core_interfaces::common::fuel_crypto::SecretKey::random(&mut rng);
                 let address = Address::from(*secret.public_key().hash());
                 tracing::info!(
                     "PrivateKey({:#x}), Address({:#x}), Balance({})",
@@ -165,8 +167,7 @@ pub struct ContractConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fuel_asm::Opcode;
-    use fuel_vm::prelude::Contract;
+    use fuel_core_interfaces::common::{fuel_asm::Opcode, fuel_vm::prelude::Contract};
     use rand::prelude::StdRng;
     use rand::{Rng, RngCore, SeedableRng};
     use std::env::temp_dir;

--- a/fuel-core/src/chain_config/serialization.rs
+++ b/fuel-core/src/chain_config/serialization.rs
@@ -1,7 +1,6 @@
 use crate::model::BlockHeight;
 use core::fmt;
-use fuel_types::bytes::WORD_SIZE;
-use fuel_types::Word;
+use fuel_core_interfaces::common::{fuel_types::bytes::WORD_SIZE, fuel_types::Word};
 use serde::{de::Error, Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 use std::convert::TryFrom;

--- a/fuel-core/src/coin_query.rs
+++ b/fuel-core/src/coin_query.rs
@@ -1,8 +1,10 @@
 use crate::database::{Database, KvStoreError};
 use crate::model::{Coin, CoinStatus};
 use crate::state::{self};
-use fuel_storage::Storage;
-use fuel_tx::{Address, AssetId, UtxoId};
+use fuel_core_interfaces::common::{
+    fuel_storage::Storage,
+    fuel_tx::{Address, AssetId, UtxoId},
+};
 use itertools::Itertools;
 use rand::prelude::*;
 use std::cmp::Reverse;
@@ -265,8 +267,7 @@ pub fn random_improve(
 mod tests {
     use crate::test_utils::*;
     use assert_matches::assert_matches;
-    use fuel_asm::Word;
-    use fuel_tx::Address;
+    use fuel_core_interfaces::common::{fuel_asm::Word, fuel_tx::Address};
 
     use super::*;
 

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -9,18 +9,22 @@ use crate::state::{
 };
 use async_trait::async_trait;
 pub use fuel_core_interfaces::db::KvStoreError;
-use fuel_core_interfaces::model::{BlockHeight, DaBlockHeight, SealedFuelBlock, ValidatorStake};
-use fuel_core_interfaces::relayer::{RelayerDb, StakingDiff};
-use fuel_storage::Storage;
-use fuel_vm::prelude::{Address, Bytes32, InterpreterStorage};
+use fuel_core_interfaces::{
+    common::{
+        fuel_storage::Storage,
+        fuel_vm::prelude::{Address, Bytes32, InterpreterStorage},
+    },
+    model::{BlockHeight, DaBlockHeight, SealedFuelBlock, ValidatorStake},
+    relayer::{RelayerDb, StakingDiff},
+};
 use serde::{de::DeserializeOwned, Serialize};
-use std::fmt::Debug;
-use std::marker::Send;
 #[cfg(feature = "rocksdb")]
 use std::path::Path;
-use std::{collections::HashMap, ops::DerefMut};
 use std::{
-    fmt::{self, Formatter},
+    collections::HashMap,
+    fmt::{self, Debug, Formatter},
+    marker::Send,
+    ops::DerefMut,
     sync::Arc,
 };
 #[cfg(feature = "rocksdb")]

--- a/fuel-core/src/database/balances.rs
+++ b/fuel-core/src/database/balances.rs
@@ -3,10 +3,12 @@ use crate::{
     database::{columns::BALANCES, Database},
     state::{IterDirection, MultiKey},
 };
-use fuel_storage::MerkleRoot;
-use fuel_vm::{
-    crypto,
-    prelude::{AssetId, ContractId, MerkleStorage, Word},
+use fuel_core_interfaces::common::{
+    fuel_storage::MerkleRoot,
+    fuel_vm::{
+        crypto,
+        prelude::{AssetId, ContractId, MerkleStorage, Word},
+    },
 };
 use itertools::Itertools;
 use std::borrow::Cow;

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -3,8 +3,7 @@ use crate::{
     model::{BlockHeight, FuelBlockDb},
     state::{Error, IterDirection},
 };
-use fuel_storage::Storage;
-use fuel_tx::Bytes32;
+use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_tx::Bytes32};
 use std::borrow::Cow;
 use std::convert::{TryFrom, TryInto};
 

--- a/fuel-core/src/database/code_root.rs
+++ b/fuel-core/src/database/code_root.rs
@@ -2,7 +2,7 @@ use crate::{
     database::{columns::CONTRACTS_CODE_ROOT, Database},
     state::Error,
 };
-use fuel_vm::prelude::{Bytes32, ContractId, Salt, Storage};
+use fuel_core_interfaces::common::fuel_vm::prelude::{Bytes32, ContractId, Salt, Storage};
 use std::borrow::Cow;
 
 impl Storage<ContractId, (Salt, Bytes32)> for Database {
@@ -32,7 +32,7 @@ impl Storage<ContractId, (Salt, Bytes32)> for Database {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fuel_vm::prelude::Contract;
+    use fuel_core_interfaces::common::fuel_vm::prelude::Contract;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 

--- a/fuel-core/src/database/coin.rs
+++ b/fuel-core/src/database/coin.rs
@@ -6,8 +6,10 @@ use crate::{
     model::Coin,
     state::{Error, IterDirection},
 };
-use fuel_storage::Storage;
-use fuel_tx::{Address, AssetId, Bytes32, UtxoId};
+use fuel_core_interfaces::common::{
+    fuel_storage::Storage,
+    fuel_tx::{Address, AssetId, Bytes32, UtxoId},
+};
 use itertools::Itertools;
 use std::borrow::Cow;
 

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -5,9 +5,11 @@ use crate::{
     },
     state::{Error, IterDirection, MultiKey},
 };
-use fuel_tx::UtxoId;
-use fuel_types::Word;
-use fuel_vm::prelude::{AssetId, Contract, ContractId, Storage};
+use fuel_core_interfaces::common::{
+    fuel_tx::UtxoId,
+    fuel_types::Word,
+    fuel_vm::prelude::{AssetId, Contract, ContractId, Storage},
+};
 use std::borrow::Cow;
 
 impl Storage<ContractId, Contract> for Database {
@@ -70,7 +72,7 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fuel_tx::TxId;
+    use fuel_core_interfaces::common::fuel_tx::TxId;
 
     #[test]
     fn contract_get() {

--- a/fuel-core/src/database/delegates_index.rs
+++ b/fuel-core/src/database/delegates_index.rs
@@ -1,7 +1,8 @@
 use crate::database::{columns, Database, KvStoreError};
-use fuel_core_interfaces::model::DaBlockHeight;
-use fuel_storage::Storage;
-use fuel_types::Address;
+use fuel_core_interfaces::{
+    common::{fuel_storage::Storage, fuel_types::Address},
+    model::DaBlockHeight,
+};
 use std::borrow::Cow;
 
 /// Delegate Index maps delegateAddress with list of da block where delegation happened. so that we

--- a/fuel-core/src/database/deposit_coin.rs
+++ b/fuel-core/src/database/deposit_coin.rs
@@ -1,7 +1,8 @@
 use crate::database::{columns, Database, KvStoreError};
-use fuel_core_interfaces::model::DepositCoin;
-use fuel_storage::Storage;
-use fuel_types::Bytes32;
+use fuel_core_interfaces::{
+    common::{fuel_storage::Storage, fuel_types::Bytes32},
+    model::DepositCoin,
+};
 use std::borrow::Cow;
 
 impl Storage<Bytes32, DepositCoin> for Database {

--- a/fuel-core/src/database/receipts.rs
+++ b/fuel-core/src/database/receipts.rs
@@ -1,6 +1,8 @@
 use crate::database::{columns::RECEIPTS, Database, KvStoreError};
-use fuel_storage::Storage;
-use fuel_tx::{Bytes32, Receipt};
+use fuel_core_interfaces::common::{
+    fuel_storage::Storage,
+    fuel_tx::{Bytes32, Receipt},
+};
 use std::borrow::Cow;
 
 impl Storage<Bytes32, Vec<Receipt>> for Database {

--- a/fuel-core/src/database/staking_diffs.rs
+++ b/fuel-core/src/database/staking_diffs.rs
@@ -1,6 +1,7 @@
 use crate::database::{columns, Database, KvStoreError};
-use fuel_core_interfaces::{model::DaBlockHeight, relayer::StakingDiff};
-use fuel_storage::Storage;
+use fuel_core_interfaces::{
+    common::fuel_storage::Storage, model::DaBlockHeight, relayer::StakingDiff,
+};
 use std::borrow::Cow;
 
 impl Storage<DaBlockHeight, StakingDiff> for Database {

--- a/fuel-core/src/database/state.rs
+++ b/fuel-core/src/database/state.rs
@@ -2,10 +2,12 @@ use crate::{
     database::{columns::CONTRACTS_STATE, Database},
     state::{Error, IterDirection, MultiKey},
 };
-use fuel_vm::prelude::MerkleRoot;
-use fuel_vm::{
-    crypto,
-    prelude::{Bytes32, ContractId, MerkleStorage},
+use fuel_core_interfaces::{
+    common::fuel_vm::prelude::MerkleRoot,
+    common::fuel_vm::{
+        crypto,
+        prelude::{Bytes32, ContractId, MerkleStorage},
+    },
 };
 use itertools::Itertools;
 use std::borrow::Cow;

--- a/fuel-core/src/database/transaction.rs
+++ b/fuel-core/src/database/transaction.rs
@@ -7,9 +7,11 @@ use crate::{
     state::{Error, IterDirection},
     tx_pool::TransactionStatus,
 };
-use fuel_storage::Storage;
-use fuel_tx::{Bytes32, Transaction};
-use fuel_types::Address;
+use fuel_core_interfaces::common::{
+    fuel_storage::Storage,
+    fuel_tx::{Bytes32, Transaction},
+    fuel_types::Address,
+};
 use std::{borrow::Cow, ops::Deref};
 
 pub type TransactionIndex = u32;

--- a/fuel-core/src/database/validator_set.rs
+++ b/fuel-core/src/database/validator_set.rs
@@ -1,7 +1,8 @@
 use crate::database::{columns, Database, KvStoreError};
-use fuel_core_interfaces::model::ValidatorStake;
-use fuel_storage::Storage;
-use fuel_types::Address;
+use fuel_core_interfaces::{
+    common::{fuel_storage::Storage, fuel_types::Address},
+    model::ValidatorStake,
+};
 use std::borrow::Cow;
 
 impl Storage<Address, (ValidatorStake, Option<Address>)> for Database {

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -4,16 +4,19 @@ use crate::{
     service::Config,
     tx_pool::TransactionStatus,
 };
-use fuel_asm::Word;
-use fuel_merkle::{binary::MerkleTree, common::StorageMap};
-use fuel_storage::Storage;
-use fuel_tx::{
-    Address, AssetId, Bytes32, Input, Output, Receipt, Transaction, TxId, UtxoId, ValidationError,
-};
-use fuel_types::{bytes::SerializableVec, ContractId};
-use fuel_vm::{
-    consts::REG_SP,
-    prelude::{Backtrace as FuelBacktrace, Interpreter},
+use fuel_core_interfaces::common::{
+    fuel_asm::Word,
+    fuel_merkle::{binary::MerkleTree, common::StorageMap},
+    fuel_storage::Storage,
+    fuel_tx::{
+        Address, AssetId, Bytes32, Input, Output, Receipt, Transaction, TxId, UtxoId,
+        ValidationError,
+    },
+    fuel_types::{bytes::SerializableVec, ContractId},
+    fuel_vm::{
+        consts::REG_SP,
+        prelude::{Backtrace as FuelBacktrace, Interpreter},
+    },
 };
 use std::{
     error::Error as StdError,
@@ -682,7 +685,7 @@ pub enum Error {
     },
     #[error("Transaction({transaction_id:#x}) execution error: {error:?}")]
     VmExecution {
-        error: fuel_vm::prelude::InterpreterError,
+        error: fuel_core_interfaces::common::fuel_vm::prelude::InterpreterError,
         transaction_id: Bytes32,
     },
     #[error("Execution error with backtrace")]
@@ -721,15 +724,18 @@ impl From<crate::state::Error> for Error {
 mod tests {
     use super::*;
     use crate::model::FuelBlockHeader;
-    use fuel_asm::Opcode;
-    use fuel_crypto::SecretKey;
-    use fuel_tx::default_parameters::MAX_GAS_PER_TX;
-    use fuel_tx::TransactionBuilder;
-    use fuel_types::{ContractId, Immediate12, Salt};
-    use fuel_vm::consts::{REG_CGAS, REG_FP, REG_ONE, REG_ZERO};
-    use fuel_vm::prelude::{Call, CallFrame};
-    use fuel_vm::script_with_data_offset;
-    use fuel_vm::util::test_helpers::TestBuilder as TxBuilder;
+    use fuel_core_interfaces::common::{
+        fuel_asm::Opcode,
+        fuel_crypto::SecretKey,
+        fuel_tx::{self, default_parameters::MAX_GAS_PER_TX, TransactionBuilder},
+        fuel_types::{ContractId, Immediate12, Salt},
+        fuel_vm::{
+            consts::{REG_CGAS, REG_FP, REG_ONE, REG_ZERO},
+            prelude::{Call, CallFrame},
+            script_with_data_offset,
+            util::test_helpers::TestBuilder as TxBuilder,
+        },
+    };
     use itertools::Itertools;
     use rand::prelude::StdRng;
     use rand::{Rng, SeedableRng};
@@ -1450,6 +1456,7 @@ mod tests {
             .collect::<Vec<u8>>(),
             &mut rng,
         );
+        use fuel_core_interfaces::common::fuel_types;
         let (script, data_offset) = script_with_data_offset!(
             data_offset,
             vec![

--- a/fuel-core/src/schema/balance.rs
+++ b/fuel-core/src/schema/balance.rs
@@ -7,7 +7,7 @@ use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
     Context, Object,
 };
-use fuel_storage::Storage;
+use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_tx, fuel_types};
 use itertools::Itertools;
 
 pub struct Balance {

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -13,7 +13,7 @@ use async_graphql::{
     Context, Object,
 };
 use chrono::{DateTime, Utc};
-use fuel_storage::Storage;
+use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_tx, fuel_types};
 use itertools::Itertools;
 use std::borrow::Cow;
 use std::convert::TryInto;

--- a/fuel-core/src/schema/chain.rs
+++ b/fuel-core/src/schema/chain.rs
@@ -1,9 +1,9 @@
-use crate::model::FuelBlockDb;
-use crate::schema::block::Block;
-use crate::schema::scalars::U64;
-use crate::{database::Database, service::Config};
+use crate::{
+    database::Database, model::FuelBlockDb, schema::block::Block, schema::scalars::U64,
+    service::Config,
+};
 use async_graphql::{Context, Object};
-use fuel_storage::Storage;
+use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_tx, fuel_types};
 
 pub const DEFAULT_NAME: &str = "Fuel.testnet";
 

--- a/fuel-core/src/schema/coin.rs
+++ b/fuel-core/src/schema/coin.rs
@@ -1,14 +1,18 @@
-use crate::coin_query::{random_improve, SpendQueryElement};
-use crate::database::{Database, KvStoreError};
-use crate::schema::scalars::{Address, AssetId, UtxoId, U64};
-use crate::service::Config;
-use crate::state::IterDirection;
+use crate::{
+    coin_query::{random_improve, SpendQueryElement},
+    database::{Database, KvStoreError},
+    schema::scalars::{Address, AssetId, UtxoId, U64},
+    service::Config,
+    state::IterDirection,
+};
 use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
     Context, Enum, InputObject, Object,
 };
-use fuel_core_interfaces::model::{Coin as CoinModel, CoinStatus as CoinStatusModel};
-use fuel_storage::Storage;
+use fuel_core_interfaces::{
+    common::{fuel_storage::Storage, fuel_tx},
+    model::{Coin as CoinModel, CoinStatus as CoinStatusModel},
+};
 use itertools::Itertools;
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -6,8 +6,10 @@ use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
     Context, InputObject, Object,
 };
-use fuel_storage::Storage;
-use fuel_vm::prelude::Contract as FuelVmContract;
+use fuel_core_interfaces::common::{
+    fuel_storage::Storage, fuel_tx, fuel_types, fuel_vm,
+    fuel_vm::prelude::Contract as FuelVmContract,
+};
 use std::iter::IntoIterator;
 
 pub struct Contract(pub(crate) fuel_types::ContractId);

--- a/fuel-core/src/schema/dap.rs
+++ b/fuel-core/src/schema/dap.rs
@@ -2,8 +2,10 @@ use crate::database::transactional::DatabaseTransaction;
 use crate::database::Database;
 use crate::schema::scalars::U64;
 use async_graphql::{Context, Object, SchemaBuilder, ID};
-use fuel_tx::ConsensusParameters;
-use fuel_vm::{consts, prelude::*};
+use fuel_core_interfaces::common::{
+    fuel_tx::ConsensusParameters,
+    fuel_vm::{self, consts, prelude::*},
+};
 use futures::lock::Mutex;
 use std::{collections::HashMap, io, sync};
 use tracing::{debug, trace};
@@ -372,7 +374,7 @@ mod gql_types {
     use crate::schema::scalars::{ContractId, U64};
 
     #[cfg(feature = "debug")]
-    use fuel_vm::prelude::Breakpoint as FuelBreakpoint;
+    use fuel_core_interfaces::common::fuel_vm::prelude::Breakpoint as FuelBreakpoint;
 
     #[derive(Debug, Clone, Copy, InputObject)]
     pub struct Breakpoint {

--- a/fuel-core/src/schema/scalars.rs
+++ b/fuel-core/src/schema/scalars.rs
@@ -3,6 +3,7 @@ use crate::model::BlockHeight;
 use async_graphql::{
     connection::CursorType, InputValueError, InputValueResult, Scalar, ScalarType, Value,
 };
+use fuel_core_interfaces::common::{fuel_tx, fuel_types};
 use std::{
     convert::TryInto,
     fmt::{Display, Formatter},

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -8,9 +8,10 @@ use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
     Context, Object,
 };
-use fuel_storage::Storage;
-use fuel_tx::Transaction as FuelTx;
-use fuel_vm::prelude::Deserializable;
+use fuel_core_interfaces::common::{
+    fuel_storage::Storage, fuel_tx::Transaction as FuelTx, fuel_types,
+    fuel_vm::prelude::Deserializable,
+};
 use itertools::Itertools;
 use std::borrow::Cow;
 use std::iter;

--- a/fuel-core/src/schema/tx/input.rs
+++ b/fuel-core/src/schema/tx/input.rs
@@ -3,7 +3,7 @@ use crate::schema::{
     scalars::{Address, AssetId, Bytes32, ContractId, HexString, UtxoId, U64},
 };
 use async_graphql::{Object, Union};
-use fuel_asm::Word;
+use fuel_core_interfaces::common::{fuel_asm::Word, fuel_tx};
 
 #[derive(Union)]
 pub enum Input {

--- a/fuel-core/src/schema/tx/output.rs
+++ b/fuel-core/src/schema/tx/output.rs
@@ -1,7 +1,7 @@
 use crate::schema::contract::Contract;
 use crate::schema::scalars::{Address, AssetId, Bytes32, U64};
 use async_graphql::{Object, Union};
-use fuel_asm::Word;
+use fuel_core_interfaces::common::{fuel_asm::Word, fuel_tx, fuel_types};
 
 #[derive(Union)]
 pub enum Output {

--- a/fuel-core/src/schema/tx/receipt.rs
+++ b/fuel-core/src/schema/tx/receipt.rs
@@ -4,8 +4,7 @@ use crate::schema::{
 };
 use async_graphql::{Enum, Object};
 use derive_more::Display;
-use fuel_asm::Word;
-use fuel_types::bytes::SerializableVec;
+use fuel_core_interfaces::common::{fuel_asm::Word, fuel_tx, fuel_types::bytes::SerializableVec};
 
 #[derive(Copy, Clone, Debug, Display, Enum, Eq, PartialEq)]
 pub enum ReceiptType {

--- a/fuel-core/src/schema/tx/types.rs
+++ b/fuel-core/src/schema/tx/types.rs
@@ -11,10 +11,13 @@ use crate::{
 };
 use async_graphql::{Context, Enum, Object, Union};
 use chrono::{DateTime, Utc};
-use fuel_core_interfaces::db::KvStoreError;
-use fuel_storage::Storage;
-use fuel_types::bytes::SerializableVec;
-use fuel_vm::prelude::ProgramState as VmProgramState;
+use fuel_core_interfaces::{
+    common::{
+        fuel_storage::Storage, fuel_tx, fuel_types, fuel_types::bytes::SerializableVec,
+        fuel_vm::prelude::ProgramState as VmProgramState,
+    },
+    db::KvStoreError,
+};
 use std::sync::Arc;
 
 pub struct ProgramState {

--- a/fuel-core/src/service/genesis.rs
+++ b/fuel-core/src/service/genesis.rs
@@ -4,11 +4,14 @@ use crate::{
     service::FuelService,
 };
 use anyhow::Result;
-use fuel_core_interfaces::model::{Coin, CoinStatus};
-use fuel_storage::{MerkleStorage, Storage};
-use fuel_tx::UtxoId;
-use fuel_types::{bytes::WORD_SIZE, AssetId, Bytes32, ContractId, Salt, Word};
-use fuel_vm::prelude::Contract;
+use fuel_core_interfaces::{
+    common::{
+        fuel_storage::{MerkleStorage, Storage},
+        fuel_tx::{Contract, UtxoId},
+        fuel_types::{bytes::WORD_SIZE, AssetId, Bytes32, ContractId, Salt, Word},
+    },
+    model::{Coin, CoinStatus},
+};
 use itertools::Itertools;
 
 impl FuelService {
@@ -161,11 +164,12 @@ mod tests {
     use crate::chain_config::{CoinConfig, ContractConfig, StateConfig};
     use crate::model::BlockHeight;
     use crate::service::Config;
-    use fuel_asm::Opcode;
-    use fuel_types::{Address, AssetId, Word};
+    use fuel_core_interfaces::common::{
+        fuel_asm::Opcode,
+        fuel_types::{Address, AssetId, Word},
+    };
     use itertools::Itertools;
-    use rand::rngs::StdRng;
-    use rand::{Rng, RngCore, SeedableRng};
+    use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
 
     #[tokio::test]
     async fn config_initializes_chain_name() {

--- a/fuel-core/src/state.rs
+++ b/fuel-core/src/state.rs
@@ -1,7 +1,5 @@
 use crate::state::in_memory::transaction::MemoryTransactionView;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 pub type Result<T> = core::result::Result<T, Error>;
 pub type DataSource = Arc<dyn TransactableStorage>;

--- a/fuel-core/src/test_utils.rs
+++ b/fuel-core/src/test_utils.rs
@@ -1,8 +1,10 @@
 use crate::database::Database;
 use crate::model::{Coin, CoinStatus};
-use fuel_asm::Word;
-use fuel_storage::Storage;
-use fuel_tx::{Address, AssetId, Bytes32, UtxoId};
+use fuel_core_interfaces::common::{
+    fuel_asm::Word,
+    fuel_storage::Storage,
+    fuel_tx::{Address, AssetId, Bytes32, UtxoId},
+};
 use itertools::Itertools;
 
 #[derive(Default)]

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -1,17 +1,22 @@
-use crate::database::{Database, KvStoreError};
-use crate::executor::{ExecutionMode, Executor};
-use crate::model::{FuelBlock, FuelBlockHeader};
-use crate::service::Config;
+use crate::{
+    database::{Database, KvStoreError},
+    executor::{ExecutionMode, Executor},
+    model::{FuelBlock, FuelBlockHeader},
+    service::Config,
+};
 use chrono::{DateTime, Utc};
-use fuel_core_interfaces::txpool::{TxPool as TxPoolTrait, TxPoolDb};
-use fuel_storage::Storage;
-use fuel_tx::{Bytes32, Receipt};
+use fuel_core_interfaces::{
+    common::{
+        fuel_storage::Storage,
+        fuel_tx::{Bytes32, Receipt},
+        fuel_vm::prelude::{ProgramState, Transaction},
+    },
+    txpool::{TxPool as TxPoolTrait, TxPoolDb},
+};
 use fuel_txpool::TxPoolService;
-use fuel_vm::prelude::{ProgramState, Transaction};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::error::Error as StdError;
-use std::sync::Arc;
+use std::{error::Error as StdError, sync::Arc};
 use thiserror::Error;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -15,7 +15,6 @@ description = "Fuel client networking"
 async-trait = "0.1.52"
 bincode = "1.3"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["serde"], version = "0.8.0" }
-fuel-tx = { version = "0.12", features = ["serde"] }
 futures = "0.3"
 futures-timer = "3.0"
 ip_network = "0.4"

--- a/fuel-p2p/src/gossipsub/messages.rs
+++ b/fuel-p2p/src/gossipsub/messages.rs
@@ -1,5 +1,5 @@
+use fuel_core_interfaces::common::fuel_tx::Transaction;
 use fuel_core_interfaces::model::{FuelBlock, Vote};
-use fuel_tx::Transaction;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -382,7 +382,7 @@ mod tests {
     #[instrument]
     async fn gossipsub_exchanges_messages() {
         use crate::gossipsub::messages::GossipsubMessage as FuelGossipsubMessage;
-        use fuel_tx::Transaction;
+        use fuel_core_interfaces::common::fuel_tx::Transaction;
 
         let mut p2p_config = build_p2p_config("gossipsub_exchanges_messages");
         let topics = vec!["create_tx".into(), "send_tx".into()];
@@ -447,8 +447,8 @@ mod tests {
     #[tokio::test]
     #[instrument]
     async fn request_response_works() {
+        use fuel_core_interfaces::common::fuel_tx::Transaction;
         use fuel_core_interfaces::model::{FuelBlock, FuelBlockHeader};
-        use fuel_tx::Transaction;
 
         let mut p2p_config = build_p2p_config("request_response_works");
 

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -24,8 +24,6 @@ ethers-providers = { version = "0.13", default-features = false, features = [
 ethers-signers = { version = "0.13", default-features = false }
 features = "0.10"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.8.0" }
-fuel-tx = { version = "0.12", features = ["serde"] }
-fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
 once_cell = "1.4"
@@ -40,15 +38,14 @@ tracing-subscriber = "0.3.9"
 url = "2.2"
 
 [dev-dependencies]
-fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.8.0", features = [
-    "test_helpers",
+fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", features = [
+    "test-helpers",
 ] }
-fuel-types = { version = "0.5", features = ["serde", "random"] }
 rand = "0.8"
 tracing-test = "0.2"
 
 [features]
-test-helpers = ["fuel-core-interfaces/test_helpers"]
+test-helpers = ["fuel-core-interfaces/test-helpers"]
 
 # Example of customizing binaries in Cargo.toml.
 [[bin]]

--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -6,10 +6,10 @@ use crate::{
 use ethers_core::types::{Log, H160};
 use ethers_providers::Middleware;
 use fuel_core_interfaces::{
+    common::fuel_tx::{Address, Bytes32},
     model::{BlockHeight, DaBlockHeight, SealedFuelBlock},
     relayer::{RelayerDb, StakingDiff},
 };
-use fuel_tx::{Address, Bytes32};
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
@@ -313,8 +313,10 @@ mod tests {
 
     use super::*;
     use crate::log::tests::*;
-    use fuel_core_interfaces::db::helpers::DummyDb;
-    use fuel_types::{Address, AssetId};
+    use fuel_core_interfaces::{
+        common::fuel_types::{Address, AssetId},
+        db::helpers::DummyDb,
+    };
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 

--- a/fuel-relayer/src/log.rs
+++ b/fuel-relayer/src/log.rs
@@ -5,8 +5,10 @@ use ethers_core::{
     abi::RawLog,
     types::{Log, U256},
 };
-use fuel_core_interfaces::model::DepositCoin;
-use fuel_types::{Address, AssetId, Bytes32, Word};
+use fuel_core_interfaces::{
+    common::fuel_types::{Address, AssetId, Bytes32, Word},
+    model::DepositCoin,
+};
 
 /// This is going to be superseded with MessageLog: https://github.com/FuelLabs/fuel-core/issues/366
 #[derive(Debug, Clone, PartialEq)]

--- a/fuel-relayer/src/pending_blocks.rs
+++ b/fuel-relayer/src/pending_blocks.rs
@@ -9,10 +9,10 @@ use ethers_middleware::{
 };
 use ethers_providers::Middleware;
 use fuel_core_interfaces::{
+    common::fuel_tx::Bytes32,
     model::{BlockHeight, DaBlockHeight, SealedFuelBlock},
     relayer::RelayerDb,
 };
-use fuel_tx::Bytes32;
 use std::{cmp::max, collections::VecDeque, sync::Arc};
 
 // use the ethers_signers crate to manage LocalWallet and Signer

--- a/fuel-relayer/src/relayer.rs
+++ b/fuel-relayer/src/relayer.rs
@@ -390,8 +390,7 @@ mod test {
     use async_trait::async_trait;
     use ethers_core::types::{BlockId, BlockNumber, FilterBlockOption, H256, U256, U64};
     use ethers_providers::SyncingStatus;
-    use fuel_core_interfaces::relayer::RelayerEvent;
-    use fuel_tx::Address;
+    use fuel_core_interfaces::{common::fuel_tx::Address, relayer::RelayerEvent};
     use tokio::sync::mpsc;
 
     use crate::{

--- a/fuel-relayer/src/validators.rs
+++ b/fuel-relayer/src/validators.rs
@@ -1,8 +1,8 @@
 use fuel_core_interfaces::{
+    common::fuel_tx::Address,
     model::{DaBlockHeight, ValidatorStake},
     relayer::RelayerDb,
 };
-use fuel_tx::Address;
 use std::collections::{hash_map::Entry, HashMap};
 use tracing::{error, info};
 

--- a/fuel-sync/Cargo.toml
+++ b/fuel-sync/Cargo.toml
@@ -12,6 +12,5 @@ description = "Fuel Synchronizer"
 [dependencies]
 anyhow = "1.0"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.8.0" }
-fuel-types = { version = "0.5", default-features = false }
 parking_lot = "0.12"
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -19,13 +19,10 @@ harness = true
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 fuel-core = { path = "../fuel-core", features = ["test-helpers"], default-features = false }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["test-helpers"] }
 fuel-crypto = { version = "0.5", features = ["random"] }
 fuel-gql-client = { path = "../fuel-client", features = ["test-helpers"] }
-fuel-storage = "0.1"
-fuel-tx = { version = "0.12", features = ["serde", "builder", "internals"] }
 fuel-txpool = { path = "../fuel-txpool" }
-fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.11", features = ["serde", "random", "test-helpers"] }
 insta = "1.8"
 itertools = "0.10"
 rand = "0.8"
@@ -35,4 +32,4 @@ tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 
 [features]
 default = ["fuel-core/default"]
-debug = ["fuel-vm/debug"]
+debug = ["fuel-core-interfaces/debug"]

--- a/fuel-tests/tests/balances.rs
+++ b/fuel-tests/tests/balances.rs
@@ -2,9 +2,8 @@ use fuel_core::{
     chain_config::{CoinConfig, StateConfig},
     service::{Config, FuelService},
 };
+use fuel_core_interfaces::common::{fuel_tx::AssetId, fuel_vm::prelude::Address};
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
-use fuel_tx::AssetId;
-use fuel_vm::prelude::Address;
 
 #[tokio::test]
 async fn balance() {

--- a/fuel-tests/tests/blocks.rs
+++ b/fuel-tests/tests/blocks.rs
@@ -1,13 +1,12 @@
 use chrono::{TimeZone, Utc};
-use fuel_core::database::Database;
-use fuel_core::model::FuelBlockHeader;
 use fuel_core::{
-    model::FuelBlockDb,
+    database::Database,
+    model::{FuelBlockDb, FuelBlockHeader},
     schema::scalars::BlockId,
     service::{Config, FuelService},
 };
+use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_types};
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
-use fuel_storage::Storage;
 use itertools::{rev, Itertools};
 
 #[tokio::test]

--- a/fuel-tests/tests/coin.rs
+++ b/fuel-tests/tests/coin.rs
@@ -4,12 +4,14 @@ use fuel_core::{
     model::{Coin, CoinStatus},
     service::{Config, FuelService},
 };
+use fuel_core_interfaces::common::{
+    fuel_storage::Storage,
+    fuel_tx::{AssetId, UtxoId},
+    fuel_vm::prelude::{Address, Bytes32, Word},
+};
 use fuel_gql_client::client::{
     schema::coin::CoinStatus as SchemeCoinStatus, FuelClient, PageDirection, PaginationRequest,
 };
-use fuel_storage::Storage;
-use fuel_tx::{AssetId, UtxoId};
-use fuel_vm::prelude::{Address, Bytes32, Word};
 
 #[tokio::test]
 async fn coin() {

--- a/fuel-tests/tests/contract.rs
+++ b/fuel-tests/tests/contract.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{TestContext, TestSetupBuilder};
+use fuel_core_interfaces::common::fuel_vm::prelude::*;
 use fuel_gql_client::client::{PageDirection, PaginationRequest};
-use fuel_vm::prelude::*;
 use rstest::rstest;
 
 const SEED: u64 = 2322;

--- a/fuel-tests/tests/dap.rs
+++ b/fuel-tests/tests/dap.rs
@@ -1,6 +1,6 @@
 use fuel_core::service::{Config, FuelService};
+use fuel_core_interfaces::common::fuel_vm::{consts::*, prelude::*};
 use fuel_gql_client::client::FuelClient;
-use fuel_vm::{consts::*, prelude::*};
 use std::convert::TryInto;
 
 #[tokio::test]

--- a/fuel-tests/tests/helpers.rs
+++ b/fuel-tests/tests/helpers.rs
@@ -1,8 +1,7 @@
 use fuel_core::chain_config::{ChainConfig, CoinConfig, ContractConfig, StateConfig};
 use fuel_core::service::{Config, FuelService};
+use fuel_core_interfaces::common::{fuel_tx::Transaction, fuel_vm::prelude::*};
 use fuel_gql_client::client::FuelClient;
-use fuel_tx::Transaction;
-use fuel_vm::prelude::*;
 use itertools::Itertools;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -1,15 +1,18 @@
 use crate::helpers::TestContext;
 use chrono::Utc;
-use fuel_core::executor::ExecutionMode;
-use fuel_core::model::{FuelBlock, FuelBlockHeader};
 use fuel_core::{
     database::Database,
-    executor::Executor,
+    executor::{ExecutionMode, Executor},
+    model::{FuelBlock, FuelBlockHeader},
     service::{Config, FuelService},
 };
-use fuel_gql_client::client::types::TransactionStatus;
-use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
-use fuel_vm::{consts::*, prelude::*};
+use fuel_core_interfaces::common::{
+    fuel_tx,
+    fuel_vm::{consts::*, prelude::*},
+};
+use fuel_gql_client::client::{
+    types::TransactionStatus, FuelClient, PageDirection, PaginationRequest,
+};
 use itertools::Itertools;
 use rand::Rng;
 use std::io;

--- a/fuel-tests/tests/tx/predicates.rs
+++ b/fuel-tests/tests/tx/predicates.rs
@@ -1,9 +1,10 @@
 // Tests related to the predicate execution feature
 
 use crate::helpers::TestSetupBuilder;
-use fuel_tx::{Input, Output, TransactionBuilder};
-use fuel_vm::consts::REG_ZERO;
-use fuel_vm::{consts::REG_ONE, prelude::Opcode};
+use fuel_core_interfaces::common::{
+    fuel_tx::{Input, Output, TransactionBuilder},
+    fuel_vm::{consts::REG_ONE, consts::REG_ZERO, prelude::Opcode},
+};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 #[tokio::test]

--- a/fuel-tests/tests/tx/utxo_validation.rs
+++ b/fuel-tests/tests/tx/utxo_validation.rs
@@ -1,9 +1,11 @@
 // Tests involving utxo-validation enabled
 use crate::helpers::{TestContext, TestSetupBuilder};
+use fuel_core_interfaces::common::{
+    fuel_tx::TransactionBuilder,
+    fuel_vm::{consts::*, prelude::*},
+};
 use fuel_crypto::SecretKey;
 use fuel_gql_client::client::types::TransactionStatus;
-use fuel_tx::TransactionBuilder;
-use fuel_vm::{consts::*, prelude::*};
 use itertools::Itertools;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -15,8 +15,6 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.8.0" }
-fuel-tx = { version = "0.12", features = ["serde"] }
-fuel-types = { version = "0.5", features = ["serde"] }
 futures = "0.3"
 parking_lot = "0.11"
 thiserror = "1.0"
@@ -25,5 +23,5 @@ tracing = "0.1"
 
 [dev-dependencies]
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.8.0", features = [
-    "test_helpers",
+    "test-helpers",
 ] }

--- a/fuel-txpool/src/containers/dependency.rs
+++ b/fuel-txpool/src/containers/dependency.rs
@@ -1,10 +1,10 @@
 use crate::{types::*, Error};
 use anyhow::anyhow;
 use fuel_core_interfaces::{
+    common::fuel_tx::{Input, Output, UtxoId},
     model::{ArcTx, Coin, CoinStatus, TxInfo},
     txpool::TxPoolDb,
 };
-use fuel_tx::{Input, Output, UtxoId};
 use std::collections::{HashMap, HashSet};
 use tracing::warn;
 
@@ -561,8 +561,10 @@ mod tests {
 
     use std::str::FromStr;
 
-    use fuel_tx::{Address, AssetId, UtxoId};
-    use fuel_types::Bytes32;
+    use fuel_core_interfaces::common::{
+        fuel_tx::{Address, AssetId, UtxoId},
+        fuel_types::Bytes32,
+    };
 
     use super::*;
 

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -138,8 +138,7 @@ impl TxPool {
 pub mod tests {
     use super::*;
     use crate::Error;
-    use fuel_core_interfaces::{db::helpers::*, model::CoinStatus};
-    use fuel_tx::UtxoId;
+    use fuel_core_interfaces::{common::fuel_tx::UtxoId, db::helpers::*, model::CoinStatus};
     use std::cmp::Reverse;
     use std::sync::Arc;
 

--- a/fuel-txpool/src/types.rs
+++ b/fuel-txpool/src/types.rs
@@ -1,5 +1,7 @@
-pub use fuel_tx::ContractId;
-pub use fuel_tx::{Transaction, TxId};
-use fuel_types::Word;
+use fuel_core_interfaces::common::fuel_types::Word;
+pub use fuel_core_interfaces::common::{
+    fuel_tx::ContractId,
+    fuel_tx::{Transaction, TxId},
+};
 
 pub type GasPrice = Word;


### PR DESCRIPTION
To make version bumps less painful, all external fuel-* deps (vm, asm, crypto, merkle, storage, ...) are centrally managed by `fuel-core-interfaces` which re-exports them for other modules. This will help avoid issues with missed version bumps, and also generally make version bumping in fuel-core less painful.

The only crate these re-exports won't affect is fuel-gql-client, as it doesn't use fuel-core-interfaces (nor should it, as the interfaces are for fuel-core internal module integrations).

If we wanted to fully dedupe these imports, we'd need to make a new workspace crate that simply imports all the common deps and re-exports them back out. This could then be used by fuel-core-interfaces and fuel-gql-client. I opted not to do this for now, since bumping in 2 places is still better than 12 and didn't want the overhead of another published crate just yet.