### PR TITLE
Handle the avalanche of breaking spec changes in fuel-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "4.0.1"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc50aa64e3bc176fe1530a270d5efccd79bde469d6957629c590fe47558689"
+checksum = "9d7bef6458f7fb35c16443c6c8af7d219c54e676f47c5a47fd834c8bb8f3bd16"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -281,13 +281,13 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "4.0.1"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3836e72f564e4d502f9ed70ef67d9ef29163901027774fec7970f2785ef27"
+checksum = "8c50c6f67f2cc6a0f22e8efdf1e92b459151feefd4c2ae8adc8c1a223e0ebd89"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling",
+ "darling 0.14.1",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "4.0.1"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c540cdcb24755edf53571ac4228b8288b0cdc1eb6c7f9af333ed185bb8e0ed"
+checksum = "a73c90d34c7456bf28a764bfa201c41ac1929b3c376af1815d5f6b176bf74fe4"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "4.0.1"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7484b68c290bbf97e961003ffc2e781c0210e342c849bac43b5a5636101926e"
+checksum = "b79f082786fccd251a8e9615df7f8d45dc8c5305f89062e79a9be570bcd08585"
 dependencies = [
  "bytes",
  "indexmap",
@@ -332,7 +332,7 @@ dependencies = [
  "http-types",
  "httparse",
  "log",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
 ]
 
 [[package]]
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-tls"
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "base-x"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base16ct"
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium 0.7.0",
@@ -821,9 +821,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 dependencies = [
  "serde",
 ]
@@ -871,7 +871,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.10",
+ "semver 1.0.12",
  "serde",
  "serde_json",
 ]
@@ -902,9 +902,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
+checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if",
  "cipher 0.3.0",
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
+checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead 0.4.3",
  "chacha20",
@@ -935,15 +935,15 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
+ "time 0.1.44",
  "winapi",
 ]
 
 [[package]]
 name = "chrono-tz"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58549f1842da3080ce63002102d5bc954c7bc843d4f47818e642abdc36253552"
+checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db058d493fb2f65f41861bfed7e3fe6335264a9f0f92710cab5bdf01fef09069"
+checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -992,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.12"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
 dependencies = [
  "atty",
  "bitflags",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1110,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
 dependencies = [
  "cache-padded",
 ]
@@ -1130,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1233,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1243,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1281,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.5",
  "typenum",
@@ -1394,7 +1394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd9f0852fe3d3637d4dccb4b69e5a8f881214fc38907a528385ff71cd7b15c3e"
 dependencies = [
  "Inflector",
- "darling",
+ "darling 0.13.4",
  "graphql-parser",
  "lazy_static",
  "proc-macro2",
@@ -1419,8 +1419,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
 ]
 
 [[package]]
@@ -1438,12 +1448,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core 0.14.1",
  "quote",
  "syn",
 ]
@@ -1455,7 +1490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.1",
+ "hashbrown",
  "lock_api",
  "parking_lot_core 0.9.3",
 ]
