### PR TITLE
protoc is required for publishing fuel-p2p

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,11 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Verify tag version
         run: |
           curl -sSLf "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -L -o dasel && chmod +x dasel


### PR DESCRIPTION
Our recent release failed due to a new dependency on protoc. This adds protoc to the publish crate job to fix the following issue:
https://github.com/FuelLabs/fuel-core/actions/runs/3246871289/jobs/5328438335