### PR TITLE
feat: Update Relayer to use module level MockDb

### DIFF
--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -342,11 +342,9 @@ impl FinalizationQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::log::tests::*;
-    use crate::mock_db::MockDb;
+    use crate::{log::tests::*, mock_db::MockDb};
     use fuel_core_interfaces::common::fuel_types::Address;
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{rngs::StdRng, Rng, SeedableRng};
 
     #[tokio::test]
     pub async fn check_messages_on_multiple_eth_blocks() {

--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -341,10 +341,10 @@ impl FinalizationQueue {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::log::tests::*;
-    use fuel_core_interfaces::{common::fuel_types::Address, db::helpers::DummyDb};
+    use crate::mock_db::MockDb;
+    use fuel_core_interfaces::common::fuel_types::Address;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
@@ -477,26 +477,45 @@ mod tests {
             ])
             .await;
 
-        let mut db = DummyDb::filled();
+        let mut db = MockDb::default();
 
         queue.commit_diffs(&mut db, 1).await;
-        assert_eq!(db.data.lock().validators.get(&v1), Some(&(0, Some(c1))),);
-        assert_eq!(db.data.lock().validators.get(&v2), None,);
-        assert_eq!(db.data.lock().messages.len(), 0,);
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v1),
+            Some(&(0, Some(c1))),
+        );
+        assert_eq!(db.data.lock().unwrap().validators.get(&v2), None,);
+        assert_eq!(db.data.lock().unwrap().messages.len(), 0,);
 
         queue.commit_diffs(&mut db, 2).await;
-        assert_eq!(db.data.lock().validators.get(&v2), Some(&(0, Some(c2))),);
-        assert_eq!(db.data.lock().messages.len(), 1,);
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v2),
+            Some(&(0, Some(c2))),
+        );
+        assert_eq!(db.data.lock().unwrap().messages.len(), 1,);
         // ensure committed message id matches message id from the log
         assert_eq!(
-            db.data.lock().messages.values().next().unwrap().id(),
+            db.data
+                .lock()
+                .unwrap()
+                .messages
+                .values()
+                .next()
+                .unwrap()
+                .id(),
             test_message.id()
         );
 
         queue.commit_diffs(&mut db, 3).await;
-        assert_eq!(db.data.lock().validators.get(&v1), Some(&(0, None)),);
-        assert_eq!(db.data.lock().validators.get(&v2), Some(&(0, Some(c2))),);
-        assert_eq!(db.data.lock().messages.len(), 1,);
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v1),
+            Some(&(0, None)),
+        );
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v2),
+            Some(&(0, Some(c2))),
+        );
+        assert_eq!(db.data.lock().unwrap().messages.len(), 1,);
     }
 
     #[tokio::test]
@@ -533,20 +552,36 @@ mod tests {
                 eth_log_withdrawal(3, delegator1, 7),
             ])
             .await;
-        let mut db = DummyDb::filled();
+
+        let mut db = MockDb::default();
 
         queue.commit_diffs(&mut db, 1).await;
-        assert_eq!(db.data.lock().validators.get(&v1), Some(&(s1, None)),);
-        assert_eq!(db.data.lock().validators.get(&v2), Some(&(s2, None)),);
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v1),
+            Some(&(s1, None)),
+        );
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v2),
+            Some(&(s2, None)),
+        );
 
         queue.commit_diffs(&mut db, 2).await;
         let s13 = s1 + s3;
-        assert_eq!(db.data.lock().validators.get(&v1), Some(&(s13, Some(c1))),);
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v1),
+            Some(&(s13, Some(c1))),
+        );
 
         queue.commit_diffs(&mut db, 3).await;
 
-        assert_eq!(db.data.lock().validators.get(&v1), Some(&(s3, Some(c1))),);
-        assert_eq!(db.data.lock().validators.get(&v2), Some(&(0, None)),);
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v1),
+            Some(&(s3, Some(c1))),
+        );
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v2),
+            Some(&(0, None)),
+        );
     }
 
     #[tokio::test]
@@ -583,15 +618,28 @@ mod tests {
                 eth_log_withdrawal(2, delegator2, 0), // amount does nothing
             ])
             .await;
