### PR TITLE
Change k8s deployment strategy

### DIFF
--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -55,6 +55,8 @@ spec:
       app: {{ template "fuel-core.name" . }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.app.replicas }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
The default k8s deployment strategy doesn't work for us since it waits for the new pod to pass the readiness probe before terminating the old one. For us that would cause an upgrade to hang indefinitely since the PVC/database was still held by the previously running node.