### PR TITLE
update x86 gnu build to use a less ancient libc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,9 @@ jobs:
       - lint-toml-files
       - cargo-verifications
     if: github.event_name == 'release' && github.event.action == 'published'
+    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         job:
           - os: ubuntu-latest

--- a/ci/Dockerfile.x86_64-unknown-linux-gnu-clang
+++ b/ci/Dockerfile.x86_64-unknown-linux-gnu-clang
@@ -1,10 +1,4 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main-centos
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
 
-RUN yum -y update && \
-    yum -y install centos-release-scl && \
-    yum-config-manager --enable rhel-server-rhscl-8-rpms && \
-    yum -y install llvm-toolset-7.0
-
-COPY centos-entrypoint /usr/bin/entrypoint.sh
-RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]
+RUN apt-get update && \
+    apt-get install --assume-yes clang libclang-dev binutils-aarch64-linux-gnu

--- a/ci/centos-entrypoint
+++ b/ci/centos-entrypoint
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-source scl_source enable llvm-toolset-7.0
-exec "$@"


### PR DESCRIPTION
fixes the publishing pipeline failure here: https://github.com/FuelLabs/fuel-core/runs/7779756065?check_suite_focus=true


test steps:
1. `$ ./ci/build-images.sh`
2. `$ cross build --profile=release --target x86_64-unknown-linux-gnu -p fuel-core`