### PR TITLE
Fix remote dispatch for namespace naming issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,9 +402,10 @@ jobs:
           repo: FuelLabs/fuel-deployment
           ref: refs/heads/master
           token: ${{ secrets.REPO_TOKEN }}
-          inputs: '{ "k8s-type": "${{ env.K8S }}", "config-directory": "${{ env.CONFIG }}", "config-env": "${{ env.ENV }}", "deployment-version": "${{ env.DEPLOYMENT_VERSION }}", "image-tag": "${{ env.IMAGE_TAG }}", "delete-infra": "${{ env.DELETE_INFRA }}" }'
+          inputs: '{ "k8s-type": "${{ env.K8S }}", "config-directory": "${{ env.CONFIG }}", "config-env": "${{ env.ENV }}", "deployment-version": "${{ env.DEPLOYMENT_VERSION }}", "image-tag": "${{ env.IMAGE_TAG }}", "delete-infra": "${{ env.DELETE_INFRA }}", "ephemeral-environment": "${{ env.EPH_ENV }}" }'
         env:
           K8S: 'eks'
           CONFIG: 'fuel-dev1'
           ENV: 'fueldevsway.env'
           DELETE_INFRA: true
+          EPH_ENV: false


### PR DESCRIPTION
- add a new boolean parameter "ephemeral-environment" for remote dispatch to dictate if the deployment for fuel core is ephemeral or not (default to "false" for fuel-core production builds

- corresponding fuel-deployment PR: https://github.com/FuelLabs/fuel-deployment/pull/78