### PR TITLE
remove owner from input messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,9 +2059,9 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "fuel-asm"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ef9990debd1fa257988a0a8be5b9d787decaba911cc3b97d7712a4b70328d"
+checksum = "6e4dcbfb02da27a232dc1a8dedcb8ed50ee3e981b40ce3618f96ce0f3c250f3e"
 dependencies = [
  "fuel-types",
  "serde",
@@ -2339,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118b773c25dbf645457fbd9b0288ac923c044d03ce68f492e539c840c3595f5e"
+checksum = "d88b96bddf1c57f1d73a51f0f58ef67b294cdb722d5f80ee76d9cf84b986769e"
 dependencies = [
  "fuel-asm",
  "fuel-crypto",
@@ -2351,6 +2351,7 @@ dependencies = [
  "num-integer",
  "rand 0.8.5",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2380,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516d60fc504570c0ad79f6dffcbd31687b15b76ecf8753bccaeae201baac29d2"
+checksum = "44bdbc4b0863a4d7d523b248d404821dc4e3b6d0034fbbf33f03b1f4283af663"
 dependencies = [
  "anyhow",
  "fuel-asm",

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -20,9 +20,9 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "1.0", features = ["surf"] }
 derive_more = { version = "0.99" }
-fuel-tx = { version = "0.18", features = ["serde"] }
+fuel-tx = { version = "0.19", features = ["serde"] }
 fuel-types = { version = "0.5", features = ["serde"] }
-fuel-vm = { version = "0.15", features = ["serde"] }
+fuel-vm = { version = "0.16", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
 itertools = "0.10"

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -289,7 +289,6 @@ type InputMessage {
 	recipient: Address!
 	amount: U64!
 	nonce: U64!
-	owner: Address!
 	witnessIndex: Int!
 	data: HexString!
 	predicate: HexString!
@@ -301,7 +300,6 @@ type Message {
 	amount: U64!
 	sender: Address!
 	recipient: Address!
-	owner: Address!
 	nonce: U64!
 	data: [Int!]!
 	daHeight: U64!

--- a/fuel-client/src/client/schema/message.rs
+++ b/fuel-client/src/client/schema/message.rs
@@ -16,7 +16,6 @@ pub struct Message {
     pub amount: U64,
     pub sender: Address,
     pub recipient: Address,
-    pub owner: Address,
     pub nonce: U64,
     pub data: Vec<i32>,
     pub da_height: U64,

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__message__tests__owned_message_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__message__tests__owned_message_query_gql_output.snap
@@ -1,6 +1,5 @@
 ---
 source: fuel-client/src/client/schema/message.rs
-assertion_line: 105
 expression: operation.query
 ---
 query Query($_0: Address, $_1: Int, $_2: String, $_3: Int, $_4: String) {
@@ -11,7 +10,6 @@ query Query($_0: Address, $_1: Int, $_2: String, $_3: Int, $_4: String) {
         amount
         sender
         recipient
-        owner
         nonce
         data
         daHeight

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -39,7 +39,6 @@ query Query($_0: TransactionId!) {
         recipient
         amount
         nonce
-        owner
         witnessIndex
         data
         predicate

--- a/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
+++ b/fuel-client/src/client/schema/tx/tests/transparent_tx.rs
@@ -228,7 +228,6 @@ pub struct InputMessage {
     recipient: Address,
     amount: U64,
     nonce: U64,
-    owner: Address,
     witness_index: i32,
     data: HexString,
     predicate: HexString,
@@ -279,7 +278,6 @@ impl TryFrom<Input> for fuel_tx::Input {
                         recipient: message.recipient.into(),
                         amount: message.amount.into(),
                         nonce: message.nonce.into(),
-                        owner: message.owner.into(),
                         witness_index: message.witness_index.try_into()?,
                         data: message.data.into(),
                     }
@@ -290,7 +288,6 @@ impl TryFrom<Input> for fuel_tx::Input {
                         recipient: message.recipient.into(),
                         amount: message.amount.into(),
                         nonce: message.nonce.into(),
-                        owner: message.owner.into(),
                         data: message.data.into(),
                         predicate: message.predicate.into(),
                         predicate_data: message.predicate_data.into(),

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -15,13 +15,13 @@ anyhow = "1.0"
 async-trait = "0.1"
 chrono = { version = "0.4" }
 derive_more = { version = "0.99" }
-fuel-asm = "0.8"
+fuel-asm = "0.9"
 fuel-crypto = { version = "0.6", default-features = false, features = [ "random" ] }
 fuel-merkle = { version = "0.3" }
 fuel-storage = "0.2"
-fuel-tx = { version = "0.18", default-features = false }
+fuel-tx = { version = "0.19", default-features = false }
 fuel-types = { version = "0.5", default-features = false }
-fuel-vm = { version = "0.15", default-features = false }
+fuel-vm = { version = "0.16", default-features = false }
 futures = "0.3"
 lazy_static = "1.4"
 parking_lot = "0.12"

--- a/fuel-core-interfaces/src/model/messages.rs
+++ b/fuel-core-interfaces/src/model/messages.rs
@@ -14,7 +14,6 @@ use fuel_types::{
 pub struct Message {
     pub sender: Address,
     pub recipient: Address,
-    pub owner: Address,
     pub nonce: Word,
     pub amount: Word,
     pub data: Vec<u8>,
@@ -29,7 +28,6 @@ impl Message {
         hasher.input(self.sender);
         hasher.input(self.recipient);
         hasher.input(self.nonce.to_be_bytes());
-        hasher.input(self.owner);
         hasher.input(self.amount.to_be_bytes());
         hasher.input(&self.data);
         MessageId::from(*hasher.digest())

--- a/fuel-core/src/chain_config.rs
+++ b/fuel-core/src/chain_config.rs
@@ -218,8 +218,6 @@ pub struct MessageConfig {
     pub sender: Address,
     #[serde_as(as = "HexType")]
     pub recipient: Address,
-    #[serde_as(as = "HexType")]
-    pub owner: Address,
     #[serde_as(as = "HexNumber")]
     pub nonce: Word,
     #[serde_as(as = "HexNumber")]
@@ -236,7 +234,6 @@ impl From<MessageConfig> for Message {
         Message {
             sender: msg.sender,
             recipient: msg.recipient,
-            owner: msg.owner,
             nonce: msg.nonce,
             amount: msg.amount,
             data: msg.data,
@@ -472,7 +469,6 @@ mod tests {
                 messages: Some(vec![MessageConfig {
                     sender: rng.gen(),
                     recipient: rng.gen(),
-                    owner: rng.gen(),
                     nonce: rng.gen(),
                     amount: rng.gen(),
                     data: vec![rng.gen()],

--- a/fuel-core/src/database/message.rs
+++ b/fuel-core/src/database/message.rs
@@ -41,7 +41,7 @@ impl Storage<MessageId, Message> for Database {
         // insert secondary record by owner
         Database::insert(
             self,
-            owner_msg_id_key(&value.owner, key),
+            owner_msg_id_key(&value.recipient, key),
             columns::OWNED_MESSAGE_IDS,
             true,
         )?;
@@ -56,7 +56,7 @@ impl Storage<MessageId, Message> for Database {
         if let Some(message) = &result {
             Database::remove::<bool>(
                 self,
-                &owner_msg_id_key(&message.owner, key),
+                &owner_msg_id_key(&message.recipient, key),
                 columns::OWNED_MESSAGE_IDS,
             )?;
         }
@@ -113,7 +113,6 @@ impl Database {
                 Ok(MessageConfig {
                     sender: msg.sender,
                     recipient: msg.recipient,
-                    owner: msg.owner,
                     nonce: msg.nonce,
                     amount: msg.amount,
                     data: msg.data,
@@ -155,22 +154,23 @@ mod tests {
         let _ =
             Storage::<MessageId, Message>::insert(&mut db, &second_id, &message).unwrap();
 
-        // verify that 2 message IDs are associated with a single Owner
-        let owned_msg_ids = db.owned_message_ids(message.owner, None, None);
+        // verify that 2 message IDs are associated with a single Owner/Recipient
+        let owned_msg_ids = db.owned_message_ids(message.recipient, None, None);
         assert_eq!(owned_msg_ids.count(), 2);
 
         // remove the first message with its given id
         let _ = Storage::<MessageId, Message>::remove(&mut db, &first_id).unwrap();
 
         // verify that only second ID is left
-        let owned_msg_ids: Vec<_> =
-            db.owned_message_ids(message.owner, None, None).collect();
+        let owned_msg_ids: Vec<_> = db
+            .owned_message_ids(message.recipient, None, None)
+            .collect();
         assert_eq!(owned_msg_ids.first().unwrap().as_ref().unwrap(), &second_id);
         assert_eq!(owned_msg_ids.len(), 1);
 
         // remove the second message with its given id
         let _ = Storage::<MessageId, Message>::remove(&mut db, &second_id).unwrap();
-        let owned_msg_ids = db.owned_message_ids(message.owner, None, None);
+        let owned_msg_ids = db.owned_message_ids(message.recipient, None, None);
         assert_eq!(owned_msg_ids.count(), 0);
     }
 }

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -518,7 +518,6 @@ impl Executor {
                     recipient,
                     amount,
                     nonce,
-                    owner,
                     data,
                     ..
                 }
@@ -528,7 +527,6 @@ impl Executor {
                     recipient,
                     amount,
                     nonce,
-                    owner,
                     data,
                     ..
                 } => {
@@ -553,7 +551,6 @@ impl Executor {
                             fuel_block_spend: Some(block_height),
                             sender: *sender,
                             recipient: *recipient,
-                            owner: *owner,
                             nonce: *nonce,
                             amount: *amount,
                             data: data.clone(),
@@ -1860,7 +1857,6 @@ mod tests {
         let mut message = Message {
             sender: rng.gen(),
             recipient: rng.gen(),
-            owner: rng.gen(),
             nonce: rng.gen(),
             amount: 1000,
             data: vec![],
@@ -1872,15 +1868,14 @@ mod tests {
             .add_unsigned_message_input(
                 rng.gen(),
                 message.sender,
-                message.recipient,
                 message.nonce,
                 message.amount,
                 vec![],
             )
             .finalize();
 
-        if let Input::MessageSigned { owner, .. } = tx.inputs()[0] {
-            message.owner = owner;
+        if let Input::MessageSigned { recipient, .. } = tx.inputs()[0] {
+            message.recipient = recipient;
         } else {
             unreachable!();
         }

--- a/fuel-core/src/schema/message.rs
+++ b/fuel-core/src/schema/message.rs
@@ -44,10 +44,6 @@ impl Message {
         self.0.recipient.into()
     }
 
-    async fn owner(&self) -> Address {
-        self.0.owner.into()
-    }
-
     async fn nonce(&self) -> U64 {
         self.0.nonce.into()
     }

--- a/fuel-core/src/schema/tx/input.rs
+++ b/fuel-core/src/schema/tx/input.rs
@@ -113,7 +113,6 @@ pub struct InputMessage {
     recipient: Address,
     amount: U64,
     nonce: U64,
-    owner: Address,
     witness_index: u8,
     data: HexString,
     predicate: HexString,
@@ -140,10 +139,6 @@ impl InputMessage {
 
     async fn nonce(&self) -> U64 {
         self.nonce
-    }
-
-    async fn owner(&self) -> Address {
-        self.owner
     }
 
     async fn witness_index(&self) -> u8 {
@@ -224,7 +219,6 @@ impl From<&fuel_tx::Input> for Input {
                 recipient,
                 amount,
                 nonce,
-                owner,
                 witness_index,
                 data,
             } => Input::Message(InputMessage {
@@ -233,7 +227,6 @@ impl From<&fuel_tx::Input> for Input {
                 recipient: Address(*recipient),
                 amount: (*amount).into(),
                 nonce: (*nonce).into(),
-                owner: Address(*owner),
                 witness_index: *witness_index,
                 data: HexString(data.clone()),
                 predicate: HexString(Default::default()),
@@ -245,7 +238,6 @@ impl From<&fuel_tx::Input> for Input {
                 recipient,
                 amount,
                 nonce,
-                owner,
                 data,
                 predicate,
                 predicate_data,
@@ -255,7 +247,6 @@ impl From<&fuel_tx::Input> for Input {
                 recipient: Address(*recipient),
                 amount: (*amount).into(),
                 nonce: (*nonce).into(),
-                owner: Address(*owner),
                 witness_index: Default::default(),
                 data: HexString(data.clone()),
                 predicate: HexString(predicate.clone()),

--- a/fuel-core/src/service/genesis.rs
+++ b/fuel-core/src/service/genesis.rs
@@ -177,7 +177,6 @@ impl FuelService {
                 let message = Message {
                     sender: msg.sender,
                     recipient: msg.recipient,
-                    owner: msg.owner,
                     nonce: msg.nonce,
                     amount: msg.amount,
                     data: msg.data.clone(),
@@ -444,7 +443,6 @@ mod tests {
         let msg = MessageConfig {
             sender: rng.gen(),
             recipient: rng.gen(),
-            owner: rng.gen(),
             nonce: rng.gen(),
             amount: rng.gen(),
             data: vec![rng.gen()],

--- a/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_simple_message_state.snap
+++ b/fuel-core/src/snapshots/fuel_core__chain_config__tests__snapshot_simple_message_state.snap
@@ -1,6 +1,5 @@
 ---
-source: fuel-core/src/genesis.rs
-assertion_line: 348
+source: fuel-core/src/chain_config.rs
 expression: json
 ---
 {
@@ -11,11 +10,10 @@ expression: json
       {
         "sender": "0x61644a25da5ad31754e23bc1eca8c766a61ceaa8c60ddc65f158a30209256e35",
         "recipient": "0xc9fba417a2d8d9ed086c0f3f03f94ec89a67bfdc6a1e22b69d667e5ac8055d00",
-        "owner": "0xa3f57027bcb10d053242a9719dca480b4f4910fa60671f2068086498c72e30fc",
-        "nonce": "0x0e1ef2963832068b",
-        "amount": "0xb04f3c08f59b309e",
-        "data": "0x39",
-        "da_height": "0x3322237b00655632"
+        "nonce": "0xf4c4c9f506cc05a3",
+        "amount": "0x43bd0a27cb68f270",
+        "data": "0xbc",
+        "da_height": "0x6438200d0d1865b1"
       }
     ]
   },

--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -482,7 +482,6 @@ mod tests {
 
         let acc1: Address = rng.gen();
         let recipient = rng.gen();
-        let sender = rng.gen();
 
         let mut queue = FinalizationQueue::new(
             0,
@@ -498,7 +497,6 @@ mod tests {
         let test_message = Message {
             sender: acc1,
             recipient,
-            owner: sender,
             nonce: 40,
             amount: 0,
             data: vec![],
@@ -513,7 +511,7 @@ mod tests {
                     2,
                     test_message.sender,
                     test_message.recipient,
-                    test_message.owner,
+                    test_message.recipient,
                     test_message.nonce as u32,
                     test_message.amount as u32,
                     test_message.data.clone(),

--- a/fuel-relayer/src/log.rs
+++ b/fuel-relayer/src/log.rs
@@ -42,7 +42,6 @@ impl From<&MessageLog> for Message {
         Self {
             sender: message.sender,
             recipient: message.recipient,
-            owner: message.owner,
             nonce: message.nonce,
             amount: message.amount,
             data: message.data.clone(),

--- a/fuel-tests/tests/snapshot.rs
+++ b/fuel-tests/tests/snapshot.rs
@@ -72,7 +72,6 @@ async fn snapshot_state_config() {
         messages: Some(vec![MessageConfig {
             sender: rng.gen(),
             recipient: rng.gen(),
-            owner: rng.gen(),
             nonce: rng.gen_range(0..1000),
             amount: rng.gen_range(0..1000),
             data: vec![],

--- a/fuel-txpool/src/containers/dependency.rs
+++ b/fuel-txpool/src/containers/dependency.rs
@@ -280,7 +280,6 @@ impl Dependency {
                 sender,
                 recipient,
                 nonce,
-                owner,
                 amount,
                 data,
                 ..
@@ -290,14 +289,12 @@ impl Dependency {
                 sender,
                 recipient,
                 nonce,
-                owner,
                 amount,
                 data,
                 ..
             } => {
-                let computed_id = Input::compute_message_id(
-                    sender, recipient, *nonce, owner, *amount, data,
-                );
+                let computed_id =
+                    Input::compute_message_id(sender, recipient, *nonce, *amount, data);
                 if message_id != &computed_id {
                     return Err(Error::NotInsertedIoWrongMessageId.into())
                 }

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -291,7 +291,6 @@ pub mod tests {
                 message.recipient,
                 message.amount,
                 message.nonce,
-                message.owner,
                 message.data.clone(),
                 Default::default(),
                 Default::default(),


### PR DESCRIPTION
closes #568 
~~blocked by [#204](https://github.com/FuelLabs/fuel-vm/pull/205)~~

Removes all references of `owner`
~~TODO: once [#204](https://github.com/FuelLabs/fuel-vm/pull/205) is closed and VM's version bumped
this draft needs to reference that latest VM version~~
