### PR TITLE
chore: Refactor txpool tests to remove usages of pre-seeded DummyDB 

### DIFF
--- a/fuel-txpool/src/lib.rs
+++ b/fuel-txpool/src/lib.rs
@@ -4,6 +4,9 @@ pub mod service;
 pub mod txpool;
 pub mod types;
 
+#[cfg(test)]
+mod mock_db;
+
 pub use config::Config;
 pub use fuel_core_interfaces::txpool::Error;
 pub use service::{Service, ServiceBuilder};

--- a/fuel-txpool/src/lib.rs
+++ b/fuel-txpool/src/lib.rs
@@ -6,6 +6,8 @@ pub mod types;
 
 #[cfg(test)]
 mod mock_db;
+#[cfg(test)]
+pub(crate) use mock_db::MockDb;
 
 pub use config::Config;
 pub use fuel_core_interfaces::txpool::Error;

--- a/fuel-txpool/src/mock_db.rs
+++ b/fuel-txpool/src/mock_db.rs
@@ -1,126 +1,119 @@
-#[cfg(test)]
-pub(crate) mod helpers {
-    use std::borrow::Cow;
-    use std::collections::HashMap;
-    use std::sync::{Arc, Mutex};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
-    use fuel_core_interfaces::{
-        common::{
-            fuel_storage::Storage,
-            fuel_tx::{Contract, ContractId, MessageId, UtxoId},
-        },
-        db::{Error, KvStoreError},
-        model::{Coin, Message},
-        txpool::TxPoolDb,
-    };
+use fuel_core_interfaces::{
+    common::{
+        fuel_storage::Storage,
+        fuel_tx::{Contract, ContractId, MessageId, UtxoId},
+    },
+    db::{Error, KvStoreError},
+    model::{Coin, Message},
+    txpool::TxPoolDb,
+};
 
-    #[derive(Default)]
-    pub(crate) struct Data {
-        pub coins: HashMap<UtxoId, Coin>,
-        pub contracts: HashMap<ContractId, Contract>,
-        pub messages: HashMap<MessageId, Message>,
-    }
-
-    #[derive(Default)]
-    pub(crate) struct MockDb {
-        pub data: Arc<Mutex<Data>>,
-    }
-
-    impl Storage<UtxoId, Coin> for MockDb {
-        type Error = KvStoreError;
-
-        fn insert(&mut self, key: &UtxoId, value: &Coin) -> Result<Option<Coin>, Self::Error> {
-            Ok(self.data.lock().unwrap().coins.insert(*key, value.clone()))
-        }
-
-        fn remove(&mut self, key: &UtxoId) -> Result<Option<Coin>, Self::Error> {
-            Ok(self.data.lock().unwrap().coins.remove(key))
-        }
-
-        fn get(&self, key: &UtxoId) -> Result<Option<Cow<Coin>>, Self::Error> {
-            Ok(self
-                .data
-                .lock()
-                .unwrap()
-                .coins
-                .get(key)
-                .map(|i| Cow::Owned(i.clone())))
-        }
-
-        fn contains_key(&self, key: &UtxoId) -> Result<bool, Self::Error> {
-            Ok(self.data.lock().unwrap().coins.contains_key(key))
-        }
-    }
-
-    impl Storage<ContractId, Contract> for MockDb {
-        type Error = Error;
-
-        fn insert(
-            &mut self,
-            key: &ContractId,
-            value: &Contract,
-        ) -> Result<Option<Contract>, Self::Error> {
-            Ok(self
-                .data
-                .lock()
-                .unwrap()
-                .contracts
-                .insert(*key, value.clone()))
-        }
-
-        fn remove(&mut self, key: &ContractId) -> Result<Option<Contract>, Self::Error> {
-            Ok(self.data.lock().unwrap().contracts.remove(key))
-        }
-
-        fn get(&self, key: &ContractId) -> Result<Option<Cow<Contract>>, Self::Error> {
-            Ok(self
-                .data
-                .lock()
-                .unwrap()
-                .contracts
-                .get(key)
-                .map(|i| Cow::Owned(i.clone())))
-        }
-
-        fn contains_key(&self, key: &ContractId) -> Result<bool, Self::Error> {
-            Ok(self.data.lock().unwrap().contracts.contains_key(key))
-        }
-    }
-
-    impl Storage<MessageId, Message> for MockDb {
-        type Error = KvStoreError;
-
-        fn insert(
-            &mut self,
-            key: &MessageId,
-            value: &Message,
-        ) -> Result<Option<Message>, Self::Error> {
-            Ok(self
-                .data
-                .lock()
-                .unwrap()
-                .messages
-                .insert(*key, value.clone()))
-        }
-
-        fn remove(&mut self, key: &MessageId) -> Result<Option<Message>, Self::Error> {
-            Ok(self.data.lock().unwrap().messages.remove(key))
-        }
-
-        fn get(&self, key: &MessageId) -> Result<Option<Cow<Message>>, Self::Error> {
-            Ok(self
-                .data
-                .lock()
-                .unwrap()
-                .messages
-                .get(key)
-                .map(|i| Cow::Owned(i.clone())))
-        }
-
-        fn contains_key(&self, key: &MessageId) -> Result<bool, Self::Error> {
-            Ok(self.data.lock().unwrap().messages.contains_key(key))
-        }
-    }
-
-    impl TxPoolDb for MockDb {}
+#[derive(Default)]
+pub(crate) struct Data {
+    pub coins: HashMap<UtxoId, Coin>,
+    pub contracts: HashMap<ContractId, Contract>,
+    pub messages: HashMap<MessageId, Message>,
 }
+
+#[derive(Default)]
+pub(crate) struct MockDb {
+    pub data: Arc<Mutex<Data>>,
+}
+
+impl Storage<UtxoId, Coin> for MockDb {
+    type Error = KvStoreError;
+
+    fn insert(&mut self, key: &UtxoId, value: &Coin) -> Result<Option<Coin>, Self::Error> {
+        Ok(self.data.lock().unwrap().coins.insert(*key, value.clone()))
+    }
+
+    fn remove(&mut self, key: &UtxoId) -> Result<Option<Coin>, Self::Error> {
+        Ok(self.data.lock().unwrap().coins.remove(key))
+    }
+
+    fn get(&self, key: &UtxoId) -> Result<Option<Cow<Coin>>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .coins
+            .get(key)
+            .map(|i| Cow::Owned(i.clone())))
+    }
+
+    fn contains_key(&self, key: &UtxoId) -> Result<bool, Self::Error> {
+        Ok(self.data.lock().unwrap().coins.contains_key(key))
+    }
+}
+
+impl Storage<ContractId, Contract> for MockDb {
+    type Error = Error;
+
+    fn insert(
+        &mut self,
+        key: &ContractId,
+        value: &Contract,
+    ) -> Result<Option<Contract>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .contracts
+            .insert(*key, value.clone()))
+    }
+
+    fn remove(&mut self, key: &ContractId) -> Result<Option<Contract>, Self::Error> {
+        Ok(self.data.lock().unwrap().contracts.remove(key))
+    }
+
+    fn get(&self, key: &ContractId) -> Result<Option<Cow<Contract>>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .contracts
+            .get(key)
+            .map(|i| Cow::Owned(i.clone())))
+    }
+
+    fn contains_key(&self, key: &ContractId) -> Result<bool, Self::Error> {
+        Ok(self.data.lock().unwrap().contracts.contains_key(key))
+    }
+}
+
+impl Storage<MessageId, Message> for MockDb {
+    type Error = KvStoreError;
+
+    fn insert(&mut self, key: &MessageId, value: &Message) -> Result<Option<Message>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .messages
+            .insert(*key, value.clone()))
+    }
+
+    fn remove(&mut self, key: &MessageId) -> Result<Option<Message>, Self::Error> {
+        Ok(self.data.lock().unwrap().messages.remove(key))
+    }
+
+    fn get(&self, key: &MessageId) -> Result<Option<Cow<Message>>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .messages
+            .get(key)
+            .map(|i| Cow::Owned(i.clone())))
+    }
+
+    fn contains_key(&self, key: &MessageId) -> Result<bool, Self::Error> {
+        Ok(self.data.lock().unwrap().messages.contains_key(key))
+    }
+}
+
+impl TxPoolDb for MockDb {}

