### PR TITLE
Revert "upgrade to rocksdb 0.18. enable jemalloc"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,17 +829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cache-padded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,12 +2034,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -3581,17 +3564,14 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.6.1+6.28.2"
+version = "6.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
+checksum = "c309a9d2470844aceb9a4a098cf5286154d20596868b75a6b36357d2bb9ca25d"
 dependencies = [
  "bindgen",
- "bzip2-sys",
  "cc",
  "glob",
  "libc",
- "libz-sys",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -4994,9 +4974,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.18.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
+checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -5922,17 +5902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.4.3+5.2.1-patched.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
 ]
 
 [[package]]

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -51,10 +51,9 @@ itertools = "0.10"
 lazy_static = "1.4"
 prometheus = { version = "0.13", optional = true }
 rand = "0.8"
-rocksdb = { version = "0.18", default-features = false, features = [
-    "lz4",
+rocksdb = { version = "0.17", features = [
+    "snappy",
     "multi-threaded-cf",
-    "jemalloc"
 ], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/fuel-core/src/state/rocks_db.rs
+++ b/fuel-core/src/state/rocks_db.rs
@@ -12,8 +12,8 @@ use crate::{
     },
 };
 use rocksdb::{
-    BoundColumnFamily, ColumnFamilyDescriptor, DBCompressionType, DBWithThreadMode, IteratorMode,
-    MultiThreaded, Options, ReadOptions, SliceTransform, WriteBatch,
+    BoundColumnFamily, ColumnFamilyDescriptor, DBWithThreadMode, IteratorMode, MultiThreaded,
+    Options, ReadOptions, SliceTransform, WriteBatch,
 };
 use std::{convert::TryFrom, path::Path, sync::Arc};
 
@@ -31,7 +31,6 @@ impl RocksDb {
 
         let mut opts = Options::default();
         opts.create_if_missing(true);
-        opts.set_compression_type(DBCompressionType::Lz4);
         let db = match DB::open_cf_descriptors(&opts, &path, cf_descriptors) {
             Err(_) => {
                 // setup cfs


### PR DESCRIPTION
Reverts FuelLabs/fuel-core#383

need to back this out for now in order to release 0.9.5, upgrading rocks is a breaking change that will require a v0.10.0+ release.

Changing to 0.18 will also impact our ability to support swayswap updates. 