### PR TITLE
show long version for fuel-core cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2159,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid 1.1.2",
+ "vergen",
 ]
 
 [[package]]
@@ -2578,6 +2599,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ghash"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,6 +2628,19 @@ checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval 0.5.3",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
 ]
 
 [[package]]
@@ -3180,6 +3226,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.4+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3605,6 +3663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3914,6 +3973,15 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -5530,6 +5598,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae2421f3e16b3afd4aa692d23b83d0ba42ee9b0081d5deeb7d21428d7195fb1"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6236,6 +6318,24 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "7.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "sysinfo",
+ "thiserror",
+ "time 0.3.14",
+]
 
 [[package]]
 name = "version_check"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -80,6 +80,9 @@ fuel-core-interfaces = { path = "../fuel-core-interfaces", features = [
 ] }
 insta = "1.8"
 
+[build-dependencies]
+vergen = { version = "7", features = ["build", "git" ] }
+
 [features]
 metrics = ["dep:fuel-metrics"]
 default = ["rocksdb", "metrics", "debug"]

--- a/fuel-core/build.rs
+++ b/fuel-core/build.rs
@@ -1,4 +1,9 @@
-use vergen::{vergen, Config, ShaKind, TimestampKind};
+use vergen::{
+    vergen,
+    Config,
+    ShaKind,
+    TimestampKind,
+};
 
 fn main() {
     let mut config = Config::default();

--- a/fuel-core/build.rs
+++ b/fuel-core/build.rs
@@ -1,0 +1,10 @@
+use vergen::{vergen, Config, ShaKind, TimestampKind};
+
+fn main() {
+    let mut config = Config::default();
+
+    *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    *config.git_mut().commit_timestamp_mut() = true;
+    *config.git_mut().commit_timestamp_kind_mut() = TimestampKind::DateOnly;
+    vergen(config).expect("Failed to configure vergen")
+}

--- a/fuel-core/src/cli.rs
+++ b/fuel-core/src/cli.rs
@@ -1,25 +1,32 @@
 use anyhow::Result;
 use clap::Parser;
-use std::{
-    env,
-    path::PathBuf,
-    str::FromStr,
-};
+use std::{env, path::PathBuf, str::FromStr};
 use tracing::log::warn;
 use tracing_subscriber::filter::EnvFilter;
 
 lazy_static::lazy_static! {
     pub static ref DEFAULT_DB_PATH: PathBuf = dirs::home_dir().unwrap().join(".fuel").join("db");
+    static ref LONG_VERSION: String = long_version();
 }
 
 pub mod run;
 pub mod snapshot;
+
+fn long_version() -> String {
+    format!(
+        "{} ({} {})",
+        env!("CARGO_PKG_VERSION"),
+        env!("VERGEN_GIT_SHA_SHORT"),
+        env!("VERGEN_GIT_COMMIT_DATE")
+    )
+}
 
 #[derive(Parser, Debug)]
 #[clap(
     name = "fuel-core",
     about = "Fuel client implementation",
     version,
+    long_version = &**LONG_VERSION,
     rename_all = "kebab-case"
 )]
 pub struct Opt {

--- a/fuel-core/src/cli.rs
+++ b/fuel-core/src/cli.rs
@@ -1,6 +1,10 @@
 use anyhow::Result;
 use clap::Parser;
-use std::{env, path::PathBuf, str::FromStr};
+use std::{
+    env,
+    path::PathBuf,
+    str::FromStr,
+};
 use tracing::log::warn;
 use tracing_subscriber::filter::EnvFilter;
 


### PR DESCRIPTION
Closes #620 
Related: https://github.com/FuelLabs/sway/pull/2772

Reason for this feat explained in issue, copy pasting here:

> In order to support nightlies and (very soon) specifically dated nightlies, fuelup needs to be able to compare dates between bins. fuelup is currently accomplishing this through a somewhat hacky method of storing the channel TOML that it downloaded a certain binary from and then comparing that versus what is on GitHub to check if it needs updating. This is a problem for custom toolchains since it might be a mess doing a lot of file I/O to track what versions/dates of components we have added/removed.

Looks like:

![Screenshot 2022-09-14 at 2 02 04 PM](https://user-images.githubusercontent.com/25565268/190072092-a3dc739d-4f37-4286-8350-bd172778a8a7.png)
