### PR TITLE
Applied the same formatting for all parts not handled by the `cargo +stable fmt`

### DIFF
--- a/fuel-client/build.rs
+++ b/fuel-client/build.rs
@@ -1,8 +1,10 @@
 use schemafy_lib::{Expander, Schema};
-use std::env;
-use std::fs::{self, File};
-use std::io::prelude::*;
-use std::path::PathBuf;
+use std::{
+    env,
+    fs::{self, File},
+    io::prelude::*,
+    path::PathBuf,
+};
 
 fn main() {
     println!("cargo:rerun-if-changed=./assets/debugAdapterProtocol.json");

--- a/fuel-client/src/client/schema.rs
+++ b/fuel-client/src/client/schema.rs
@@ -5,10 +5,12 @@ pub mod schema {
 }
 
 use hex::FromHexError;
-use std::array::TryFromSliceError;
-use std::fmt::{self, Debug};
-use std::io::ErrorKind;
-use std::num::TryFromIntError;
+use std::{
+    array::TryFromSliceError,
+    fmt::{self, Debug},
+    io::ErrorKind,
+    num::TryFromIntError,
+};
 use thiserror::Error;
 
 pub use primitives::*;

--- a/fuel-client/src/client/schema/balance.rs
+++ b/fuel-client/src/client/schema/balance.rs
@@ -1,5 +1,7 @@
-use crate::client::schema::{schema, Address, AssetId, PageInfo, U64};
-use crate::client::{PageDirection, PaginatedResult, PaginationRequest};
+use crate::client::{
+    schema::{schema, Address, AssetId, PageInfo, U64},
+    PageDirection, PaginatedResult, PaginationRequest,
+};
 
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct BalanceArgs {

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -1,7 +1,10 @@
-use crate::client::schema::{
-    primitives::Address, primitives::DateTime, schema, BlockId, ConnectionArgs, PageInfo, U64,
+use crate::client::{
+    schema::{
+        primitives::{Address, DateTime},
+        schema, BlockId, ConnectionArgs, PageInfo, U64,
+    },
+    PaginatedResult,
 };
-use crate::client::PaginatedResult;
 
 use super::tx::TransactionIdFragment;
 

--- a/fuel-client/src/client/schema/coin.rs
+++ b/fuel-client/src/client/schema/coin.rs
@@ -1,5 +1,7 @@
-use crate::client::schema::{schema, Address, AssetId, PageInfo, UtxoId, U64};
-use crate::client::{PageDirection, PaginatedResult, PaginationRequest};
+use crate::client::{
+    schema::{schema, Address, AssetId, PageInfo, UtxoId, U64},
+    PageDirection, PaginatedResult, PaginationRequest,
+};
 
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct CoinByIdArgs {

--- a/fuel-client/src/client/schema/contract.rs
+++ b/fuel-client/src/client/schema/contract.rs
@@ -1,5 +1,7 @@
-use crate::client::schema::{schema, AssetId, ContractId, HexString, PageInfo, Salt, U64};
-use crate::client::{PageDirection, PaginatedResult, PaginationRequest};
+use crate::client::{
+    schema::{schema, AssetId, ContractId, HexString, PageInfo, Salt, U64},
+    PageDirection, PaginatedResult, PaginationRequest,
+};
 
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct ContractByIdArgs {

--- a/fuel-client/src/client/schema/primitives.rs
+++ b/fuel-client/src/client/schema/primitives.rs
@@ -1,13 +1,13 @@
 use super::schema;
-use crate::client::schema::ConversionError;
-use crate::client::schema::ConversionError::HexStringPrefixError;
+use crate::client::schema::{ConversionError, ConversionError::HexStringPrefixError};
 use core::fmt;
 use cynic::impl_scalar;
 use fuel_tx::InstructionResult;
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::{Debug, Display, Formatter, LowerHex};
-use std::str::FromStr;
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    fmt::{Debug, Display, Formatter, LowerHex},
+    str::FromStr,
+};
 
 pub type DateTime = chrono::DateTime<chrono::Utc>;
 impl_scalar!(DateTime, schema::DateTime);

--- a/fuel-client/src/client/schema/tx.rs
+++ b/fuel-client/src/client/schema/tx.rs
@@ -1,11 +1,12 @@
 use super::block::BlockIdFragment;
-use crate::client::schema::{
-    schema, Address, ConnectionArgs, ConversionError, HexString, PageInfo, TransactionId,
+use crate::client::{
+    schema::{
+        schema, Address, ConnectionArgs, ConversionError, HexString, PageInfo, TransactionId,
+    },
+    types::TransactionResponse,
+    PageDirection, PaginatedResult, PaginationRequest,
 };
-use crate::client::types::TransactionResponse;
-use crate::client::{PageDirection, PaginatedResult, PaginationRequest};
-use fuel_types::bytes::Deserializable;
-use fuel_types::Bytes32;
+use fuel_types::{bytes::Deserializable, Bytes32};
 use std::convert::{TryFrom, TryInto};
 
 #[derive(cynic::FragmentArguments, Debug)]

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -104,56 +104,60 @@ impl TryFrom<Transaction> for fuel_vm::prelude::Transaction {
                 witnesses: tx.witnesses.into_iter().map(|w| w.0 .0.into()).collect(),
                 metadata: None,
             },
-            false => Self::Create {
-                gas_price: tx.gas_price.into(),
-                gas_limit: tx.gas_limit.into(),
-                maturity: tx.maturity.into(),
-                bytecode_length: tx
-                    .bytecode_length
-                    .ok_or_else(|| ConversionError::MissingField("bytecode_length".to_string()))?
-                    .into(),
-                bytecode_witness_index: tx
-                    .bytecode_witness_index
-                    .ok_or_else(|| {
-                        ConversionError::MissingField("bytecode_witness_index".to_string())
-                    })?
-                    .try_into()?,
-                salt: tx
-                    .salt
-                    .ok_or_else(|| ConversionError::MissingField("salt".to_string()))?
-                    .into(),
-                storage_slots: tx
-                    .storage_slots
-                    .ok_or_else(|| ConversionError::MissingField("storage_slots".to_string()))?
-                    .into_iter()
-                    .map(|slot| {
-                        if slot.0 .0.len() != 64 {
-                            return Err(ConversionError::BytesLength);
-                        }
-                        let key = &slot.0 .0[0..32];
-                        let value = &slot.0 .0[32..];
-                        Ok(StorageSlot::new(
-                            // unwrap is safe because length is checked
-                            fuel_types::Bytes32::try_from(key)
-                                .map_err(|_| ConversionError::BytesLength)?,
-                            fuel_types::Bytes32::try_from(value)
-                                .map_err(|_| ConversionError::BytesLength)?,
-                        ))
-                    })
-                    .try_collect()?,
-                inputs: tx
-                    .inputs
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<Result<Vec<fuel_tx::Input>, ConversionError>>()?,
-                outputs: tx
-                    .outputs
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<Result<Vec<fuel_tx::Output>, ConversionError>>()?,
-                witnesses: tx.witnesses.into_iter().map(|w| w.0 .0.into()).collect(),
-                metadata: None,
-            },
+            false => {
+                Self::Create {
+                    gas_price: tx.gas_price.into(),
+                    gas_limit: tx.gas_limit.into(),
+                    maturity: tx.maturity.into(),
+                    bytecode_length: tx
+                        .bytecode_length
+                        .ok_or_else(|| {
+                            ConversionError::MissingField("bytecode_length".to_string())
+                        })?
+                        .into(),
+                    bytecode_witness_index: tx
+                        .bytecode_witness_index
+                        .ok_or_else(|| {
+                            ConversionError::MissingField("bytecode_witness_index".to_string())
+                        })?
+                        .try_into()?,
+                    salt: tx
+                        .salt
+                        .ok_or_else(|| ConversionError::MissingField("salt".to_string()))?
+                        .into(),
+                    storage_slots: tx
+                        .storage_slots
+                        .ok_or_else(|| ConversionError::MissingField("storage_slots".to_string()))?
+                        .into_iter()
+                        .map(|slot| {
+                            if slot.0 .0.len() != 64 {
+                                return Err(ConversionError::BytesLength);
+                            }
+                            let key = &slot.0 .0[0..32];
+                            let value = &slot.0 .0[32..];
+                            Ok(StorageSlot::new(
+                                // unwrap is safe because length is checked
+                                fuel_types::Bytes32::try_from(key)
+                                    .map_err(|_| ConversionError::BytesLength)?,
+                                fuel_types::Bytes32::try_from(value)
+                                    .map_err(|_| ConversionError::BytesLength)?,
+                            ))
+                        })
+                        .try_collect()?,
+                    inputs: tx
+                        .inputs
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<Vec<fuel_tx::Input>, ConversionError>>()?,
+                    outputs: tx
+                        .outputs
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<Vec<fuel_tx::Output>, ConversionError>>()?,
+                    witnesses: tx.witnesses.into_iter().map(|w| w.0 .0.into()).collect(),
+                    metadata: None,
+                }
+            }
         })
     }
 }

--- a/fuel-client/src/client/types.rs
+++ b/fuel-client/src/client/types.rs
@@ -1,5 +1,7 @@
-use crate::client::schema::tx::{OpaqueTransaction, TransactionStatus as SchemaTxStatus};
-use crate::client::schema::ConversionError;
+use crate::client::schema::{
+    tx::{OpaqueTransaction, TransactionStatus as SchemaTxStatus},
+    ConversionError,
+};
 use chrono::{DateTime, Utc};
 use fuel_tx::Transaction;
 use fuel_types::bytes::Deserializable;

--- a/fuel-core-interfaces/src/model/txpool.rs
+++ b/fuel-core-interfaces/src/model/txpool.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Utc};
 use fuel_tx::Transaction;
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 pub type ArcTx = Arc<Transaction>;
 

