### PR TITLE
Remove pin, fix txpool recv

### DIFF
--- a/fuel-core/src/service/graph_api.rs
+++ b/fuel-core/src/service/graph_api.rs
@@ -91,20 +91,17 @@ async fn shutdown_signal() {
     {
         let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate())
             .expect("failed to install sigterm handler");
-        let sigterm = sigterm.recv();
 
         let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt())
             .expect("failed to install sigint handler");
-        let sigint = sigint.recv();
-
-        tokio::pin!(sigterm);
-        tokio::pin!(sigint);
         loop {
             tokio::select! {
-                _ = &mut sigterm => {
+                _ = sigterm.recv() => {
+                    info!("sigterm received");
                     break;
                 }
-                _ = &mut sigint => {
+                _ = sigint.recv() => {
+                    info!("sigint received");
                     break;
                 }
             }
@@ -114,7 +111,8 @@ async fn shutdown_signal() {
     {
         tokio::signal::ctrl_c()
             .await
-            .expect("failed to install CTRL+C signal handler")
+            .expect("failed to install CTRL+C signal handler");
+        info!("CTRL+C received");
     }
 }
 

--- a/fuel-txpool/src/interface.rs
+++ b/fuel-txpool/src/interface.rs
@@ -23,15 +23,14 @@ impl Interface {
         loop {
             tokio::select! {
                 event = receiver.recv() => {
-                    let event = event.unwrap();
-                    if matches!(event,TxPoolMpsc::Stop) {
+                    if matches!(event,Some(TxPoolMpsc::Stop) | None) {
                         break;
                     }
                     let interface = self.clone();
 
                     // this is litlle bit risky but we can always add semaphore to limit number of requests.
                     tokio::spawn( async move {
-                    match event {
+                    match event.unwrap() {
                         TxPoolMpsc::Includable { response } => {
                             let _ = response.send(interface.includable().await);
                         }


### PR DESCRIPTION
pins can be removed and we can just wait in `select!`
added `info` logs
and found bug inside txpool while testing shutdown