### PR TITLE
Require test-utils feature in fuel-txpool

### DIFF
--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1.21", default-features = false, features = ["sync"] }
 tracing = "0.1"
 
 [dev-dependencies]
-fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["test-helpers"] }
+fuel-txpool = { path = ".", features = ["test-helpers"] }
 
 [features]
 test-helpers = ["fuel-core-interfaces/test-helpers"]

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -21,5 +21,8 @@ thiserror = "1.0"
 tokio = { version = "1.21", default-features = false, features = ["sync"] }
 tracing = "0.1"
 
+[dev-dependencies]
+fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["test-helpers"] }
+
 [features]
 test-helpers = ["fuel-core-interfaces/test-helpers"]


### PR DESCRIPTION
Currently `cargo test --workspace` enables `test-utils` feature so all crates compile without errors. However, running `cargo test -p fuel-txpool` fails to compile since nothing in the `fuel-txpool` crate requires the feature. This PR fixes the issue, and after this all of the member crates compile correctly.

This PR doesn't add CI tests for this, but if such test is desired, the following snippet should do the job:

```bash
printf 'import toml\nwith open("Cargo.toml") as f: print("\\n".join(x for x in toml.load(f)["workspace"]["members"] if x not in ["fuel-benches", "fuel-client"]))' | python3 | xargs -n 1 -I% cargo check --tests -p %
```