--- a/fuel-core-interfaces/src/model/vote.rs
+++ b/fuel-core-interfaces/src/model/vote.rs
@@ -11,6 +11,6 @@ pub struct ConsensusVote {
     height: u64,
     round: u64,
     signature: Signature,
-    //step: Step,
+    // step: Step,
     validator: PublicKey,
 }

--- a/fuel-core-interfaces/src/relayer.rs
+++ b/fuel-core-interfaces/src/relayer.rs
@@ -149,7 +149,7 @@ pub type ValidatorSet = HashMap<ValidatorId, (ValidatorStake, Option<ConsensusId
 
 #[derive(Debug)]
 pub enum RelayerRequest {
-    //expand with https://docs.rs/tokio/0.2.12/tokio/sync/index.html#oneshot-channel
+    // expand with https://docs.rs/tokio/0.2.12/tokio/sync/index.html#oneshot-channel
     // so that we return list of validator to consensus.
     GetValidatorSet {
         /// represent validator set for current block and it is on relayer to calculate it with slider in mind.

--- a/fuel-core-interfaces/src/txpool.rs
+++ b/fuel-core-interfaces/src/txpool.rs
@@ -1,13 +1,10 @@
-use crate::model::ArcTx;
 use crate::{
     db::{Error as DbStateError, KvStoreError},
-    model::TxInfo,
-    model::{Coin, Message},
+    model::{ArcTx, Coin, Message, TxInfo},
 };
 use derive_more::{Deref, DerefMut};
 use fuel_storage::Storage;
-use fuel_tx::{ContractId, UtxoId};
-use fuel_tx::{Transaction, TxId};
+use fuel_tx::{ContractId, Transaction, TxId, UtxoId};
 use fuel_types::MessageId;
 use fuel_vm::prelude::Contract;
 use std::sync::Arc;

--- a/fuel-core/src/chain_config.rs
+++ b/fuel-core/src/chain_config.rs
@@ -221,10 +221,8 @@ impl From<MessageConfig> for Message {
 mod tests {
     use super::*;
     use fuel_core_interfaces::common::{fuel_asm::Opcode, fuel_vm::prelude::Contract};
-    use rand::prelude::StdRng;
-    use rand::{Rng, RngCore, SeedableRng};
-    use std::env::temp_dir;
-    use std::fs::write;
+    use rand::{prelude::StdRng, Rng, RngCore, SeedableRng};
+    use std::{env::temp_dir, fs::write};
 
     #[test]
     fn from_str_loads_from_file() {

--- a/fuel-core/src/chain_config/serialization.rs
+++ b/fuel-core/src/chain_config/serialization.rs
@@ -1,6 +1,6 @@
 use crate::model::BlockHeight;
 use core::fmt;
-use fuel_core_interfaces::common::{fuel_types::bytes::WORD_SIZE, fuel_types::Word};
+use fuel_core_interfaces::common::fuel_types::{bytes::WORD_SIZE, Word};
 use serde::{de::Error, Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 use std::convert::TryFrom;
@@ -29,7 +29,7 @@ impl<'de> DeserializeAs<'de, Word> for HexNumber {
                 return Err(D::Error::custom(format!(
                     "value cant exceed {} bytes",
                     WORD_SIZE
-                )));
+                )))
             }
             len if len < WORD_SIZE => {
                 // pad if length < word size
@@ -94,8 +94,7 @@ where
 pub mod serde_hex {
     use core::fmt;
     use hex::{FromHex, ToHex};
-    use serde::de::Error;
-    use serde::{Deserializer, Serializer};
+    use serde::{de::Error, Deserializer, Serializer};
     use std::convert::TryFrom;
 
     pub fn serialize<T, S>(target: T, ser: S) -> Result<S::Ok, S::Error>

--- a/fuel-core/src/cli/run.rs
+++ b/fuel-core/src/cli/run.rs
@@ -1,5 +1,4 @@
-use crate::cli::DEFAULT_DB_PATH;
-use crate::FuelService;
+use crate::{cli::DEFAULT_DB_PATH, FuelService};
 use clap::Parser;
 use fuel_core::service::{Config, DbType, VMConfig};
 use std::{env, io, net, path::PathBuf};

--- a/fuel-core/src/cli/run/relayer.rs
+++ b/fuel-core/src/cli/run/relayer.rs
@@ -1,8 +1,7 @@
 use clap::Args;
 use fuel_core_interfaces::model::DaBlockHeight;
 use fuel_relayer::{Config, H160};
-use std::str::FromStr;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 #[derive(Debug, Clone, Args)]
 pub struct RelayerArgs {

--- a/fuel-core/src/cli/snapshot.rs
+++ b/fuel-core/src/cli/snapshot.rs
@@ -28,7 +28,10 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
 #[cfg(feature = "rocksdb")]
 pub async fn exec(command: Command) -> anyhow::Result<()> {
     use anyhow::Context;
-    use fuel_core::{chain_config::ChainConfig, chain_config::StateConfig, database::Database};
+    use fuel_core::{
+        chain_config::{ChainConfig, StateConfig},
+        database::Database,
+    };
 
     let path = command.database_path;
     let config: ChainConfig = command.chain_config.parse()?;

--- a/fuel-core/src/coin_query.rs
+++ b/fuel-core/src/coin_query.rs
@@ -1,6 +1,8 @@
-use crate::database::{Database, KvStoreError};
-use crate::model::{Coin, CoinStatus};
-use crate::state::{self};
+use crate::{
+    database::{Database, KvStoreError},
+    model::{Coin, CoinStatus},
+    state::{self},
+};
 use fuel_core_interfaces::common::{
     fuel_storage::Storage,
     fuel_tx::{Address, AssetId, UtxoId},

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -1,17 +1,17 @@
 #[cfg(feature = "rocksdb")]
 use crate::database::columns::COLUMN_NUM;
-use crate::database::transactional::DatabaseTransaction;
-use crate::model::FuelBlockDb;
 #[cfg(feature = "rocksdb")]
 use crate::state::rocks_db::RocksDb;
-use crate::state::{
-    in_memory::memory_store::MemoryStore, ColumnId, DataSource, Error, IterDirection,
+use crate::{
+    database::transactional::DatabaseTransaction,
+    model::FuelBlockDb,
+    state::{in_memory::memory_store::MemoryStore, ColumnId, DataSource, Error, IterDirection},
 };
 use async_trait::async_trait;
-use fuel_core_interfaces::common::fuel_asm::Word;
 pub use fuel_core_interfaces::db::KvStoreError;
 use fuel_core_interfaces::{
     common::{
+        fuel_asm::Word,
         fuel_storage::Storage,
         fuel_vm::prelude::{Address, Bytes32, InterpreterStorage},
     },
@@ -125,9 +125,8 @@ impl Drop for DropResources {
     }
 }
 
-/*** SAFETY: we are safe to do it because DataSource is Send+Sync and there is nowhere it is overwritten
- * it is not Send+Sync by default because Storage insert fn takes &mut self
-*/
+/// * SAFETY: we are safe to do it because DataSource is Send+Sync and there is nowhere it is overwritten
+/// it is not Send+Sync by default because Storage insert fn takes &mut self
 unsafe impl Send for Database {}
 unsafe impl Sync for Database {}
 
@@ -408,8 +407,7 @@ impl RelayerDb for Database {
     async fn get_finalized_da_height(&self) -> DaBlockHeight {
         match self.get(metadata::FINALIZED_DA_HEIGHT_KEY, METADATA) {
             Ok(res) => {
-                return res
-                    .expect("get_finalized_da_height value should be always present and set");
+                return res.expect("get_finalized_da_height value should be always present and set")
             }
             Err(err) => {
                 panic!("get_finalized_da_height database corruption, err:{:?}", err);
@@ -427,7 +425,7 @@ impl RelayerDb for Database {
         match self.get(metadata::VALIDATORS_DA_HEIGHT_KEY, METADATA) {
             Ok(res) => {
                 return res
-                    .expect("get_validators_da_height value should be always present and set");
+                    .expect("get_validators_da_height value should be always present and set")
             }
             Err(err) => {
                 panic!(

--- a/fuel-core/src/database/balances.rs
+++ b/fuel-core/src/database/balances.rs
@@ -1,7 +1,6 @@
-use crate::state::Error;
 use crate::{
     database::{columns::BALANCES, Database},
-    state::{IterDirection, MultiKey},
+    state::{Error, IterDirection, MultiKey},
 };
 use fuel_core_interfaces::common::{
     fuel_storage::MerkleRoot,

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -1,11 +1,16 @@
 use crate::{
-    database::{columns::BLOCKS, columns::BLOCK_IDS, Database, KvStoreError},
+    database::{
+        columns::{BLOCKS, BLOCK_IDS},
+        Database, KvStoreError,
+    },
     model::{BlockHeight, FuelBlockDb},
     state::{Error, IterDirection},
 };
 use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_tx::Bytes32};
-use std::borrow::Cow;
-use std::convert::{TryFrom, TryInto};
+use std::{
+    borrow::Cow,
+    convert::{TryFrom, TryInto},
+};
 
 impl Storage<Bytes32, FuelBlockDb> for Database {
     type Error = KvStoreError;

--- a/fuel-core/src/database/code_root.rs
+++ b/fuel-core/src/database/code_root.rs
@@ -33,8 +33,7 @@ impl Storage<ContractId, (Salt, Bytes32)> for Database {
 mod tests {
     use super::*;
     use fuel_core_interfaces::common::fuel_vm::prelude::Contract;
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{rngs::StdRng, Rng, SeedableRng};
 
     #[test]
     fn get() {

--- a/fuel-core/src/database/coin.rs
+++ b/fuel-core/src/database/coin.rs
@@ -7,11 +7,13 @@ use crate::{
     model::Coin,
     state::{Error, IterDirection},
 };
-use fuel_core_interfaces::common::{
-    fuel_storage::Storage,
-    fuel_tx::{Address, AssetId, Bytes32, UtxoId},
+use fuel_core_interfaces::{
+    common::{
+        fuel_storage::Storage,
+        fuel_tx::{Address, AssetId, Bytes32, UtxoId},
+    },
+    model::Coin as CoinModel,
 };
-use fuel_core_interfaces::model::Coin as CoinModel;
 use itertools::Itertools;
 use std::borrow::Cow;
 

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -1,9 +1,8 @@
-use crate::database::InterpreterStorage;
 use crate::{
     chain_config::ContractConfig,
     database::{
         columns::{BALANCES, CONTRACTS, CONTRACTS_STATE, CONTRACT_UTXO_ID},
-        Database,
+        Database, InterpreterStorage,
     },
     state::{Error, IterDirection, MultiKey},
 };

--- a/fuel-core/src/database/message.rs
+++ b/fuel-core/src/database/message.rs
@@ -10,8 +10,7 @@ use fuel_core_interfaces::{
     },
     model::Message,
 };
-use std::borrow::Cow;
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 impl Storage<MessageId, Message> for Database {
     type Error = KvStoreError;

--- a/fuel-core/src/database/metadata.rs
+++ b/fuel-core/src/database/metadata.rs
@@ -1,8 +1,9 @@
-use crate::database::columns::METADATA;
-use crate::database::Database;
-use crate::model::BlockHeight;
-use crate::service::config::Config;
-use crate::state::Error;
+use crate::{
+    database::{columns::METADATA, Database},
+    model::BlockHeight,
+    service::config::Config,
+    state::Error,
+};
 
 pub(crate) const DB_VERSION_KEY: &[u8] = b"version";
 pub(crate) const CHAIN_NAME_KEY: &[u8] = b"chain_name";

--- a/fuel-core/src/database/state.rs
+++ b/fuel-core/src/database/state.rs
@@ -2,12 +2,9 @@ use crate::{
     database::{columns::CONTRACTS_STATE, Database},
     state::{Error, IterDirection, MultiKey},
 };
-use fuel_core_interfaces::{
-    common::fuel_vm::prelude::MerkleRoot,
-    common::fuel_vm::{
-        crypto,
-        prelude::{Bytes32, ContractId, MerkleStorage},
-    },
+use fuel_core_interfaces::common::fuel_vm::{
+    crypto,
+    prelude::{Bytes32, ContractId, MerkleRoot, MerkleStorage},
 };
 use itertools::Itertools;
 use std::borrow::Cow;

--- a/fuel-core/src/database/transactional.rs
+++ b/fuel-core/src/database/transactional.rs
@@ -1,5 +1,4 @@
-use crate::database::Database;
-use crate::state::in_memory::transaction::MemoryTransactionView;
+use crate::{database::Database, state::in_memory::transaction::MemoryTransactionView};
 use std::{
     fmt::Debug,
     ops::{Deref, DerefMut},

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -335,7 +335,9 @@ impl Executor {
                             return Err(TransactionValidityError::MessageAlreadySpent(*message_id));
                         }
                         if BlockHeight::from(message.da_height) > block_da_height {
-                            return Err(TransactionValidityError::MessageSpendTooEarly(*message_id));
+                            return Err(TransactionValidityError::MessageSpendTooEarly(
+                                *message_id,
+                            ));
                         }
                     } else {
                         return Err(TransactionValidityError::MessageDoesNotExist(*message_id));

--- a/fuel-core/src/schema/balance.rs
+++ b/fuel-core/src/schema/balance.rs
@@ -1,12 +1,13 @@
-use crate::database::{Database, KvStoreError};
-use crate::model::{Coin as CoinModel, CoinStatus};
-use crate::schema::scalars::{Address, AssetId, U64};
-use crate::state::{Error, IterDirection};
+use crate::{
+    database::{Database, KvStoreError},
+    model::{Coin as CoinModel, CoinStatus},
+    schema::scalars::{Address, AssetId, U64},
+    state::{Error, IterDirection},
+};
 use anyhow::anyhow;
-use async_graphql::InputObject;
 use async_graphql::{
     connection::{query, Connection, Edge, EmptyFields},
-    Context, Object,
+    Context, InputObject, Object,
 };
 use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_tx, fuel_types};
 use itertools::Itertools;
@@ -135,79 +136,81 @@ impl BalanceQuery {
             before,
             first,
             last,
-            |after: Option<AssetId>, before: Option<AssetId>, first, last| async move {
-                let (records_to_fetch, direction) = if let Some(first) = first {
-                    (first, IterDirection::Forward)
-                } else if let Some(last) = last {
-                    (last, IterDirection::Reverse)
-                } else {
-                    (0, IterDirection::Forward)
-                };
+            |after: Option<AssetId>, before: Option<AssetId>, first, last| {
+                async move {
+                    let (records_to_fetch, direction) = if let Some(first) = first {
+                        (first, IterDirection::Forward)
+                    } else if let Some(last) = last {
+                        (last, IterDirection::Reverse)
+                    } else {
+                        (0, IterDirection::Forward)
+                    };
 
-                if (first.is_some() && before.is_some())
-                    || (after.is_some() && before.is_some())
-                    || (last.is_some() && after.is_some())
-                {
-                    return Err(anyhow!("Wrong argument combination"));
-                }
+                    if (first.is_some() && before.is_some())
+                        || (after.is_some() && before.is_some())
+                        || (last.is_some() && after.is_some())
+                    {
+                        return Err(anyhow!("Wrong argument combination"));
+                    }
 
-                let after = after.map(fuel_tx::AssetId::from);
-                let before = before.map(fuel_tx::AssetId::from);
+                    let after = after.map(fuel_tx::AssetId::from);
+                    let before = before.map(fuel_tx::AssetId::from);
 
-                let start;
-                let end;
+                    let start;
+                    let end;
 
-                if direction == IterDirection::Forward {
-                    start = after;
-                    end = before;
-                } else {
-                    start = before;
-                    end = after;
-                }
+                    if direction == IterDirection::Forward {
+                        start = after;
+                        end = before;
+                    } else {
+                        start = before;
+                        end = after;
+                    }
 
-                let mut balances = balances.into_iter();
-                if direction == IterDirection::Reverse {
-                    balances = balances.rev().collect::<Vec<Balance>>().into_iter();
-                }
-                if let Some(start) = start {
-                    balances = balances
-                        .skip_while(|balance| balance.asset_id == start)
-                        .collect::<Vec<Balance>>()
-                        .into_iter();
-                }
-                let mut started = None;
-                if start.is_some() {
-                    // skip initial result
-                    started = balances.next();
-                }
+                    let mut balances = balances.into_iter();
+                    if direction == IterDirection::Reverse {
+                        balances = balances.rev().collect::<Vec<Balance>>().into_iter();
+                    }
+                    if let Some(start) = start {
+                        balances = balances
+                            .skip_while(|balance| balance.asset_id == start)
+                            .collect::<Vec<Balance>>()
+                            .into_iter();
+                    }
+                    let mut started = None;
+                    if start.is_some() {
+                        // skip initial result
+                        started = balances.next();
+                    }
 
-                // take desired amount of results
-                let balances = balances
-                    .take_while(|balance| {
-                        // take until we've reached the end
-                        if let Some(end) = end.as_ref() {
-                            if balance.asset_id == *end {
-                                return false;
+                    // take desired amount of results
+                    let balances = balances
+                        .take_while(|balance| {
+                            // take until we've reached the end
+                            if let Some(end) = end.as_ref() {
+                                if balance.asset_id == *end {
+                                    return false;
+                                }
                             }
-                        }
-                        true
-                    })
-                    .take(records_to_fetch);
-                let mut balances: Vec<Balance> = balances.collect();
-                if direction == IterDirection::Reverse {
-                    balances.reverse();
+                            true
+                        })
+                        .take(records_to_fetch);
+                    let mut balances: Vec<Balance> = balances.collect();
+                    if direction == IterDirection::Reverse {
+                        balances.reverse();
+                    }
+
+                    let mut connection =
+                        Connection::new(started.is_some(), records_to_fetch <= balances.len());
+
+                    connection.edges.extend(
+                        balances
+                            .into_iter()
+                            .map(|item| Edge::new(item.asset_id.into(), item)),
+                    );
+
+                    Ok::<Connection<AssetId, Balance>, anyhow::Error>(connection)
                 }
-
-                let mut connection =
-                    Connection::new(started.is_some(), records_to_fetch <= balances.len());
-
-                connection.edges.extend(
-                    balances
-                        .into_iter()
-                        .map(|item| Edge::new(item.asset_id.into(), item)),
-                );
-
-                Ok::<Connection<AssetId, Balance>, anyhow::Error>(connection)
             },
         )
         .await

--- a/fuel-core/src/schema/chain.rs
+++ b/fuel-core/src/schema/chain.rs
@@ -1,5 +1,7 @@
 use crate::{
-    database::Database, model::FuelBlockDb, schema::block::Block, schema::scalars::U64,
+    database::Database,
+    model::FuelBlockDb,
+    schema::{block::Block, scalars::U64},
     service::Config,
 };
 use async_graphql::{Context, Object};

--- a/fuel-core/src/schema/coin.rs
+++ b/fuel-core/src/schema/coin.rs
@@ -105,91 +105,93 @@ impl CoinQuery {
             before,
             first,
             last,
-            |after: Option<UtxoId>, before: Option<UtxoId>, first, last| async move {
-                let (records_to_fetch, direction) = if let Some(first) = first {
-                    (first, IterDirection::Forward)
-                } else if let Some(last) = last {
-                    (last, IterDirection::Reverse)
-                } else {
-                    (0, IterDirection::Forward)
-                };
+            |after: Option<UtxoId>, before: Option<UtxoId>, first, last| {
+                async move {
+                    let (records_to_fetch, direction) = if let Some(first) = first {
+                        (first, IterDirection::Forward)
+                    } else if let Some(last) = last {
+                        (last, IterDirection::Reverse)
+                    } else {
+                        (0, IterDirection::Forward)
+                    };
 
-                if (first.is_some() && before.is_some())
-                    || (after.is_some() && before.is_some())
-                    || (last.is_some() && after.is_some())
-                {
-                    return Err(anyhow!("Wrong argument combination"));
-                }
+                    if (first.is_some() && before.is_some())
+                        || (after.is_some() && before.is_some())
+                        || (last.is_some() && after.is_some())
+                    {
+                        return Err(anyhow!("Wrong argument combination"));
+                    }
 
-                let after = after.map(fuel_tx::UtxoId::from);
-                let before = before.map(fuel_tx::UtxoId::from);
+                    let after = after.map(fuel_tx::UtxoId::from);
+                    let before = before.map(fuel_tx::UtxoId::from);
 
-                let start;
-                let end;
+                    let start;
+                    let end;
 
-                if direction == IterDirection::Forward {
-                    start = after;
-                    end = before;
-                } else {
-                    start = before;
-                    end = after;
-                }
+                    if direction == IterDirection::Forward {
+                        start = after;
+                        end = before;
+                    } else {
+                        start = before;
+                        end = after;
+                    }
 
-                let owner: fuel_tx::Address = filter.owner.into();
+                    let owner: fuel_tx::Address = filter.owner.into();
 
-                let mut coin_ids = db.owned_coins(owner, start, Some(direction));
-                let mut started = None;
-                if start.is_some() {
-                    // skip initial result
-                    started = coin_ids.next();
-                }
+                    let mut coin_ids = db.owned_coins(owner, start, Some(direction));
+                    let mut started = None;
+                    if start.is_some() {
+                        // skip initial result
+                        started = coin_ids.next();
+                    }
 
-                // take desired amount of results
-                let coins = coin_ids
-                    .take_while(|r| {
-                        // take until we've reached the end
-                        if let (Ok(t), Some(end)) = (r, end.as_ref()) {
-                            if *t == *end {
-                                return false;
+                    // take desired amount of results
+                    let coins = coin_ids
+                        .take_while(|r| {
+                            // take until we've reached the end
+                            if let (Ok(t), Some(end)) = (r, end.as_ref()) {
+                                if *t == *end {
+                                    return false;
+                                }
                             }
-                        }
-                        true
-                    })
-                    .take(records_to_fetch);
-                let mut coins: Vec<fuel_tx::UtxoId> = coins.try_collect()?;
-                if direction == IterDirection::Reverse {
-                    coins.reverse();
-                }
+                            true
+                        })
+                        .take(records_to_fetch);
+                    let mut coins: Vec<fuel_tx::UtxoId> = coins.try_collect()?;
+                    if direction == IterDirection::Reverse {
+                        coins.reverse();
+                    }
 
-                // TODO: do a batch get instead
-                let coins: Vec<Coin> = coins
-                    .into_iter()
-                    .map(|id| {
-                        Storage::<fuel_tx::UtxoId, CoinModel>::get(db, &id)
-                            .transpose()
-                            .ok_or(KvStoreError::NotFound)?
-                            .map(|coin| Coin(id, coin.into_owned()))
-                    })
-                    .try_collect()?;
-
-                // filter coins by asset ID
-                let mut coins = coins;
-                if let Some(asset_id) = filter.asset_id {
-                    coins.retain(|coin| coin.1.asset_id == asset_id.0);
-                }
-
-                // filter coins by status
-                coins.retain(|coin| coin.1.status == CoinStatusModel::Unspent);
-
-                let mut connection =
-                    Connection::new(started.is_some(), records_to_fetch <= coins.len());
-                connection.edges.extend(
-                    coins
+                    // TODO: do a batch get instead
+                    let coins: Vec<Coin> = coins
                         .into_iter()
-                        .map(|item| Edge::new(UtxoId::from(item.0), item)),
-                );
+                        .map(|id| {
+                            Storage::<fuel_tx::UtxoId, CoinModel>::get(db, &id)
+                                .transpose()
+                                .ok_or(KvStoreError::NotFound)?
+                                .map(|coin| Coin(id, coin.into_owned()))
+                        })
+                        .try_collect()?;
 
-                Ok::<Connection<UtxoId, Coin>, anyhow::Error>(connection)
+                    // filter coins by asset ID
+                    let mut coins = coins;
+                    if let Some(asset_id) = filter.asset_id {
+                        coins.retain(|coin| coin.1.asset_id == asset_id.0);
+                    }
+
+                    // filter coins by status
+                    coins.retain(|coin| coin.1.status == CoinStatusModel::Unspent);
+
+                    let mut connection =
+                        Connection::new(started.is_some(), records_to_fetch <= coins.len());
+                    connection.edges.extend(
+                        coins
+                            .into_iter()
+                            .map(|item| Edge::new(UtxoId::from(item.0), item)),
+                    );
+
+                    Ok::<Connection<UtxoId, Coin>, anyhow::Error>(connection)
+                }
             },
         )
         .await

--- a/fuel-core/src/schema/dap.rs
+++ b/fuel-core/src/schema/dap.rs
@@ -1,6 +1,7 @@
-use crate::database::transactional::DatabaseTransaction;
-use crate::database::Database;
-use crate::schema::scalars::U64;
+use crate::{
+    database::{transactional::DatabaseTransaction, Database},
+    schema::scalars::U64,
+};
 use async_graphql::{Context, Object, SchemaBuilder, ID};
 use fuel_core_interfaces::common::{
     fuel_tx::ConsensusParameters,

--- a/fuel-core/src/schema/message.rs
+++ b/fuel-core/src/schema/message.rs
@@ -70,80 +70,87 @@ impl MessageQuery {
             before,
             first,
             last,
-            |after: Option<MessageId>, before: Option<MessageId>, first, last| async move {
-                let (records_to_fetch, direction) = if let Some(first) = first {
-                    (first, IterDirection::Forward)
-                } else if let Some(last) = last {
-                    (last, IterDirection::Reverse)
-                } else {
-                    (0, IterDirection::Forward)
-                };
+            |after: Option<MessageId>, before: Option<MessageId>, first, last| {
+                async move {
+                    let (records_to_fetch, direction) = if let Some(first) = first {
+                        (first, IterDirection::Forward)
+                    } else if let Some(last) = last {
+                        (last, IterDirection::Reverse)
+                    } else {
+                        (0, IterDirection::Forward)
+                    };
 
-                if (first.is_some() && before.is_some())
-                    || (after.is_some() && before.is_some())
-                    || (last.is_some() && after.is_some())
-                {
-                    return Err(anyhow!("Wrong argument combination"));
-                }
-
-                let start = if direction == IterDirection::Forward {
-                    after
-                } else {
-                    before
-                };
-
-                let (mut messages, has_next_page, has_previous_page) = if let Some(owner) = owner {
-                    let mut message_ids =
-                        db.owned_message_ids(owner.into(), start.map(Into::into), Some(direction));
-                    let mut started = None;
-                    if start.is_some() {
-                        // skip initial result
-                        started = message_ids.next();
+                    if (first.is_some() && before.is_some())
+                        || (after.is_some() && before.is_some())
+                        || (last.is_some() && after.is_some())
+                    {
+                        return Err(anyhow!("Wrong argument combination"));
                     }
-                    let message_ids = message_ids.take(records_to_fetch + 1);
-                    let message_ids: Vec<fuel_types::MessageId> = message_ids.try_collect()?;
-                    let has_next_page = message_ids.len() > records_to_fetch;
 
-                    let messages: Vec<model::Message> = message_ids
-                        .iter()
-                        .take(records_to_fetch)
-                        .map(|msg_id| {
-                            Storage::<fuel_types::MessageId, model::Message>::get(&db, msg_id)
-                                .transpose()
-                                .ok_or(KvStoreError::NotFound)?
-                                .map(|f| f.into_owned())
-                        })
-                        .try_collect()?;
-                    (messages, has_next_page, started.is_some())
-                } else {
-                    let mut messages = db.all_messages(start.map(Into::into), Some(direction));
-                    let mut started = None;
-                    if start.is_some() {
-                        // skip initial result
-                        started = messages.next();
+                    let start = if direction == IterDirection::Forward {
+                        after
+                    } else {
+                        before
+                    };
+
+                    let (mut messages, has_next_page, has_previous_page) = if let Some(owner) =
+                        owner
+                    {
+                        let mut message_ids = db.owned_message_ids(
+                            owner.into(),
+                            start.map(Into::into),
+                            Some(direction),
+                        );
+                        let mut started = None;
+                        if start.is_some() {
+                            // skip initial result
+                            started = message_ids.next();
+                        }
+                        let message_ids = message_ids.take(records_to_fetch + 1);
+                        let message_ids: Vec<fuel_types::MessageId> = message_ids.try_collect()?;
+                        let has_next_page = message_ids.len() > records_to_fetch;
+
+                        let messages: Vec<model::Message> = message_ids
+                            .iter()
+                            .take(records_to_fetch)
+                            .map(|msg_id| {
+                                Storage::<fuel_types::MessageId, model::Message>::get(&db, msg_id)
+                                    .transpose()
+                                    .ok_or(KvStoreError::NotFound)?
+                                    .map(|f| f.into_owned())
+                            })
+                            .try_collect()?;
+                        (messages, has_next_page, started.is_some())
+                    } else {
+                        let mut messages = db.all_messages(start.map(Into::into), Some(direction));
+                        let mut started = None;
+                        if start.is_some() {
+                            // skip initial result
+                            started = messages.next();
+                        }
+                        let messages: Vec<model::Message> =
+                            messages.take(records_to_fetch + 1).try_collect()?;
+                        let has_next_page = messages.len() > records_to_fetch;
+                        let messages = messages.into_iter().take(records_to_fetch).collect();
+                        (messages, has_next_page, started.is_some())
+                    };
+
+                    // reverse after filtering next page test record to maintain consistent ordering
+                    // in the response regardless of whether first or last was used.
+                    if direction == IterDirection::Forward {
+                        messages.reverse();
                     }
-                    let messages: Vec<model::Message> =
-                        messages.take(records_to_fetch + 1).try_collect()?;
-                    let has_next_page = messages.len() > records_to_fetch;
-                    let messages = messages.into_iter().take(records_to_fetch).collect();
-                    (messages, has_next_page, started.is_some())
-                };
 
-                // reverse after filtering next page test record to maintain consistent ordering
-                // in the response regardless of whether first or last was used.
-                if direction == IterDirection::Forward {
-                    messages.reverse();
+                    let mut connection = Connection::new(has_previous_page, has_next_page);
+
+                    connection.edges.extend(
+                        messages
+                            .into_iter()
+                            .map(|message| Edge::new(message.id().into(), Message(message))),
+                    );
+
+                    Ok::<Connection<MessageId, Message>, anyhow::Error>(connection)
                 }
-
-                let mut connection = Connection::new(has_previous_page, has_next_page);
-
-                connection.edges.extend(
-                    messages
-                        .into_iter()
-                        .map(|message| Edge::new(message.id().into(), Message(message))),
-                );
-
-                Ok::<Connection<MessageId, Message>, anyhow::Error>(connection)
             },
         )
         .await

--- a/fuel-core/src/schema/scalars.rs
+++ b/fuel-core/src/schema/scalars.rs
@@ -1,5 +1,4 @@
-use crate::database::transaction::OwnedTransactionIndexCursor;
-use crate::model::BlockHeight;
+use crate::{database::transaction::OwnedTransactionIndexCursor, model::BlockHeight};
 use async_graphql::{
     connection::CursorType, InputValueError, InputValueResult, Scalar, ScalarType, Value,
 };

--- a/fuel-core/src/schema/tx/input.rs
+++ b/fuel-core/src/schema/tx/input.rs
@@ -1,7 +1,8 @@
-use crate::schema::scalars::TxPointer;
 use crate::schema::{
     contract::Contract,
-    scalars::{Address, AssetId, Bytes32, ContractId, HexString, MessageId, UtxoId, U64},
+    scalars::{
+        Address, AssetId, Bytes32, ContractId, HexString, MessageId, TxPointer, UtxoId, U64,
+    },
 };
 use async_graphql::{Object, Union};
 use fuel_core_interfaces::common::fuel_tx;

--- a/fuel-core/src/schema/tx/output.rs
+++ b/fuel-core/src/schema/tx/output.rs
@@ -1,5 +1,7 @@
-use crate::schema::contract::Contract;
-use crate::schema::scalars::{Address, AssetId, Bytes32, U64};
+use crate::schema::{
+    contract::Contract,
+    scalars::{Address, AssetId, Bytes32, U64},
+};
 use async_graphql::{Object, Union};
 use fuel_core_interfaces::common::{fuel_asm::Word, fuel_tx, fuel_types};
 

--- a/fuel-core/src/schema/tx/receipt.rs
+++ b/fuel-core/src/schema/tx/receipt.rs
@@ -1,7 +1,6 @@
-use crate::schema::scalars::MessageId;
 use crate::schema::{
     contract::Contract,
-    scalars::{Address, AssetId, Bytes32, HexString, U64},
+    scalars::{Address, AssetId, Bytes32, HexString, MessageId, U64},
 };
 use async_graphql::{Enum, Object};
 use derive_more::Display;

--- a/fuel-core/src/service/genesis.rs
+++ b/fuel-core/src/service/genesis.rs
@@ -4,14 +4,13 @@ use crate::{
     service::{config::Config, FuelService},
 };
 use anyhow::Result;
-use fuel_core_interfaces::model::Message;
 use fuel_core_interfaces::{
     common::{
         fuel_storage::{MerkleStorage, Storage},
         fuel_tx::{Contract, MessageId, UtxoId},
         fuel_types::{bytes::WORD_SIZE, AssetId, Bytes32, ContractId, Salt, Word},
     },
-    model::{Coin, CoinStatus},
+    model::{Coin, CoinStatus, Message},
 };
 use itertools::Itertools;
 
@@ -177,16 +176,18 @@ mod tests {
     use std::vec;
 
     use super::*;
-    use crate::chain_config::{
-        ChainConfig, CoinConfig, ContractConfig, MessageConfig, StateConfig,
+    use crate::{
+        chain_config::{ChainConfig, CoinConfig, ContractConfig, MessageConfig, StateConfig},
+        model::BlockHeight,
+        service::config::Config,
     };
-    use crate::model::BlockHeight;
-    use crate::service::config::Config;
-    use fuel_core_interfaces::common::{
-        fuel_asm::Opcode,
-        fuel_types::{Address, AssetId, Word},
+    use fuel_core_interfaces::{
+        common::{
+            fuel_asm::Opcode,
+            fuel_types::{Address, AssetId, Word},
+        },
+        model::Message,
     };
-    use fuel_core_interfaces::model::Message;
     use itertools::Itertools;
     use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
 

--- a/fuel-core/src/service/graph_api.rs
+++ b/fuel-core/src/service/graph_api.rs
@@ -1,11 +1,14 @@
 use super::modules::Modules;
-use crate::database::Database;
-use crate::schema::{build_schema, dap, CoreSchema};
-use crate::service::metrics::metrics;
-use crate::service::Config;
+use crate::{
+    database::Database,
+    schema::{build_schema, dap, CoreSchema},
+    service::{metrics::metrics, Config},
+};
 use anyhow::Result;
 use async_graphql::{
-    extensions::Tracing, http::playground_source, http::GraphQLPlaygroundConfig, Request, Response,
+    extensions::Tracing,
+    http::{playground_source, GraphQLPlaygroundConfig},
+    Request, Response,
 };
 use axum::{
     extract::Extension,
@@ -15,15 +18,13 @@ use axum::{
         },
         HeaderValue,
     },
-    response::Html,
-    response::IntoResponse,
+    response::{Html, IntoResponse},
     routing::{get, post},
     Json, Router,
 };
 use serde_json::json;
 use std::net::{SocketAddr, TcpListener};
-use tokio::signal::unix::SignalKind;
-use tokio::task::JoinHandle;
+use tokio::{signal::unix::SignalKind, task::JoinHandle};
 use tower_http::{set_header::SetResponseHeaderLayer, trace::TraceLayer};
 use tracing::info;
 

--- a/fuel-core/src/service/metrics.rs
+++ b/fuel-core/src/service/metrics.rs
@@ -18,8 +18,7 @@ pub mod prometheus_metrics {
     use super::{Body, IntoResponse};
     use hyper::{header::CONTENT_TYPE, Response};
     use lazy_static::lazy_static;
-    use prometheus::register_int_counter;
-    use prometheus::{self, Encoder, IntCounter, TextEncoder};
+    use prometheus::{self, register_int_counter, Encoder, IntCounter, TextEncoder};
 
     /// DatabaseMetrics is a wrapper struct for all
     /// of the initialized counters for Database-related metrics

--- a/fuel-core/src/service/modules.rs
+++ b/fuel-core/src/service/modules.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::let_unit_value)]
-use crate::database::Database;
-use crate::service::Config;
+use crate::{database::Database, service::Config};
 use anyhow::Result;
 #[cfg(feature = "p2p")]
 use fuel_core_interfaces::p2p::P2pDb;
@@ -9,8 +8,7 @@ use fuel_core_interfaces::relayer::RelayerDb;
 use fuel_core_interfaces::txpool::TxPoolDb;
 use futures::future::join_all;
 use std::sync::Arc;
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
+use tokio::{sync::mpsc, task::JoinHandle};
 
 pub struct Modules {
     pub txpool: Arc<fuel_txpool::Service>,

--- a/fuel-core/src/state/in_memory/transaction.rs
+++ b/fuel-core/src/state/in_memory/transaction.rs
@@ -1,13 +1,15 @@
 use crate::state::{
-    in_memory::column_key, in_memory::memory_store::MemoryStore, BatchOperations, ColumnId,
-    DataSource, IterDirection, KeyValueStore, Result, TransactableStorage, Transaction,
-    TransactionError, TransactionResult, WriteOperation,
+    in_memory::{column_key, memory_store::MemoryStore},
+    BatchOperations, ColumnId, DataSource, IterDirection, KeyValueStore, Result,
+    TransactableStorage, Transaction, TransactionError, TransactionResult, WriteOperation,
 };
 use itertools::{EitherOrBoth, Itertools};
-use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::sync::{Arc, Mutex};
+use std::{
+    cmp::Ordering,
+    collections::HashMap,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+};
 
 #[derive(Debug)]
 pub struct MemoryTransactionView {

--- a/fuel-core/src/state/rocks_db.rs
+++ b/fuel-core/src/state/rocks_db.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "prometheus")]
 use crate::service::metrics::prometheus_metrics::DATABASE_METRICS;
-use crate::state::KVItem;
 use crate::{
     database::{
         columns,
@@ -8,8 +7,8 @@ use crate::{
         metadata::{DB_VERSION, DB_VERSION_KEY},
     },
     state::{
-        BatchOperations, ColumnId, Error, IterDirection, KeyValueStore, TransactableStorage,
-        WriteOperation,
+        BatchOperations, ColumnId, Error, IterDirection, KVItem, KeyValueStore,
+        TransactableStorage, WriteOperation,
     },
 };
 use rocksdb::{

--- a/fuel-core/src/test_utils.rs
+++ b/fuel-core/src/test_utils.rs
@@ -1,5 +1,7 @@
-use crate::database::Database;
-use crate::model::{Coin, CoinStatus};
+use crate::{
+    database::Database,
+    model::{Coin, CoinStatus},
+};
 use fuel_core_interfaces::common::{
     fuel_asm::Word,
     fuel_storage::Storage,

--- a/fuel-p2p/src/discovery.rs
+++ b/fuel-p2p/src/discovery.rs
@@ -137,7 +137,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
                 }
 
                 NetworkBehaviourAction::Dial { handler, opts } => {
-                    return Poll::Ready(NetworkBehaviourAction::Dial { handler, opts });
+                    return Poll::Ready(NetworkBehaviourAction::Dial { handler, opts })
                 }
                 NetworkBehaviourAction::CloseConnection {
                     peer_id,
@@ -146,7 +146,7 @@ impl NetworkBehaviour for DiscoveryBehaviour {
                     return Poll::Ready(NetworkBehaviourAction::CloseConnection {
                         peer_id,
                         connection,
-                    });
+                    })
                 }
                 NetworkBehaviourAction::NotifyHandler {
                     peer_id,

--- a/fuel-p2p/src/discovery/mdns.rs
+++ b/fuel-p2p/src/discovery/mdns.rs
@@ -1,8 +1,9 @@
-use futures::future::BoxFuture;
-use futures::FutureExt;
-use libp2p::mdns::{MdnsConfig, MdnsEvent};
-use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters};
-use libp2p::{mdns::Mdns, Multiaddr, PeerId};
+use futures::{future::BoxFuture, FutureExt};
+use libp2p::{
+    mdns::{Mdns, MdnsConfig, MdnsEvent},
+    swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters},
+    Multiaddr, PeerId,
+};
 use std::task::{Context, Poll};
 use tracing::warn;
 

--- a/fuel-p2p/src/gossipsub/messages.rs
+++ b/fuel-p2p/src/gossipsub/messages.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
-use fuel_core_interfaces::common::fuel_tx::Transaction;
-use fuel_core_interfaces::model::{ConsensusVote, FuelBlock};
+use fuel_core_interfaces::{
+    common::fuel_tx::Transaction,
+    model::{ConsensusVote, FuelBlock},
+};
 
 use serde::{Deserialize, Serialize};
 

--- a/fuel-p2p/src/gossipsub/topics.rs
+++ b/fuel-p2p/src/gossipsub/topics.rs
@@ -61,8 +61,10 @@ impl GossipsubTopics {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fuel_core_interfaces::common::fuel_tx::Transaction;
-    use fuel_core_interfaces::model::{ConsensusVote, FuelBlock};
+    use fuel_core_interfaces::{
+        common::fuel_tx::Transaction,
+        model::{ConsensusVote, FuelBlock},
+    };
     use libp2p::gossipsub::Topic;
     use std::sync::Arc;
 

--- a/fuel-p2p/src/orchestrator.rs
+++ b/fuel-p2p/src/orchestrator.rs
@@ -6,9 +6,13 @@ use fuel_core_interfaces::p2p::{
 };
 
 use libp2p::request_response::RequestId;
-use tokio::sync::mpsc::{Receiver, Sender};
-use tokio::sync::Mutex;
-use tokio::task::JoinHandle;
+use tokio::{
+    sync::{
+        mpsc::{Receiver, Sender},
+        Mutex,
+    },
+    task::JoinHandle,
+};
 use tracing::warn;
 
 use crate::{

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -1,12 +1,11 @@
-use crate::codecs::bincode::BincodeCodec;
-use crate::request_response::messages::OutboundResponse;
 use crate::{
     behavior::{FuelBehaviour, FuelBehaviourEvent},
+    codecs::bincode::BincodeCodec,
     config::{build_transport, P2PConfig},
     gossipsub::messages::GossipsubBroadcastRequest,
     peer_info::PeerInfo,
     request_response::messages::{
-        RequestError, RequestMessage, ResponseChannelItem, ResponseError,
+        OutboundResponse, RequestError, RequestMessage, ResponseChannelItem, ResponseError,
     },
 };
 use futures::prelude::*;
@@ -133,22 +132,25 @@ impl FuelP2PService {
 #[cfg(test)]
 mod tests {
     use super::{FuelBehaviourEvent, FuelP2PService};
-    use crate::gossipsub::messages::{GossipsubBroadcastRequest, GossipsubMessage};
-    use crate::gossipsub::topics::{
-        GossipTopic, CON_VOTE_GOSSIP_TOPIC, NEW_BLOCK_GOSSIP_TOPIC, NEW_TX_GOSSIP_TOPIC,
+    use crate::{
+        config::P2PConfig,
+        gossipsub::{
+            messages::{GossipsubBroadcastRequest, GossipsubMessage},
+            topics::{
+                GossipTopic, CON_VOTE_GOSSIP_TOPIC, NEW_BLOCK_GOSSIP_TOPIC, NEW_TX_GOSSIP_TOPIC,
+            },
+        },
+        peer_info::PeerInfo,
+        request_response::messages::{OutboundResponse, RequestMessage, ResponseChannelItem},
+        service::FuelP2PEvent,
     };
-    use crate::request_response::messages::{
-        OutboundResponse, RequestMessage, ResponseChannelItem,
-    };
-    use crate::{config::P2PConfig, peer_info::PeerInfo, service::FuelP2PEvent};
     use ctor::ctor;
-    use fuel_core_interfaces::common::fuel_tx::Transaction;
-    use fuel_core_interfaces::model::{ConsensusVote, FuelBlock};
-    use libp2p::gossipsub::Topic;
-    use libp2p::identity::Keypair;
-    use libp2p::{Multiaddr, PeerId};
-    use std::collections::HashMap;
-    use std::{sync::Arc, time::Duration};
+    use fuel_core_interfaces::{
+        common::fuel_tx::Transaction,
+        model::{ConsensusVote, FuelBlock},
+    };
+    use libp2p::{gossipsub::Topic, identity::Keypair, Multiaddr, PeerId};
+    use std::{collections::HashMap, sync::Arc, time::Duration};
     use tokio::sync::{mpsc, oneshot};
     use tracing_attributes::instrument;
     use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
@@ -448,9 +450,9 @@ mod tests {
     #[tokio::test]
     #[instrument]
     async fn request_response_works() {
-        use fuel_core_interfaces::common::fuel_tx::Transaction;
-        use fuel_core_interfaces::model::{
-            FuelBlock, FuelBlockConsensus, FuelBlockHeader, SealedFuelBlock,
+        use fuel_core_interfaces::{
+            common::fuel_tx::Transaction,
+            model::{FuelBlock, FuelBlockConsensus, FuelBlockHeader, SealedFuelBlock},
         };
 
         let mut p2p_config = P2PConfig::default_with_network("request_response_works");

--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -270,7 +270,7 @@ impl FinalizationQueue {
         }
         self.remove_bundled_reverted_events();
 
-        //TODO to be paranoid, recheck every block and all events got from eth client.
+        // TODO to be paranoid, recheck every block and all events got from eth client.
 
         let mut validators: HashMap<ValidatorId, Option<ConsensusId>> = HashMap::new();
         while let Some(diff) = self.pending.front_mut() {

--- a/fuel-relayer/src/log.rs
+++ b/fuel-relayer/src/log.rs
@@ -5,10 +5,9 @@ use ethers_core::{
     abi::RawLog,
     types::{Log, U256},
 };
-use fuel_core_interfaces::model::DaBlockHeight;
 use fuel_core_interfaces::{
     common::fuel_types::{Address, Bytes32, Word},
-    model::{ConsensusId, Message, ValidatorId},
+    model::{ConsensusId, DaBlockHeight, Message, ValidatorId},
 };
 
 /// Bridge message send from da to fuel network.
@@ -225,8 +224,7 @@ pub mod tests {
 
     use bytes::{Bytes, BytesMut};
     use ethers_core::types::{Bytes as EthersBytes, H160, H256, U64};
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{rngs::StdRng, Rng, SeedableRng};
 
     use super::*;
     use crate::config;

--- a/fuel-relayer/src/pending_blocks.rs
+++ b/fuel-relayer/src/pending_blocks.rs
@@ -37,7 +37,7 @@ struct PendingBlock {
     pub reverted: bool,
     pub da_height: DaBlockHeight,
     pub block_height: BlockHeight,
-    pub block_root: Bytes32, //is this block hash?
+    pub block_root: Bytes32, // is this block hash?
 }
 
 impl PendingBlock {
@@ -150,7 +150,7 @@ impl PendingBlocks {
     ) -> Vec<Arc<SealedFuelBlock>> {
         // if queue is empty check last_finalized_committed fuel block and send all newest ones that we know about.
         let mut from_height = self.last_committed_finalized_fuel_height;
-        //get blocks range that start from last pending queue item that is not reverted and goes to current block.
+        // get blocks range that start from last pending queue item that is not reverted and goes to current block.
         for pending in self.pending_block_commits.iter() {
             if !pending.reverted {
                 from_height = pending.block_height;
@@ -337,7 +337,7 @@ impl PendingBlocks {
                 .validators
                 .iter()
                 .map(|(_, (_, sig))| sig.to_vec().into())
-                .collect(); //bytes
+                .collect(); // bytes
             let withdrawals = block
                 .withdrawals()
                 .iter()
@@ -378,8 +378,8 @@ impl PendingBlocks {
             // Use EthGasStation as the gas oracle
             // https://github.com/FuelLabs/fuel-core/issues/363
             // TODO check how this is going to be done in testnet.
-            //let gas_oracle = EthGasStation::new(None);
-            //let provider = GasOracleMiddleware::new(provider, gas_oracle);
+            // let gas_oracle = EthGasStation::new(None);
+            // let provider = GasOracleMiddleware::new(provider, gas_oracle);
 
             // Manage nonces locally
             let provider = NonceManagerMiddleware::new(provider, address);

--- a/fuel-relayer/src/relayer.rs
+++ b/fuel-relayer/src/relayer.rs
@@ -531,17 +531,21 @@ mod test {
             async fn run<'a>(&mut self, _: &mut MockData, trigger: TriggerType<'a>) {
                 match self.i {
                     // check if eth client is in sync.
-                    0 => assert_eq!(
-                        TriggerType::Syncing,
-                        trigger,
-                        "We need to check if eth client is synced"
-                    ),
+                    0 => {
+                        assert_eq!(
+                            TriggerType::Syncing,
+                            trigger,
+                            "We need to check if eth client is synced"
+                        )
+                    }
                     // get best eth block number so that we know until when to sync
-                    1 => assert_eq!(
-                        TriggerType::GetBlockNumber,
-                        trigger,
-                        "We need to get Best eth block number"
-                    ),
+                    1 => {
+                        assert_eq!(
+                            TriggerType::GetBlockNumber,
+                            trigger,
+                            "We need to get Best eth block number"
+                        )
+                    }
                     // get first batch of logs.
                     2 => match trigger {
                         TriggerType::GetLogs(filter) => {

--- a/fuel-relayer/src/test_helpers/middleware.rs
+++ b/fuel-relayer/src/test_helpers/middleware.rs
@@ -4,11 +4,7 @@ use ethers_providers::{
     FilterWatcher, JsonRpcClient, Middleware, Provider, ProviderError, SyncingStatus,
 };
 use serde::{de::DeserializeOwned, Serialize};
-use std::fmt;
-use std::io::BufWriter;
-use std::sync::Arc;
-use std::time::Duration;
-use std::{fmt::Debug, str::FromStr};
+use std::{fmt, fmt::Debug, io::BufWriter, str::FromStr, sync::Arc, time::Duration};
 use thiserror::Error;
 use tokio::sync::Mutex;
 
@@ -168,15 +164,13 @@ impl JsonRpcClient for MockMiddleware {
     }
 }
 
-/*
-Needed functionality for relayer to function:
-* syncing API
-* get_block_number API
-* get_logs API.
-* .watch() API for logs with filter. Impl LogStream
-    * LogsWatcher only uses .next()
-* get_block API using only HASH
-*/
+// Needed functionality for relayer to function:
+// syncing API
+// get_block_number API
+// get_logs API.
+// .watch() API for logs with filter. Impl LogStream
+// LogsWatcher only uses .next()
+// get_block API using only HASH
 
 #[async_trait]
 impl Middleware for MockMiddleware {

--- a/fuel-relayer/src/test_helpers/mod.rs
+++ b/fuel-relayer/src/test_helpers/mod.rs
@@ -4,8 +4,7 @@ pub use middleware::*;
 use fuel_core_interfaces::{block_importer::ImportBlockBroadcast, relayer::RelayerRequest};
 use tokio::sync::{broadcast, mpsc};
 
-use crate::mock_db::MockDb;
-use crate::{service::Context, Config, Relayer};
+use crate::{mock_db::MockDb, service::Context, Config, Relayer};
 
 pub async fn relayer(
     config: Config,

--- a/fuel-tests/tests/blocks.rs
+++ b/fuel-tests/tests/blocks.rs
@@ -5,10 +5,10 @@ use fuel_core::{
     schema::scalars::BlockId,
     service::{Config, FuelService},
 };
-use fuel_core_interfaces::common::fuel_tx;
-use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_types};
-use fuel_gql_client::client::types::TransactionStatus;
-use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
+use fuel_core_interfaces::common::{fuel_storage::Storage, fuel_tx, fuel_types};
+use fuel_gql_client::client::{
+    types::TransactionStatus, FuelClient, PageDirection, PaginationRequest,
+};
 use itertools::{rev, Itertools};
 
 #[tokio::test]

--- a/fuel-tests/tests/helpers.rs
+++ b/fuel-tests/tests/helpers.rs
@@ -2,7 +2,10 @@ use fuel_core::{
     chain_config::{ChainConfig, CoinConfig, ContractConfig, StateConfig},
     service::{Config, FuelService},
 };
-use fuel_core_interfaces::common::{fuel_tx::Contract, fuel_tx::Transaction, fuel_vm::prelude::*};
+use fuel_core_interfaces::common::{
+    fuel_tx::{Contract, Transaction},
+    fuel_vm::prelude::*,
+};
 use fuel_gql_client::client::FuelClient;
 use itertools::Itertools;
 use rand::{rngs::StdRng, Rng, SeedableRng};

--- a/fuel-tests/tests/messages.rs
+++ b/fuel-tests/tests/messages.rs
@@ -3,8 +3,7 @@ use fuel_core::{
     service::{Config, FuelService},
 };
 use fuel_core_interfaces::common::fuel_tx::TransactionBuilder;
-use fuel_crypto::fuel_types::Address;
-use fuel_crypto::SecretKey;
+use fuel_crypto::{fuel_types::Address, SecretKey};
 use fuel_gql_client::client::{FuelClient, PageDirection, PaginationRequest};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::ops::Deref;

--- a/fuel-tests/tests/metrics.rs
+++ b/fuel-tests/tests/metrics.rs
@@ -1,4 +1,4 @@
-use fuel_core::{service::Config, service::DbType, service::FuelService};
+use fuel_core::service::{Config, DbType, FuelService};
 use fuel_core_interfaces::common::{
     fuel_tx,
     fuel_tx::{Address, AssetId},

--- a/fuel-tests/tests/tx/predicates.rs
+++ b/fuel-tests/tests/tx/predicates.rs
@@ -3,7 +3,10 @@
 use crate::helpers::TestSetupBuilder;
 use fuel_core_interfaces::common::{
     fuel_tx::{Input, Output, TransactionBuilder},
-    fuel_vm::{consts::REG_ONE, consts::REG_ZERO, prelude::Opcode},
+    fuel_vm::{
+        consts::{REG_ONE, REG_ZERO},
+        prelude::Opcode,
+    },
 };
 use rand::{rngs::StdRng, Rng, SeedableRng};
 

--- a/fuel-txpool/src/containers/dependency.rs
+++ b/fuel-txpool/src/containers/dependency.rs
@@ -206,9 +206,7 @@ impl Dependency {
                     }
                 }
                 Output::Contract { .. } => return Err(Error::NotInsertedIoContractOutput.into()),
-                Output::Message { .. } => {
-                    return Err(Error::NotInsertedIoMessageInput.into());
-                }
+                Output::Message { .. } => return Err(Error::NotInsertedIoMessageInput.into()),
                 Output::Change {
                     to,
                     asset_id,
@@ -331,7 +329,7 @@ impl Dependency {
                                 return Err(Error::NotInsertedCollision(*spend_by, *utxo_id).into());
                             } else {
                                 if state.is_in_database() {
-                                    //this means it is loaded from db. Get tx to compare output.
+                                    // this means it is loaded from db. Get tx to compare output.
                                     let coin = db.utxo(utxo_id)?.ok_or(
                                         Error::NotInsertedInputUtxoIdNotExisting(*utxo_id),
                                     )?;
@@ -429,7 +427,7 @@ impl Dependency {
                             .or_insert(ContractState {
                                 used_by: HashSet::new(),
                                 depth: 0,
-                                origin: None, //there is no owner if contract is in db
+                                origin: None, // there is no owner if contract is in db
                                 gas_price: GasPrice::MAX,
                             })
                             .used_by

--- a/fuel-txpool/src/mock_db.rs
+++ b/fuel-txpool/src/mock_db.rs
@@ -1,6 +1,8 @@
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use fuel_core_interfaces::{
     common::{

--- a/fuel-txpool/src/service.rs
+++ b/fuel-txpool/src/service.rs
@@ -1,10 +1,14 @@
 use crate::{Config, TxPool};
 use anyhow::anyhow;
-use fuel_core_interfaces::block_importer::ImportBlockBroadcast;
-use fuel_core_interfaces::txpool::{self, TxPoolDb, TxPoolMpsc, TxStatusBroadcast};
+use fuel_core_interfaces::{
+    block_importer::ImportBlockBroadcast,
+    txpool::{self, TxPoolDb, TxPoolMpsc, TxStatusBroadcast},
+};
 use std::sync::Arc;
-use tokio::sync::{broadcast, mpsc, Mutex, RwLock};
-use tokio::task::JoinHandle;
+use tokio::{
+    sync::{broadcast, mpsc, Mutex, RwLock},
+    task::JoinHandle,
+};
 
 pub struct ServiceBuilder {
     sender: txpool::Sender,

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -7,8 +7,7 @@ use fuel_core_interfaces::{
     model::{ArcTx, TxInfo},
     txpool::{TxPoolDb, TxStatus, TxStatusBroadcast},
 };
-use std::cmp::Reverse;
-use std::collections::HashMap;
+use std::{cmp::Reverse, collections::HashMap};
 use tokio::sync::{broadcast, RwLock};
 
 #[derive(Debug, Clone)]
@@ -72,7 +71,7 @@ impl TxPool {
         // if some transaction were removed so we don't need to check limit
         if rem.is_empty() {
             if max_limit_hit {
-                //remove last tx from sort
+                // remove last tx from sort
                 let rem_tx = self.by_gas_price.last().unwrap(); // safe to unwrap limit is hit
                 self.remove_inner(&rem_tx);
                 return Ok(vec![rem_tx]);
@@ -220,7 +219,7 @@ impl TxPool {
 
     /// When block is updated we need to receive all spend outputs and remove them from txpool.
     pub async fn block_update(
-        txpool: &RwLock<Self>, /*spend_outputs: [Input], added_outputs: [AddedOutputs]*/
+        txpool: &RwLock<Self>, // spend_outputs: [Input], added_outputs: [AddedOutputs]
     ) {
         txpool.write().await;
         // TODO https://github.com/FuelLabs/fuel-core/issues/465
@@ -312,10 +311,12 @@ pub mod tests {
     }
 
     use super::*;
-    use crate::txpool::tests::helpers::{
-        create_coin_input, create_coin_output, create_contract_input, create_contract_output,
+    use crate::{
+        txpool::tests::helpers::{
+            create_coin_input, create_coin_output, create_contract_input, create_contract_output,
+        },
+        Error,
     };
-    use crate::Error;
     use fuel_core_interfaces::{
         common::{
             fuel_storage::Storage,
@@ -323,8 +324,7 @@ pub mod tests {
         },
         model::{BlockHeight, Coin, CoinStatus, Message},
     };
-    use std::str::FromStr;
-    use std::{cmp::Reverse, sync::Arc};
+    use std::{cmp::Reverse, str::FromStr, sync::Arc};
 
     #[tokio::test]
     async fn simple_insertion() {

--- a/fuel-txpool/src/types.rs
+++ b/fuel-txpool/src/types.rs
@@ -1,7 +1,4 @@
+pub use fuel_core_interfaces::common::fuel_tx::{ContractId, Transaction, TxId};
 use fuel_core_interfaces::common::fuel_types::Word;
-pub use fuel_core_interfaces::common::{
-    fuel_tx::ContractId,
-    fuel_tx::{Transaction, TxId},
-};
 
 pub type GasPrice = Word;


### PR DESCRIPTION
While we are thinking about [using non-standard](https://github.com/FuelLabs/fuel-core/pull/575) `rustfmt.toml`. 
We can apply the same formatting for parts not handled by the default rustfmt.

In most cases, it is sorting of imports, uncollapsing statements, add whitespace for comments=)