### PR TITLE
fix prometheus flag

### DIFF
--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -20,7 +20,7 @@ harness = true
 [[test]]
 name = "metrics_test"
 path = "tests/metrics.rs"
-required-features = ["fuel-core/prometheus", "fuel-core/rocksdb"]
+required-features = ["fuel-core/metrics", "fuel-core/rocksdb"]
 harness = true
 
 [dependencies]

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -16,13 +16,6 @@ name = "integration_tests"
 path = "tests/lib.rs"
 harness = true
 
-
-[[test]]
-name = "metrics_test"
-path = "tests/metrics.rs"
-required-features = ["fuel-core/metrics", "fuel-core/rocksdb"]
-harness = true
-
 [dependencies]
 async-std = "1.12"
 chrono = { version = "0.4", features = ["serde"] }
@@ -42,5 +35,6 @@ tempfile = "3.3"
 tokio = { version = "1.8", features = ["macros", "rt-multi-thread"] }
 
 [features]
-default = ["fuel-core/default"]
+metrics = ["fuel-core/rocksdb", "fuel-core/metrics"]
+default = ["fuel-core/default", "metrics"]
 debug = ["fuel-core-interfaces/debug"]

--- a/fuel-tests/tests/lib.rs
+++ b/fuel-tests/tests/lib.rs
@@ -8,6 +8,8 @@ mod debugger;
 mod health;
 mod helpers;
 mod messages;
+#[cfg(feature = "metrics")]
+mod metrics;
 mod node_info;
 mod snapshot;
 mod tx;

--- a/fuel-tests/tests/metrics.rs
+++ b/fuel-tests/tests/metrics.rs
@@ -1,18 +1,8 @@
-use fuel_core::service::{
-    Config,
-    DbType,
-    FuelService,
-};
+use fuel_core::service::{Config, DbType, FuelService};
 use fuel_core_interfaces::common::{
     fuel_tx,
-    fuel_tx::{
-        Address,
-        AssetId,
-    },
-    fuel_vm::{
-        consts::*,
-        prelude::*,
-    },
+    fuel_tx::{Address, AssetId},
+    fuel_vm::{consts::*, prelude::*},
 };
 use fuel_gql_client::client::FuelClient;
 use tempfile::TempDir;

--- a/fuel-tests/tests/metrics.rs
+++ b/fuel-tests/tests/metrics.rs
@@ -1,8 +1,18 @@
-use fuel_core::service::{Config, DbType, FuelService};
+use fuel_core::service::{
+    Config,
+    DbType,
+    FuelService,
+};
 use fuel_core_interfaces::common::{
     fuel_tx,
-    fuel_tx::{Address, AssetId},
-    fuel_vm::{consts::*, prelude::*},
+    fuel_tx::{
+        Address,
+        AssetId,
+    },
+    fuel_vm::{
+        consts::*,
+        prelude::*,
+    },
 };
 use fuel_gql_client::client::FuelClient;
 use tempfile::TempDir;


### PR DESCRIPTION
When moving metrics out into their own crate, a feature flag for integration testing didn't get modified as needed. This was causing the following compilation warning:
```
warning: invalid feature `fuel-core/prometheus` in required-features of target `metrics_test`: feature `prometheus` does not exist in package `fuel-core v0.10.1 (/path/to/fuel-core/fuel-core)`
```

This PR fixes the warning and also restructures the metrics test to share the same test harness as other integ tests to avoid stressing the linker too much with multiple targets.