### PR TITLE
Prevent benchmarks from running during standard CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,9 @@ jobs:
           - command: make
             args: check --locked
           - command: test
-            args: --all-targets --all-features --workspace
+            args: --tests --all-features --workspace
           - command: test
-            args: --all-targets --no-default-features --workspace
+            args: --tests --no-default-features --workspace
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45
     continue-on-error: ${{ matrix.skip-error || false }}


### PR DESCRIPTION
When VM benchmarks were added to fuel-core, they unintentionally started being included in the standard test pass in all CI runs due to `cargo test --all-targets`, increasing the times a lot. This PR restricts our cargo test parameters so that benchmarks aren't run on every CI workflow.