@@ -1616,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "elliptic-curve"
@@ -1702,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "17.0.0"
+version = "17.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69517146dfab88e9238c00c724fd8e277951c3cc6f22b016d72f422a832213e"
+checksum = "f186de076b3e77b8e6d73c99d1b52edc2a229e604f4b5eb6992c06c11d79d537"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -1757,7 +1792,7 @@ dependencies = [
  "futures-util",
  "hex",
  "once_cell",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "serde",
  "serde_json",
  "thiserror",
@@ -1825,7 +1860,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "strum 0.24.0",
+ "strum 0.24.1",
  "syn",
  "thiserror",
  "tiny-keccak",
@@ -1840,7 +1875,7 @@ checksum = "808898439b94c18e4f554881e337a02ccf18a6476a5ceb74a6b79a501996cb48"
 dependencies = [
  "ethers-core",
  "reqwest",
- "semver 1.0.10",
+ "semver 1.0.12",
  "serde",
  "serde-aux",
  "serde_json",
@@ -1892,7 +1927,7 @@ dependencies = [
  "http",
  "once_cell",
  "parking_lot 0.11.2",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "reqwest",
  "serde",
  "serde_json",
@@ -1929,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
@@ -1960,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -2000,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -2060,9 +2095,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuel-asm"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16628e172a06a411c57972c55a67404f1684118be3bbca79148bf5a00fff48f0"
+checksum = "cf02de44ec38d5977d61896cd228b45c9596a38f940f964cacb2d683ada6a064"
 dependencies = [
  "fuel-types",
  "serde",
@@ -2166,7 +2201,7 @@ dependencies = [
  "derive_more",
  "fuel-asm",
  "fuel-crypto",
- "fuel-merkle 0.3.0",
+ "fuel-merkle",
  "fuel-storage 0.1.0",
  "fuel-tx",
  "fuel-types",
@@ -2219,42 +2254,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8148b67b9ca99755b8c73fbc5bad7710590e1d7e245680ffd351289915258851"
-dependencies = [
- "bytes",
- "digest 0.9.0",
- "fuel-storage 0.1.0",
- "generic-array 0.14.5",
- "hex",
- "lazy_static",
- "sha2 0.9.9",
- "thiserror",
-]
-
-[[package]]
-name = "fuel-merkle"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab10247f9eababf72a64120da05cfef57fbf811ebd2c93dbbbbeccddcce5f11"
-dependencies = [
- "digest 0.10.3",
- "fuel-storage 0.2.0",
- "hex",
- "sha2 0.10.2",
- "thiserror",
-]
-
-[[package]]
-name = "fuel-merkle"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa59f2a4e6cd6d83a51981c5ac706d58fc8ef53700003948c826827b88cfff1"
 dependencies = [
  "digest 0.10.3",
  "fuel-storage 0.2.0",
- "hashbrown 0.12.1",
+ "hashbrown",
  "hex",
  "sha2 0.10.2",
  "thiserror",
@@ -2360,15 +2366,16 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.13.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43dbfcd95f2b6fb19e6272832b5d6ecf14f8283c3329994baa38a4faed65d437"
+checksum = "2cd230b9907fce301cff8304f80e272d825a426003762b2efd9672fdd3fa5d26"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
- "fuel-merkle 0.2.0",
+ "fuel-merkle",
  "fuel-types",
  "itertools",
+ "num-integer",
  "rand 0.8.5",
  "serde",
 ]
@@ -2400,14 +2407,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d7835c37e4f13bc6eecdd946bd1e0485db30175757425fac689e889f8acc20"
+checksum = "a6250bf62faa0cc69e60e30d27f451c00612f5239453f151251fe8a8935f7bb4"
 dependencies = [
  "anyhow",
  "fuel-asm",
  "fuel-crypto",
- "fuel-merkle 0.1.1",
+ "fuel-merkle",
  "fuel-storage 0.1.0",
  "fuel-tx",
  "fuel-types",
@@ -2691,18 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -2828,9 +2826,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
@@ -2915,9 +2913,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3054,12 +3052,12 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown 0.11.2",
+ "hashbrown",
  "serde",
 ]
 
@@ -3071,9 +3069,9 @@ checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "insta"
-version = "1.14.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc3e639bcba360d9237acabd22014c16f3df772db463b7446cd81b070714767"
+checksum = "1e21173d5699a654cf191b0c05b0a937bb4f7cf07ee2e32da2af07a963e31577"
 dependencies = [
  "console",
  "once_cell",
@@ -3145,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3264,7 +3262,7 @@ dependencies = [
  "libp2p-yamux",
  "multiaddr",
  "parking_lot 0.12.1",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "rand 0.7.3",
  "smallvec",
 ]
@@ -3290,7 +3288,7 @@ dependencies = [
  "multihash",
  "multistream-select",
  "parking_lot 0.12.1",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "prost",
  "prost-build",
  "rand 0.8.5",
@@ -3514,7 +3512,7 @@ dependencies = [
  "instant",
  "libp2p-core",
  "log",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "rand 0.7.3",
  "smallvec",
  "thiserror",
@@ -3563,7 +3561,7 @@ dependencies = [
  "rw-stream-sink",
  "soketto",
  "url",
- "webpki-roots 0.22.3",
+ "webpki-roots 0.22.4",
 ]
 
 [[package]]
@@ -3596,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
+checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
  "base64 0.13.0",
@@ -3655,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -3681,11 +3679,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8015d95cb7b2ddd3c0d32ca38283ceb1eea09b4713ee380bceb942d85a244228"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3775,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "multer"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8f35e687561d5c1667590911e6698a8cb714a134a7505718a182e7bc9d3836"
+checksum = "a30ba6d97eb198c5e8a35d67d5779d6680cca35652a60ee90fc23dc431d4fde8"
 dependencies = [
  "bytes",
  "encoding_rs",
@@ -3787,7 +3785,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin 0.9.3",
+ "spin 0.9.4",
  "version_check",
 ]
 
@@ -3851,7 +3849,7 @@ dependencies = [
  "bytes",
  "futures",
  "log",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "smallvec",
  "unsigned-varint",
 ]
@@ -3942,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4036,9 +4034,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4068,9 +4066,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg 1.1.0",
  "cc",
@@ -4081,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "owning_ref"
@@ -4096,12 +4094,12 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.1.2"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b44461635bbb1a0300f100a841e571e7d919c81c73075ef5d152ffdb521066"
+checksum = "9182e4a71cae089267ab03e67c99368db7cd877baf50f931e5d6d4b71e195ac0"
 dependencies = [
  "arrayvec 0.7.2",
- "bitvec 1.0.0",
+ "bitvec 1.0.1",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -4110,9 +4108,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c45ed1f39709f5a89338fab50e59816b2e8815f5bb58276e7ddf9afd495f73f8"
+checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4279,18 +4277,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+checksum = "4724fa946c8d1e7cd881bd3dbee63ce32fc1e9e191e35786b3dc1320a3f68131"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "32ba0c43d7a1b6492b2924a62290cfd83987828af037b0743b38e6ab092aee58"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -4298,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "5b450720b6f75cfbfabc195814bd3765f337a4f9a83186f8537297cac12f6705"
 dependencies = [
  "phf_shared",
  "rand 0.8.5",
@@ -4308,9 +4306,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "9dd5609d4b2df87167f908a32e1b146ce309c16cf35df76bc11f440b756048e4"
 dependencies = [
  "siphasher",
  "uncased",
@@ -4318,27 +4316,27 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9615c18d31137579e9ff063499264ddc1278e7b1982757ebc111028c4d1dc909"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
 dependencies = [
- "pin-project-internal 0.4.29",
+ "pin-project-internal 0.4.30",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
- "pin-project-internal 1.0.10",
+ "pin-project-internal 1.0.11",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044964427019eed9d49d9d5bbce6047ef18f37100ea400912a9fa4a3523ab12a"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4347,9 +4345,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4499,9 +4497,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4829,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -4849,9 +4847,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4869,9 +4867,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -4920,7 +4918,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.22.3",
+ "webpki-roots 0.22.4",
  "winreg 0.10.1",
 ]
 
@@ -5081,7 +5079,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.10",
+ "semver 1.0.12",
 ]
 
 [[package]]
@@ -5120,9 +5118,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "rw-stream-sink"
@@ -5131,7 +5129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
  "futures",
- "pin-project 0.4.29",
+ "pin-project 0.4.30",
  "static_assertions",
 ]
 
@@ -5300,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 dependencies = [
  "serde",
 ]
@@ -5321,18 +5319,18 @@ checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-aux"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93abf9799c576f004252b2a05168d58527fb7c54de12e94b4d12fe3475ffad24"
+checksum = "d0a77223b653fa95f3f9864f3eb25b93e4ed170687eb42d85b6b98af21d5e1de"
 dependencies = [
  "serde",
  "serde_json",
@@ -5340,9 +5338,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5351,9 +5349,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -5399,7 +5397,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -5407,9 +5405,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
@@ -5581,9 +5579,12 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "smallvec"
@@ -5642,9 +5643,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 
 [[package]]
 name = "spki"
@@ -5740,11 +5741,11 @@ checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
 
 [[package]]
 name = "strum"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros 0.24.0",
+ "strum_macros 0.24.2",
 ]
 
 [[package]]
@@ -5761,9 +5762,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -5937,11 +5938,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -5962,9 +5964,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa",
  "libc",
@@ -6020,10 +6022,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
+ "autocfg 1.1.0",
  "bytes",
  "libc",
  "memchr",
@@ -6072,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06cda1232a49558c46f8a504d5b93101d42c0bf7f911f12a105ba48168f821ae"
+checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
@@ -6083,7 +6086,7 @@ dependencies = [
  "tokio-rustls",
  "tungstenite",
  "webpki 0.22.0",
- "webpki-roots 0.22.3",
+ "webpki-roots 0.22.4",
 ]
 
 [[package]]
@@ -6111,13 +6114,13 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "pin-project-lite 0.2.9",
  "tokio",
  "tokio-util",
@@ -6154,9 +6157,9 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -6178,15 +6181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.9",
+ "time 0.3.11",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6195,9 +6198,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6211,7 +6214,7 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "futures",
  "futures-task",
- "pin-project 1.0.10",
+ "pin-project 1.0.11",
  "tracing",
 ]
 
@@ -6238,13 +6241,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "serde",
  "serde_json",
@@ -6259,9 +6262,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6992d8a98f570be1c729fe8b6f464fb18c4117054c10f1f952c22d533b48a74"
+checksum = "9e3d272c44878d2bbc9f4a20ad463724f03e19dbc667c6e84ac433ab7ffcc70b"
 dependencies = [
  "lazy_static",
  "tracing-core",
@@ -6271,9 +6274,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719fa6c65bada6a7a3b8466702ec6fb4c4189b69339f78c9e597f796e493712e"
+checksum = "744324b12d69a9fc1edea4b38b7b1311295b662d161ad5deac17bb1358224a08"
 dependencies = [
  "lazy_static",
  "quote",
@@ -6331,9 +6334,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -6358,9 +6361,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "uint"
@@ -6400,15 +6403,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -6560,15 +6563,21 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6576,13 +6585,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -6591,9 +6600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6603,9 +6612,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6613,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6626,9 +6635,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasm-timer"
@@ -6647,9 +6656,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6686,9 +6695,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki 0.22.0",
 ]

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -20,9 +20,9 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "1.0", features = ["surf"] }
 derive_more = { version = "0.99" }
-fuel-tx = { version = "0.13", features = ["serde"] }
+fuel-tx = { version = "0.16", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.12", features = ["serde"] }
+fuel-vm = { version = "0.13", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
 itertools = "0.10"

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -17,6 +17,10 @@ type BalanceConnection {
 	A list of edges.
 	"""
 	edges: [BalanceEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Balance!]!
 }
 
 """
@@ -28,7 +32,7 @@ type BalanceEdge {
 	"""
 	cursor: String!
 	"""
-	"The item at the end of the edge
+	The item at the end of the edge
 	"""
 	node: Balance!
 }
@@ -57,6 +61,10 @@ type BlockConnection {
 	A list of edges.
 	"""
 	edges: [BlockEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Block!]!
 }
 
 """
@@ -68,7 +76,7 @@ type BlockEdge {
 	"""
 	cursor: String!
 	"""
-	"The item at the end of the edge
+	The item at the end of the edge
 	"""
 	node: Block!
 }
@@ -116,6 +124,10 @@ type CoinConnection {
 	A list of edges.
 	"""
 	edges: [CoinEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Coin!]!
 }
 
 """
@@ -127,7 +139,7 @@ type CoinEdge {
 	"""
 	cursor: String!
 	"""
-	"The item at the end of the edge
+	The item at the end of the edge
 	"""
 	node: Coin!
 }
@@ -162,11 +174,12 @@ type ConsensusParameters {
 	maxGasPerTx: U64!
 	maxScriptLength: U64!
 	maxScriptDataLength: U64!
-	maxStaticContracts: U64!
 	maxStorageSlots: U64!
 	maxPredicateLength: U64!
 	maxPredicateDataLength: U64!
 	gasPriceFactor: U64!
+	gasPerByte: U64!
+	maxMessageDataLength: U64!
 }
 
 type Contract {
@@ -190,6 +203,10 @@ type ContractBalanceConnection {
 	A list of edges.
 	"""
 	edges: [ContractBalanceEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ContractBalance!]!
 }
 
 """
@@ -201,7 +218,7 @@ type ContractBalanceEdge {
 	"""
 	cursor: String!
 	"""
-	"The item at the end of the edge
+	The item at the end of the edge
 	"""
 	node: ContractBalance!
 }
@@ -244,7 +261,7 @@ type FailureStatus {
 scalar HexString
 
 
-union Input = | InputCoin | InputContract
+union Input = InputCoin | InputContract | InputMessage
 
 type InputCoin {
 	utxoId: UtxoId!
@@ -264,6 +281,26 @@ type InputContract {
 	contract: Contract!
 }
 
+type InputMessage {
+	messageId: MessageId!
+	sender: Address!
+	recipient: Address!
+	amount: U64!
+	nonce: U64!
+	owner: Address!
+	witnessIndex: Int!
+	data: HexString!
+	predicate: HexString!
+	predicateData: HexString!
+}
+
+
+scalar MessageId
+
+type MessageOutput {
+	recipient: Address!
+	amount: U64!
+}
 
 type Mutation {
 	startSession: ID!
@@ -296,7 +333,7 @@ type NodeInfo {
 	nodeVersion: String!
 }
 
-union Output = | CoinOutput | ContractOutput | WithdrawalOutput | ChangeOutput | VariableOutput | ContractCreated
+union Output = CoinOutput | ContractOutput | MessageOutput | ChangeOutput | VariableOutput | ContractCreated
 
 """
 A separate `Breakpoint` type to be used as an output, as a single
@@ -389,6 +426,10 @@ type Receipt {
 	result: U64
 	gasUsed: U64
 	data: HexString
+	messageId: MessageId
+	sender: Address
+	recipient: Address
+	nonce: Bytes32
 }
 
 enum ReceiptType {
@@ -402,6 +443,7 @@ enum ReceiptType {
 	TRANSFER
 	TRANSFER_OUT
 	SCRIPT_RESULT
+	MESSAGE_OUT
 }
 
 enum ReturnType {
@@ -451,7 +493,6 @@ type Transaction {
 	inputContracts: [Contract!]!
 	gasPrice: U64!
 	gasLimit: U64!
-	bytePrice: U64!
 	maturity: U64!
 	isScript: Boolean!
 	inputs: [Input!]!
@@ -465,7 +506,6 @@ type Transaction {
 	bytecodeWitnessIndex: Int
 	bytecodeLength: U64
 	salt: Salt
-	staticContracts: [Contract!]
 	storageSlots: [HexString!]
 	"""
 	Return the transaction bytes using canonical encoding
@@ -482,6 +522,10 @@ type TransactionConnection {
 	A list of edges.
 	"""
 	edges: [TransactionEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Transaction!]!
 }
 
 """
@@ -493,26 +537,20 @@ type TransactionEdge {
 	"""
 	cursor: String!
 	"""
-	"The item at the end of the edge
+	The item at the end of the edge
 	"""
 	node: Transaction!
 }
 
 scalar TransactionId
 
-union TransactionStatus = | SubmittedStatus | SuccessStatus | FailureStatus
+union TransactionStatus = SubmittedStatus | SuccessStatus | FailureStatus
 
 scalar U64
 
 scalar UtxoId
 
 type VariableOutput {
-	to: Address!
-	amount: U64!
-	assetId: AssetId!
-}
-
-type WithdrawalOutput {
 	to: Address!
 	amount: U64!
 	assetId: AssetId!

--- a/fuel-client/src/client/schema/chain.rs
+++ b/fuel-client/src/client/schema/chain.rs
@@ -11,11 +11,12 @@ pub struct ConsensusParameters {
     pub max_gas_per_tx: U64,
     pub max_script_length: U64,
     pub max_script_data_length: U64,
-    pub max_static_contracts: U64,
     pub max_storage_slots: U64,
     pub max_predicate_length: U64,
     pub max_predicate_data_length: U64,
     pub gas_price_factor: U64,
+    pub gas_per_byte: U64,
+    pub max_message_data_length: U64,
 }
 
 impl From<ConsensusParameters> for TxConsensusParameters {
@@ -28,11 +29,12 @@ impl From<ConsensusParameters> for TxConsensusParameters {
             max_gas_per_tx: params.max_gas_per_tx.into(),
             max_script_length: params.max_script_length.into(),
             max_script_data_length: params.max_script_data_length.into(),
-            max_static_contracts: params.max_static_contracts.into(),
             max_storage_slots: params.max_storage_slots.into(),
             max_predicate_length: params.max_predicate_length.into(),
             max_predicate_data_length: params.max_predicate_data_length.into(),
             gas_price_factor: params.gas_price_factor.into(),
+            gas_per_byte: params.gas_per_byte.into(),
+            max_message_data_length: params.max_message_data_length.into(),
         }
     }
 }

--- a/fuel-client/src/client/schema/primitives.rs
+++ b/fuel-client/src/client/schema/primitives.rs
@@ -93,6 +93,7 @@ fuel_type_scalar!(AssetId, AssetId);
 fuel_type_scalar!(ContractId, ContractId);
 fuel_type_scalar!(Salt, Salt);
 fuel_type_scalar!(TransactionId, Bytes32);
+fuel_type_scalar!(MessageId, MessageId);
 
 #[derive(cynic::Scalar, Debug, Clone, Default)]
 pub struct UtxoId(pub HexFormatted<fuel_tx::UtxoId>);

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -1,6 +1,6 @@
 ---
 source: fuel-client/src/client/schema/chain.rs
-assertion_line: 64
+assertion_line: 66
 expression: operation.query
 ---
 query Query {
@@ -25,11 +25,12 @@ query Query {
       maxGasPerTx
       maxScriptLength
       maxScriptDataLength
-      maxStaticContracts
       maxStorageSlots
       maxPredicateLength
       maxPredicateDataLength
       gasPriceFactor
+      gasPerByte
+      maxMessageDataLength
     }
   }
 }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -1,14 +1,12 @@
 ---
 source: fuel-client/src/client/schema/tx.rs
-assertion_line: 273
+assertion_line: 275
 expression: operation.query
-
 ---
 query Query($_0: TransactionId!) {
   transaction(id: $_0) {
     gasLimit
     gasPrice
-    bytePrice
     id
     inputAssetIds
     inputContracts {
@@ -34,6 +32,18 @@ query Query($_0: TransactionId!) {
           id
         }
       }
+      ... on InputMessage {
+        messageId
+        sender
+        recipient
+        amount
+        nonce
+        owner
+        witnessIndex
+        data
+        predicate
+        predicateData
+      }
     }
     isScript
     outputs {
@@ -48,10 +58,9 @@ query Query($_0: TransactionId!) {
         balanceRoot
         stateRoot
       }
-      ... on WithdrawalOutput {
-        to
+      ... on MessageOutput {
+        recipient
         amount
-        assetId
       }
       ... on ChangeOutput {
         to
@@ -128,13 +137,14 @@ query Query($_0: TransactionId!) {
       result
       gasUsed
       data
+      messageId
+      sender
+      recipient
+      nonce
     }
     script
     scriptData
     salt
-    staticContracts {
-      id
-    }
     storageSlots
     bytecodeWitnessIndex
     bytecodeLength

--- a/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_receipt.rs
@@ -1,6 +1,6 @@
 use crate::client::schema::{
     contract::ContractIdFragment, schema, Address, AssetId, Bytes32, ConversionError,
-    ConversionError::MissingField, HexString, U64,
+    ConversionError::MissingField, HexString, MessageId, U64,
 };
 use fuel_types::Word;
 
@@ -30,6 +30,10 @@ pub struct Receipt {
     pub result: Option<U64>,
     pub gas_used: Option<U64>,
     pub data: Option<HexString>,
+    pub message_id: Option<MessageId>,
+    pub sender: Option<Address>,
+    pub recipient: Option<Address>,
+    pub nonce: Option<Bytes32>,
 }
 
 #[derive(cynic::Enum, Clone, Copy, Debug)]
@@ -45,6 +49,7 @@ pub enum ReceiptType {
     Transfer,
     TransferOut,
     ScriptResult,
+    MessageOut,
 }
 
 impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
@@ -315,6 +320,40 @@ impl TryFrom<Receipt> for fuel_vm::prelude::Receipt {
                 gas_used: schema
                     .gas_used
                     .ok_or_else(|| MissingField("gas_used".to_string()))?
+                    .into(),
+            },
+            ReceiptType::MessageOut => fuel_tx::Receipt::MessageOut {
+                message_id: schema
+                    .message_id
+                    .ok_or_else(|| MissingField("message_id".to_string()))?
+                    .into(),
+                sender: schema
+                    .sender
+                    .ok_or_else(|| MissingField("sender".to_string()))?
+                    .into(),
+                recipient: schema
+                    .recipient
+                    .ok_or_else(|| MissingField("recipient".to_string()))?
+                    .into(),
+                amount: schema
+                    .amount
+                    .ok_or_else(|| MissingField("amount".to_string()))?
+                    .into(),
+                nonce: schema
+                    .nonce
+                    .ok_or_else(|| MissingField("nonce".to_string()))?
+                    .into(),
+                len: schema
+                    .len
+                    .ok_or_else(|| MissingField("len".to_string()))?
+                    .into(),
+                digest: schema
+                    .digest
+                    .ok_or_else(|| MissingField("digest".to_string()))?
+                    .into(),
+                data: schema
+                    .data
+                    .ok_or_else(|| MissingField("data".to_string()))?
                     .into(),
             },
         })

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -2,8 +2,8 @@ use crate::client::schema::{
     contract::ContractIdFragment,
     schema,
     tx::{tests::transparent_receipt::Receipt, TransactionStatus, TxIdArgs},
-    Address, AssetId, Bytes32, ConnectionArgs, ConversionError, HexString, PageInfo, Salt,
-    TransactionId, UtxoId, U64,
+    Address, AssetId, Bytes32, ConnectionArgs, ConversionError, HexString, MessageId, PageInfo,
+    Salt, TransactionId, UtxoId, U64,
 };
 use core::convert::{TryFrom, TryInto};
 use fuel_tx::StorageSlot;
@@ -51,7 +51,6 @@ pub struct TransactionEdge {
 pub struct Transaction {
     pub gas_limit: U64,
     pub gas_price: U64,
-    pub byte_price: U64,
     pub id: TransactionId,
     pub input_asset_ids: Vec<AssetId>,
     pub input_contracts: Vec<ContractIdFragment>,
@@ -66,7 +65,6 @@ pub struct Transaction {
     pub script: Option<HexString>,
     pub script_data: Option<HexString>,
     pub salt: Option<Salt>,
-    pub static_contracts: Option<Vec<ContractIdFragment>>,
     pub storage_slots: Option<Vec<HexString>>,
     pub bytecode_witness_index: Option<i32>,
     pub bytecode_length: Option<U64>,
@@ -80,7 +78,6 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
             true => Self::Script {
                 gas_price: tx.gas_price.into(),
                 gas_limit: tx.gas_limit.into(),
-                byte_price: tx.byte_price.into(),
                 maturity: tx.maturity.into(),
                 receipts_root: tx
                     .receipts_root
@@ -110,7 +107,6 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
             false => Self::Create {
                 gas_price: tx.gas_price.into(),
                 gas_limit: tx.gas_limit.into(),
-                byte_price: tx.byte_price.into(),
                 maturity: tx.maturity.into(),
                 bytecode_length: tx
                     .bytecode_length
@@ -126,12 +122,6 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
                     .salt
                     .ok_or_else(|| ConversionError::MissingField("salt".to_string()))?
                     .into(),
-                static_contracts: tx
-                    .static_contracts
-                    .ok_or_else(|| ConversionError::MissingField("static_contracts".to_string()))?
-                    .into_iter()
-                    .map(|c| c.id.into())
-                    .collect(),
                 storage_slots: tx
                     .storage_slots
                     .ok_or_else(|| ConversionError::MissingField("storage_slots".to_string()))?
@@ -173,6 +163,7 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
 pub enum Input {
     InputCoin(InputCoin),
     InputContract(InputContract),
+    InputMessage(InputMessage),
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -195,6 +186,21 @@ pub struct InputContract {
     pub balance_root: Bytes32,
     pub state_root: Bytes32,
     pub contract: ContractIdFragment,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct InputMessage {
+    message_id: MessageId,
+    sender: Address,
+    recipient: Address,
+    amount: U64,
+    nonce: U64,
+    owner: Address,
+    witness_index: i32,
+    data: HexString,
+    predicate: HexString,
+    predicate_data: HexString,
 }
 
 impl TryFrom<Input> for fuel_tx::Input {
@@ -230,6 +236,32 @@ impl TryFrom<Input> for fuel_tx::Input {
                 state_root: contract.state_root.into(),
                 contract_id: contract.contract.id.into(),
             },
+            Input::InputMessage(message) => {
+                if message.predicate.0 .0.is_empty() {
+                    fuel_tx::Input::MessageSigned {
+                        message_id: message.message_id.into(),
+                        sender: message.sender.into(),
+                        recipient: message.recipient.into(),
+                        amount: message.amount.into(),
+                        nonce: message.nonce.into(),
+                        owner: message.owner.into(),
+                        witness_index: message.witness_index.try_into()?,
+                        data: message.data.into(),
+                    }
+                } else {
+                    fuel_tx::Input::MessagePredicate {
+                        message_id: message.message_id.into(),
+                        sender: message.sender.into(),
+                        recipient: message.recipient.into(),
+                        amount: message.amount.into(),
+                        nonce: message.nonce.into(),
+                        owner: message.owner.into(),
+                        data: message.data.into(),
+                        predicate: message.predicate.into(),
+                        predicate_data: message.predicate_data.into(),
+                    }
+                }
+            }
         })
     }
 }
@@ -239,7 +271,7 @@ impl TryFrom<Input> for fuel_tx::Input {
 pub enum Output {
     CoinOutput(CoinOutput),
     ContractOutput(ContractOutput),
-    WithdrawalOutput(WithdrawalOutput),
+    MessageOutput(MessageOutput),
     ChangeOutput(ChangeOutput),
     VariableOutput(VariableOutput),
     ContractCreated(ContractCreated),
@@ -255,10 +287,9 @@ pub struct CoinOutput {
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
-pub struct WithdrawalOutput {
-    pub to: Address,
+pub struct MessageOutput {
+    pub recipient: Address,
     pub amount: U64,
-    pub asset_id: AssetId,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -307,10 +338,9 @@ impl TryFrom<Output> for fuel_tx::Output {
                 balance_root: contract.balance_root.into(),
                 state_root: contract.state_root.into(),
             },
-            Output::WithdrawalOutput(withdrawal) => Self::Withdrawal {
-                to: withdrawal.to.into(),
-                amount: withdrawal.amount.into(),
-                asset_id: withdrawal.asset_id.into(),
+            Output::MessageOutput(message) => Self::Message {
+                recipient: message.recipient.into(),
+                amount: message.amount.into(),
             },
             Output::ChangeOutput(change) => Self::Change {
                 to: change.to.into(),

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -15,13 +15,13 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4" }
 derive_more = { version = "0.99" }
-fuel-asm = "0.5"
+fuel-asm = "0.6"
 fuel-crypto = { version = "0.5", default-features = false, features = [ "random" ] }
 fuel-merkle = { version = "0.3" }
 fuel-storage = "0.1"
-fuel-tx = { version = "0.13", default-features = false }
+fuel-tx = { version = "0.16", default-features = false }
 fuel-types = { version = "0.5", default-features = false }
-fuel-vm = { version = "0.12", default-features = false }
+fuel-vm = { version = "0.13", default-features = false }
 futures = "0.3"
 lazy_static = "1.4"
 parking_lot = "0.12"

--- a/fuel-core-interfaces/src/db.rs
+++ b/fuel-core-interfaces/src/db.rs
@@ -192,7 +192,6 @@ pub mod helpers {
             let tx1 = Transaction::Script {
                 gas_price: TX1_GAS_PRICE,
                 gas_limit: 1_000_000,
-                byte_price: TX1_BYTE_PRICE,
                 maturity: 0,
                 receipts_root: Default::default(),
                 script,
@@ -231,7 +230,6 @@ pub mod helpers {
             let tx1_faulty = Transaction::Script {
                 gas_price: 10,
                 gas_limit: 1_000_000,
-                byte_price: 10,
                 maturity: 0,
                 receipts_root: Default::default(),
                 script,
@@ -263,7 +261,6 @@ pub mod helpers {
             let tx2 = Transaction::Script {
                 gas_price: 9,
                 gas_limit: 1_000_001,
-                byte_price: 9,
                 maturity: 0,
                 receipts_root: Default::default(),
                 script,
@@ -296,7 +293,6 @@ pub mod helpers {
             let tx2_faulty = Transaction::Script {
                 gas_price: 9,
                 gas_limit: 1_000_001,
-                byte_price: 9,
                 maturity: 0,
                 receipts_root: Default::default(),
                 script,
@@ -336,7 +332,6 @@ pub mod helpers {
             let tx3 = Transaction::Script {
                 gas_price: 20, // more then tx1
                 gas_limit: 1_000_001,
-                byte_price: 20,
                 maturity: 0,
                 receipts_root: Default::default(),
                 script,
@@ -370,7 +365,6 @@ pub mod helpers {
             let tx4 = Transaction::Script {
                 gas_price: 20, // more then tx1
                 gas_limit: 1_000_001,
-                byte_price: 20,
                 maturity: 0,
                 receipts_root: Default::default(),
                 script,
@@ -403,7 +397,6 @@ pub mod helpers {
             let tx5 = Transaction::Script {
                 gas_price: 5, //lower then tx1
                 gas_limit: 1_000_000,
-                byte_price: 5,
                 maturity: 0,
                 receipts_root: Default::default(),
                 script,
@@ -465,7 +458,6 @@ pub mod helpers {
                 fun(Transaction::script(
                     10,
                     1000,
-                    10,
                     0,
                     script.clone(),
                     Vec::new(),
@@ -480,7 +472,6 @@ pub mod helpers {
                 fun(Transaction::script(
                     10,
                     1000,
-                    10,
                     0,
                     script.clone(),
                     Vec::new(),
@@ -495,7 +486,6 @@ pub mod helpers {
                 fun(Transaction::script(
                     10,
                     1000,
-                    10,
                     0,
                     script,
                     Vec::new(),
@@ -510,7 +500,6 @@ pub mod helpers {
                 fun(Transaction::script(
                     10,
                     1000,
-                    10,
                     0,
                     Vec::new(),
                     Vec::new(),

--- a/fuel-core-interfaces/src/txpool.rs
+++ b/fuel-core-interfaces/src/txpool.rs
@@ -156,8 +156,6 @@ pub enum Error {
     NoMetadata,
     #[error("Transaction is not inserted. The gas price is too low.")]
     NotInsertedGasPriceTooLow,
-    #[error("Transaction is not inserted. The byte price is too low.")]
-    NotInsertedBytePriceTooLow,
     #[error(
         "Transaction is not inserted. More priced tx {0:#x} already spend this UTXO output: {1:#x}"
     )]
@@ -190,8 +188,10 @@ pub enum Error {
         "Transaction is not inserted. Input output mismatch. Expected coin but output is contract"
     )]
     NotInsertedIoContractOutput,
-    #[error("Transaction is not inserted. Input output mismatch. Expected coin but output is withdrawal")]
-    NotInsertedIoWithdrawalInput,
+    #[error(
+        "Transaction is not inserted. Input output mismatch. Expected coin but output is message"
+    )]
+    NotInsertedIoMessageInput,
     #[error("Transaction is not inserted. Maximum depth of dependent transaction chain reached")]
     NotInsertedMaxDepth,
     // small todo for now it can pass but in future we should include better messages

--- a/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_configurable_block_height.snap
+++ b/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_configurable_block_height.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/config/chain_config.rs
+assertion_line: 223
 expression: json
 ---
 {
@@ -16,10 +17,11 @@ expression: json
     "max_gas_per_tx": 100000000,
     "max_script_length": 1048576,
     "max_script_data_length": 1048576,
-    "max_static_contracts": 255,
     "max_storage_slots": 255,
     "max_predicate_length": 1048576,
     "max_predicate_data_length": 1048576,
-    "gas_price_factor": 1000000000
+    "gas_price_factor": 1000000000,
+    "gas_per_byte": 4,
+    "max_message_data_length": 1048576
   }
 }

--- a/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_contract_with_balances.snap
+++ b/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_contract_with_balances.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/config/chain_config.rs
+assertion_line: 275
 expression: json
 ---
 {
@@ -27,10 +28,11 @@ expression: json
     "max_gas_per_tx": 100000000,
     "max_script_length": 1048576,
     "max_script_data_length": 1048576,
-    "max_static_contracts": 255,
     "max_storage_slots": 255,
     "max_predicate_length": 1048576,
     "max_predicate_data_length": 1048576,
-    "gas_price_factor": 1000000000
+    "gas_price_factor": 1000000000,
+    "gas_per_byte": 4,
+    "max_message_data_length": 1048576
   }
 }

--- a/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_contract_with_state.snap
+++ b/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_contract_with_state.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/config/chain_config.rs
+assertion_line: 260
 expression: json
 ---
 {
@@ -27,10 +28,11 @@ expression: json
     "max_gas_per_tx": 100000000,
     "max_script_length": 1048576,
     "max_script_data_length": 1048576,
-    "max_static_contracts": 255,
     "max_storage_slots": 255,
     "max_predicate_length": 1048576,
     "max_predicate_data_length": 1048576,
-    "gas_price_factor": 1000000000
+    "gas_price_factor": 1000000000,
+    "gas_per_byte": 4,
+    "max_message_data_length": 1048576
   }
 }

--- a/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_local_testnet_config.snap
+++ b/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_local_testnet_config.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/config/chain_config.rs
+assertion_line: 201
 expression: json
 ---
 {
@@ -42,10 +43,11 @@ expression: json
     "max_gas_per_tx": 100000000,
     "max_script_length": 1048576,
     "max_script_data_length": 1048576,
-    "max_static_contracts": 255,
     "max_storage_slots": 255,
     "max_predicate_length": 1048576,
     "max_predicate_data_length": 1048576,
-    "gas_price_factor": 1000000000
+    "gas_price_factor": 1000000000,
+    "gas_per_byte": 4,
+    "max_message_data_length": 1048576
   }
 }

--- a/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_simple_coin_state.snap
+++ b/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_simple_coin_state.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/config/chain_config.rs
+assertion_line: 290
 expression: json
 ---
 {
@@ -26,10 +27,11 @@ expression: json
     "max_gas_per_tx": 100000000,
     "max_script_length": 1048576,
     "max_script_data_length": 1048576,
-    "max_static_contracts": 255,
     "max_storage_slots": 255,
     "max_predicate_length": 1048576,
     "max_predicate_data_length": 1048576,
-    "gas_price_factor": 1000000000
+    "gas_price_factor": 1000000000,
+    "gas_per_byte": 4,
+    "max_message_data_length": 1048576
   }
 }

--- a/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_simple_contract.snap
+++ b/fuel-core/src/config/snapshots/fuel_core__config__chain_config__tests__snapshot_simple_contract.snap
@@ -1,5 +1,6 @@
 ---
 source: fuel-core/src/config/chain_config.rs
+assertion_line: 245
 expression: json
 ---
 {
@@ -21,10 +22,11 @@ expression: json
     "max_gas_per_tx": 100000000,
     "max_script_length": 1048576,
     "max_script_data_length": 1048576,
-    "max_static_contracts": 255,
     "max_storage_slots": 255,
     "max_predicate_length": 1048576,
     "max_predicate_data_length": 1048576,
-    "gas_price_factor": 1000000000
+    "gas_price_factor": 1000000000,
+    "gas_per_byte": 4,
+    "max_message_data_length": 1048576
   }
 }

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -5,6 +5,7 @@ use crate::{
     tx_pool::TransactionStatus,
 };
 use chrono::Utc;
+use fuel_core_interfaces::common::fuel_tx::{CheckedTransaction, TransactionFee};
 use fuel_core_interfaces::{
     common::{
         fuel_asm::Word,
@@ -100,7 +101,17 @@ impl Executor {
                 return Err(Error::TransactionIdCollision(tx_id));
             }
 
-            self.verify_tx_predicates(tx)?;
+            self.compute_contract_input_utxo_ids(tx, &mode, block_db_transaction.deref())?;
+
+            let checked_tx = CheckedTransaction::check_unsigned(
+                tx.clone(),
+                block.header.height.into(),
+                &self.config.chain_conf.transaction_parameters,
+            )?;
+            let min_fee = checked_tx.min_fee();
+            let max_fee = checked_tx.max_fee();
+
+            self.verify_tx_predicates(&checked_tx)?;
 
             if self.config.utxo_validation {
                 // validate transaction has at least one coin
@@ -111,11 +122,6 @@ impl Executor {
                 tx.validate_input_signature()
                     .map_err(TransactionValidityError::from)?;
             }
-
-            self.compute_contract_input_utxo_ids(tx, &mode, block_db_transaction.deref())?;
-
-            // verify that the tx has enough gas to cover committed costs
-            self.verify_gas(tx)?;
 
             // index owners of inputs and outputs with tx-id, regardless of validity (hence block_tx instead of tx_db)
             self.persist_owners_index(
@@ -136,7 +142,7 @@ impl Executor {
                 self.config.chain_conf.transaction_parameters,
             );
             let vm_result = vm
-                .transact(tx.clone())
+                .transact(checked_tx)
                 .map_err(|error| Error::VmExecution {
                     error,
                     transaction_id: tx_id,
@@ -149,7 +155,8 @@ impl Executor {
             }
 
             // update block commitment
-            let tx_fee = self.total_fee_paid(tx, vm_result.receipts())?;
+            let tx_fee =
+                self.total_fee_paid(min_fee, max_fee, tx.gas_price(), vm_result.receipts())?;
             coinbase = coinbase.checked_add(tx_fee).ok_or(Error::FeeOverflow)?;
 
             // include the canonical serialization of the malleated tx into the commitment,
@@ -276,7 +283,6 @@ impl Executor {
         Ok(())
     }
 
-    // Waiting until accounts and genesis block setup is working
     fn verify_input_state(
         &self,
         db: &Database,
@@ -298,6 +304,9 @@ impl Executor {
                     }
                 }
                 Input::Contract { .. } => {}
+                // TODO: message validation waiting on db storage of messages + genesis
+                Input::MessageSigned { .. } => {}
+                Input::MessagePredicate { .. } => {}
             }
         }
 
@@ -305,13 +314,17 @@ impl Executor {
     }
 
     /// Verify all the predicates of a tx.
-    pub fn verify_tx_predicates(&self, tx: &Transaction) -> Result<(), Error> {
+    pub fn verify_tx_predicates(&self, tx: &CheckedTransaction) -> Result<(), Error> {
         // fail if tx contains any predicates when predicates are disabled
         if !self.config.predicates {
-            let has_predicate = tx.inputs().iter().any(|input| input.is_coin_predicate());
+            let has_predicate = tx
+                .as_ref()
+                .inputs()
+                .iter()
+                .any(|input| input.is_coin_predicate());
             if has_predicate {
                 return Err(Error::TransactionValidity(
-                    TransactionValidityError::PredicateExecutionDisabled(tx.id()),
+                    TransactionValidityError::PredicateExecutionDisabled(tx.transaction().id()),
                 ));
             }
         } else {
@@ -321,7 +334,7 @@ impl Executor {
                 self.config.chain_conf.transaction_parameters,
             ) {
                 return Err(Error::TransactionValidity(
-                    TransactionValidityError::InvalidPredicate(tx.id()),
+                    TransactionValidityError::InvalidPredicate(tx.transaction().id()),
                 ));
             }
         }
@@ -388,68 +401,26 @@ impl Executor {
         Ok(())
     }
 
-    /// verify that the transaction has enough gas to cover fees
-    fn verify_gas(&self, tx: &Transaction) -> Result<(), Error> {
-        if tx.gas_price() != 0 || tx.byte_price() != 0 {
-            let gas: Word = tx
-                .inputs()
-                .iter()
-                .filter_map(|input| match input {
-                    Input::CoinSigned {
-                        amount, asset_id, ..
-                    } if asset_id == &AssetId::default() => Some(amount),
-                    Input::CoinPredicate {
-                        amount, asset_id, ..
-                    } if asset_id == &AssetId::default() => Some(amount),
-                    _ => None,
-                })
-                .sum();
-            let spent_gas: Word = tx
-                .outputs()
-                .iter()
-                .filter_map(|output| match output {
-                    Output::Coin {
-                        amount, asset_id, ..
-                    } if asset_id == &AssetId::default() => Some(amount),
-                    Output::Withdrawal {
-                        amount, asset_id, ..
-                    } if asset_id == &AssetId::default() => Some(amount),
-                    _ => None,
-                })
-                .sum();
-            let factor = self
-                .config
-                .chain_conf
-                .transaction_parameters
-                .gas_price_factor as f64;
-            let byte_fees =
-                ((tx.metered_bytes_size() as Word * tx.byte_price()) as f64 / factor).ceil() as u64;
-            let gas_fees = ((tx.gas_limit() * tx.gas_price()) as f64 / factor).ceil() as u64;
-            let total_gas_required = spent_gas
-                .checked_add(byte_fees)
-                .ok_or(Error::FeeOverflow)?
-                .checked_add(gas_fees)
-                .ok_or(Error::FeeOverflow)?;
-            gas.checked_sub(total_gas_required)
-                .ok_or(Error::InsufficientFeeAmount {
-                    provided: gas,
-                    required: total_gas_required,
-                })?;
-        }
-
-        Ok(())
-    }
-
-    fn total_fee_paid(&self, tx: &Transaction, receipts: &[Receipt]) -> Result<Word, Error> {
-        let mut fee = tx.metered_bytes_size() as Word * tx.byte_price();
-
+    fn total_fee_paid(
+        &self,
+        min_fee: u64,
+        max_fee: u64,
+        gas_price: u64,
+        receipts: &[Receipt],
+    ) -> Result<Word, Error> {
         for r in receipts {
             if let Receipt::ScriptResult { gas_used, .. } = r {
-                fee = fee.checked_add(*gas_used).ok_or(Error::FeeOverflow)?;
+                return TransactionFee::gas_refund_value(
+                    &self.config.chain_conf.transaction_parameters,
+                    *gas_used,
+                    gas_price,
+                )
+                .and_then(|refund| max_fee.checked_sub(refund))
+                .ok_or(Error::FeeOverflow);
             }
         }
-
-        Ok(fee)
+        // if there's no script result (i.e. create) then fee == base amount
+        Ok(min_fee)
     }
 
     /// In production mode, lookup and set the proper utxo ids for contract inputs
@@ -543,8 +514,8 @@ impl Executor {
                         ));
                     }
                 }
-                Output::Withdrawal { .. } => {
-                    // TODO: Handle withdrawals somehow (new field on the block type?)
+                Output::Message { .. } => {
+                    // TODO: Handle message outputs somehow (new field on the block type?)
                 }
                 Output::Change {
                     to,
@@ -624,7 +595,7 @@ impl Executor {
         for output in tx.outputs() {
             match output {
                 Output::Coin { to, .. }
-                | Output::Withdrawal { to, .. }
+                | Output::Message { recipient: to, .. }
                 | Output::Change { to, .. }
                 | Output::Variable { to, .. } => {
                     owners.push(to);
@@ -704,8 +675,6 @@ pub enum Error {
     TransactionIdCollision(Bytes32),
     #[error("output already exists")]
     OutputAlreadyExists,
-    #[error("Transaction doesn't include enough value to pay for gas: {provided} < {required}")]
-    InsufficientFeeAmount { provided: Word, required: Word },
     #[error("The computed fee caused an integer overflow")]
     FeeOverflow,
     #[error("Invalid transaction: {0}")]
@@ -722,6 +691,8 @@ pub enum Error {
         error: fuel_core_interfaces::common::fuel_vm::prelude::InterpreterError,
         transaction_id: Bytes32,
     },
+    #[error(transparent)]
+    InvalidTransaction(#[from] ValidationError),
     #[error("Execution error with backtrace")]
     Backtrace(Box<FuelBacktrace>),
     #[error("Transaction doesn't match expected result: {transaction_id:#x}")]
@@ -758,11 +729,10 @@ impl From<crate::state::Error> for Error {
 mod tests {
     use super::*;
     use crate::model::FuelBlockHeader;
-    use fuel_core_interfaces::common::fuel_tx::ConsensusParameters;
     use fuel_core_interfaces::common::{
         fuel_asm::Opcode,
         fuel_crypto::SecretKey,
-        fuel_tx::{self, TransactionBuilder},
+        fuel_tx::{self, ConsensusParameters, Transaction, TransactionBuilder},
         fuel_types::{ContractId, Immediate12, Immediate18, Salt},
         fuel_vm::{
             consts::{REG_CGAS, REG_FP, REG_ONE, REG_ZERO},
@@ -785,6 +755,8 @@ mod tests {
                     .coin_output(AssetId::default(), (i as Word) * 50)
                     .change_output(AssetId::default())
                     .build()
+                    .transaction()
+                    .clone()
             })
             .collect_vec();
 
@@ -806,9 +778,7 @@ mod tests {
             0,
             0,
             0,
-            0,
             salt,
-            vec![],
             vec![],
             vec![],
             vec![Output::ContractCreated {
@@ -899,7 +869,7 @@ mod tests {
             .await;
         assert!(matches!(
             produce_result,
-            Err(Error::InsufficientFeeAmount { required, .. }) if required == (gas_limit as f64 / factor).ceil() as u64
+            Err(Error::InvalidTransaction(ValidationError::InsufficientFeeAmount { expected, .. })) if expected == (gas_limit as f64 / factor).ceil() as u64
         ));
 
         let verify_result = verifier
@@ -907,7 +877,7 @@ mod tests {
             .await;
         assert!(matches!(
             verify_result,
-            Err(Error::InsufficientFeeAmount {required, ..}) if required == (gas_limit as f64 / factor).ceil() as u64
+            Err(Error::InvalidTransaction(ValidationError::InsufficientFeeAmount { expected, ..})) if expected == (gas_limit as f64 / factor).ceil() as u64
         ))
     }
 
@@ -980,7 +950,6 @@ mod tests {
             0,
             0,
             0,
-            0,
             vec![],
             vec![],
             vec![input],
@@ -1038,8 +1007,8 @@ mod tests {
         let tx =
             TransactionBuilder::script(vec![Opcode::RET(REG_ONE)].into_iter().collect(), vec![])
                 .add_unsigned_coin_input(
+                    SecretKey::random(&mut rng),
                     rng.gen(),
-                    &SecretKey::random(&mut rng),
                     10,
                     Default::default(),
                     0,
@@ -1099,11 +1068,12 @@ mod tests {
         let input_amount = 10;
         let fake_output_amount = 100;
 
-        let tx = TxBuilder::new(2322u64)
+        let tx: Transaction = TxBuilder::new(2322u64)
             .gas_limit(1)
             .coin_input(Default::default(), input_amount)
             .change_output(Default::default())
-            .build();
+            .build()
+            .into();
 
         let tx_id = tx.id();
 
@@ -1148,11 +1118,12 @@ mod tests {
     #[tokio::test]
     async fn executor_invalidates_blocks_with_diverging_tx_commitment() {
         let mut rng = StdRng::seed_from_u64(2322u64);
-        let tx = TxBuilder::new(2322u64)
+        let tx: Transaction = TxBuilder::new(2322u64)
             .gas_limit(1)
             .coin_input(Default::default(), 10)
             .change_output(Default::default())
-            .build();
+            .build()
+            .into();
 
         let producer = Executor {
             database: Default::default(),
@@ -1187,7 +1158,7 @@ mod tests {
     // invalidate a block if a tx is missing at least one coin input
     #[tokio::test]
     async fn executor_invalidates_missing_coin_input() {
-        let tx = TxBuilder::new(2322u64).build();
+        let tx: Transaction = TxBuilder::new(2322u64).build().into();
         let tx_id = tx.id();
 
         let executor = Executor {
@@ -1219,10 +1190,11 @@ mod tests {
     #[tokio::test]
     async fn input_coins_are_marked_as_spent() {
         // ensure coins are marked as spent after tx is processed
-        let tx = TxBuilder::new(2322u64)
+        let tx: Transaction = TxBuilder::new(2322u64)
             .coin_input(AssetId::default(), 100)
             .change_output(AssetId::default())
-            .build();
+            .build()
+            .into();
 
         let db = Database::default();
         let executor = Executor {
@@ -1241,9 +1213,10 @@ mod tests {
             .unwrap();
 
         // assert the tx coin is spent
-        let coin = Storage::<UtxoId, Coin>::get(&db, block.transactions[0].inputs()[0].utxo_id())
-            .unwrap()
-            .unwrap();
+        let coin =
+            Storage::<UtxoId, Coin>::get(&db, block.transactions[0].inputs()[0].utxo_id().unwrap())
+                .unwrap()
+                .unwrap();
         assert_eq!(coin.status, CoinStatus::Spent);
     }
 
@@ -1256,8 +1229,8 @@ mod tests {
         let tx =
             TransactionBuilder::script(vec![Opcode::RET(REG_ONE)].into_iter().collect(), vec![])
                 .add_unsigned_coin_input(
+                    SecretKey::random(&mut rng),
                     rng.gen(),
-                    &SecretKey::random(&mut rng),
                     100,
                     Default::default(),
                     0,
@@ -1324,9 +1297,10 @@ mod tests {
             .unwrap();
 
         // assert the tx coin is spent
-        let coin = Storage::<UtxoId, Coin>::get(&db, block.transactions[0].inputs()[0].utxo_id())
-            .unwrap()
-            .unwrap();
+        let coin =
+            Storage::<UtxoId, Coin>::get(&db, block.transactions[0].inputs()[0].utxo_id().unwrap())
+                .unwrap()
+                .unwrap();
         assert_eq!(coin.status, CoinStatus::Spent);
         // assert block created from coin before spend is still intact (only a concern when utxo-validation is enabled)
         assert_eq!(coin.block_created, starting_block)
@@ -1343,11 +1317,13 @@ mod tests {
             transactions: vec![tx],
         };
 
-        let tx2 = TxBuilder::new(2322)
-            .script(vec![Opcode::RET(1)])
+        let tx2: Transaction = TxBuilder::new(2322)
+            .start_script(vec![Opcode::RET(1)], vec![])
             .contract_input(contract_id)
             .contract_output(&contract_id)
-            .build();
+            .build()
+            .into();
+
         let mut second_block = FuelBlock {
             header: FuelBlockHeader {
                 height: 2u64.into(),
@@ -1396,22 +1372,30 @@ mod tests {
         // create a contract in block 1
         // verify a block 2 containing contract id from block 1, with wrong input contract utxo_id
         let (tx, contract_id) = create_contract(vec![], &mut rng);
-        let tx2 = TxBuilder::new(2322)
-            .script(vec![Opcode::ADDI(0x10, REG_ZERO, 0), Opcode::RET(1)])
+        let tx2: Transaction = TxBuilder::new(2322)
+            .start_script(
+                vec![Opcode::ADDI(0x10, REG_ZERO, 0), Opcode::RET(1)],
+                vec![],
+            )
             .contract_input(contract_id)
             .contract_output(&contract_id)
-            .build();
+            .build()
+            .into();
 
         let mut first_block = FuelBlock {
             header: Default::default(),
             transactions: vec![tx, tx2],
         };
 
-        let tx3 = TxBuilder::new(2322)
-            .script(vec![Opcode::ADDI(0x10, REG_ZERO, 1), Opcode::RET(1)])
+        let tx3: Transaction = TxBuilder::new(2322)
+            .start_script(
+                vec![Opcode::ADDI(0x10, REG_ZERO, 1), Opcode::RET(1)],
+                vec![],
+            )
             .contract_input(contract_id)
             .contract_output(&contract_id)
-            .build();
+            .build()
+            .into();
         let tx_id = tx3.id();
 
         let mut second_block = FuelBlock {
@@ -1528,17 +1512,17 @@ mod tests {
         .copied()
         .collect();
 
-        let tx2 = TxBuilder::new(2322)
+        let tx2: Transaction = TxBuilder::new(2322)
             .gas_limit(ConsensusParameters::DEFAULT.max_gas_per_tx)
-            .script(script)
-            .script_data(script_data)
+            .start_script(script, script_data)
             .contract_input(contract_id)
             .coin_input(asset_id, input_amount)
             .variable_output(Default::default())
             .coin_output(asset_id, coin_output_amount)
             .change_output(asset_id)
             .contract_output(&contract_id)
-            .build();
+            .build()
+            .into();
         let tx2_id = tx2.id();
 
         let database = Database::default();
@@ -1579,12 +1563,13 @@ mod tests {
         let input_amount = 0;
         let coin_output_amount = 0;
 
-        let tx = TxBuilder::new(2322)
+        let tx: Transaction = TxBuilder::new(2322)
             .coin_input(asset_id, input_amount)
             .variable_output(Default::default())
             .coin_output(asset_id, coin_output_amount)
             .change_output(asset_id)
-            .build();
+            .build()
+            .into();
         let tx_id = tx.id();
 
         let database = Database::default();
@@ -1604,7 +1589,7 @@ mod tests {
             .unwrap();
 
         for idx in 0..2 {
-            let id = fuel_tx::UtxoId::new(tx_id, idx);
+            let id = UtxoId::new(tx_id, idx);
             let maybe_utxo = Storage::<UtxoId, Coin>::get(&database, &id).unwrap();
             assert!(maybe_utxo.is_none());
         }

--- a/fuel-core/src/schema/chain.rs
+++ b/fuel-core/src/schema/chain.rs
@@ -41,10 +41,6 @@ impl ConsensusParameters {
         self.0.max_script_data_length.into()
     }
 
-    async fn max_static_contracts(&self) -> U64 {
-        self.0.max_static_contracts.into()
-    }
-
     async fn max_storage_slots(&self) -> U64 {
         self.0.max_storage_slots.into()
     }
@@ -59,6 +55,14 @@ impl ConsensusParameters {
 
     async fn gas_price_factor(&self) -> U64 {
         self.0.gas_price_factor.into()
+    }
+
+    async fn gas_per_byte(&self) -> U64 {
+        self.0.gas_per_byte.into()
+    }
+
+    async fn max_message_data_length(&self) -> U64 {
+        self.0.max_message_data_length.into()
     }
 }
 

--- a/fuel-core/src/schema/scalars.rs
+++ b/fuel-core/src/schema/scalars.rs
@@ -274,3 +274,4 @@ fuel_type_scalar!("AssetId", AssetId, AssetId, 32);
 fuel_type_scalar!("ContractId", ContractId, ContractId, 32);
 fuel_type_scalar!("Salt", Salt, Salt, 32);
 fuel_type_scalar!("TransactionId", TransactionId, Bytes32, 32);
+fuel_type_scalar!("MessageId", MessageId, MessageId, 32);

--- a/fuel-core/src/schema/tx/input.rs
+++ b/fuel-core/src/schema/tx/input.rs
@@ -1,23 +1,24 @@
 use crate::schema::{
     contract::Contract,
-    scalars::{Address, AssetId, Bytes32, ContractId, HexString, UtxoId, U64},
+    scalars::{Address, AssetId, Bytes32, ContractId, HexString, MessageId, UtxoId, U64},
 };
 use async_graphql::{Object, Union};
-use fuel_core_interfaces::common::{fuel_asm::Word, fuel_tx};
+use fuel_core_interfaces::common::fuel_tx;
 
 #[derive(Union)]
 pub enum Input {
     Coin(InputCoin),
     Contract(InputContract),
+    Message(InputMessage),
 }
 
 pub struct InputCoin {
     utxo_id: UtxoId,
     owner: Address,
-    amount: Word,
+    amount: U64,
     asset_id: AssetId,
     witness_index: u8,
-    maturity: Word,
+    maturity: U64,
     predicate: HexString,
     predicate_data: HexString,
 }
@@ -33,7 +34,7 @@ impl InputCoin {
     }
 
     async fn amount(&self) -> U64 {
-        self.amount.into()
+        self.amount
     }
 
     async fn asset_id(&self) -> AssetId {
@@ -45,7 +46,7 @@ impl InputCoin {
     }
 
     async fn maturity(&self) -> U64 {
-        self.maturity.into()
+        self.maturity
     }
 
     async fn predicate(&self) -> HexString {
@@ -83,6 +84,62 @@ impl InputContract {
     }
 }
 
+pub struct InputMessage {
+    message_id: MessageId,
+    sender: Address,
+    recipient: Address,
+    amount: U64,
+    nonce: U64,
+    owner: Address,
+    witness_index: u8,
+    data: HexString,
+    predicate: HexString,
+    predicate_data: HexString,
+}
+
+#[Object]
+impl InputMessage {
+    async fn message_id(&self) -> MessageId {
+        self.message_id
+    }
+
+    async fn sender(&self) -> Address {
+        self.sender
+    }
+
+    async fn recipient(&self) -> Address {
+        self.recipient
+    }
+
+    async fn amount(&self) -> U64 {
+        self.amount
+    }
+
+    async fn nonce(&self) -> U64 {
+        self.nonce
+    }
+
+    async fn owner(&self) -> Address {
+        self.owner
+    }
+
+    async fn witness_index(&self) -> u8 {
+        self.witness_index
+    }
+
+    async fn data(&self) -> &HexString {
+        &self.data
+    }
+
+    async fn predicate(&self) -> &HexString {
+        &self.predicate
+    }
+
+    async fn predicate_data(&self) -> &HexString {
+        &self.predicate_data
+    }
+}
+
 impl From<&fuel_tx::Input> for Input {
     fn from(input: &fuel_tx::Input) -> Self {
         match input {
@@ -96,10 +153,10 @@ impl From<&fuel_tx::Input> for Input {
             } => Input::Coin(InputCoin {
                 utxo_id: UtxoId(*utxo_id),
                 owner: Address(*owner),
-                amount: *amount,
+                amount: (*amount).into(),
                 asset_id: AssetId(*asset_id),
                 witness_index: *witness_index,
-                maturity: *maturity,
+                maturity: (*maturity).into(),
                 predicate: HexString(Default::default()),
                 predicate_data: HexString(Default::default()),
             }),
@@ -114,10 +171,10 @@ impl From<&fuel_tx::Input> for Input {
             } => Input::Coin(InputCoin {
                 utxo_id: UtxoId(*utxo_id),
                 owner: Address(*owner),
-                amount: *amount,
+                amount: (*amount).into(),
                 asset_id: AssetId(*asset_id),
                 witness_index: Default::default(),
-                maturity: *maturity,
+                maturity: (*maturity).into(),
                 predicate: HexString(predicate.clone()),
                 predicate_data: HexString(predicate_data.clone()),
             }),
@@ -131,6 +188,49 @@ impl From<&fuel_tx::Input> for Input {
                 balance_root: Bytes32(*balance_root),
                 state_root: Bytes32(*state_root),
                 contract_id: ContractId(*contract_id),
+            }),
+            fuel_tx::Input::MessageSigned {
+                message_id,
+                sender,
+                recipient,
+                amount,
+                nonce,
+                owner,
+                witness_index,
+                data,
+            } => Input::Message(InputMessage {
+                message_id: MessageId(*message_id),
+                sender: Address(*sender),
+                recipient: Address(*recipient),
+                amount: (*amount).into(),
+                nonce: (*nonce).into(),
+                owner: Address(*owner),
+                witness_index: *witness_index,
+                data: HexString(data.clone()),
+                predicate: HexString(Default::default()),
+                predicate_data: HexString(Default::default()),
+            }),
+            fuel_tx::Input::MessagePredicate {
+                message_id,
+                sender,
+                recipient,
+                amount,
+                nonce,
+                owner,
+                data,
+                predicate,
+                predicate_data,
+            } => Input::Message(InputMessage {
+                message_id: MessageId(*message_id),
+                sender: Address(*sender),
+                recipient: Address(*recipient),
+                amount: (*amount).into(),
+                nonce: (*nonce).into(),
+                owner: Address(*owner),
+                witness_index: Default::default(),
+                data: HexString(data.clone()),
+                predicate: HexString(predicate.clone()),
+                predicate_data: HexString(predicate_data.clone()),
             }),
         }
     }

--- a/fuel-core/src/schema/tx/output.rs
+++ b/fuel-core/src/schema/tx/output.rs
@@ -7,7 +7,7 @@ use fuel_core_interfaces::common::{fuel_asm::Word, fuel_tx, fuel_types};
 pub enum Output {
     Coin(CoinOutput),
     Contract(ContractOutput),
-    Withdrawal(WithdrawalOutput),
+    Message(MessageOutput),
     Change(ChangeOutput),
     Variable(VariableOutput),
     ContractCreated(ContractCreated),
@@ -34,20 +34,19 @@ impl CoinOutput {
     }
 }
 
-pub struct WithdrawalOutput(CoinOutput);
+pub struct MessageOutput {
+    amount: Word,
+    recipient: fuel_types::Address,
+}
 
 #[Object]
-impl WithdrawalOutput {
-    async fn to(&self) -> Address {
-        self.0.to.into()
+impl MessageOutput {
+    async fn recipient(&self) -> Address {
+        self.recipient.into()
     }
 
     async fn amount(&self) -> U64 {
-        self.0.amount.into()
-    }
-
-    async fn asset_id(&self) -> AssetId {
-        self.0.asset_id.into()
+        self.amount.into()
     }
 }
 
@@ -143,15 +142,10 @@ impl From<&fuel_tx::Output> for Output {
                 balance_root: *balance_root,
                 state_root: *state_root,
             }),
-            fuel_tx::Output::Withdrawal {
-                to,
-                amount,
-                asset_id,
-            } => Output::Withdrawal(WithdrawalOutput(CoinOutput {
-                to: *to,
+            fuel_tx::Output::Message { recipient, amount } => Output::Message(MessageOutput {
+                recipient: *recipient,
                 amount: *amount,
-                asset_id: *asset_id,
-            })),
+            }),
             fuel_tx::Output::Change {
                 to,
                 amount,

--- a/fuel-core/src/schema/tx/receipt.rs
+++ b/fuel-core/src/schema/tx/receipt.rs
@@ -1,3 +1,4 @@
+use crate::schema::scalars::MessageId;
 use crate::schema::{
     contract::Contract,
     scalars::{Address, AssetId, Bytes32, HexString, U64},
@@ -18,6 +19,7 @@ pub enum ReceiptType {
     Transfer,
     TransferOut,
     ScriptResult,
+    MessageOut,
 }
 
 impl From<&fuel_tx::Receipt> for ReceiptType {
@@ -33,6 +35,7 @@ impl From<&fuel_tx::Receipt> for ReceiptType {
             fuel_tx::Receipt::Transfer { .. } => ReceiptType::Transfer,
             fuel_tx::Receipt::TransferOut { .. } => ReceiptType::TransferOut,
             fuel_tx::Receipt::ScriptResult { .. } => ReceiptType::ScriptResult,
+            fuel_tx::Receipt::MessageOut { .. } => ReceiptType::MessageOut,
         }
     }
 }
@@ -112,6 +115,18 @@ impl Receipt {
     }
     async fn data(&self) -> Option<HexString> {
         self.0.data().map(|d| d.to_vec().into())
+    }
+    async fn message_id(&self) -> Option<MessageId> {
+        self.0.message_id().copied().map(MessageId)
+    }
+    async fn sender(&self) -> Option<Address> {
+        self.0.sender().copied().map(Address)
+    }
+    async fn recipient(&self) -> Option<Address> {
+        self.0.recipient().copied().map(Address)
+    }
+    async fn nonce(&self) -> Option<Bytes32> {
+        self.0.nonce().copied().map(Bytes32)
     }
 }
 

--- a/fuel-core/src/schema/tx/types.rs
+++ b/fuel-core/src/schema/tx/types.rs
@@ -194,10 +194,6 @@ impl Transaction {
         self.0.gas_limit().into()
     }
 
-    async fn byte_price(&self) -> U64 {
-        self.0.byte_price().into()
-    }
-
     async fn maturity(&self) -> U64 {
         self.0.maturity().into()
     }
@@ -292,15 +288,6 @@ impl Transaction {
         match self.0 {
             fuel_tx::Transaction::Script { .. } => None,
             fuel_tx::Transaction::Create { salt, .. } => Some(salt.into()),
-        }
-    }
-
-    async fn static_contracts(&self) -> Option<Vec<Contract>> {
-        match &self.0 {
-            fuel_tx::Transaction::Script { .. } => None,
-            fuel_tx::Transaction::Create {
-                static_contracts, ..
-            } => Some(static_contracts.iter().cloned().map(Into::into).collect()),
         }
     }
 

--- a/fuel-tests/tests/metrics.rs
+++ b/fuel-tests/tests/metrics.rs
@@ -45,7 +45,6 @@ async fn test_database_metrics() {
             0,
             1000000,
             0,
-            0,
             script,
             vec![],
             vec![],

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -45,7 +45,6 @@ async fn dry_run() {
 
     let gas_price = 0;
     let gas_limit = 1_000_000;
-    let byte_price = 0;
     let maturity = 0;
 
     let script = vec![
@@ -62,7 +61,6 @@ async fn dry_run() {
     let tx = fuel_tx::Transaction::script(
         gas_price,
         gas_limit,
-        byte_price,
         maturity,
         script,
         vec![],
@@ -93,7 +91,6 @@ async fn submit() {
     let gas_price = 0;
     let gas_limit = 1_000_000;
     let maturity = 0;
-    let byte_price = 0;
 
     let script = vec![
         Opcode::ADDI(0x10, REG_ZERO, 0xca),
@@ -109,7 +106,6 @@ async fn submit() {
     let tx = fuel_tx::Transaction::script(
         gas_price,
         gas_limit,
-        byte_price,
         maturity,
         script,
         vec![],
@@ -459,7 +455,6 @@ impl TestContext {
         let tx = Transaction::Script {
             gas_price: 0,
             gas_limit: 1_000_000,
-            byte_price: 0,
             maturity: 0,
             receipts_root: Default::default(),
             script,
@@ -503,7 +498,6 @@ async fn initialize_client(db: Database) -> FuelClient {
 // add random val for unique tx
 fn create_mock_tx(val: u64) -> Transaction {
     fuel_tx::Transaction::script(
-        0,
         0,
         0,
         0,

--- a/fuel-tests/tests/tx/utxo_validation.rs
+++ b/fuel-tests/tests/tx/utxo_validation.rs
@@ -21,15 +21,19 @@ async fn submit_utxo_verified_tx_with_min_gas_price() {
     let transactions = (1..=10)
         .into_iter()
         .map(|i| {
-            let secret = SecretKey::random(&mut rng);
             TransactionBuilder::script(
                 Opcode::RET(REG_ONE).to_bytes().into_iter().collect(),
                 vec![],
             )
             .gas_limit(100)
             .gas_price(1)
-            .byte_price(1)
-            .add_unsigned_coin_input(rng.gen(), &secret, 1000 + i, Default::default(), 0)
+            .add_unsigned_coin_input(
+                SecretKey::random(&mut rng),
+                rng.gen(),
+                1000 + i,
+                Default::default(),
+                0,
+            )
             .add_input(Input::Contract {
                 utxo_id: Default::default(),
                 balance_root: Default::default(),
@@ -96,7 +100,6 @@ async fn submit_utxo_verified_tx_below_min_gas_price_fails() {
     )
     .gas_limit(100)
     .gas_price(1)
-    .byte_price(1)
     .finalize();
 
     // initialize node with higher minimum gas price
@@ -214,8 +217,8 @@ async fn concurrent_tx_submission_produces_expected_blocks() {
             )
             .gas_limit(1000 + i as u64)
             .add_unsigned_coin_input(
+                secret.clone(),
                 rng.gen(),
-                &secret,
                 rng.gen_range(1..1000),
                 Default::default(),
                 0,

--- a/fuel-tests/tests/tx/utxo_validation.rs
+++ b/fuel-tests/tests/tx/utxo_validation.rs
@@ -217,7 +217,7 @@ async fn concurrent_tx_submission_produces_expected_blocks() {
             )
             .gas_limit(1000 + i as u64)
             .add_unsigned_coin_input(
-                secret.clone(),
+                secret,
                 rng.gen(),
                 rng.gen_range(1..1000),
                 Default::default(),


### PR DESCRIPTION
Makes fuel-core compatible with fuel-vm 0.13.

Incorporates / propagates the following breaking changes:

- https://github.com/FuelLabs/fuel-specs/pull/384
- https://github.com/FuelLabs/fuel-specs/pull/383
- https://github.com/FuelLabs/fuel-specs/pull/373
- https://github.com/FuelLabs/fuel-specs/pull/372
- https://github.com/FuelLabs/fuel-specs/pull/368
- https://github.com/FuelLabs/fuel-specs/pull/366
- https://github.com/FuelLabs/fuel-specs/pull/359
- https://github.com/FuelLabs/fuel-specs/pull/353
- https://github.com/FuelLabs/fuel-specs/pull/343
- https://github.com/FuelLabs/fuel-specs/pull/338
- https://github.com/FuelLabs/fuel-specs/pull/333
- https://github.com/FuelLabs/fuel-specs/pull/332
- https://github.com/FuelLabs/fuel-specs/pull/330
- https://github.com/FuelLabs/fuel-specs/pull/318