-        let mut db = DummyDb::filled();
+
+        let mut db = MockDb::default();
 
         queue.commit_diffs(&mut db, 1).await;
-        assert_eq!(db.data.lock().validators.get(&v1), Some(&(s1, None)),);
-        assert_eq!(db.data.lock().validators.get(&v2), Some(&(s1, None)),);
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v1),
+            Some(&(s1, None)),
+        );
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v2),
+            Some(&(s1, None)),
+        );
 
         queue.commit_diffs(&mut db, 2).await;
-        assert_eq!(db.data.lock().validators.get(&v1), Some(&(s1, None)),);
-        assert_eq!(db.data.lock().validators.get(&v2), Some(&(0, None)),);
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v1),
+            Some(&(s1, None)),
+        );
+        assert_eq!(
+            db.data.lock().unwrap().validators.get(&v2),
+            Some(&(0, None)),
+        );
     }
 
     #[tokio::test]
@@ -662,7 +710,8 @@ mod tests {
 
         queue.append_eth_logs(vec![reg1_revert, reg2_revert]).await;
 
-        let mut db = DummyDb::filled();
+        let mut db = MockDb::default();
+
         queue.commit_diffs(&mut db, 1).await;
 
         assert_eq!(queue.pending.len(), 0)
@@ -708,7 +757,8 @@ mod tests {
                 eth_log_withdrawal(4, delegator2, 0),
             ])
             .await;
-        let mut db = DummyDb::filled();
+
+        let mut db = MockDb::default();
 
         // finalize all logs
         queue.commit_diffs(&mut db, 5).await;

--- a/fuel-relayer/src/lib.rs
+++ b/fuel-relayer/src/lib.rs
@@ -5,6 +5,8 @@ pub(crate) mod log;
 pub(crate) mod pending_blocks;
 pub(crate) mod validators;
 
+#[cfg(test)]
+mod mock_db;
 mod relayer;
 mod service;
 #[cfg(test)]

