### PR TITLE
Use nix to include a precompiled version of rocksdb in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: '${{ matrix.command }} ${{ matrix.args }}'
+      - uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v10
+      - run: nix develop
       - name: ${{ matrix.command }} ${{ matrix.args }}
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,6 @@ jobs:
     continue-on-error: ${{ matrix.skip-error || false }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - name: Install Cargo Make
         uses: davidB/rust-cargo-make@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           version: "0.36.0"
       - uses: Swatinem/rust-cache@v2
         with:
-          key: 'nix ${{ matrix.command }} ${{ matrix.args }}'
+          key: 'nix2 ${{ matrix.command }} ${{ matrix.args }}'
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix develop --command which protoc
       - name: ${{ matrix.command }} ${{ matrix.args }}
-        run: nix develop --command ${{ matrix.command }} ${{ matrix.args }}
+        run: nix develop --command cargo ${{ matrix.command }} ${{ matrix.args }}
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v2
         if: always() && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,9 @@ jobs:
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix develop
-      - run: which protoc
+      - run: nix develop --command which protoc
       - name: ${{ matrix.command }} ${{ matrix.args }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: ${{ matrix.command }}
-          args: ${{ matrix.args }}
+        run: nix develop --command ${{ matrix.command }} ${{ matrix.args }}
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v2
         if: always() && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,12 +106,7 @@ jobs:
       - name: Install Cargo Make
         uses: davidB/rust-cargo-make@v1
         with:
-          version: "0.36.0"      
-      - name: Restore nix binary cache
-        uses: actions/cache@v3
-        with:
-          path: /nix/store
-          key: ${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          version: "0.36.0"
       - uses: Swatinem/rust-cache@v2
         with:
           key: 'nix ${{ matrix.command }} ${{ matrix.args }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,11 @@ jobs:
         uses: davidB/rust-cargo-make@v1
         with:
           version: "0.36.0"      
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:          
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Restore nix binary cache
+        uses: actions/cache@v3
+        with:
+          path: /nix/store
+          key: ${{ runner.os }}-${{ hashFiles('flake.lock') }}
       - uses: Swatinem/rust-cache@v2
         with:
           key: 'nix ${{ matrix.command }} ${{ matrix.args }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - run: nix develop
+      - run: which protoc
       - name: ${{ matrix.command }} ${{ matrix.args }}
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/cachix-action@v10
       - run: nix develop
       - name: ${{ matrix.command }} ${{ matrix.args }}
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: '${{ matrix.command }} ${{ matrix.args }}'
+          key: 'nix ${{ matrix.command }} ${{ matrix.args }}'
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,12 +2150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 
 [[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
 name = "fuel-asm"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3690,7 +3684,6 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -5896,17 +5889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.5.2+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec45c14da997d0925c7835883e4d5c181f196fa142f8c19d7643d1e9af2592c3"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
 ]
 
 [[package]]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1664989420,
+        "narHash": "sha256-Q8IxomUjjmewsoJgO3htkXLfCckQ7HkDJ/ZhdYVf/fA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "37bd39839acf99c5b738319f42478296f827f274",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665024572,
+        "narHash": "sha256-b6Tnu74VzdMaJgKHM9iJ6fVf9svzYI+ktfzMGoDt/Og=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "fb4d8ee5220b76d1ffb4b4e1fedcf3cbc93ead1a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "ref": "master",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "A Nix flake containing the standard fuel-core optimized build environment";
+
+    inputs = {
+        nixpkgs = {
+          url = "github:NixOS/nixpkgs/nixos-unstable";
+        };
+        rust-overlay = {
+          url = "github:oxalica/rust-overlay/master";
+          inputs.nixpkgs.follows = "nixpkgs";
+        };
+        flake-utils.url = "github:numtide/flake-utils";
+    };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in
+      with pkgs;
+      {
+        devShell = pkgs.mkShell {
+            buildInputs = [
+                pkgs.grpc-tools
+                pkgs.clang
+                pkgs.pkg-config
+                rust-bin.stable."1.64.0".default
+            ];
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+            PROTOC = "${pkgs.grpc-tools}/bin/protoc";
+            ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
+        };
+      });
+}

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -91,4 +91,6 @@ debug = ["fuel-core-interfaces/debug"]
 relayer = ["dep:fuel-relayer"]
 p2p = ["dep:fuel-p2p"]
 # features to enable in production, but increase build times
-production = ["rocksdb?/jemalloc"]
+# TODO: figure out how to avoid duplicate fuel-core builds when using --all-features for clippy and tests
+#       production = ["rocksdb?/jemalloc"]
+production = []


### PR DESCRIPTION
testing a fuel-core nix dev-shell