### PR TITLE
style: %s/produce_block/produce_blocks/g

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -282,7 +282,7 @@ type Mutation {
 	Submits transaction to the txpool
 	"""
 	submit(tx: HexString!): Transaction!
-	produceBlock(blocksToProduce: U64!): U64!
+	produceBlocks(blocksToProduce: U64!): U64!
 }
 
 type NodeInfo {

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -303,7 +303,7 @@ impl FuelClient {
         Ok(receipts?)
     }
 
-    pub async fn produce_block(&self, blocks_to_produce: u64) -> io::Result<u64> {
+    pub async fn produce_blocks(&self, blocks_to_produce: u64) -> io::Result<u64> {
         let query = schema::block::BlockMutation::build(&ProduceBlockArgs {
             blocks_to_produce: blocks_to_produce.into(),
         });

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -308,7 +308,7 @@ impl FuelClient {
             blocks_to_produce: blocks_to_produce.into(),
         });
 
-        let new_height = self.query(query).await?.produce_block;
+        let new_height = self.query(query).await?.produce_blocks;
 
         Ok(new_height.into())
     }

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -12,23 +12,23 @@ pub struct BlockByIdArgs {
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
-    schema_path = "./assets/schema.sdl",
-    graphql_type = "Query",
-    argument_struct = "BlockByIdArgs"
+schema_path = "./assets/schema.sdl",
+graphql_type = "Query",
+argument_struct = "BlockByIdArgs"
 )]
 pub struct BlockByIdQuery {
-    #[arguments(id = &args.id)]
+    #[arguments(id = & args.id)]
     pub block: Option<Block>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
-    schema_path = "./assets/schema.sdl",
-    graphql_type = "Query",
-    argument_struct = "ConnectionArgs"
+schema_path = "./assets/schema.sdl",
+graphql_type = "Query",
+argument_struct = "ConnectionArgs"
 )]
 pub struct BlocksQuery {
-    #[arguments(after = &args.after, before = &args.before, first = &args.first, last = &args.last)]
+    #[arguments(after = & args.after, before = & args.before, first = & args.first, last = & args.last)]
     pub blocks: BlockConnection,
 }
 
@@ -98,6 +98,15 @@ mod tests {
         use cynic::QueryBuilder;
         let operation = BlockByIdQuery::build(BlockByIdArgs {
             id: BlockId::default(),
+        });
+        insta::assert_snapshot!(operation.query)
+    }
+
+    #[test]
+    fn block_mutation_query_gql_output() {
+        use cynic::MutationBuilder;
+        let operation = BlockMutation::build(ProduceBlockArgs {
+            blocks_to_produce: U64(0)
         });
         insta::assert_snapshot!(operation.query)
     }

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -12,9 +12,9 @@ pub struct BlockByIdArgs {
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
-schema_path = "./assets/schema.sdl",
-graphql_type = "Query",
-argument_struct = "BlockByIdArgs"
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    argument_struct = "BlockByIdArgs"
 )]
 pub struct BlockByIdQuery {
     #[arguments(id = & args.id)]
@@ -23,9 +23,9 @@ pub struct BlockByIdQuery {
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
-schema_path = "./assets/schema.sdl",
-graphql_type = "Query",
-argument_struct = "ConnectionArgs"
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    argument_struct = "ConnectionArgs"
 )]
 pub struct BlocksQuery {
     #[arguments(after = & args.after, before = & args.before, first = & args.first, last = & args.last)]
@@ -106,7 +106,7 @@ mod tests {
     fn block_mutation_query_gql_output() {
         use cynic::MutationBuilder;
         let operation = BlockMutation::build(ProduceBlockArgs {
-            blocks_to_produce: U64(0)
+            blocks_to_produce: U64(0),
         });
         insta::assert_snapshot!(operation.query)
     }

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -86,7 +86,7 @@ pub struct ProduceBlockArgs {
 )]
 pub struct BlockMutation {
     #[arguments(blocks_to_produce = &args.blocks_to_produce)]
-    pub produce_block: U64,
+    pub produce_blocks: U64,
 }
 
 #[cfg(test)]

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_mutation_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_mutation_query_gql_output.snap
@@ -1,0 +1,8 @@
+---
+source: fuel-client/src/client/schema/block.rs
+expression: operation.query
+---
+mutation Mutation($_0: U64!) {
+  produceBlocks(blocksToProduce: $_0)
+}
+

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -184,7 +184,7 @@ pub struct BlockMutation;
 
 #[Object]
 impl BlockMutation {
-    async fn produce_block(
+    async fn produce_blocks(
         &self,
         ctx: &Context<'_>,
         blocks_to_produce: U64,

--- a/fuel-tests/tests/blocks.rs
+++ b/fuel-tests/tests/blocks.rs
@@ -46,7 +46,7 @@ async fn produce_block() {
 
     let client = FuelClient::from(srv.bound_address);
 
-    let new_height = client.produce_block(5).await.unwrap();
+    let new_height = client.produce_blocks(5).await.unwrap();
 
     assert_eq!(5, new_height);
 
@@ -85,7 +85,7 @@ async fn produce_block_negative() {
 
     let client = FuelClient::from(srv.bound_address);
 
-    let new_height = client.produce_block(5).await;
+    let new_height = client.produce_blocks(5).await;
 
     assert_eq!(
         "Response errors; Manual Blocks must be enabled to use this endpoint",


### PR DESCRIPTION
Since the argument can be multiple blocks, it makes sense for it to be plural.
