### PR TITLE
Patch fuel-core v0.11.1 to re-publish

### DIFF
--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-core
 description: Fuel Core Helm Chart
 type: application
-appVersion: "0.11.0"
+appVersion: "0.11.1"
 version: 0.1.0

--- a/fuel-block-executor/Cargo.toml
+++ b/fuel-block-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-executor"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,5 +11,5 @@ description = "Fuel Block Executor"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1" }
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-block-importer/Cargo.toml
+++ b/fuel-block-importer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-importer"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Block Importer"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1" }
 parking_lot = "0.12"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-block-producer/Cargo.toml
+++ b/fuel-block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-producer"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -13,7 +13,7 @@ description = "Fuel Block Producer"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1" }
 parking_lot = "0.12"
 tokio = { version = "1.21", features = ["full"] }
 tracing = { version = "0.1" }

--- a/fuel-chain-config/Cargo.toml
+++ b/fuel-chain-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-chain-config"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -12,10 +12,10 @@ description = "Fuel Chain config types"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1", features = [
     "serde",
 ] }
-fuel-poa-coordinator = { path = "../fuel-poa-coordinator", version = "0.11.0" }
+fuel-poa-coordinator = { path = "../fuel-poa-coordinator", version = "0.11.1" }
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"
 rand = "0.8"

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-gql-client"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"

--- a/fuel-core-bft/Cargo.toml
+++ b/fuel-core-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-bft"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Core BFT"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1" }
 parking_lot = "0.12"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-interfaces"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -35,20 +35,20 @@ derive_more = { version = "0.99" }
 dirs = "4.0"
 enum-iterator = "1.2"
 env_logger = "0.9"
-fuel-block-executor = { path = "../fuel-block-executor", version = "0.11.0" }
-fuel-block-importer = { path = "../fuel-block-importer", version = "0.11.0" }
-fuel-block-producer = { path = "../fuel-block-producer", version = "0.11.0" }
-fuel-chain-config = { path = "../fuel-chain-config", version = "0.11.0" }
-fuel-core-bft = { path = "../fuel-core-bft", version = "0.11.0" }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0", features = [
+fuel-block-executor = { path = "../fuel-block-executor", version = "0.11.1" }
+fuel-block-importer = { path = "../fuel-block-importer", version = "0.11.1" }
+fuel-block-producer = { path = "../fuel-block-producer", version = "0.11.1" }
+fuel-chain-config = { path = "../fuel-chain-config", version = "0.11.1" }
+fuel-core-bft = { path = "../fuel-core-bft", version = "0.11.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1", features = [
     "serde",
 ] }
-fuel-metrics = { path = "../fuel-metrics", version = "0.11.0", optional = true }
-fuel-p2p = { path = "../fuel-p2p", version = "0.11.0", optional = true }
-fuel-poa-coordinator = { path = "../fuel-poa-coordinator", version = "0.11.0" }
-fuel-relayer = { path = "../fuel-relayer", version = "0.11.0", optional = true }
-fuel-sync = { path = "../fuel-sync", version = "0.11.0" }
-fuel-txpool = { path = "../fuel-txpool", version = "0.11.0" }
+fuel-metrics = { path = "../fuel-metrics", version = "0.11.1", optional = true }
+fuel-p2p = { path = "../fuel-p2p", version = "0.11.1", optional = true }
+fuel-poa-coordinator = { path = "../fuel-poa-coordinator", version = "0.11.1" }
+fuel-relayer = { path = "../fuel-relayer", version = "0.11.1", optional = true }
+fuel-sync = { path = "../fuel-sync", version = "0.11.1" }
+fuel-txpool = { path = "../fuel-txpool", version = "0.11.1" }
 futures = "0.3"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"

--- a/fuel-metrics/Cargo.toml
+++ b/fuel-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-metrics"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-p2p"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 edition = "2021"
@@ -14,7 +14,7 @@ description = "Fuel client networking"
 anyhow = "1.0"
 async-trait = "0.1"
 bincode = "1.3"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["serde"], version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["serde"], version = "0.11.1" }
 futures = "0.3"
 futures-timer = "3.0"
 ip_network = "0.4"

--- a/fuel-poa-coordinator/Cargo.toml
+++ b/fuel-poa-coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-poa-coordinator"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,7 +11,7 @@ description = "Fuel Core PoA Coordinator"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1" }
 humantime-serde = "1.1.1"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-relayer"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -26,7 +26,7 @@ ethers-providers = { version = "0.17", default-features = false, features = [
 ] }
 ethers-signers = { version = "0.17", default-features = false }
 features = "0.10"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.11.1" }
 futures = "0.3"
 hex = "0.4"
 once_cell = "1.4"

--- a/fuel-sync/Cargo.toml
+++ b/fuel-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-sync"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Synchronizer"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1" }
 parking_lot = "0.12"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-txpool"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -14,7 +14,7 @@ description = "Transaction pool"
 anyhow = "1.0"
 async-trait = "0.1"
 chrono = "0.4"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.11.1" }
 futures = "0.3"
 parking_lot = "0.11"
 thiserror = "1.0"


### PR DESCRIPTION
Crate publishing failed due to a missing CI step. Releasing a new patch version since some artifacts already went out with v0.11