### PR TITLE
Bump the rust version in the docker to `1.63`

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM lukemathwalker/cargo-chef:latest-rust-1.61 as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.63 as chef
 WORKDIR /build/
 # hadolint ignore=DL3008
 RUN apt-get update && \


### PR DESCRIPTION
[The change with the owner](https://github.com/FuelLabs/fuel-core/runs/8276498168?check_suite_focus=true) requires a feature stabalized in the 1.63 release of rust.