### PR TITLE
Fix typo in relayer

### DIFF
--- a/fuel-core/src/cli/run/relayer.rs
+++ b/fuel-core/src/cli/run/relayer.rs
@@ -53,7 +53,7 @@ impl From<RelayerArgs> for Config {
             eth_chain_id: args.eth_chain_id,
             eth_v2_commit_contract: args.eth_v2_commit_contract,
             eth_v2_listening_contracts: args.eth_v2_listening_contracts,
-            eth_v2_contracts_deployet: args.eth_v2_contracts_deployet,
+            eth_v2_contracts_deployet: args.eth_v2_contracts_deployment,
             initial_sync_step: args.initial_sync_step,
             initial_sync_refresh: Duration::from_secs(args.initial_sync_refresh),
         }


### PR DESCRIPTION
changed `eth_v2_contracts_deployet` to `eth_v2_contracts_deployment`
closes #498 