### PR TITLE
using arc'd tmpfile to fix bal(1M) benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,7 +2270,6 @@ dependencies = [
  "fuel-core",
  "fuel-core-interfaces",
  "rand 0.8.5",
- "tempfile",
 ]
 
 [[package]]

--- a/fuel-benches/Cargo.toml
+++ b/fuel-benches/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 fuel-core = { path = "../fuel-core" }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["test-helpers"] }
 rand = "0.8"
-tempfile = "3.3"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/fuel-benches/benches/set/blockchain.rs
+++ b/fuel-benches/benches/set/blockchain.rs
@@ -13,9 +13,7 @@ pub fn run(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("blockchain");
 
-    // TODO Add cases with 1m+
-    // Blocked by https://github.com/FuelLabs/fuel-core/issues/636
-    let cases = vec![1, 10, 100, 1_000, 10_000, 100_000];
+    let cases = vec![1, 10, 100, 1_000, 10_000, 100_000, 1_000_000];
     let asset: AssetId = rng.gen();
     let contract: ContractId = rng.gen();
 

--- a/fuel-benches/src/lib.rs
+++ b/fuel-benches/src/lib.rs
@@ -1,20 +1,21 @@
-use std::{
-    io,
-    iter,
-};
+pub use fuel_core::database::Database;
 use fuel_core_interfaces::common::fuel_tx::{
     StorageSlot,
     TransactionBuilder,
 };
-pub use fuel_core::database::Database;
 pub use fuel_core_interfaces::common::{
     consts::*,
     prelude::*,
 };
 pub use rand::Rng;
+use std::{
+    io,
+    iter,
+};
 
-fn new_db() -> io::Result<Database> {
-    Ok(Database::default())
+fn new_db() -> Database {
+    // when rocksdb is enabled, this creates a new db instance with a temporary path
+    Database::default()
 }
 
 pub struct ContractCode {
@@ -128,7 +129,7 @@ impl VmBench {
         let input = Input::contract(utxo_id, balance_root, state_root, tx_pointer, id);
         let output = Output::contract(0, rng.gen(), rng.gen());
 
-        let mut db = new_db()?;
+        let mut db = new_db();
 
         db.deploy_contract_with_id(&salt, &[], &contract, &state_root, &id)?;
 
@@ -288,7 +289,7 @@ impl TryFrom<VmBench> for VmBenchPrepared {
             prepare_db,
         } = case;
 
-        let mut db = db.map(Ok).unwrap_or_else(new_db)?;
+        let mut db = db.unwrap_or_else(new_db);
 
         if prepare_script.iter().any(|op| matches!(op, Opcode::RET(_))) {
             return Err(io::Error::new(

--- a/fuel-benches/src/lib.rs
+++ b/fuel-benches/src/lib.rs
@@ -2,13 +2,10 @@ use std::{
     io,
     iter,
 };
-
 use fuel_core_interfaces::common::fuel_tx::{
     StorageSlot,
     TransactionBuilder,
 };
-use tempfile::TempDir;
-
 pub use fuel_core::database::Database;
 pub use fuel_core_interfaces::common::{
     consts::*,
@@ -17,7 +14,7 @@ pub use fuel_core_interfaces::common::{
 pub use rand::Rng;
 
 fn new_db() -> io::Result<Database> {
-    TempDir::new().and_then(|t| Database::open(t.as_ref()).map_err(|e| e.into()))
+    Ok(Database::default())
 }
 
 pub struct ContractCode {


### PR DESCRIPTION
use `Database::default` to get a tmpfile rocksdb db instance. This solves [problems](https://github.com/FuelLabs/fuel-core/pull/630#issuecomment-1254248494) related to prematurely dropping the tempfile by using an Arc.