### PR TITLE
fix publishing issues that came up in 0.9

### DIFF
--- a/ci/Dockerfile.x86_64-unknown-linux-gnu-clang
+++ b/ci/Dockerfile.x86_64-unknown-linux-gnu-clang
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos
 
 RUN yum -y update && \
     yum -y install centos-release-scl && \

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -3,6 +3,9 @@ name = "fuel-relayer"
 version = "0.9.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
+homepage = "https://fuel.network/"
+keywords = ["blockchain", "fuel", "fuel-vm"]
+license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
 description = "Fuel Relayer"
 


### PR DESCRIPTION
We'll need to find a more stable place to source our cross base images from, as we are currently stuck with always using the latest on master from ghcr.io/cross-rs.