--- a/fuel-txpool/src/mock_db.rs
+++ b/fuel-txpool/src/mock_db.rs
@@ -1,0 +1,126 @@
+#[cfg(test)]
+pub(crate) mod helpers {
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use fuel_core_interfaces::{
+        common::{
+            fuel_storage::Storage,
+            fuel_tx::{Contract, ContractId, MessageId, UtxoId},
+        },
+        db::{Error, KvStoreError},
+        model::{Coin, Message},
+        txpool::TxPoolDb,
+    };
+
+    #[derive(Default)]
+    pub(crate) struct Data {
+        pub coins: HashMap<UtxoId, Coin>,
+        pub contracts: HashMap<ContractId, Contract>,
+        pub messages: HashMap<MessageId, Message>,
+    }
+
+    #[derive(Default)]
+    pub(crate) struct MockDb {
+        pub data: Arc<Mutex<Data>>,
+    }
+
+    impl Storage<UtxoId, Coin> for MockDb {
+        type Error = KvStoreError;
+
+        fn insert(&mut self, key: &UtxoId, value: &Coin) -> Result<Option<Coin>, Self::Error> {
+            Ok(self.data.lock().unwrap().coins.insert(*key, value.clone()))
+        }
+
+        fn remove(&mut self, key: &UtxoId) -> Result<Option<Coin>, Self::Error> {
+            Ok(self.data.lock().unwrap().coins.remove(key))
+        }
+
+        fn get(&self, key: &UtxoId) -> Result<Option<Cow<Coin>>, Self::Error> {
+            Ok(self
+                .data
+                .lock()
+                .unwrap()
+                .coins
+                .get(key)
+                .map(|i| Cow::Owned(i.clone())))
+        }
+
+        fn contains_key(&self, key: &UtxoId) -> Result<bool, Self::Error> {
+            Ok(self.data.lock().unwrap().coins.contains_key(key))
+        }
+    }
+
+    impl Storage<ContractId, Contract> for MockDb {
+        type Error = Error;
+
+        fn insert(
+            &mut self,
+            key: &ContractId,
+            value: &Contract,
+        ) -> Result<Option<Contract>, Self::Error> {
+            Ok(self
+                .data
+                .lock()
+                .unwrap()
+                .contracts
+                .insert(*key, value.clone()))
+        }
+
+        fn remove(&mut self, key: &ContractId) -> Result<Option<Contract>, Self::Error> {
+            Ok(self.data.lock().unwrap().contracts.remove(key))
+        }
+
+        fn get(&self, key: &ContractId) -> Result<Option<Cow<Contract>>, Self::Error> {
+            Ok(self
+                .data
+                .lock()
+                .unwrap()
+                .contracts
+                .get(key)
+                .map(|i| Cow::Owned(i.clone())))
+        }
+
+        fn contains_key(&self, key: &ContractId) -> Result<bool, Self::Error> {
+            Ok(self.data.lock().unwrap().contracts.contains_key(key))
+        }
+    }
+
+    impl Storage<MessageId, Message> for MockDb {
+        type Error = KvStoreError;
+
+        fn insert(
+            &mut self,
+            key: &MessageId,
+            value: &Message,
+        ) -> Result<Option<Message>, Self::Error> {
+            Ok(self
+                .data
+                .lock()
+                .unwrap()
+                .messages
+                .insert(*key, value.clone()))
+        }
+
+        fn remove(&mut self, key: &MessageId) -> Result<Option<Message>, Self::Error> {
+            Ok(self.data.lock().unwrap().messages.remove(key))
+        }
+
+        fn get(&self, key: &MessageId) -> Result<Option<Cow<Message>>, Self::Error> {
+            Ok(self
+                .data
+                .lock()
+                .unwrap()
+                .messages
+                .get(key)
+                .map(|i| Cow::Owned(i.clone())))
+        }
+
+        fn contains_key(&self, key: &MessageId) -> Result<bool, Self::Error> {
+            Ok(self.data.lock().unwrap().messages.contains_key(key))
+        }
+    }
+
+    impl TxPoolDb for MockDb {}
+}

