### PR TITLE
 Refactor `FuelBlockHeader::number` to name `da_height` and type `DaBlockHeight` 

### DIFF
--- a/fuel-core-interfaces/src/model.rs
+++ b/fuel-core-interfaces/src/model.rs
@@ -1,7 +1,7 @@
 mod block;
 mod block_height;
-mod da_block_height;
 mod coin;
+mod da_block_height;
 mod messages;
 mod txpool;
 mod vote;
@@ -17,12 +17,12 @@ pub use block::{
     FuelBlockHeader,
     SealedFuelBlock,
 };
-pub use da_block_height::DaBlockHeight;
 pub use block_height::BlockHeight;
 pub use coin::{
     Coin,
     CoinStatus,
 };
+pub use da_block_height::DaBlockHeight;
 pub use messages::*;
 pub use txpool::{
     ArcTx,

--- a/fuel-core-interfaces/src/model.rs
+++ b/fuel-core-interfaces/src/model.rs
@@ -1,5 +1,6 @@
 mod block;
 mod block_height;
+mod da_block_height;
 mod coin;
 mod messages;
 mod txpool;
@@ -16,6 +17,7 @@ pub use block::{
     FuelBlockHeader,
     SealedFuelBlock,
 };
+pub use da_block_height::DaBlockHeight;
 pub use block_height::BlockHeight;
 pub use coin::{
     Coin,
@@ -28,7 +30,6 @@ pub use txpool::{
 };
 pub use vote::ConsensusVote;
 
-pub type DaBlockHeight = u64;
 pub type ValidatorStake = u64;
 
 /// Validator address used for registration of validator on DA layer

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -1,16 +1,18 @@
 pub use super::BlockHeight;
 use super::ValidatorStake;
-use crate::common::{
-    fuel_crypto::Hasher,
-    fuel_tx::{
-        Address,
-        AssetId,
-        Bytes32,
-        Transaction,
+use crate::{
+    common::{
+        fuel_crypto::Hasher,
+        fuel_tx::{
+            Address,
+            AssetId,
+            Bytes32,
+            Transaction,
+        },
+        fuel_types::Word,
     },
-    fuel_types::Word,
+    model::DaBlockHeight,
 };
-use crate::model::DaBlockHeight;
 use chrono::{
     DateTime,
     TimeZone,

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -10,6 +10,7 @@ use crate::common::{
     },
     fuel_types::Word,
 };
+use crate::model::DaBlockHeight;
 use chrono::{
     DateTime,
     TimeZone,
@@ -29,7 +30,7 @@ pub struct FuelBlockHeader {
     /// example, they should verify that the block number satisfies the finality requirements of the
     /// layer 1 chain. They should also verify that the block number isn't too stale and is increasing.
     /// Some similar concerns are noted in this issue: https://github.com/FuelLabs/fuel-specs/issues/220
-    pub number: BlockHeight,
+    pub da_height: DaBlockHeight,
     /// Block header hash of the previous block.
     pub parent_hash: Bytes32,
     /// Merkle root of all previous block header hashes.
@@ -58,7 +59,7 @@ impl FuelBlockHeader {
     fn hash(&self) -> Bytes32 {
         let mut hasher = Hasher::default();
         hasher.input(&self.height.to_bytes()[..]);
-        hasher.input(&self.number.to_bytes()[..]);
+        hasher.input(&self.da_height.to_bytes()[..]);
         hasher.input(self.parent_hash.as_ref());
         hasher.input(self.prev_root.as_ref());
         hasher.input(self.transactions_root.as_ref());
@@ -81,7 +82,7 @@ impl Default for FuelBlockHeader {
         Self {
             time: Utc.timestamp(0, 0),
             height: BlockHeight::default(),
-            number: BlockHeight::default(),
+            da_height: DaBlockHeight::default(),
             parent_hash: Bytes32::default(),
             prev_root: Bytes32::default(),
             transactions_root: Bytes32::default(),

--- a/fuel-core-interfaces/src/model/da_block_height.rs
+++ b/fuel-core-interfaces/src/model/da_block_height.rs
@@ -1,0 +1,82 @@
+use derive_more::{
+    Add,
+    Deref,
+    Display,
+    From,
+    Into,
+};
+
+use std::ops::{Add, Sub, Rem};
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    PartialOrd,
+    Eq,
+    Add,
+    Ord,
+    Display,
+    Into,
+    From,
+    Deref,
+    Hash,
+)]
+pub struct DaBlockHeight(pub u64);
+
+impl From<DaBlockHeight> for Vec<u8> {
+    fn from(height: DaBlockHeight) -> Self {
+        height.0.to_be_bytes().to_vec()
+    }
+}
+
+impl From<usize> for DaBlockHeight {
+    fn from(n: usize) -> Self {
+        DaBlockHeight(n as u64)
+    }
+}
+
+impl Add<u64> for DaBlockHeight {
+    type Output = Self;
+
+    fn add(self, other: u64) -> Self::Output {
+        Self::from(self.0 + other)
+    }
+}
+
+impl Sub for DaBlockHeight {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self::Output {
+        Self::from(self.0 - other.as_u64())
+    }
+}
+
+impl Rem for DaBlockHeight {
+    type Output = Self;
+
+    fn rem(self, other: Self) -> Self::Output {
+        Self::from(self.0 % other.as_u64())
+    }
+}
+
+impl DaBlockHeight {
+    pub fn to_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+
+    pub fn to_usize(self) -> usize {
+        self.0 as usize
+    }
+
+    pub fn as_usize(&self) -> usize {
+        self.0 as usize
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}

--- a/fuel-core-interfaces/src/model/da_block_height.rs
+++ b/fuel-core-interfaces/src/model/da_block_height.rs
@@ -4,12 +4,10 @@ use derive_more::{
     Display,
     From,
     Into,
+    Rem,
     Sub,
 };
-use std::ops::{
-    Add,
-    Rem,
-};
+use std::ops::Add;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(
@@ -26,9 +24,11 @@ use std::ops::{
     Display,
     Into,
     From,
+    Rem,
     Deref,
     Hash,
 )]
+#[rem(forward)]
 pub struct DaBlockHeight(pub u64);
 
 impl From<DaBlockHeight> for Vec<u8> {
@@ -48,14 +48,6 @@ impl Add<u64> for DaBlockHeight {
 
     fn add(self, other: u64) -> Self::Output {
         Self::from(self.0 + other)
-    }
-}
-
-impl Rem for DaBlockHeight {
-    type Output = Self;
-
-    fn rem(self, other: Self) -> Self::Output {
-        Self::from(self.0 % other.as_u64())
     }
 }
 

--- a/fuel-core-interfaces/src/model/da_block_height.rs
+++ b/fuel-core-interfaces/src/model/da_block_height.rs
@@ -5,7 +5,6 @@ use derive_more::{
     From,
     Into,
 };
-
 use std::ops::{
     Add,
     Rem,

--- a/fuel-core-interfaces/src/model/da_block_height.rs
+++ b/fuel-core-interfaces/src/model/da_block_height.rs
@@ -6,7 +6,11 @@ use derive_more::{
     Into,
 };
 
-use std::ops::{Add, Sub, Rem};
+use std::ops::{
+    Add,
+    Rem,
+    Sub,
+};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(

--- a/fuel-core-interfaces/src/model/da_block_height.rs
+++ b/fuel-core-interfaces/src/model/da_block_height.rs
@@ -1,10 +1,10 @@
 use derive_more::{
     Add,
-    Sub, 
     Deref,
     Display,
     From,
     Into,
+    Sub,
 };
 use std::ops::{
     Add,

--- a/fuel-core-interfaces/src/model/da_block_height.rs
+++ b/fuel-core-interfaces/src/model/da_block_height.rs
@@ -1,5 +1,6 @@
 use derive_more::{
     Add,
+    Sub, 
     Deref,
     Display,
     From,
@@ -8,11 +9,11 @@ use derive_more::{
 use std::ops::{
     Add,
     Rem,
-    Sub,
 };
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(
+    Sub,
     Copy,
     Clone,
     Debug,
@@ -47,14 +48,6 @@ impl Add<u64> for DaBlockHeight {
 
     fn add(self, other: u64) -> Self::Output {
         Self::from(self.0 + other)
-    }
-}
-
-impl Sub for DaBlockHeight {
-    type Output = Self;
-
-    fn sub(self, other: Self) -> Self::Output {
-        Self::from(self.0 - other.as_u64())
     }
 }
 

--- a/fuel-core-interfaces/src/relayer.rs
+++ b/fuel-core-interfaces/src/relayer.rs
@@ -115,7 +115,7 @@ pub trait RelayerDb:
             if *index >= da_height {
                 break
             }
-            last_da_height = *index;
+            last_da_height = **index;
         }
         // means that first delegate is in future or not existing in current delegate_index
         if last_da_height == 0 {
@@ -124,7 +124,7 @@ pub trait RelayerDb:
         // get staking diff
         let staking_diff = self
             .storage::<StakingDiffs>()
-            .get(&last_da_height)
+            .get(&last_da_height.into())
             .expect("Expect to get data without problem")?;
 
         staking_diff.delegations.get(delegate).unwrap().clone()

--- a/fuel-core/src/chain_config.rs
+++ b/fuel-core/src/chain_config.rs
@@ -474,7 +474,7 @@ mod tests {
                     nonce: rng.gen(),
                     amount: rng.gen(),
                     data: vec![rng.gen()],
-                    da_height: rng.gen(),
+                    da_height: DaBlockHeight(rng.gen()),
                 }]),
                 ..Default::default()
             }),

--- a/fuel-core/src/chain_config/serialization.rs
+++ b/fuel-core/src/chain_config/serialization.rs
@@ -1,5 +1,7 @@
-use crate::model::BlockHeight;
-use crate::model::DaBlockHeight;
+use crate::model::{
+    BlockHeight,
+    DaBlockHeight,
+};
 use core::fmt;
 use fuel_core_interfaces::common::fuel_types::{
     bytes::WORD_SIZE,

--- a/fuel-core/src/chain_config/serialization.rs
+++ b/fuel-core/src/chain_config/serialization.rs
@@ -1,4 +1,5 @@
 use crate::model::BlockHeight;
+use crate::model::DaBlockHeight;
 use core::fmt;
 use fuel_core_interfaces::common::fuel_types::{
     bytes::WORD_SIZE,
@@ -69,6 +70,26 @@ impl SerializeAs<BlockHeight> for HexNumber {
 
 impl<'de> DeserializeAs<'de, BlockHeight> for HexNumber {
     fn deserialize_as<D>(deserializer: D) -> Result<BlockHeight, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let number: u64 = HexNumber::deserialize_as(deserializer)?;
+        Ok(number.into())
+    }
+}
+
+impl SerializeAs<DaBlockHeight> for HexNumber {
+    fn serialize_as<S>(value: &DaBlockHeight, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let number: u64 = (*value).into();
+        HexNumber::serialize_as(&number, serializer)
+    }
+}
+
+impl<'de> DeserializeAs<'de, DaBlockHeight> for HexNumber {
+    fn deserialize_as<D>(deserializer: D) -> Result<DaBlockHeight, D::Error>
     where
         D: Deserializer<'de>,
     {

--- a/fuel-core/src/cli/run/relayer.rs
+++ b/fuel-core/src/cli/run/relayer.rs
@@ -18,7 +18,7 @@ pub struct RelayerArgs {
 
     /// Block number after we can start filtering events related to fuel.
     /// It does not need to be accurate and can be set in past before contracts are deployed.
-    #[clap(long = "relayer-v2-deployment", default_value = "0")]
+    #[clap(long = "relayer-v2-deployment", parse(try_from_str = parse_da_block_height), default_value = "0")]
     pub eth_v2_contracts_deployment: DaBlockHeight,
 
     /// Ethereum contract address. Create EthAddress into fuel_types
@@ -50,10 +50,14 @@ pub fn parse_h160(input: &str) -> Result<H160, <H160 as FromStr>::Err> {
     H160::from_str(input)
 }
 
+pub fn parse_da_block_height(input: &str) -> Result<DaBlockHeight, anyhow::Error> {
+    Ok(DaBlockHeight(u64::from_str(input)?))
+}
+
 impl From<RelayerArgs> for Config {
     fn from(args: RelayerArgs) -> Self {
         Config {
-            da_finalization: args.da_finalization,
+            da_finalization: DaBlockHeight(args.da_finalization),
             eth_client: args.eth_client,
             eth_chain_id: args.eth_chain_id,
             eth_v2_commit_contract: args.eth_v2_commit_contract,

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -423,7 +423,9 @@ mod relayer {
                     };
                     use std::io::Cursor;
                     let mut i = Cursor::new(i);
-                    Self(DaBlockHeight::from(i.read_u64::<BigEndian>().unwrap_or_default()))
+                    Self(DaBlockHeight::from(
+                        i.read_u64::<BigEndian>().unwrap_or_default(),
+                    ))
                 }
             }
             let mut out = Vec::new();

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -412,7 +412,7 @@ mod relayer {
                 }
                 to_da_height
             } else {
-                DaBlockHeight::MAX
+                DaBlockHeight::from(u64::MAX)
             };
             struct WrapU64Be(pub DaBlockHeight);
             impl From<Vec<u8>> for WrapU64Be {
@@ -423,7 +423,7 @@ mod relayer {
                     };
                     use std::io::Cursor;
                     let mut i = Cursor::new(i);
-                    Self(i.read_u64::<BigEndian>().unwrap_or_default())
+                    Self(DaBlockHeight::from(i.read_u64::<BigEndian>().unwrap_or_default()))
                 }
             }
             let mut out = Vec::new();

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -408,7 +408,7 @@ impl Executor {
                                 *message_id,
                             ))
                         }
-                        if message.da_height.as_u64() > block_da_height.as_u64() {
+                        if message.da_height > block_da_height {
                             return Err(TransactionValidityError::MessageSpendTooEarly(
                                 *message_id,
                             ))

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -60,6 +60,7 @@ use fuel_core_interfaces::{
     model::{
         FuelBlockHeader,
         Message,
+        DaBlockHeight
     },
 };
 use fuel_storage::{
@@ -191,7 +192,7 @@ impl Executor {
                     block_db_transaction.deref(),
                     tx,
                     block.header.height,
-                    block.header.number,
+                    block.header.da_height,
                 )?;
                 // validate transaction signature
                 tx.validate_input_signature()
@@ -377,7 +378,7 @@ impl Executor {
         db: &Database,
         transaction: &Transaction,
         block_height: BlockHeight,
-        block_da_height: BlockHeight,
+        block_da_height: DaBlockHeight,
     ) -> Result<(), TransactionValidityError> {
         for input in transaction.inputs() {
             match input {
@@ -407,7 +408,7 @@ impl Executor {
                                 *message_id,
                             ))
                         }
-                        if BlockHeight::from(message.da_height) > block_da_height {
+                        if message.da_height.as_u64() > block_da_height.as_u64() {
                             return Err(TransactionValidityError::MessageSpendTooEarly(
                                 *message_id,
                             ))

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -58,9 +58,9 @@ use fuel_core_interfaces::{
         Transactions,
     },
     model::{
+        DaBlockHeight,
         FuelBlockHeader,
         Message,
-        DaBlockHeight
     },
 };
 use fuel_storage::{
@@ -981,6 +981,7 @@ mod tests {
         },
         model::{
             CheckedMessage,
+            DaBlockHeight,
             Message,
         },
         relayer::RelayerDb,
@@ -1872,7 +1873,7 @@ mod tests {
             nonce: rng.gen(),
             amount: 1000,
             data: vec![],
-            da_height,
+            da_height: DaBlockHeight(da_height),
             fuel_block_spend: None,
         };
 

--- a/fuel-core/src/model.rs
+++ b/fuel-core/src/model.rs
@@ -1,8 +1,8 @@
 pub use fuel_core_interfaces::model::{
-    DaBlockHeight,
     BlockHeight,
     Coin,
     CoinStatus,
+    DaBlockHeight,
     FuelBlock,
     FuelBlockDb,
     FuelBlockHeader,

--- a/fuel-core/src/model.rs
+++ b/fuel-core/src/model.rs
@@ -1,4 +1,5 @@
 pub use fuel_core_interfaces::model::{
+    DaBlockHeight,
     BlockHeight,
     Coin,
     CoinStatus,

--- a/fuel-core/src/resource_query.rs
+++ b/fuel-core/src/resource_query.rs
@@ -243,7 +243,6 @@ mod tests {
             Messages,
         },
         model::{
-            BlockHeight,
             DaBlockHeight,
             Message,
         },
@@ -783,7 +782,7 @@ mod tests {
                 nonce,
                 amount,
                 data: vec![],
-                da_height: DaBlockHeight::from(BlockHeight::from(1u64)),
+                da_height: DaBlockHeight::from(1u64),
                 fuel_block_spend: None,
             };
 

--- a/fuel-core/src/schema/message.rs
+++ b/fuel-core/src/schema/message.rs
@@ -60,7 +60,7 @@ impl Message {
     }
 
     async fn da_height(&self) -> U64 {
-        self.0.da_height.into()
+        self.0.da_height.as_u64().into()
     }
 
     async fn fuel_block_spend(&self) -> Option<U64> {

--- a/fuel-core/src/service/genesis.rs
+++ b/fuel-core/src/service/genesis.rs
@@ -217,7 +217,10 @@ mod tests {
             MessageConfig,
             StateConfig,
         },
-        model::BlockHeight,
+        model::{
+            BlockHeight,
+            DaBlockHeight,
+        },
         service::config::Config,
     };
     use fuel_core_interfaces::{
@@ -444,7 +447,7 @@ mod tests {
             nonce: rng.gen(),
             amount: rng.gen(),
             data: vec![rng.gen()],
-            da_height: 0,
+            da_height: DaBlockHeight(0),
         };
 
         config.chain_conf.initial_state = Some(StateConfig {

--- a/fuel-relayer/src/config.rs
+++ b/fuel-relayer/src/config.rs
@@ -13,7 +13,7 @@ use std::{
     time::Duration,
 };
 
-pub(crate) const REPORT_INIT_SYNC_PROGRESS_EVERY_N_BLOCKS: DaBlockHeight = 1000;
+pub(crate) const REPORT_INIT_SYNC_PROGRESS_EVERY_N_BLOCKS: DaBlockHeight = DaBlockHeight{0: 1000u64};
 pub(crate) const NUMBER_OF_TRIES_FOR_INITIAL_SYNC: u64 = 10;
 
 pub fn keccak256(data: &'static str) -> H256 {
@@ -60,7 +60,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            da_finalization: 64,
+            da_finalization: DaBlockHeight::from(64u64),
             // Some(String::from("http://localhost:8545"))
             eth_client: None,
             eth_chain_id: 1, // ethereum mainnet
@@ -69,7 +69,7 @@ impl Default for Config {
                 "0x03E4538018285e1c03CCce2F92C9538c87606911",
             )
             .unwrap()],
-            eth_v2_contracts_deployment: 0,
+            eth_v2_contracts_deployment: DaBlockHeight::from(0u64),
             initial_sync_step: 1000,
             initial_sync_refresh: Duration::from_secs(5),
         }

--- a/fuel-relayer/src/config.rs
+++ b/fuel-relayer/src/config.rs
@@ -13,7 +13,8 @@ use std::{
     time::Duration,
 };
 
-pub(crate) const REPORT_INIT_SYNC_PROGRESS_EVERY_N_BLOCKS: DaBlockHeight = DaBlockHeight{0: 1000u64};
+pub(crate) const REPORT_INIT_SYNC_PROGRESS_EVERY_N_BLOCKS: DaBlockHeight =
+    DaBlockHeight(1000u64);
 pub(crate) const NUMBER_OF_TRIES_FOR_INITIAL_SYNC: u64 = 10;
 
 pub fn keccak256(data: &'static str) -> H256 {

--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -423,17 +423,17 @@ mod tests {
 
         if let EthEventLog::Message(message) = &message1_db {
             let msg = Message::from(message).check();
-            assert_eq!(msg.da_height, 0);
+            assert_eq!(msg.da_height, DaBlockHeight(0));
             assert_eq!(diff1.messages.get(msg.id()), Some(&msg));
         }
         if let EthEventLog::Message(message) = &message2_db {
             let msg = Message::from(message).check();
-            assert_eq!(msg.da_height, 1);
+            assert_eq!(msg.da_height, DaBlockHeight(1));
             assert_eq!(diff2.messages.get(msg.id()), Some(&msg));
         }
         if let EthEventLog::Message(message) = &message3_db {
             let msg = Message::from(message).check();
-            assert_eq!(msg.da_height, 1);
+            assert_eq!(msg.da_height, DaBlockHeight(1));
             assert_eq!(diff2.messages.get(msg.id()), Some(&msg));
         }
     }
@@ -500,7 +500,7 @@ mod tests {
             nonce: 40,
             amount: 0,
             data: vec![],
-            da_height: 2,
+            da_height: DaBlockHeight(2),
             fuel_block_spend: None,
         };
         queue
@@ -522,7 +522,7 @@ mod tests {
 
         let mut db = MockDb::default();
 
-        queue.commit_diffs(&mut db, 1).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(1)).await;
         assert_eq!(
             db.data.lock().unwrap().validators.get(&v1),
             Some(&(0, Some(c1))),
@@ -530,7 +530,7 @@ mod tests {
         assert_eq!(db.data.lock().unwrap().validators.get(&v2), None,);
         assert_eq!(db.data.lock().unwrap().messages.len(), 0,);
 
-        queue.commit_diffs(&mut db, 2).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(2)).await;
         assert_eq!(
             db.data.lock().unwrap().validators.get(&v2),
             Some(&(0, Some(c2))),
@@ -549,7 +549,7 @@ mod tests {
             test_message.id()
         );
 
-        queue.commit_diffs(&mut db, 3).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(3)).await;
         assert_eq!(
             db.data.lock().unwrap().validators.get(&v1),
             Some(&(0, None)),
@@ -600,7 +600,7 @@ mod tests {
 
         let mut db = MockDb::default();
 
-        queue.commit_diffs(&mut db, 1).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(1)).await;
         assert_eq!(
             db.data.lock().unwrap().validators.get(&v1),
             Some(&(s1, None)),
@@ -610,14 +610,14 @@ mod tests {
             Some(&(s2, None)),
         );
 
-        queue.commit_diffs(&mut db, 2).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(2)).await;
         let s13 = s1 + s3;
         assert_eq!(
             db.data.lock().unwrap().validators.get(&v1),
             Some(&(s13, Some(c1))),
         );
 
-        queue.commit_diffs(&mut db, 3).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(3)).await;
 
         assert_eq!(
             db.data.lock().unwrap().validators.get(&v1),
@@ -668,7 +668,7 @@ mod tests {
 
         let mut db = MockDb::default();
 
-        queue.commit_diffs(&mut db, 1).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(1)).await;
         assert_eq!(
             db.data.lock().unwrap().validators.get(&v1),
             Some(&(s1, None)),
@@ -678,7 +678,7 @@ mod tests {
             Some(&(s1, None)),
         );
 
-        queue.commit_diffs(&mut db, 2).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(2)).await;
         assert_eq!(
             db.data.lock().unwrap().validators.get(&v1),
             Some(&(s1, None)),
@@ -763,7 +763,7 @@ mod tests {
 
         let mut db = MockDb::default();
 
-        queue.commit_diffs(&mut db, 1).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(1)).await;
 
         assert_eq!(queue.pending.len(), 0)
     }
@@ -814,36 +814,36 @@ mod tests {
         let mut db = MockDb::default();
 
         // finalize all logs
-        queue.commit_diffs(&mut db, 5).await;
+        queue.commit_diffs(&mut db, DaBlockHeight(5)).await;
 
-        let set = queue.get_validators(6, &mut db).await;
+        let set = queue.get_validators(DaBlockHeight(6), &mut db).await;
         assert_eq!(set, None);
 
-        let set = queue.get_validators(5, &mut db).await;
+        let set = queue.get_validators(DaBlockHeight(5), &mut db).await;
         assert!(set.is_some(), "Should be some for 5");
         let set = set.unwrap();
         assert_eq!(set.get(&v1), Some(&(s1, Some(cons1))));
         assert_eq!(set.get(&v2), None);
 
-        let set = queue.get_validators(4, &mut db).await;
+        let set = queue.get_validators(DaBlockHeight(4), &mut db).await;
         assert!(set.is_some(), "Should be some for 4");
         let set = set.unwrap();
         assert_eq!(set.get(&v1), Some(&(s1, Some(cons1))));
         assert_eq!(set.get(&v2), None);
 
-        let set = queue.get_validators(3, &mut db).await;
+        let set = queue.get_validators(DaBlockHeight(3), &mut db).await;
         assert!(set.is_some(), "Should be some for 3");
         let set = set.unwrap();
         assert_eq!(set.get(&v1), Some(&(s1 + s3, Some(cons1))));
         assert_eq!(set.get(&v2), None);
 
-        let set = queue.get_validators(2, &mut db).await;
+        let set = queue.get_validators(DaBlockHeight(2), &mut db).await;
         assert!(set.is_some(), "Should be some for 2");
         let set = set.unwrap();
         assert_eq!(set.get(&v1), Some(&(s1, Some(cons1))));
         assert_eq!(set.get(&v2), Some(&(s1, Some(cons2))));
 
-        let set = queue.get_validators(1, &mut db).await;
+        let set = queue.get_validators(DaBlockHeight(1), &mut db).await;
         assert!(set.is_some(), "Should be some for 1");
         let set = set.unwrap();
         assert_eq!(set.get(&v1), Some(&(s1, Some(cons1))));

--- a/fuel-relayer/src/finalization_queue.rs
+++ b/fuel-relayer/src/finalization_queue.rs
@@ -105,7 +105,7 @@ impl FinalizationQueue {
             pending: VecDeque::new(),
             validators: Validators::default(),
             bundled_removed_eth_events: Vec::new(),
-            finalized_da_height: 0,
+            finalized_da_height: DaBlockHeight::from(0u64),
         }
     }
 
@@ -176,7 +176,7 @@ impl FinalizationQueue {
                 self.bundled_removed_eth_events.len()
             );
 
-            let mut lowest_removed_da_height = DaBlockHeight::MAX;
+            let mut lowest_removed_da_height = DaBlockHeight::from(u64::MAX);
 
             for (da_height, events) in
                 std::mem::take(&mut self.bundled_removed_eth_events).into_iter()
@@ -215,7 +215,7 @@ impl FinalizationQueue {
             return
         }
         let removed = log.removed.unwrap_or(false);
-        let da_height = log.block_number.unwrap().as_u64() as DaBlockHeight;
+        let da_height = DaBlockHeight::from(log.block_number.unwrap().as_u64());
         let event = event.unwrap();
         debug!("append inbound log:{:?}", event);
         // bundle removed events and return

--- a/fuel-relayer/src/log.rs
+++ b/fuel-relayer/src/log.rs
@@ -635,7 +635,7 @@ pub mod tests {
                 nonce: nonce as u64,
                 amount: amount as u64,
                 data,
-                da_height: eth_block
+                da_height: DaBlockHeight(eth_block)
             }),
             "Decoded log does not match data we encoded"
         );

--- a/fuel-relayer/src/log.rs
+++ b/fuel-relayer/src/log.rs
@@ -124,7 +124,7 @@ impl TryFrom<&Log> for EthEventLog {
                     // Safety: logs without block numbers are rejected by
                     // FinalizationQueue::append_eth_log before the conversion to EthEventLog happens.
                     // If block_number is none, that means the log is pending.
-                    da_height: log.block_number.unwrap().as_u64(),
+                    da_height: DaBlockHeight::from(log.block_number.unwrap().as_u64()),
                 })
             }
             n if n == *config::ETH_LOG_VALIDATOR_REGISTRATION => {

--- a/fuel-relayer/src/pending_blocks.rs
+++ b/fuel-relayer/src/pending_blocks.rs
@@ -480,15 +480,15 @@ mod tests {
         let b4 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::False);
-        blocks.handle_block_commit(b2, 3u64.into(), 10, IsReverted::False);
-        blocks.handle_block_commit(b3, 4u64.into(), 11, IsReverted::False);
-        blocks.handle_block_commit(b4, 5u64.into(), 13, IsReverted::False);
-        blocks.handle_block_commit(b4, 5u64.into(), 13, IsReverted::True);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::False);
+        blocks.handle_block_commit(b2, 3u64.into(), DaBlockHeight(10), IsReverted::False);
+        blocks.handle_block_commit(b3, 4u64.into(), DaBlockHeight(11), IsReverted::False);
+        blocks.handle_block_commit(b4, 5u64.into(), DaBlockHeight(13), IsReverted::False);
+        blocks.handle_block_commit(b4, 5u64.into(), DaBlockHeight(13), IsReverted::True);
 
         let q = &blocks.pending_block_commits;
         assert_eq!(q.len(), 4, "Should contain for pending blocks");
-        blocks.handle_da_finalization(10);
+        blocks.handle_da_finalization(DaBlockHeight(10));
 
         let q = &blocks.pending_block_commits;
         assert_eq!(q.len(), 2, "Should contains only two pending blocks");
@@ -508,8 +508,8 @@ mod tests {
         let b2 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::False);
-        blocks.handle_block_commit(b2, 0u64.into(), 9, IsReverted::False);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::False);
+        blocks.handle_block_commit(b2, 0u64.into(), DaBlockHeight(9), IsReverted::False);
         assert!(logs_contain(
             "Committed block 0 is lower then current lowest pending block 2."
         ))
@@ -524,8 +524,8 @@ mod tests {
         let b2 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::False);
-        blocks.handle_block_commit(b2, 4u64.into(), 10, IsReverted::False);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::False);
+        blocks.handle_block_commit(b2, 4u64.into(), DaBlockHeight(10), IsReverted::False);
         assert!(logs_contain(
             "Committed block height 4 should be only increased by one from current height 2"
         ))
@@ -540,8 +540,8 @@ mod tests {
         let b2 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::False);
-        blocks.handle_block_commit(b2, 2u64.into(), 10, IsReverted::False);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::False);
+        blocks.handle_block_commit(b2, 2u64.into(), DaBlockHeight(10), IsReverted::False);
         assert!(logs_contain(
             "We received block 2 commit that was not reverted"
         ))
@@ -555,7 +555,7 @@ mod tests {
         let b1 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 3u64.into(), 9, IsReverted::False);
+        blocks.handle_block_commit(b1, 3u64.into(), DaBlockHeight(9), IsReverted::False);
         assert!(logs_contain(
             "Missing block commitments between last finalized commitment 1 to new height 3"
         ))
@@ -570,9 +570,9 @@ mod tests {
         let b2 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::False);
-        blocks.handle_block_commit(b2, 3u64.into(), 9, IsReverted::False);
-        blocks.handle_block_commit(b2, 1u64.into(), 9, IsReverted::True);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::False);
+        blocks.handle_block_commit(b2, 3u64.into(), DaBlockHeight(9), IsReverted::False);
+        blocks.handle_block_commit(b2, 1u64.into(), DaBlockHeight(9), IsReverted::True);
         assert!(logs_contain(
             "All pending block commits should be present in block queue. height:1 last_known:2"
         ))
@@ -587,8 +587,8 @@ mod tests {
         let b2 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::False);
-        blocks.handle_block_commit(b2, 3u64.into(), 10, IsReverted::True);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::False);
+        blocks.handle_block_commit(b2, 3u64.into(), DaBlockHeight(10), IsReverted::True);
         assert!(logs_contain(
             "Something unexpected happened.Reverted block commits are not something found in the future"
         ))
@@ -602,9 +602,9 @@ mod tests {
         let b1 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::False);
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::True);
-        blocks.handle_block_commit(b1, 2u64.into(), 9, IsReverted::True);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::False);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::True);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(9), IsReverted::True);
         assert!(logs_contain(
             "We received block 2 commit that was already reverted"
         ))
@@ -618,7 +618,7 @@ mod tests {
         let b1 = rng.gen();
 
         let mut blocks = block_commit(1u64.into());
-        blocks.handle_block_commit(b1, 10u64.into(), 9, IsReverted::True);
+        blocks.handle_block_commit(b1, 10u64.into(), DaBlockHeight(9), IsReverted::True);
         assert!(logs_contain(
             "Revert for height 10 received while pending block queue is empty and LFCFB is 1"
         ))
@@ -657,7 +657,7 @@ mod tests {
 
         let mut blocks = block_commit(1u64.into());
         let mut db = Box::new(MockDb::default());
-        blocks.handle_block_commit(b1, 2u64.into(), 2, IsReverted::False);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(2), IsReverted::False);
 
         db.tap_sealed_blocks_mut(|sealed_blocks| {
             let mut block1 = SealedFuelBlock::default();
@@ -698,9 +698,9 @@ mod tests {
 
         let mut blocks = block_commit(1u64.into());
         let mut db = Box::new(MockDb::default());
-        blocks.handle_block_commit(b1, 2u64.into(), 2, IsReverted::False);
-        blocks.handle_block_commit(b2, 3u64.into(), 3, IsReverted::False);
-        blocks.handle_block_commit(b2, 3u64.into(), 3, IsReverted::True);
+        blocks.handle_block_commit(b1, 2u64.into(), DaBlockHeight(2), IsReverted::False);
+        blocks.handle_block_commit(b2, 3u64.into(), DaBlockHeight(3), IsReverted::False);
+        blocks.handle_block_commit(b2, 3u64.into(), DaBlockHeight(3), IsReverted::True);
 
         db.tap_sealed_blocks_mut(|sealed_blocks| {
             let mut block1 = SealedFuelBlock::default();

--- a/fuel-relayer/src/pending_blocks.rs
+++ b/fuel-relayer/src/pending_blocks.rs
@@ -85,7 +85,7 @@ pub fn from_fuel_to_block_header(fuel_block: &SealedFuelBlock) -> abi::fuel::Blo
         producer: H160::from_slice(&fuel_block.header.producer.as_ref()[12..]),
         previous_block_root: <[u8; 32]>::try_from(fuel_block.id()).unwrap(),
         height: fuel_block.header.height.into(),
-        block_number: fuel_block.header.number.into(), // TODO
+        block_number: fuel_block.header.da_height.as_u64() as u32,
         digest_root: [0; 32],
         digest_hash: [0; 32],
         digest_length: 0,

--- a/fuel-relayer/src/relayer.rs
+++ b/fuel-relayer/src/relayer.rs
@@ -139,8 +139,8 @@ impl Relayer {
         );
         // should be always more then last finalized_da_heights
 
-        let best_finalized_block = provider.get_block_number().await?.as_u64()
-            - self.ctx.config.da_finalization();
+        let best_finalized_block = DaBlockHeight::from(provider.get_block_number().await?.as_u64()
+            - self.ctx.config.da_finalization().as_u64());
 
         // 1. sync from HardCoddedContractCreatingBlock->BestEthBlock-100)
         let step = self.ctx.config.initial_sync_step(); // do some stats on optimal value
@@ -153,11 +153,11 @@ impl Relayer {
             last_finalized_da_height, best_finalized_block
         );
 
-        for start in (last_finalized_da_height..best_finalized_block).step_by(step) {
-            let end = min(start + step as DaBlockHeight, best_finalized_block);
-            if (start - last_finalized_da_height)
+        for start in (last_finalized_da_height.as_u64()..best_finalized_block.as_u64()).step_by(step) {
+            let end = min(DaBlockHeight::from(start + step as u64), best_finalized_block);
+            if (DaBlockHeight::from(start) - last_finalized_da_height)
                 % config::REPORT_INIT_SYNC_PROGRESS_EVERY_N_BLOCKS
-                == 0
+                == DaBlockHeight::from(0u64)
             {
                 info!("getting log from height:{}", start);
             }
@@ -165,7 +165,7 @@ impl Relayer {
             // TODO  can be parallelized
             let filter = Filter::new()
                 .from_block(start)
-                .to_block(end)
+                .to_block(end.as_u64())
                 .address(ValueOrArray::Array(contracts.clone()));
             let logs = handle_interrupt!(self, provider.get_logs(&filter))??;
             self.queue.append_eth_logs(logs).await;
@@ -196,7 +196,7 @@ impl Relayer {
 
             // 2. sync overlap from LastIncludedEthBlock-> BestEthBlock) they are saved in dequeue.
             let filter = Filter::new()
-                .from_block(last_included_block)
+                .from_block(last_included_block.as_u64())
                 .to_block(best_block)
                 .address(ValueOrArray::Array(contracts.clone()));
 
@@ -233,13 +233,13 @@ impl Relayer {
 
         // 5. Continue to active listen on eth events. and prune(commit to db) dequeue for older finalized events
         let finalized_da_height =
-            best_block.as_u64() as DaBlockHeight - self.ctx.config.da_finalization();
+            DaBlockHeight::from(best_block.as_u64()) - self.ctx.config.da_finalization();
         self.queue
             .commit_diffs(self.ctx.db.as_mut(), finalized_da_height)
             .await;
 
         watchers
-            .map(|(w1, w2)| (best_block.as_u64() as DaBlockHeight, w1, w2))
+            .map(|(w1, w2)| (DaBlockHeight::from(best_block.as_u64()), w1, w2))
             .ok_or_else(|| RelayerError::ProviderError.into())
     }
 
@@ -383,8 +383,7 @@ impl Relayer {
         trace!("Received new block hash:{:x?}", block_hash);
         if let Some(block) = provider.get_block(BlockId::Hash(block_hash)).await? {
             if let Some(da_height) = block.number {
-                let finalized_da_height = da_height.as_u64() as DaBlockHeight
-                    - self.ctx.config.da_finalization();
+                let finalized_da_height = DaBlockHeight::from(da_height.as_u64()) - self.ctx.config.da_finalization();
 
                 self.queue
                     .commit_diffs(self.ctx.db.as_mut(), finalized_da_height)

--- a/fuel-relayer/src/validators.rs
+++ b/fuel-relayer/src/validators.rs
@@ -76,7 +76,7 @@ impl Validators {
                 let mut validators = self.set.clone();
                 // get staking diffs to revert from our current set.
                 let diffs = db
-                    .get_staking_diffs(DaBlockHeight::from(da_height.as_u64() + 1u64), Some(self.da_height))
+                    .get_staking_diffs(da_height + 1u64, Some(self.da_height))
                     .await;
 
                 for (diff_height, diff) in diffs.into_iter().rev() {
@@ -164,7 +164,7 @@ impl Validators {
         let mut validators = HashMap::new();
         // get staking diffs.
         let diffs = db
-            .get_staking_diffs(DaBlockHeight::from(self.da_height.as_u64() + 1), Some(da_height))
+            .get_staking_diffs(self.da_height + 1u64, Some(da_height))
             .await;
         let mut delegates_cached: HashMap<
             Address,

--- a/fuel-relayer/src/validators.rs
+++ b/fuel-relayer/src/validators.rs
@@ -76,7 +76,7 @@ impl Validators {
                 let mut validators = self.set.clone();
                 // get staking diffs to revert from our current set.
                 let diffs = db
-                    .get_staking_diffs(da_height + 1, Some(self.da_height))
+                    .get_staking_diffs(DaBlockHeight::from(da_height.as_u64() + 1u64), Some(self.da_height))
                     .await;
 
                 for (diff_height, diff) in diffs.into_iter().rev() {
@@ -164,7 +164,7 @@ impl Validators {
         let mut validators = HashMap::new();
         // get staking diffs.
         let diffs = db
-            .get_staking_diffs(self.da_height + 1, Some(da_height))
+            .get_staking_diffs(DaBlockHeight::from(self.da_height.as_u64() + 1), Some(da_height))
             .await;
         let mut delegates_cached: HashMap<
             Address,

--- a/fuel-tests/tests/messages.rs
+++ b/fuel-tests/tests/messages.rs
@@ -8,10 +8,13 @@ use fuel_core::{
         FuelService,
     },
 };
-use fuel_core_interfaces::common::{
-    fuel_crypto::SecretKey,
-    fuel_tx::TransactionBuilder,
-    fuel_types::Address,
+use fuel_core_interfaces::{
+    common::{
+        fuel_crypto::SecretKey,
+        fuel_tx::TransactionBuilder,
+        fuel_types::Address,
+    },
+    model::DaBlockHeight,
 };
 use fuel_gql_client::{
     client::{
@@ -41,7 +44,7 @@ async fn can_submit_genesis_message() {
         nonce: rng.gen(),
         amount: rng.gen(),
         data: vec![rng.gen()],
-        da_height: 0,
+        da_height: DaBlockHeight(0),
     };
     let tx1 = TransactionBuilder::script(vec![], vec![])
         .add_unsigned_message_input(

--- a/fuel-tests/tests/resource.rs
+++ b/fuel-tests/tests/resource.rs
@@ -16,10 +16,7 @@ use fuel_core_interfaces::{
         fuel_tx::AssetId,
         fuel_vm::prelude::Address,
     },
-    model::{
-        BlockHeight,
-        DaBlockHeight,
-    },
+    model::DaBlockHeight,
 };
 use fuel_gql_client::client::{
     schema::resource::Resource,
@@ -252,7 +249,7 @@ mod messages {
                         nonce: nonce as u64,
                         amount,
                         data: vec![],
-                        da_height: DaBlockHeight::from(BlockHeight::from(1u64)),
+                        da_height: DaBlockHeight::from(1u64),
                     })
                     .collect(),
             ),
@@ -433,7 +430,7 @@ mod messages_and_coins {
                         nonce: nonce as u64,
                         amount,
                         data: vec![],
-                        da_height: DaBlockHeight::from(BlockHeight::from(1u64)),
+                        da_height: DaBlockHeight::from(1u64),
                     })
                     .collect(),
             ),

--- a/fuel-tests/tests/snapshot.rs
+++ b/fuel-tests/tests/snapshot.rs
@@ -20,7 +20,10 @@ use fuel_core_interfaces::{
         },
         fuel_vm::prelude::AssetId,
     },
-    model::BlockHeight,
+    model::{
+        BlockHeight,
+        DaBlockHeight,
+    },
 };
 use rand::{
     rngs::StdRng,
@@ -75,7 +78,7 @@ async fn snapshot_state_config() {
             nonce: rng.gen_range(0..1000),
             amount: rng.gen_range(0..1000),
             data: vec![],
-            da_height: rng.gen_range(0..1000),
+            da_height: DaBlockHeight(rng.gen_range(0..1000)),
         }]),
     };
 


### PR DESCRIPTION
Closes #516 I ended up using u64 because it played much more nicely with the existing changes and I had misinterpreted the issue when I initially asked in that issue.

Migrates `BlockHeight` instances where `DaBlockHeight` should've been used over