### PR TITLE
v0.9.5 patch release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-executor"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-importer"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-producer"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-interfaces"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gql-client"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-p2p"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2284,7 +2284,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-relayer"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2328,7 +2328,7 @@ checksum = "34b9161e86d434a93088409530a4f71f42e074b3bbcbb7a27bfe666583f92fd7"
 
 [[package]]
 name = "fuel-sync"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-txpool"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b253058fc10bdc066f22d33df764de72601558b61efd1769475b21311332a15"
+checksum = "8485da19cae4529a5fc7736b9a300a5443bed0bfac9fd88c94e0978cf437ef2a"
 dependencies = [
  "rand 0.8.5",
  "serde",
@@ -2400,10 +2400,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5700e457c2c6139a3b671014fa0a3bd57afb74de56abb118487b8d56ed21862"
+checksum = "72d7835c37e4f13bc6eecdd946bd1e0485db30175757425fac689e889f8acc20"
 dependencies = [
+ "anyhow",
  "fuel-asm",
  "fuel-crypto",
  "fuel-merkle 0.1.1",

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-core
 description: Fuel Core Helm Chart
 type: application
-appVersion: "0.9.4"
+appVersion: "0.9.5"
 version: 0.1.0

--- a/fuel-block-executor/Cargo.toml
+++ b/fuel-block-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-executor"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,5 +11,5 @@ description = "Fuel Block Executor"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.4" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.5" }
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-block-importer/Cargo.toml
+++ b/fuel-block-importer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-importer"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Block Importer"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.4" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.5" }
 parking_lot = "0.12"
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-block-producer/Cargo.toml
+++ b/fuel-block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-producer"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Block Producer"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.4" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.5" }
 parking_lot = "0.12"
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-gql-client"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"

--- a/fuel-core-bft/Cargo.toml
+++ b/fuel-core-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-bft"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Core BFT"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.4" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.5" }
 parking_lot = "0.12"
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-interfaces"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -33,16 +33,16 @@ clap = { version = "3.1", features = ["env", "derive"] }
 derive_more = { version = "0.99" }
 dirs = "3.0"
 env_logger = "0.9"
-fuel-block-executor = { path = "../fuel-block-executor", version = "0.9.4" }
-fuel-block-importer = { path = "../fuel-block-importer", version = "0.9.4" }
-fuel-block-producer = { path = "../fuel-block-producer", version = "0.9.4" }
-fuel-core-bft = { path = "../fuel-core-bft", version = "0.9.4" }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.4", features = [
+fuel-block-executor = { path = "../fuel-block-executor", version = "0.9.5" }
+fuel-block-importer = { path = "../fuel-block-importer", version = "0.9.5" }
+fuel-block-producer = { path = "../fuel-block-producer", version = "0.9.5" }
+fuel-core-bft = { path = "../fuel-core-bft", version = "0.9.5" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.5", features = [
     "serde",
 ] }
-fuel-relayer = { path = "../fuel-relayer", version = "0.9.4" }
-fuel-sync = { path = "../fuel-sync", version = "0.9.4" }
-fuel-txpool = { path = "../fuel-txpool", version = "0.9.4" }
+fuel-relayer = { path = "../fuel-relayer", version = "0.9.5" }
+fuel-sync = { path = "../fuel-sync", version = "0.9.5" }
+fuel-txpool = { path = "../fuel-txpool", version = "0.9.5" }
 futures = "0.3"
 graphql-parser = "0.3.0"
 hex = { version = "0.4", features = ["serde"] }

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-p2p"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 edition = "2021"
@@ -14,7 +14,7 @@ description = "Fuel client networking"
 [dependencies]
 async-trait = "0.1.52"
 bincode = "1.3"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["serde"], version = "0.9.4" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["serde"], version = "0.9.5" }
 futures = "0.3"
 futures-timer = "3.0"
 ip_network = "0.4"

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-relayer"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -26,7 +26,7 @@ ethers-providers = { version = "0.13", default-features = false, features = [
 ] }
 ethers-signers = { version = "0.13", default-features = false }
 features = "0.10"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.9.4" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.9.5" }
 futures = "0.3"
 hex = "0.4"
 once_cell = "1.4"

--- a/fuel-sync/Cargo.toml
+++ b/fuel-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-sync"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Synchronizer"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.4" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.5" }
 parking_lot = "0.12"
 tokio = { version = "1.14", features = ["full"] }

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-txpool"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -14,7 +14,7 @@ description = "Transaction pool"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.4" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.5" }
 futures = "0.3"
 parking_lot = "0.11"
 thiserror = "1.0"
@@ -22,6 +22,6 @@ tokio = { version = "1.14", default-features = false, features = ["sync"] }
 tracing = "0.1"
 
 [dev-dependencies]
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.4", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.9.5", features = [
     "test-helpers",
 ] }


### PR DESCRIPTION
- tx maturity fixes (from fuel-vm v0.12.1)
- new api to produce blocks in test environments
- snapshot node state to json via cli
- new cli format for running fuel-core
- other internal changes and work for future client features
- gas overflow bug fix