--- a/fuel-relayer/src/mock_db.rs
+++ b/fuel-relayer/src/mock_db.rs
@@ -1,0 +1,227 @@
+use async_trait::async_trait;
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use fuel_core_interfaces::common::fuel_tx::Address;
+use fuel_core_interfaces::model::{
+    BlockHeight, ConsensusId, DaBlockHeight, SealedFuelBlock, ValidatorId, ValidatorStake,
+};
+use fuel_core_interfaces::relayer::{RelayerDb, StakingDiff, ValidatorSet};
+use fuel_core_interfaces::{
+    common::{fuel_storage::Storage, fuel_tx::MessageId},
+    db::KvStoreError,
+    model::Message,
+};
+
+#[derive(Default)]
+pub(crate) struct Data {
+    pub messages: HashMap<MessageId, Message>,
+    pub validators: HashMap<ValidatorId, (ValidatorStake, Option<ConsensusId>)>,
+    pub delegator_index: HashMap<Address, Vec<DaBlockHeight>>,
+    pub staking_diffs: HashMap<DaBlockHeight, StakingDiff>,
+
+    pub chain_height: BlockHeight,
+    pub sealed_blocks: HashMap<BlockHeight, Arc<SealedFuelBlock>>,
+    pub validators_height: DaBlockHeight,
+    pub finalized_da_height: DaBlockHeight,
+    pub last_committed_finalized_fuel_height: BlockHeight,
+}
+
+#[derive(Default)]
+pub(crate) struct MockDb {
+    pub data: Arc<Mutex<Data>>,
+}
+
+impl Storage<MessageId, Message> for MockDb {
+    type Error = KvStoreError;
+
+    fn insert(&mut self, key: &MessageId, value: &Message) -> Result<Option<Message>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .messages
+            .insert(*key, value.clone()))
+    }
+
+    fn remove(&mut self, key: &MessageId) -> Result<Option<Message>, Self::Error> {
+        Ok(self.data.lock().unwrap().messages.remove(key))
+    }
+
+    fn get(&self, key: &MessageId) -> Result<Option<Cow<Message>>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .messages
+            .get(key)
+            .map(|i| Cow::Owned(i.clone())))
+    }
+
+    fn contains_key(&self, key: &MessageId) -> Result<bool, Self::Error> {
+        Ok(self.data.lock().unwrap().messages.contains_key(key))
+    }
+}
+
+impl Storage<ValidatorId, (ValidatorStake, Option<ConsensusId>)> for MockDb {
+    type Error = KvStoreError;
+
+    fn insert(
+        &mut self,
+        key: &ValidatorId,
+        value: &(ValidatorStake, Option<ConsensusId>),
+    ) -> Result<Option<(ValidatorStake, Option<ConsensusId>)>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .validators
+            .insert(*key, value.clone()))
+    }
+
+    fn remove(
+        &mut self,
+        key: &ValidatorId,
+    ) -> Result<Option<(ValidatorStake, Option<ConsensusId>)>, Self::Error> {
+        Ok(self.data.lock().unwrap().validators.remove(key))
+    }
+
+    fn get(
+        &self,
+        key: &ValidatorId,
+    ) -> Result<Option<Cow<(ValidatorStake, Option<ConsensusId>)>>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .validators
+            .get(key)
+            .map(|i| Cow::Owned(i.clone())))
+    }
+
+    fn contains_key(&self, key: &ValidatorId) -> Result<bool, Self::Error> {
+        Ok(self.data.lock().unwrap().validators.contains_key(key))
+    }
+}
+
+impl Storage<Address, Vec<DaBlockHeight>> for MockDb {
+    type Error = KvStoreError;
+
+    fn insert(
+        &mut self,
+        key: &Address,
+        value: &Vec<DaBlockHeight>,
+    ) -> Result<Option<Vec<DaBlockHeight>>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .delegator_index
+            .insert(*key, value.clone()))
+    }
+
+    fn remove(&mut self, key: &Address) -> Result<Option<Vec<DaBlockHeight>>, Self::Error> {
+        Ok(self.data.lock().unwrap().delegator_index.remove(key))
+    }
+
+    fn get(&self, key: &Address) -> Result<Option<Cow<Vec<DaBlockHeight>>>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .delegator_index
+            .get(key)
+            .map(|i| Cow::Owned(i.clone())))
+    }
+
+    fn contains_key(&self, key: &Address) -> Result<bool, Self::Error> {
+        Ok(self.data.lock().unwrap().delegator_index.contains_key(key))
+    }
+}
+
+impl Storage<DaBlockHeight, StakingDiff> for MockDb {
+    type Error = KvStoreError;
+
+    fn insert(
+        &mut self,
+        key: &DaBlockHeight,
+        value: &StakingDiff,
+    ) -> Result<Option<StakingDiff>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .staking_diffs
+            .insert(*key, value.clone()))
+    }
+
+    fn remove(&mut self, key: &DaBlockHeight) -> Result<Option<StakingDiff>, Self::Error> {
+        Ok(self.data.lock().unwrap().staking_diffs.remove(key))
+    }
+
+    fn get(&self, key: &DaBlockHeight) -> Result<Option<Cow<StakingDiff>>, Self::Error> {
+        Ok(self
+            .data
+            .lock()
+            .unwrap()
+            .staking_diffs
+            .get(key)
+            .map(|i| Cow::Owned(i.clone())))
+    }
+
+    fn contains_key(&self, key: &DaBlockHeight) -> Result<bool, Self::Error> {
+        Ok(self.data.lock().unwrap().staking_diffs.contains_key(key))
+    }
+}
+
+#[async_trait]
+impl RelayerDb for MockDb {
+    async fn get_chain_height(&self) -> BlockHeight {
+        self.data.lock().unwrap().chain_height
+    }
+
+    async fn get_sealed_block(&self, height: BlockHeight) -> Option<Arc<SealedFuelBlock>> {
+        self.data
+            .lock()
+            .unwrap()
+            .sealed_blocks
+            .get(&height)
+            .cloned()
+    }
+
+    async fn get_validators(&self) -> ValidatorSet {
+        self.data.lock().unwrap().validators.clone()
+    }
+
+    async fn set_validators_da_height(&self, height: DaBlockHeight) {
+        self.data.lock().unwrap().validators_height = height;
+    }
+
+    async fn get_validators_da_height(&self) -> DaBlockHeight {
+        self.data.lock().unwrap().validators_height
+    }
+
+    async fn set_finalized_da_height(&self, height: DaBlockHeight) {
+        self.data.lock().unwrap().finalized_da_height = height;
+    }
+
+    async fn get_finalized_da_height(&self) -> DaBlockHeight {
+        self.data.lock().unwrap().finalized_da_height
+    }
+
+    async fn get_last_committed_finalized_fuel_height(&self) -> BlockHeight {
+        self.data
+            .lock()
+            .unwrap()
+            .last_committed_finalized_fuel_height
+    }
+
+    async fn set_last_committed_finalized_fuel_height(&self, block_height: BlockHeight) {
+        self.data
+            .lock()
+            .unwrap()
+            .last_committed_finalized_fuel_height = block_height;
+    }
+}

