### PR TITLE
Fuel Client URL parsing error context

### DIFF
--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -1,4 +1,5 @@
 use crate::client::schema::contract::ContractBalanceQueryArgs;
+use anyhow::Context;
 use cynic::{http::SurfExt, Id, MutationBuilder, Operation, QueryBuilder};
 use fuel_vm::prelude::*;
 use itertools::Itertools;
@@ -35,7 +36,8 @@ impl FromStr for FuelClient {
     type Err = anyhow::Error;
 
     fn from_str(str: &str) -> Result<Self, Self::Err> {
-        let mut url = surf::Url::parse(str)?;
+        let mut url =
+            surf::Url::parse(str).with_context(|| format!("Invalid fuel-core URL: {}", str))?;
         url.set_path("/graphql");
         Ok(Self { url })
     }


### PR DESCRIPTION
Fuel Client expects a valid parseable URL for construction, but provided no context with the error. This could lead to confusion for forc users if they provided a bad argument like `forc run something_not_a_url`, as they'd only receive an error message like `relative URL without a base`.

Using anyhow to provide context, the error message will now include the provided URL back so users can more easily identify the problem.

New error format:
```
called `Result::unwrap()` on an `Err` value: Invalid fuel-core URL: something_not_a_url

Caused by:
    relative URL without a base
```