### PR TITLE
Enable relayer in docker builds

### DIFF
--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -91,4 +91,4 @@ debug = ["fuel-core-interfaces/debug"]
 relayer = ["dep:fuel-relayer"]
 p2p = ["dep:fuel-p2p"]
 # features to enable in production, but increase build times
-production = ["rocksdb?/jemalloc"]
+production = ["rocksdb?/jemalloc", "relayer"]


### PR DESCRIPTION
The relayer is still optional by default, but now it will be included in docker image builds of fuel core. This unblocks e2e integration testing.