--- a/fuel-relayer/src/mock_db.rs
+++ b/fuel-relayer/src/mock_db.rs
@@ -1,18 +1,22 @@
 use async_trait::async_trait;
 
-use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap};
-use std::sync::{Arc, Mutex};
-
-use fuel_core_interfaces::common::fuel_tx::Address;
-use fuel_core_interfaces::model::{
-    BlockHeight, ConsensusId, DaBlockHeight, SealedFuelBlock, ValidatorId, ValidatorStake,
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap},
+    sync::{Arc, Mutex},
 };
-use fuel_core_interfaces::relayer::{RelayerDb, StakingDiff, ValidatorSet};
+
 use fuel_core_interfaces::{
-    common::{fuel_storage::Storage, fuel_tx::MessageId},
+    common::{
+        fuel_storage::Storage,
+        fuel_tx::{Address, MessageId},
+    },
     db::KvStoreError,
-    model::Message,
+    model::{
+        BlockHeight, ConsensusId, DaBlockHeight, Message, SealedFuelBlock, ValidatorId,
+        ValidatorStake,
+    },
+    relayer::{RelayerDb, StakingDiff, ValidatorSet},
 };
 
 #[derive(Default)]

--- a/fuel-relayer/src/mock_db.rs
+++ b/fuel-relayer/src/mock_db.rs
@@ -82,12 +82,7 @@ impl Storage<ValidatorId, (ValidatorStake, Option<ConsensusId>)> for MockDb {
         key: &ValidatorId,
         value: &(ValidatorStake, Option<ConsensusId>),
     ) -> Result<Option<(ValidatorStake, Option<ConsensusId>)>, Self::Error> {
-        Ok(self
-            .data
-            .lock()
-            .unwrap()
-            .validators
-            .insert(*key, value.clone()))
+        Ok(self.data.lock().unwrap().validators.insert(*key, *value))
     }
 
     fn remove(
@@ -107,7 +102,7 @@ impl Storage<ValidatorId, (ValidatorStake, Option<ConsensusId>)> for MockDb {
             .unwrap()
             .validators
             .get(key)
-            .map(|i| Cow::Owned(i.clone())))
+            .map(|i| Cow::Owned(*i)))
     }
 
     fn contains_key(&self, key: &ValidatorId) -> Result<bool, Self::Error> {

--- a/fuel-relayer/src/mock_db.rs
+++ b/fuel-relayer/src/mock_db.rs
@@ -34,6 +34,15 @@ pub(crate) struct MockDb {
     pub data: Arc<Mutex<Data>>,
 }
 
+impl MockDb {
+    pub fn tap_sealed_blocks_mut<F, R>(&mut self, func: F) -> R
+    where
+        F: Fn(&mut HashMap<BlockHeight, Arc<SealedFuelBlock>>) -> R,
+    {
+        func(&mut self.data.lock().unwrap().sealed_blocks)
+    }
+}
+
 impl Storage<MessageId, Message> for MockDb {
     type Error = KvStoreError;
 

--- a/fuel-relayer/src/mock_db.rs
+++ b/fuel-relayer/src/mock_db.rs
@@ -240,7 +240,6 @@ impl RelayerDb for MockDb {
     ) -> Vec<(DaBlockHeight, StakingDiff)> {
         let mut out = Vec::new();
         let diffs = &self.data.lock().unwrap().staking_diffs;
-        // in BTreeMap iteration are done on sorted items.
         for (block, diff) in diffs {
             if *block >= from_da_height {
                 if let Some(end_block) = to_da_height {

--- a/fuel-relayer/src/pending_blocks.rs
+++ b/fuel-relayer/src/pending_blocks.rs
@@ -576,13 +576,11 @@ mod tests {
         let mut db = Box::new(MockDb::default());
 
         db.tap_sealed_blocks_mut(|sealed_blocks| {
-            let block = SealedFuelBlock::default();
-
-            let mut block1 = block.clone();
+            let mut block1 = SealedFuelBlock::default();
             block1.block.header.height = 1u64.into();
-            let mut block2 = block.clone();
+            let mut block2 = SealedFuelBlock::default();
             block2.block.header.height = 2u64.into();
-            let mut block3 = block.clone();
+            let mut block3 = SealedFuelBlock::default();
             block3.block.header.height = 3u64.into();
 
             sealed_blocks.insert(1u64.into(), Arc::new(block1));
@@ -608,13 +606,11 @@ mod tests {
         blocks.handle_block_commit(b1, 2u64.into(), 2, IsReverted::False);
 
         db.tap_sealed_blocks_mut(|sealed_blocks| {
-            let block = SealedFuelBlock::default();
-
-            let mut block1 = block.clone();
+            let mut block1 = SealedFuelBlock::default();
             block1.block.header.height = 1u64.into();
-            let mut block2 = block.clone();
+            let mut block2 = SealedFuelBlock::default();
             block2.block.header.height = 2u64.into();
-            let mut block3 = block.clone();
+            let mut block3 = SealedFuelBlock::default();
             block3.block.header.height = 3u64.into();
 
             sealed_blocks.insert(1u64.into(), Arc::new(block1));
@@ -651,15 +647,13 @@ mod tests {
         blocks.handle_block_commit(b2, 3u64.into(), 3, IsReverted::True);
 
         db.tap_sealed_blocks_mut(|sealed_blocks| {
-            let block = SealedFuelBlock::default();
-
-            let mut block1 = block.clone();
+            let mut block1 = SealedFuelBlock::default();
             block1.block.header.height = 1u64.into();
-            let mut block2 = block.clone();
+            let mut block2 = SealedFuelBlock::default();
             block2.block.header.height = 2u64.into();
-            let mut block3 = block.clone();
+            let mut block3 = SealedFuelBlock::default();
             block3.block.header.height = 3u64.into();
-            let mut block4 = block.clone();
+            let mut block4 = SealedFuelBlock::default();
             block4.block.header.height = 4u64.into();
 
             sealed_blocks.insert(1u64.into(), Arc::new(block1));

--- a/fuel-relayer/src/pending_blocks.rs
+++ b/fuel-relayer/src/pending_blocks.rs
@@ -399,7 +399,6 @@ impl PendingBlocks {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
-    use fuel_core_interfaces::db::helpers::DummyDb;
     use rand::{prelude::StdRng, Rng, SeedableRng};
 
     use super::*;
@@ -594,28 +593,18 @@ mod tests {
             },
         };
 
-        let mut block1 = block.clone();
-        block1.block.header.height = 1u64.into();
-        let mut block2 = block.clone();
-        block2.block.header.height = 2u64.into();
-        let mut block3 = block.clone();
-        block3.block.header.height = 3u64.into();
+        db.tap_sealed_blocks_mut(|sealed_blocks| {
+            let mut block1 = block.clone();
+            block1.block.header.height = 1u64.into();
+            let mut block2 = block.clone();
+            block2.block.header.height = 2u64.into();
+            let mut block3 = block.clone();
+            block3.block.header.height = 3u64.into();
 
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(1u64.into(), Arc::new(block1));
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(2u64.into(), Arc::new(block2));
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(3u64.into(), Arc::new(block3));
+            sealed_blocks.insert(1u64.into(), Arc::new(block1));
+            sealed_blocks.insert(2u64.into(), Arc::new(block2));
+            sealed_blocks.insert(3u64.into(), Arc::new(block3));
+        });
 
         let out = blocks.bundle(3u64.into(), db.as_mut()).await;
         assert_eq!(out.len(), 3, "We should have bundled 3 blocks");
@@ -649,28 +638,18 @@ mod tests {
             },
         };
 
-        let mut block1 = block.clone();
-        block1.block.header.height = 1u64.into();
-        let mut block2 = block.clone();
-        block2.block.header.height = 2u64.into();
-        let mut block3 = block.clone();
-        block3.block.header.height = 3u64.into();
+        db.tap_sealed_blocks_mut(|sealed_blocks| {
+            let mut block1 = block.clone();
+            block1.block.header.height = 1u64.into();
+            let mut block2 = block.clone();
+            block2.block.header.height = 2u64.into();
+            let mut block3 = block.clone();
+            block3.block.header.height = 3u64.into();
 
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(1u64.into(), Arc::new(block1));
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(2u64.into(), Arc::new(block2));
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(3u64.into(), Arc::new(block3));
+            sealed_blocks.insert(1u64.into(), Arc::new(block1));
+            sealed_blocks.insert(2u64.into(), Arc::new(block2));
+            sealed_blocks.insert(3u64.into(), Arc::new(block3));
+        });
 
         let out = blocks.bundle(3u64.into(), db.as_mut()).await;
         assert_eq!(out.len(), 2, "We should have bundled 2 blocks");
@@ -715,35 +694,21 @@ mod tests {
             },
         };
 
-        let mut block1 = block.clone();
-        block1.block.header.height = 1u64.into();
-        let mut block2 = block.clone();
-        block2.block.header.height = 2u64.into();
-        let mut block3 = block.clone();
-        block3.block.header.height = 3u64.into();
-        let mut block4 = block.clone();
-        block4.block.header.height = 4u64.into();
+        db.tap_sealed_blocks_mut(|sealed_blocks| {
+            let mut block1 = block.clone();
+            block1.block.header.height = 1u64.into();
+            let mut block2 = block.clone();
+            block2.block.header.height = 2u64.into();
+            let mut block3 = block.clone();
+            block3.block.header.height = 3u64.into();
+            let mut block4 = block.clone();
+            block4.block.header.height = 4u64.into();
 
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(1u64.into(), Arc::new(block1));
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(2u64.into(), Arc::new(block2));
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(3u64.into(), Arc::new(block3));
-        db.data
-            .lock()
-            .unwrap()
-            .sealed_blocks
-            .insert(4u64.into(), Arc::new(block4));
+            sealed_blocks.insert(1u64.into(), Arc::new(block1));
+            sealed_blocks.insert(2u64.into(), Arc::new(block2));
+            sealed_blocks.insert(3u64.into(), Arc::new(block3));
+            sealed_blocks.insert(4u64.into(), Arc::new(block4));
+        });
 
         let out = blocks.bundle(4u64.into(), db.as_mut()).await;
         assert_eq!(out.len(), 3, "We should have bundled 3 blocks");

--- a/fuel-relayer/src/pending_blocks.rs
+++ b/fuel-relayer/src/pending_blocks.rs
@@ -398,12 +398,9 @@ impl PendingBlocks {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
-    use rand::{prelude::StdRng, Rng, SeedableRng};
-
     use super::*;
     use crate::mock_db::MockDb;
-    use fuel_core_interfaces::model::{FuelBlock, FuelBlockConsensus, FuelBlockHeader};
+    use rand::{prelude::StdRng, Rng, SeedableRng};
     use tracing_test::traced_test;
 
     pub fn block_commit(last_committed_fuel_block: BlockHeight) -> PendingBlocks {
@@ -578,22 +575,9 @@ mod tests {
         let mut blocks = block_commit(1u64.into());
         let mut db = Box::new(MockDb::default());
 
-        let block = SealedFuelBlock {
-            block: FuelBlock {
-                header: FuelBlockHeader {
-                    number: BlockHeight::from(2u64),
-                    time: Utc::now(),
-                    ..Default::default()
-                },
-                transactions: Vec::new(),
-            },
-            consensus: FuelBlockConsensus {
-                required_stake: 10,
-                ..Default::default()
-            },
-        };
-
         db.tap_sealed_blocks_mut(|sealed_blocks| {
+            let block = SealedFuelBlock::default();
+
             let mut block1 = block.clone();
             block1.block.header.height = 1u64.into();
             let mut block2 = block.clone();
@@ -623,22 +607,9 @@ mod tests {
         let mut db = Box::new(MockDb::default());
         blocks.handle_block_commit(b1, 2u64.into(), 2, IsReverted::False);
 
-        let block = SealedFuelBlock {
-            block: FuelBlock {
-                header: FuelBlockHeader {
-                    number: BlockHeight::from(2u64),
-                    time: Utc::now(),
-                    ..Default::default()
-                },
-                transactions: Vec::new(),
-            },
-            consensus: FuelBlockConsensus {
-                required_stake: 10,
-                ..Default::default()
-            },
-        };
-
         db.tap_sealed_blocks_mut(|sealed_blocks| {
+            let block = SealedFuelBlock::default();
+
             let mut block1 = block.clone();
             block1.block.header.height = 1u64.into();
             let mut block2 = block.clone();
@@ -679,22 +650,9 @@ mod tests {
         blocks.handle_block_commit(b2, 3u64.into(), 3, IsReverted::False);
         blocks.handle_block_commit(b2, 3u64.into(), 3, IsReverted::True);
 
-        let block = SealedFuelBlock {
-            block: FuelBlock {
-                header: FuelBlockHeader {
-                    number: BlockHeight::from(2u64),
-                    time: Utc::now(),
-                    ..Default::default()
-                },
-                transactions: Vec::new(),
-            },
-            consensus: FuelBlockConsensus {
-                required_stake: 10,
-                ..Default::default()
-            },
-        };
-
         db.tap_sealed_blocks_mut(|sealed_blocks| {
+            let block = SealedFuelBlock::default();
+
             let mut block1 = block.clone();
             block1.block.header.height = 1u64.into();
             let mut block2 = block.clone();

--- a/fuel-relayer/src/test_helpers/mod.rs
+++ b/fuel-relayer/src/test_helpers/mod.rs
@@ -6,6 +6,7 @@ use fuel_core_interfaces::{
 };
 use tokio::sync::{broadcast, mpsc};
 
+use crate::mock_db::MockDb;
 use crate::{service::Context, Config, Relayer};
 
 pub async fn relayer(
@@ -15,7 +16,7 @@ pub async fn relayer(
     mpsc::Sender<RelayerRequest>,
     broadcast::Sender<ImportBlockBroadcast>,
 ) {
-    let db = Box::new(DummyDb::filled());
+    let db = Box::new(MockDb::default());
     let (request_sender, receiver) = mpsc::channel(10);
     let (broadcast_tx, new_block_event) = broadcast::channel(100);
     let private_key =

--- a/fuel-relayer/src/test_helpers/mod.rs
+++ b/fuel-relayer/src/test_helpers/mod.rs
@@ -1,9 +1,7 @@
 pub mod middleware;
 pub use middleware::*;
 
-use fuel_core_interfaces::{
-    block_importer::ImportBlockBroadcast, db::helpers::DummyDb, relayer::RelayerRequest,
-};
+use fuel_core_interfaces::{block_importer::ImportBlockBroadcast, relayer::RelayerRequest};
 use tokio::sync::{broadcast, mpsc};
 
 use crate::mock_db::MockDb;


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-core/issues/517

This PR removes the Relayer tests' dependency on the existing `DummyDb` that comes pre-seeded, and uses a module level database, `MockDb` instead. `MockDb` does not come seeded with any data, and tests are expected to perform explicit setup. This means tests become more descriptive, self-documenting, and stable by removing sensitivity to data changes across shared test configurations. 

The Relayer module is also the last area where the `DummyDb` is used. Once this PR is merged, we can also remove the `DummyDb` entirely, allowing us to move closer towards a convention of explicit test setup.