### PR TITLE
Wrap txpool sender

### DIFF
--- a/fuel-block-producer/src/service.rs
+++ b/fuel-block-producer/src/service.rs
@@ -1,5 +1,5 @@
 use crate::Config;
-use fuel_core_interfaces::{block_producer::BlockProducerMpsc, txpool::TxPoolMpsc};
+use fuel_core_interfaces::{block_producer::BlockProducerMpsc, txpool};
 use parking_lot::Mutex;
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -17,7 +17,7 @@ impl Service {
         })
     }
 
-    pub async fn start(&self, _txpool: mpsc::Sender<TxPoolMpsc>) {
+    pub async fn start(&self, _txpool: txpool::Sender) {
         let mut join = self.join.lock();
         if join.is_none() {
             *join = Some(tokio::spawn(async {}));

--- a/fuel-core/src/schema/tx.rs
+++ b/fuel-core/src/schema/tx.rs
@@ -300,30 +300,16 @@ impl TxMutation {
 
         let includable = if cfg.utxo_validation {
             // include transaction
-            let (response, receiver) = oneshot::channel();
-            let _ = txpool
-                .sender()
-                .send(TxPoolMpsc::Insert {
-                    txs: vec![Arc::new(tx.clone())],
-                    response,
-                })
-                .await;
-            receiver.await?.get(0).unwrap().as_ref()?;
+            let ret = txpool.sender().insert(vec![Arc::new(tx.clone())]).await?;
+            ret.get(0).unwrap().as_ref()?;
 
             // get includable transactions
-            let (response, receiver) = oneshot::channel();
-            let _ = txpool
-                .sender()
-                .send(TxPoolMpsc::Includable { response })
-                .await;
-            let txs = receiver.await?;
+            let txs = txpool.sender().includable().await?;
 
-            // remove transaction
-            let _ = txpool
+            txpool
                 .sender()
-                .send(TxPoolMpsc::Remove { ids: vec![tx.id()] })
-                .await;
-
+                .remove(txs.iter().map(|tx| tx.id()).collect())
+                .await?;
             txs
         } else {
             vec![Arc::new(tx.clone())]


### PR DESCRIPTION
Wrap txpool mpsc::Sender around Sender structure that gives us better ergonomic in calling functionalities from txpool,

related to: https://github.com/FuelLabs/fuel-core/issues/429