### PR TITLE
disable docker buildx during macos binary builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
+        if: matrix.job.cross_image
         uses: docker/setup-buildx-action@v1
 
       - name: Setup custom cross env ${{ matrix.job.cross_image }}


### PR DESCRIPTION
docker isn't needed to build mac binaries, and has recently has stopped working on mac. Disable running docker on mac-os.