### PR TITLE
Remove Feature Flags from Tx Gossiping

### DIFF
--- a/fuel-block-producer/Cargo.toml
+++ b/fuel-block-producer/Cargo.toml
@@ -26,5 +26,4 @@ rand = "0.8"
 rstest = "0.15"
 
 [features]
-p2p = ["fuel-txpool/p2p"]
 test-helpers = ["fuel-core-interfaces/test-helpers"]

--- a/fuel-block-producer/tests/integration.rs
+++ b/fuel-block-producer/tests/integration.rs
@@ -134,11 +134,9 @@ async fn block_producer() -> Result<()> {
         .txpool_sender(TxPoolSender::new(txpool_sender))
         .txpool_receiver(txpool_receiver);
 
-    #[cfg(feature = "p2p")]
-    {
-        let (p2p_request_event_sender, _p2p_request_event_receiver) = mpsc::channel(100);
-        txpool_builder.network_sender(p2p_request_event_sender);
-    }
+    let (p2p_request_event_sender, _p2p_request_event_receiver) = mpsc::channel(100);
+    txpool_builder.network_sender(p2p_request_event_sender);
+    
 
     let txpool = txpool_builder.build().unwrap();
     txpool.start().await?;

--- a/fuel-block-producer/tests/integration.rs
+++ b/fuel-block-producer/tests/integration.rs
@@ -136,7 +136,6 @@ async fn block_producer() -> Result<()> {
 
     let (p2p_request_event_sender, _p2p_request_event_receiver) = mpsc::channel(100);
     txpool_builder.network_sender(p2p_request_event_sender);
-    
 
     let txpool = txpool_builder.build().unwrap();
     txpool.start().await?;

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -88,6 +88,6 @@ metrics = ["dep:fuel-metrics"]
 default = ["rocksdb", "metrics", "debug"]
 debug = ["fuel-core-interfaces/debug"]
 relayer = ["dep:fuel-relayer"]
-p2p = ["dep:fuel-p2p", "fuel-txpool/p2p", "fuel-block-producer/p2p"]
+p2p = ["dep:fuel-p2p"]
 # features to enable in production, but increase build times
 production = ["rocksdb?/jemalloc"]

--- a/fuel-core/src/service/modules.rs
+++ b/fuel-core/src/service/modules.rs
@@ -145,7 +145,6 @@ pub async fn start_modules(config: &Config, database: &Database) -> Result<Modul
         .txpool_sender(Sender::new(txpool_sender))
         .txpool_receiver(txpool_receiver);
 
-    #[cfg(feature = "p2p")]
     txpool_builder.network_sender(p2p_request_event_sender.clone());
 
     let txpool = txpool_builder.build()?;

--- a/fuel-core/src/service/modules.rs
+++ b/fuel-core/src/service/modules.rs
@@ -103,7 +103,7 @@ pub async fn start_modules(config: &Config, database: &Database) -> Result<Modul
     #[cfg(feature = "p2p")]
     let (p2p_request_event_sender, p2p_request_event_receiver) = mpsc::channel(100);
     #[cfg(not(feature = "p2p"))]
-    let (p2p_request_event_sender, _p2p_request_event_receiver) = mpsc::channel(100);
+    let (p2p_request_event_sender, mut p2p_request_event_receiver) = mpsc::channel(100);
 
     #[cfg(feature = "p2p")]
     let network_service = {
@@ -126,6 +126,8 @@ pub async fn start_modules(config: &Config, database: &Database) -> Result<Modul
 
         let keep_alive = Box::new(block_event_sender);
         Box::leak(keep_alive);
+
+        tokio::spawn(async move { while (p2p_request_event_receiver.recv().await).is_some() {} });
     }
 
     let (tx_status_sender, mut tx_status_receiver) = broadcast::channel(100);

--- a/fuel-core/src/service/modules.rs
+++ b/fuel-core/src/service/modules.rs
@@ -127,7 +127,9 @@ pub async fn start_modules(config: &Config, database: &Database) -> Result<Modul
         let keep_alive = Box::new(block_event_sender);
         Box::leak(keep_alive);
 
-        tokio::spawn(async move { while (p2p_request_event_receiver.recv().await).is_some() {} });
+        tokio::spawn(async move {
+            while (p2p_request_event_receiver.recv().await).is_some() {}
+        });
     }
 
     let (tx_status_sender, mut tx_status_receiver) = broadcast::channel(100);

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -22,5 +22,4 @@ tokio = { version = "1.21", default-features = false, features = ["sync"] }
 tracing = "0.1"
 
 [features]
-p2p = []
 test-helpers = ["fuel-core-interfaces/test-helpers"]

--- a/fuel-txpool/src/service.rs
+++ b/fuel-txpool/src/service.rs
@@ -5,7 +5,10 @@ use crate::{
 use anyhow::anyhow;
 use fuel_core_interfaces::{
     block_importer::ImportBlockBroadcast,
-    p2p::TransactionBroadcast,
+    p2p::{
+        P2pRequestEvent,
+        TransactionBroadcast,
+    },
     txpool::{
         self,
         TxPoolDb,
@@ -24,7 +27,6 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::error;
-use fuel_core_interfaces::p2p::P2pRequestEvent;
 
 pub struct ServiceBuilder {
     config: Config,
@@ -384,7 +386,6 @@ pub mod tests {
             .txpool_sender(txpool_sender)
             .txpool_receiver(txpool_receiver);
 
-
         let (network_sender, _) = mpsc::channel(100);
         builder.network_sender(network_sender);
 
@@ -472,7 +473,6 @@ pub mod tests {
             .txpool_sender(txpool_sender)
             .txpool_receiver(txpool_receiver);
 
-
         let (network_sender, _) = mpsc::channel(100);
         builder.network_sender(network_sender);
 
@@ -540,7 +540,6 @@ pub mod tests {
             .tx_status_sender(tx_status_sender)
             .txpool_sender(txpool_sender)
             .txpool_receiver(txpool_receiver);
-
 
         let (network_sender, _) = mpsc::channel(100);
         builder.network_sender(network_sender);

--- a/fuel-txpool/src/txpool.rs
+++ b/fuel-txpool/src/txpool.rs
@@ -29,9 +29,7 @@ use tokio::sync::{
     RwLock,
 };
 
-#[cfg(feature = "p2p")]
 use fuel_core_interfaces::p2p::P2pRequestEvent;
-#[cfg(feature = "p2p")]
 use tokio::sync::mpsc;
 
 #[derive(Debug, Clone)]
@@ -150,7 +148,6 @@ impl TxPool {
         Ok(())
     }
 
-    #[cfg(feature = "p2p")]
     pub async fn insert_with_broadcast(
         txpool: &RwLock<Self>,
         db: &dyn TxPoolDb,


### PR DESCRIPTION
Removes the feature flag of p2p from the txpool, and instead just requires a noop `network_sender` to be supplied