--- a/fuel-txpool/src/service.rs
+++ b/fuel-txpool/src/service.rs
@@ -203,10 +203,10 @@ impl Service {
 
 #[cfg(any(test))]
 pub mod tests {
-
     use super::*;
+    use crate::MockDb;
     use fuel_core_interfaces::{
-        db::helpers::*,
+        common::fuel_tx::TransactionBuilder,
         txpool::{Error as TxpoolError, TxStatus},
     };
     use tokio::sync::oneshot;
@@ -214,7 +214,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_start_stop() {
         let config = Config::default();
-        let db = Box::new(DummyDb::filled());
+        let db = Box::new(MockDb::default());
         let (bs, _br) = broadcast::channel(10);
 
         let mut builder = ServiceBuilder::new();
@@ -239,26 +239,35 @@ pub mod tests {
     #[tokio::test]
     async fn test_filter_by_negative() {
         let config = Config::default();
-        let db = Box::new(DummyDb::filled());
+        let db = Box::new(MockDb::default());
         let (_bs, br) = broadcast::channel(10);
-
-        let tx1_hash = *TX_ID1;
-        let tx2_hash = *TX_ID2;
-        let tx3_hash = *TX_ID3;
-
-        let tx1 = Arc::new(DummyDb::dummy_tx(tx1_hash));
-        let tx2 = Arc::new(DummyDb::dummy_tx(tx2_hash));
 
         let mut builder = ServiceBuilder::new();
         builder.config(config).db(db).import_block_event(br);
         let service = builder.build().unwrap();
         service.start().await.ok();
 
+        let tx1 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(10)
+                .finalize(),
+        );
+        let tx2 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(20)
+                .finalize(),
+        );
+        let tx3 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(30)
+                .finalize(),
+        );
+
         let (response, receiver) = oneshot::channel();
         let _ = service
             .sender()
             .send(TxPoolMpsc::Insert {
-                txs: vec![tx1, tx2],
+                txs: vec![tx1.clone(), tx2.clone()],
                 response,
             })
             .await;
@@ -272,29 +281,38 @@ pub mod tests {
         let _ = service
             .sender()
             .send(TxPoolMpsc::FilterByNegative {
-                ids: vec![tx1_hash, tx3_hash],
+                ids: vec![tx1.id(), tx2.id(), tx3.id()],
                 response,
             })
             .await;
         let out = receiver.await.unwrap();
 
         assert_eq!(out.len(), 1, "Should be len 1:{:?}", out);
-        assert_eq!(out[0], tx3_hash, "Found tx id match{:?}", out);
+        assert_eq!(out[0], tx3.id(), "Found tx id match{:?}", out);
         service.stop().await.unwrap().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_find() {
         let config = Config::default();
-        let db = Box::new(DummyDb::filled());
+        let db = Box::new(MockDb::default());
         let (_bs, br) = broadcast::channel(10);
 
-        let tx1_hash = *TX_ID1;
-        let tx2_hash = *TX_ID2;
-        let tx3_hash = *TX_ID3;
-
-        let tx1 = Arc::new(DummyDb::dummy_tx(tx1_hash));
-        let tx2 = Arc::new(DummyDb::dummy_tx(tx2_hash));
+        let tx1 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(10)
+                .finalize(),
+        );
+        let tx2 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(20)
+                .finalize(),
+        );
+        let tx3 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(30)
+                .finalize(),
+        );
 
         let mut builder = ServiceBuilder::new();
         builder.config(config).db(db).import_block_event(br);
@@ -305,7 +323,7 @@ pub mod tests {
         let _ = service
             .sender()
             .send(TxPoolMpsc::Insert {
-                txs: vec![tx1, tx2],
+                txs: vec![tx1.clone(), tx2.clone()],
                 response,
             })
             .await;
@@ -318,7 +336,7 @@ pub mod tests {
         let _ = service
             .sender()
             .send(TxPoolMpsc::Find {
-                ids: vec![tx1_hash, tx3_hash],
+                ids: vec![tx1.id(), tx3.id()],
                 response,
             })
             .await;
@@ -326,7 +344,7 @@ pub mod tests {
         assert_eq!(out.len(), 2, "Should be len 2:{:?}", out);
         assert!(out[0].is_some(), "Tx1 should be some:{:?}", out);
         let id = out[0].as_ref().unwrap().id();
-        assert_eq!(id, tx1_hash, "Found tx id match{:?}", out);
+        assert_eq!(id, tx1.id(), "Found tx id match{:?}", out);
         assert!(out[1].is_none(), "Tx3 should not be found:{:?}", out);
         service.stop().await.unwrap().await.unwrap();
     }
@@ -334,14 +352,19 @@ pub mod tests {
     #[tokio::test]
     async fn simple_insert_removal_subscription() {
         let config = Config::default();
-        let db = Box::new(DummyDb::filled());
+        let db = Box::new(MockDb::default());
         let (_bs, br) = broadcast::channel(10);
 
-        let tx1_hash = *TX_ID1;
-        let tx2_hash = *TX_ID2;
-
-        let tx1 = Arc::new(DummyDb::dummy_tx(tx1_hash));
-        let tx2 = Arc::new(DummyDb::dummy_tx(tx2_hash));
+        let tx1 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(10)
+                .finalize(),
+        );
+        let tx2 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(20)
+                .finalize(),
+        );
 
         let mut builder = ServiceBuilder::new();
         builder.config(config).db(db).import_block_event(br);
@@ -386,7 +409,7 @@ pub mod tests {
         let _ = service
             .sender()
             .send(TxPoolMpsc::Remove {
-                ids: vec![tx1_hash, tx2_hash],
+                ids: vec![tx1.id(), tx2.id()],
                 response,
             })
             .await;

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -251,7 +251,7 @@ impl TxPool {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::mock_db::helpers::MockDb;
+    use crate::MockDb;
     mod helpers {
         use fuel_core_interfaces::{common::fuel_tx::Input, model::Message};
 

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -522,7 +522,7 @@ pub mod tests {
             .expect_err("Tx should be Err, got Ok");
         assert!(matches!(
             err.downcast_ref::<Error>(),
-            Some(Error::NotInsertedInputUtxoIdNotExisting(id)) if id == &UtxoId::new(nonexistent_id, 0)
+            Some(Error::NotInsertedInputUtxoIdNotExisting(utxo_id)) if utxo_id == &UtxoId::new(nonexistent_id, 0)
         ));
     }
 
@@ -559,7 +559,7 @@ pub mod tests {
             .expect_err("Tx should be Err, got Ok");
         assert!(matches!(
             err.downcast_ref::<Error>(),
-            Some(Error::NotInsertedInputUtxoIdSpent(id)) if id == &UtxoId::new(db_tx_id, 0)
+            Some(Error::NotInsertedInputUtxoIdSpent(utxo_id)) if utxo_id == &UtxoId::new(db_tx_id, 0)
         ));
     }
 
@@ -801,12 +801,12 @@ pub mod tests {
         txpool
             .insert_inner(tx1, &db)
             .await
-            .expect("Tx1 should be OK, got Err");
+            .expect("Tx1 should be Ok, got Err");
 
         let err = txpool
             .insert_inner(tx2, &db)
             .await
-            .expect_err("expected insertion failure");
+            .expect_err("Tx2 should be Err, got Ok");
         assert!(matches!(
             err.downcast_ref::<Error>(),
             Some(Error::NotInsertedLimitHit)

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -418,7 +418,7 @@ pub mod tests {
             .expect("Tx1 should be Ok, got Err");
 
         let err = txpool
-            .insert_inner(tx_faulty.clone(), &db)
+            .insert_inner(tx_faulty, &db)
             .await
             .expect_err("Tx2 should be Err, got Ok");
         assert!(matches!(
@@ -554,7 +554,7 @@ pub mod tests {
         );
 
         let err = txpool
-            .insert_inner(tx.clone(), &db)
+            .insert_inner(tx, &db)
             .await
             .expect_err("Tx should be Err, got Ok");
         assert!(matches!(

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -395,14 +395,12 @@ pub mod tests {
 
     use super::*;
     use crate::Error;
-    use fuel_core_interfaces::common::fuel_tx::{Contract, Input, Output};
-    use fuel_core_interfaces::model::{BlockHeight, Coin};
     use fuel_core_interfaces::{
         common::{
             fuel_storage::Storage,
-            fuel_tx::{TransactionBuilder, UtxoId},
+            fuel_tx::{Contract, Input, Output, TransactionBuilder, UtxoId},
         },
-        model::{CoinStatus, Message},
+        model::{BlockHeight, Coin, CoinStatus, Message},
     };
     use std::str::FromStr;
     use std::{cmp::Reverse, sync::Arc};
@@ -1161,7 +1159,7 @@ pub mod tests {
         let txs = txpool.sorted_includable();
 
         assert_eq!(txs.len(), 3, "Should have 3 txs");
-        assert_eq!(txs[0].id(), tx3.id(), "First should be tx4");
+        assert_eq!(txs[0].id(), tx3.id(), "First should be tx3");
         assert_eq!(txs[1].id(), tx1.id(), "Second should be tx1");
         assert_eq!(txs[2].id(), tx2.id(), "Third should be tx2");
     }
@@ -1243,14 +1241,13 @@ pub mod tests {
 
     #[tokio::test]
     async fn tx_at_least_min_gas_price_is_insertable() {
-        let gas_price = 10;
         let mut txpool = TxPool::new(Config {
-            min_gas_price: gas_price,
+            min_gas_price: 10,
             ..Default::default()
         });
         let db = helpers::MockDb::default();
         let tx = TransactionBuilder::script(vec![], vec![])
-            .gas_price(gas_price)
+            .gas_price(10)
             .finalize();
 
         let out = txpool.insert_inner(Arc::new(tx), &db).await;
@@ -1259,14 +1256,13 @@ pub mod tests {
 
     #[tokio::test]
     async fn tx_below_min_gas_price_is_not_insertable() {
-        let gas_price = 10;
         let mut txpool = TxPool::new(Config {
-            min_gas_price: gas_price + 1,
+            min_gas_price: 11,
             ..Default::default()
         });
         let db = helpers::MockDb::default();
         let tx = TransactionBuilder::script(vec![], vec![])
-            .gas_price(gas_price)
+            .gas_price(10)
             .finalize();
 
         let err = txpool

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -882,7 +882,7 @@ pub mod tests {
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
                 .add_output(Output::ContractCreated {
-                    contract_id: contract_id.clone(),
+                    contract_id,
                     state_root: Contract::default_state_root(),
                 })
                 .finalize(),
@@ -895,7 +895,7 @@ pub mod tests {
                     balance_root: Default::default(),
                     state_root: Default::default(),
                     tx_pointer: Default::default(),
-                    contract_id: contract_id.clone(),
+                    contract_id,
                 })
                 .finalize(),
         );
@@ -925,7 +925,7 @@ pub mod tests {
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
                 .add_output(Output::ContractCreated {
-                    contract_id: contract_id.clone(),
+                    contract_id,
                     state_root: Contract::default_state_root(),
                 })
                 .finalize(),
@@ -938,7 +938,7 @@ pub mod tests {
                     balance_root: Default::default(),
                     state_root: Default::default(),
                     tx_pointer: Default::default(),
-                    contract_id: contract_id.clone(),
+                    contract_id,
                 })
                 .finalize(),
         );

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -409,7 +409,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn simple_insertion() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let db = helpers::MockDb::default();
 
         let tx = Arc::new(
@@ -428,7 +428,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn simple_dependency_tx1_tx2() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let db = helpers::MockDb::default();
 
         let tx1 = Arc::new(
@@ -463,7 +463,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn faulty_t2_collided_on_contract_id_from_tx1() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let mut db = helpers::MockDb::default();
 
         let db_tx_id =
@@ -548,7 +548,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn fails_to_insert_tx2_with_missing_utxo_dependency_on_faulty_tx1() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let mut db = helpers::MockDb::default();
 
         let db_tx_id =
@@ -620,7 +620,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn not_inserted_known_tx() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let db = helpers::MockDb::default();
 
         let tx = Arc::new(TransactionBuilder::script(vec![], vec![]).finalize());
@@ -642,7 +642,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn try_to_insert_tx2_missing_utxo() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let db = helpers::MockDb::default();
 
         let nonexistent_id =
@@ -674,21 +674,14 @@ pub mod tests {
 
     #[tokio::test]
     async fn tx1_try_to_use_spent_coin() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let mut db = helpers::MockDb::default();
 
-        let tx0 = Arc::new(
-            TransactionBuilder::script(vec![], vec![])
-                .gas_price(10)
-                .add_output(Output::Coin {
-                    amount: Default::default(),
-                    to: Default::default(),
-                    asset_id: Default::default(),
-                })
-                .finalize(),
-        );
+        let db_tx_id =
+            TxId::from_str("0x0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
         db.insert(
-            &UtxoId::new(tx0.id(), 0),
+            &UtxoId::new(db_tx_id, 0),
             &Coin {
                 owner: Default::default(),
                 amount: Default::default(),
@@ -703,7 +696,7 @@ pub mod tests {
         let tx1 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
+                    utxo_id: UtxoId::new(db_tx_id, 0),
                     owner: Default::default(),
                     amount: Default::default(),
                     asset_id: Default::default(),
@@ -720,27 +713,20 @@ pub mod tests {
             .expect_err("Tx1 should be err");
         assert!(matches!(
             err.downcast_ref::<Error>(),
-            Some(Error::NotInsertedInputUtxoIdSpent(id)) if id == &UtxoId::new(tx0.id(), 0)
+            Some(Error::NotInsertedInputUtxoIdSpent(id)) if id == &UtxoId::new(db_tx_id, 0)
         ));
     }
 
     #[tokio::test]
     async fn more_priced_tx3_removes_tx1() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let mut db = helpers::MockDb::default();
 
-        let tx0 = Arc::new(
-            TransactionBuilder::script(vec![], vec![])
-                .gas_price(10)
-                .add_output(Output::Coin {
-                    amount: Default::default(),
-                    to: Default::default(),
-                    asset_id: Default::default(),
-                })
-                .finalize(),
-        );
+        let db_tx_id =
+            TxId::from_str("0x0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
         db.insert(
-            &UtxoId::new(tx0.id(), 0),
+            &UtxoId::new(db_tx_id, 0),
             &Coin {
                 owner: Default::default(),
                 amount: Default::default(),
@@ -756,7 +742,7 @@ pub mod tests {
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
                 .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
+                    utxo_id: UtxoId::new(db_tx_id, 0),
                     owner: Default::default(),
                     amount: Default::default(),
                     asset_id: Default::default(),
@@ -770,7 +756,7 @@ pub mod tests {
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(20)
                 .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
+                    utxo_id: UtxoId::new(db_tx_id, 0),
                     owner: Default::default(),
                     amount: Default::default(),
                     asset_id: Default::default(),
@@ -781,14 +767,11 @@ pub mod tests {
                 .finalize(),
         );
 
-        // txpool
-        //     .insert_inner(tx0, &db)
-        //     .await
-        //     .expect("Tx0 should be okay");
         txpool
             .insert_inner(tx1.clone(), &db)
             .await
             .expect("Tx1 should be okay");
+
         let vec = txpool
             .insert_inner(tx2, &db)
             .await
@@ -798,10 +781,10 @@ pub mod tests {
 
     #[tokio::test]
     async fn underpriced_tx1_not_included_coin_collision() {
-        let mut txpool = TxPool::new(Config::default());
-        let mut db = helpers::MockDb::default();
+        let mut txpool = TxPool::new(Default::default());
+        let db = helpers::MockDb::default();
 
-        let tx0 = Arc::new(
+        let tx1 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
                 .add_output(Output::Coin {
@@ -811,24 +794,11 @@ pub mod tests {
                 })
                 .finalize(),
         );
-        db.insert(
-            &UtxoId::new(tx0.id(), 0),
-            &Coin {
-                owner: Default::default(),
-                amount: Default::default(),
-                asset_id: Default::default(),
-                maturity: Default::default(),
-                status: CoinStatus::Unspent,
-                block_created: BlockHeight::default(),
-            },
-        )
-        .expect("unable to insert seed coin data");
-
-        let tx1 = Arc::new(
+        let tx2 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(20)
                 .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
+                    utxo_id: UtxoId::new(tx1.id(), 0),
                     owner: Default::default(),
                     amount: Default::default(),
                     asset_id: Default::default(),
@@ -838,11 +808,11 @@ pub mod tests {
                 })
                 .finalize(),
         );
-        let tx2 = Arc::new(
+        let tx3 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
                 .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
+                    utxo_id: UtxoId::new(tx1.id(), 0),
                     owner: Default::default(),
                     amount: Default::default(),
                     asset_id: Default::default(),
@@ -853,28 +823,28 @@ pub mod tests {
                 .finalize(),
         );
 
-        // txpool
-        //     .insert_inner(tx0, &db)
-        //     .await
-        //     .expect("Tx0 should be okay");
         txpool
-            .insert_inner(tx1, &db)
+            .insert_inner(tx1.clone(), &db)
             .await
             .expect("Tx1 should be okay");
+        txpool
+            .insert_inner(tx2.clone(), &db)
+            .await
+            .expect("Tx2 should be okay");
 
         let err = txpool
-            .insert_inner(tx2, &db)
+            .insert_inner(tx3.clone(), &db)
             .await
-            .expect_err("Tx2 should be err");
+            .expect_err("Tx3 should be err");
         assert!(matches!(
             err.downcast_ref::<Error>(),
-            Some(Error::NotInsertedCollision(_, _))
+            Some(Error::NotInsertedCollision(id, utxo_id)) if id == &tx2.id() && utxo_id == &UtxoId::new(tx1.id(), 0)
         ));
     }
 
     #[tokio::test]
     async fn overpriced_tx5_contract_input_not_inserted() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let db = helpers::MockDb::default();
 
         let contract_id = ContractId::default();
@@ -917,7 +887,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn dependent_contract_input_inserted() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let db = helpers::MockDb::default();
 
         let contract_id = ContractId::default();
@@ -951,21 +921,14 @@ pub mod tests {
 
     #[tokio::test]
     async fn more_priced_tx3_removes_tx1_and_dependent_tx2() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let mut db = helpers::MockDb::default();
 
-        let tx0 = Arc::new(
-            TransactionBuilder::script(vec![], vec![])
-                .gas_price(10)
-                .add_output(Output::Coin {
-                    amount: Default::default(),
-                    to: Default::default(),
-                    asset_id: Default::default(),
-                })
-                .finalize(),
-        );
+        let db_tx_id =
+            TxId::from_str("0x0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
         db.insert(
-            &UtxoId::new(tx0.id(), 0),
+            &UtxoId::new(db_tx_id, 0),
             &Coin {
                 owner: Default::default(),
                 amount: Default::default(),
@@ -981,7 +944,7 @@ pub mod tests {
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
                 .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
+                    utxo_id: UtxoId::new(db_tx_id, 0),
                     owner: Default::default(),
                     amount: Default::default(),
                     asset_id: Default::default(),
@@ -1014,7 +977,7 @@ pub mod tests {
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(20)
                 .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
+                    utxo_id: UtxoId::new(db_tx_id, 0),
                     owner: Default::default(),
                     amount: Default::default(),
                     asset_id: Default::default(),
@@ -1025,10 +988,6 @@ pub mod tests {
                 .finalize(),
         );
 
-        // txpool
-        //     .insert_inner(tx0.clone(), &db)
-        //     .await
-        //     .expect("Tx0 should be OK");
         txpool
             .insert_inner(tx1.clone(), &db)
             .await
@@ -1098,33 +1057,15 @@ pub mod tests {
     }
 
     #[tokio::test]
-    async fn tx2_depth_hit() {
+    async fn tx_depth_hit() {
         let mut txpool = TxPool::new(Config {
             max_depth: 1,
             ..Default::default()
         });
         let db = helpers::MockDb::default();
 
-        let tx0 = Arc::new(
-            TransactionBuilder::script(vec![], vec![])
-                .add_output(Output::Coin {
-                    amount: Default::default(),
-                    to: Default::default(),
-                    asset_id: Default::default(),
-                })
-                .finalize(),
-        );
         let tx1 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
-                .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
-                    owner: Default::default(),
-                    amount: Default::default(),
-                    asset_id: Default::default(),
-                    tx_pointer: Default::default(),
-                    witness_index: Default::default(),
-                    maturity: Default::default(),
-                })
                 .add_output(Output::Coin {
                     amount: Default::default(),
                     to: Default::default(),
@@ -1143,20 +1084,38 @@ pub mod tests {
                     witness_index: Default::default(),
                     maturity: Default::default(),
                 })
+                .add_output(Output::Coin {
+                    amount: Default::default(),
+                    to: Default::default(),
+                    asset_id: Default::default(),
+                })
+                .finalize(),
+        );
+        let tx3 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .add_input(Input::CoinSigned {
+                    utxo_id: UtxoId::new(tx2.id(), 0),
+                    owner: Default::default(),
+                    amount: Default::default(),
+                    asset_id: Default::default(),
+                    tx_pointer: Default::default(),
+                    witness_index: Default::default(),
+                    maturity: Default::default(),
+                })
                 .finalize(),
         );
 
         txpool
-            .insert_inner(tx0, &db)
+            .insert_inner(tx1, &db)
             .await
             .expect("Tx1 should be OK");
         txpool
-            .insert_inner(tx1, &db)
+            .insert_inner(tx2, &db)
             .await
             .expect("Tx1 should be OK");
 
         let err = txpool
-            .insert_inner(tx2, &db)
+            .insert_inner(tx3, &db)
             .await
             .expect_err("expected insertion failure");
         assert!(matches!(
@@ -1167,7 +1126,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn sorted_out_tx1_2_4() {
-        let mut txpool = TxPool::new(Config::default());
+        let mut txpool = TxPool::new(Default::default());
         let db = helpers::MockDb::default();
 
         let tx1 = Arc::new(
@@ -1180,7 +1139,7 @@ pub mod tests {
                 .gas_price(9)
                 .finalize(),
         );
-        let tx4 = Arc::new(
+        let tx3 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(20)
                 .finalize(),
@@ -1195,58 +1154,26 @@ pub mod tests {
             .await
             .expect("Tx2 should be OK, get err:{:?}");
         txpool
-            .insert_inner(tx4.clone(), &db)
+            .insert_inner(tx3.clone(), &db)
             .await
             .expect("Tx4 should be OK, get err:{:?}");
 
         let txs = txpool.sorted_includable();
 
         assert_eq!(txs.len(), 3, "Should have 3 txs");
-        assert_eq!(txs[0].id(), tx4.id(), "First should be tx4");
+        assert_eq!(txs[0].id(), tx3.id(), "First should be tx4");
         assert_eq!(txs[1].id(), tx1.id(), "Second should be tx1");
         assert_eq!(txs[2].id(), tx2.id(), "Third should be tx2");
     }
 
     #[tokio::test]
     async fn find_dependent_tx1_tx2() {
-        let mut txpool = TxPool::new(Config::default());
-        let mut db = helpers::MockDb::default();
-
-        let tx0 = Arc::new(
-            TransactionBuilder::script(vec![], vec![])
-                .gas_price(10)
-                .add_output(Output::Coin {
-                    amount: Default::default(),
-                    to: Default::default(),
-                    asset_id: Default::default(),
-                })
-                .finalize(),
-        );
-        db.insert(
-            &UtxoId::new(tx0.id(), 0),
-            &Coin {
-                owner: Default::default(),
-                amount: Default::default(),
-                asset_id: Default::default(),
-                maturity: Default::default(),
-                status: CoinStatus::Unspent,
-                block_created: BlockHeight::default(),
-            },
-        )
-        .expect("unable to insert seed coin data");
+        let mut txpool = TxPool::new(Default::default());
+        let db = helpers::MockDb::default();
 
         let tx1 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
-                .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx0.id(), 0),
-                    owner: Default::default(),
-                    amount: Default::default(),
-                    asset_id: Default::default(),
-                    tx_pointer: Default::default(),
-                    witness_index: Default::default(),
-                    maturity: Default::default(),
-                })
                 .add_output(Output::Coin {
                     amount: Default::default(),
                     to: Default::default(),
@@ -1256,9 +1183,28 @@ pub mod tests {
         );
         let tx2 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
-                .gas_price(9)
+                .gas_price(10)
                 .add_input(Input::CoinSigned {
                     utxo_id: UtxoId::new(tx1.id(), 0),
+                    owner: Default::default(),
+                    amount: Default::default(),
+                    asset_id: Default::default(),
+                    tx_pointer: Default::default(),
+                    witness_index: Default::default(),
+                    maturity: Default::default(),
+                })
+                .add_output(Output::Coin {
+                    amount: Default::default(),
+                    to: Default::default(),
+                    asset_id: Default::default(),
+                })
+                .finalize(),
+        );
+        let tx3 = Arc::new(
+            TransactionBuilder::script(vec![], vec![])
+                .gas_price(9)
+                .add_input(Input::CoinSigned {
+                    utxo_id: UtxoId::new(tx2.id(), 0),
                     owner: Default::default(),
                     amount: Default::default(),
                     asset_id: Default::default(),
@@ -1269,30 +1215,30 @@ pub mod tests {
                 .finalize(),
         );
 
-        // txpool
-        //     .insert_inner(tx0.clone(), &db)
-        //     .await
-        //     .expect("Tx0 should be OK, get err:{:?}");
         txpool
             .insert_inner(tx1.clone(), &db)
             .await
-            .expect("Tx1 should be OK, get err:{:?}");
+            .expect("Tx0 should be OK, get err:{:?}");
         txpool
             .insert_inner(tx2.clone(), &db)
+            .await
+            .expect("Tx1 should be OK, get err:{:?}");
+        txpool
+            .insert_inner(tx3.clone(), &db)
             .await
             .expect("Tx2 should be OK, get err:{:?}");
 
         let mut seen = HashMap::new();
         txpool
             .dependency()
-            .find_dependent(tx2.clone(), &mut seen, txpool.txs());
+            .find_dependent(tx3.clone(), &mut seen, txpool.txs());
 
         let mut list: Vec<ArcTx> = seen.into_iter().map(|(_, tx)| tx).collect();
         // sort from high to low price
         list.sort_by_key(|tx| Reverse(tx.gas_price()));
         assert_eq!(list.len(), 2, "We should have two items");
-        assert_eq!(list[0].id(), tx1.id(), "Tx1 should be first.");
-        assert_eq!(list[1].id(), tx2.id(), "Tx2 should be second.");
+        assert_eq!(list[0].id(), tx2.id(), "Tx2 should be first.");
+        assert_eq!(list[1].id(), tx3.id(), "Tx3 should be second.");
     }
 
     #[tokio::test]
@@ -1300,7 +1246,7 @@ pub mod tests {
         let gas_price = 10;
         let mut txpool = TxPool::new(Config {
             min_gas_price: gas_price,
-            ..Config::default()
+            ..Default::default()
         });
         let db = helpers::MockDb::default();
         let tx = TransactionBuilder::script(vec![], vec![])
@@ -1316,7 +1262,7 @@ pub mod tests {
         let gas_price = 10;
         let mut txpool = TxPool::new(Config {
             min_gas_price: gas_price + 1,
-            ..Config::default()
+            ..Default::default()
         });
         let db = helpers::MockDb::default();
         let tx = TransactionBuilder::script(vec![], vec![])

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -403,7 +403,6 @@ pub mod tests {
                 .add_output(create_contract_output(contract_id))
                 .finalize(),
         );
-
         let tx_faulty = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(9)
@@ -458,7 +457,6 @@ pub mod tests {
                 .add_output(create_contract_output(contract_id))
                 .finalize(),
         );
-
         let tx = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .add_input(create_coin_input(tx_faulty.id(), 0))

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -700,8 +700,10 @@ pub mod tests {
         let tx2 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
-                    contract_id,
-                })
+                .add_input(create_contract_input(
+                    Default::default(),
+                    Default::default(),
+                ))
                 .finalize(),
         );
 
@@ -735,21 +737,14 @@ pub mod tests {
         let tx1 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
-                .add_input(Input::CoinSigned {
+                .add_input(create_coin_input(db_tx_id, 0))
+                .add_output(create_coin_output())
                 .finalize(),
         );
         let tx2 = Arc::new(
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(9)
-                .add_input(Input::CoinSigned {
-                    utxo_id: UtxoId::new(tx1.id(), 0),
-                    owner: Default::default(),
-                    amount: Default::default(),
-                    asset_id: Default::default(),
-                    tx_pointer: Default::default(),
-                    witness_index: Default::default(),
-                    maturity: Default::default(),
-                })
+                .add_input(create_coin_input(tx1.id(), 0))
                 .finalize(),
         );
         let tx3 = Arc::new(

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -523,7 +523,7 @@ pub mod tests {
             TransactionBuilder::script(vec![], vec![])
                 .gas_price(10)
                 .add_output(Output::Coin {
-                    amount: 100,
+                    amount: Default::default(),
                     to: Default::default(),
                     asset_id: Default::default(),
                 })
@@ -533,7 +533,7 @@ pub mod tests {
             &UtxoId::new(tx0.id(), 0),
             &Coin {
                 owner: Default::default(),
-                amount: 100,
+                amount: Default::default(),
                 asset_id: Default::default(),
                 maturity: Default::default(),
                 status: CoinStatus::Spent,
@@ -547,7 +547,7 @@ pub mod tests {
                 .add_input(Input::CoinSigned {
                     utxo_id: UtxoId::new(tx0.id(), 0),
                     owner: Default::default(),
-                    amount: 100,
+                    amount: Default::default(),
                     asset_id: Default::default(),
                     tx_pointer: Default::default(),
                     witness_index: Default::default(),


### PR DESCRIPTION
Related issues:
- closes https://github.com/FuelLabs/fuel-core/issues/561
- progresses https://github.com/FuelLabs/fuel-core/issues/517

This PR refactors all tests in the fuel-txpool submodule to remove usages of the pre-seeded `DummyDb`. Tests now use a lightweight, empty by default database `MockDb`. 

This approach has some advantages:
- All tests are now responsible for their own setup and teardown. Tests are no longer sensitive to changes to external state.
- All tests communicate their required initial state through explicit setup code. The tests more clearly which transactions in the tests are valid or invalid, and how dependencies are structured. Test setup is no longer implicit or hidden in other files.

On the other side, this has some small disadvantages:
- Tests are now verbose and require more lines of code to setup, including bulky setups for the transactions

In my opinion, the advantages far outweigh the disadvantages and I believe this approach is superior to using a pre-seeded database.

In doing this refactor I noticed some things that I think should be addressed:
- Test names are frequently not descriptive; readers must try to infer the goal of the test by reading the code
- Many error cases are untested. Specifically, I noticed the following errors are not tested:
    - `NotInsertedOutputNotExisting` (code search shows this isn't even thrown)
    - `NotInsertedInputContractNotExisting`
    - `NotInsertedContractIdAlreadyTaken`
    - `NotInsertedIoWrongOwner` (checked in `dependency.rs` but not in any txpool tests)
    - `NotInsertedIoWrongAmount` (checked in `dependency.rs` but not in any txpool tests)
    - `NotInsertedIoWrongAssetId` (checked in `dependency.rs` but not in any txpool tests)
    - `NotInsertedIoWrongMessageId`
    - `NotInsertedIoContractOutput` (checked in `dependency.rs` but not in any txpool tests)
    - `NotInsertedIoMessageInput` (checked in `dependency.rs` but not in any txpool tests)
- Inconsistencies in field names across structs make code confusing, e.g.,
    - `CoinState::is_spend_by` vs. `ContractState::used_by` vs. `MessageState::spent_by`
- Some instances of awkward phrasing in error names and messages, e.g.,
    - `NotInsertedInputUtxoIdNotExisting` should be `NotInsertedInputUtxoIdDoesNotExist`