### PR TITLE
Breakout metrics into `fuel-metrics`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
  "fuel-core-bft",
  "fuel-core-interfaces",
  "fuel-crypto",
+ "fuel-metrics",
  "fuel-p2p",
  "fuel-relayer",
  "fuel-sync",
@@ -2232,6 +2233,16 @@ dependencies = [
  "hex",
  "sha2 0.10.2",
  "thiserror",
+]
+
+[[package]]
+name = "fuel-metrics"
+version = "0.10.1"
+dependencies = [
+ "axum",
+ "hyper",
+ "lazy_static",
+ "prometheus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "fuel-core",
   "fuel-core-bft",
   "fuel-core-interfaces",
+  "fuel-metrics",
   "fuel-p2p",
   "fuel-relayer",
   "fuel-sync",

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -52,7 +52,6 @@ hex = { version = "0.4", features = ["serde"] }
 hyper = "0.14"
 itertools = "0.10"
 lazy_static = "1.4"
-prometheus = { version = "0.13", optional = true }
 rand = "0.8"
 rocksdb = { version = "0.19", default-features = false, features = [
     "lz4",

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -36,12 +36,12 @@ env_logger = "0.9"
 fuel-block-executor = { path = "../fuel-block-executor", version = "0.10.1" }
 fuel-block-importer = { path = "../fuel-block-importer", version = "0.10.1" }
 fuel-block-producer = { path = "../fuel-block-producer", version = "0.10.1" }
-fuel-metrics = { path = "../fuel-metrics", version = "0.10.1", optional = true }
 fuel-core-bft = { path = "../fuel-core-bft", version = "0.10.1" }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.10.1", features = [
     "serde",
 ] }
 fuel-crypto = { version = "0.6", default-features = false, features = [ "random" ] }
+fuel-metrics = { path = "../fuel-metrics", version = "0.10.1", optional = true }
 fuel-p2p = { path = "../fuel-p2p", version = "0.10.1", optional = true }
 fuel-relayer = { path = "../fuel-relayer", version = "0.10.1", optional = true }
 fuel-sync = { path = "../fuel-sync", version = "0.10.1" }

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -36,6 +36,7 @@ env_logger = "0.9"
 fuel-block-executor = { path = "../fuel-block-executor", version = "0.10.1" }
 fuel-block-importer = { path = "../fuel-block-importer", version = "0.10.1" }
 fuel-block-producer = { path = "../fuel-block-producer", version = "0.10.1" }
+fuel-metrics = { path = "../fuel-metrics", version = "0.10.1", optional = true }
 fuel-core-bft = { path = "../fuel-core-bft", version = "0.10.1" }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.10.1", features = [
     "serde",
@@ -85,8 +86,8 @@ fuel-core-interfaces = { path = "../fuel-core-interfaces", features = [
 insta = "1.8"
 
 [features]
-prometheus = ["dep:prometheus"]
-default = ["rocksdb", "prometheus", "debug"]
+metrics = ["dep:fuel-metrics"]
+default = ["rocksdb", "metrics", "debug"]
 debug = ["fuel-core-interfaces/debug"]
 test-helpers = []
 relayer = ["dep:fuel-relayer"]

--- a/fuel-core/src/service/metrics.rs
+++ b/fuel-core/src/service/metrics.rs
@@ -1,64 +1,16 @@
 use axum::response::IntoResponse;
+#[cfg(feature = "metrics")]
+use fuel_metrics::core_metrics::encode_metrics_response;
 use hyper::{Body, Request};
 
 pub async fn metrics(_req: Request<Body>) -> impl IntoResponse {
-    #[cfg(feature = "prometheus")]
+    #[cfg(feature = "metrics")]
     {
-        prometheus_metrics::encode_metrics_response()
+        encode_metrics_response()
     }
-    #[cfg(not(feature = "prometheus"))]
+    #[cfg(not(feature = "metrics"))]
     {
         use axum::http::StatusCode;
         (StatusCode::NOT_FOUND, "metrics collection disabled")
-    }
-}
-
-#[cfg(feature = "prometheus")]
-pub mod prometheus_metrics {
-    use super::{Body, IntoResponse};
-    use hyper::{header::CONTENT_TYPE, Response};
-    use lazy_static::lazy_static;
-    use prometheus::register_int_counter;
-    use prometheus::{self, Encoder, IntCounter, TextEncoder};
-
-    /// DatabaseMetrics is a wrapper struct for all
-    /// of the initialized counters for Database-related metrics
-    #[derive(Clone, Debug)]
-    pub struct DatabaseMetrics {
-        pub write_meter: IntCounter,
-        pub read_meter: IntCounter,
-        pub bytes_written_meter: IntCounter,
-        pub bytes_read_meter: IntCounter,
-    }
-
-    lazy_static! {
-        pub static ref DATABASE_METRICS: DatabaseMetrics = DatabaseMetrics {
-            write_meter: register_int_counter!("Writes", "Number of database write operations")
-                .unwrap(),
-            read_meter: register_int_counter!("Reads", "Number of database read operations")
-                .unwrap(),
-            bytes_written_meter: register_int_counter!(
-                "Bytes_Written",
-                "The number of bytes written to the database"
-            )
-            .unwrap(),
-            bytes_read_meter: register_int_counter!(
-                "Bytes_Read",
-                "The number of bytes read from the database"
-            )
-            .unwrap(),
-        };
-    }
-
-    pub fn encode_metrics_response() -> impl IntoResponse {
-        let mut buffer = vec![];
-        let encoder = TextEncoder::new();
-        let metric_families = prometheus::gather();
-        encoder.encode(&metric_families, &mut buffer).unwrap();
-        Response::builder()
-            .status(200)
-            .header(CONTENT_TYPE, encoder.format_type())
-            .body(Body::from(buffer))
-            .unwrap()
     }
 }

--- a/fuel-metrics/Cargo.toml
+++ b/fuel-metrics/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fuel-metrics"
+version = "0.10.1"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+categories = ["cryptography::cryptocurrencies"]
+edition = "2021"
+homepage = "https://fuel.network/"
+keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
+license = "BUSL-1.1"
+repository = "https://github.com/FuelLabs/fuel-core"
+description = "Fuel metrics"
+
+[dependencies]
+axum = "0.4"
+lazy_static = "1.4"
+prometheus = "0.13"
+hyper = "0.14"
+

--- a/fuel-metrics/Cargo.toml
+++ b/fuel-metrics/Cargo.toml
@@ -12,7 +12,7 @@ description = "Fuel metrics"
 
 [dependencies]
 axum = "0.4"
+hyper = "0.14"
 lazy_static = "1.4"
 prometheus = "0.13"
-hyper = "0.14"
 

--- a/fuel-metrics/src/core_metrics.rs
+++ b/fuel-metrics/src/core_metrics.rs
@@ -1,0 +1,71 @@
+use axum::response::IntoResponse;
+use hyper::{header::CONTENT_TYPE, Body, Response};
+use lazy_static::lazy_static;
+use prometheus::register_int_counter;
+use prometheus::{self, Encoder, IntCounter, TextEncoder};
+
+/// DatabaseMetrics is a wrapper struct for all
+/// of the initialized counters for Database-related metrics
+#[derive(Clone, Debug)]
+pub struct DatabaseMetrics {
+    pub write_meter: IntCounter,
+    pub read_meter: IntCounter,
+    pub bytes_written_meter: IntCounter,
+    pub bytes_read_meter: IntCounter,
+}
+
+lazy_static! {
+    pub static ref DATABASE_METRICS: DatabaseMetrics = DatabaseMetrics {
+        write_meter: register_int_counter!("Writes", "Number of database write operations")
+            .unwrap(),
+        read_meter: register_int_counter!("Reads", "Number of database read operations").unwrap(),
+        bytes_written_meter: register_int_counter!(
+            "Bytes_Written",
+            "The number of bytes written to the database"
+        )
+        .unwrap(),
+        bytes_read_meter: register_int_counter!(
+            "Bytes_Read",
+            "The number of bytes read from the database"
+        )
+        .unwrap(),
+    };
+}
+
+/// CoreMetrics tracks metrics for most of fuel-core, wrapping core metrics similar to
+/// DatabaseMetrics, kept seperate from GQLMetrics which holds more specific endpoint metrics
+#[derive(Clone, Debug)]
+pub struct CoreMetrics {
+    pub blocks_processed: IntCounter,
+    pub transactions_executed: IntCounter,
+    pub requests_handled: IntCounter,
+}
+
+lazy_static! {
+    pub static ref CORE_METRICS: CoreMetrics = CoreMetrics {
+        blocks_processed: register_int_counter!("Blocks_Processed", "Number of blocks processed")
+            .unwrap(),
+        transactions_executed: register_int_counter!(
+            "Transactions_Processed",
+            "Number of transactions executed"
+        )
+        .unwrap(),
+        requests_handled: register_int_counter!(
+            "Requests_Handled",
+            "Number of GraphQL Requests handled"
+        )
+        .unwrap(),
+    };
+}
+
+pub fn encode_metrics_response() -> impl IntoResponse {
+    let mut buffer = vec![];
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    Response::builder()
+        .status(200)
+        .header(CONTENT_TYPE, encoder.format_type())
+        .body(Body::from(buffer))
+        .unwrap()
+}

--- a/fuel-metrics/src/lib.rs
+++ b/fuel-metrics/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod core_metrics;


### PR DESCRIPTION
Moves Metrics into `fuel-metrics` allowing future metrics to be done inside of an optional crate