### PR TITLE
Add a CI check to ensure Cargo.lock file remains up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
             args: --all-targets --all-features
           - command: make
             args: build
+          - command: check
+            args: --locked --all-targets --all-features
           - command: test
             args: --all-targets --all-features --workspace --exclude fuel-p2p
           - command: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           - command: make
             args: build
           - command: check
-            args: --locked --all-targets --all-features
+            args: --locked --workspace
           - command: test
             args: --all-targets --all-features --workspace --exclude fuel-p2p
           - command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,7 +2130,6 @@ dependencies = [
  "insta",
  "itertools",
  "lazy_static",
- "prometheus",
  "rand 0.8.5",
  "rocksdb",
  "serde",


### PR DESCRIPTION
This adds a new CI "cargo-verification" check to ensure the `Cargo.lock` file is valid for the current state of all manifests within the workspace. This avoids having `Cargo.lock` files changes leak into unrelated PRs, and allows tools like Nix to always have a valid lock file present at each published release to ensure reproducible builds.