### PR TITLE
PoA Block Signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "parking_lot 0.12.1",
+ "secrecy",
  "serde",
  "thiserror",
  "tokio",
@@ -5440,6 +5441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,13 +2381,14 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]
 name = "fuel-crypto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27380c9c0a97da57123eb981289431069371cc71439f8d0192b604c1414f705"
+checksum = "00ff4fc0f9a733676b465765c9fb3c5a50ba447dce19b3df22549d4f386e79e3"
 dependencies = [
  "borrown",
  "coins-bip32",
@@ -2398,6 +2399,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "sha2 0.10.6",
+ "zeroize",
 ]
 
 [[package]]

--- a/fuel-block-producer/src/block_producer.rs
+++ b/fuel-block-producer/src/block_producer.rs
@@ -236,7 +236,7 @@ impl Producer {
             // TODO: this should use a proper BMT MMR
             let hash = previous_block.id();
             let prev_root = ephemeral_merkle_root(
-                vec![*previous_block.header.prev_root(), hash].iter(),
+                vec![*previous_block.header.prev_root(), hash.into()].iter(),
             );
 
             Ok(PreviousBlockInfo {

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -19,6 +19,7 @@ fuel-vm = { version = "0.18", default-features = false, features = ["random"] }
 futures = "0.3"
 lazy_static = "1.4"
 parking_lot = "0.12"
+secrecy = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -23,6 +23,7 @@ secrecy = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }
+zeroize = "1.5"
 
 [features]
 test-helpers = [

--- a/fuel-core-interfaces/src/block_importer.rs
+++ b/fuel-core-interfaces/src/block_importer.rs
@@ -22,7 +22,7 @@ impl ImportBlockBroadcast {
     pub fn block(&self) -> &FuelBlock {
         match self {
             Self::PendingFuelBlockImported { block } => block.as_ref(),
-            Self::SealedFuelBlockImported { block, .. } => block.as_ref(),
+            Self::SealedFuelBlockImported { block, .. } => &block.as_ref().block,
         }
     }
 }

--- a/fuel-core-interfaces/src/db.rs
+++ b/fuel-core-interfaces/src/db.rs
@@ -65,6 +65,8 @@ pub enum Error {
     InvalidDatabaseVersion,
     #[error("error occurred in the underlying datastore `{0}`")]
     DatabaseError(Box<dyn std::error::Error + Send + Sync>),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 impl From<Error> for std::io::Error {

--- a/fuel-core-interfaces/src/executor.rs
+++ b/fuel-core-interfaces/src/executor.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     db::KvStoreError,
     model::{
+        BlockId,
         FuelBlock,
         PartialFuelBlock,
     },
@@ -136,7 +137,7 @@ pub enum Error {
 
 impl ExecutionBlock {
     /// Get the hash of the full [`FuelBlock`] if validating.
-    pub fn id(&self) -> Option<Bytes32> {
+    pub fn id(&self) -> Option<BlockId> {
         match self {
             ExecutionTypes::Production(_) => None,
             ExecutionTypes::Validation(v) => Some(v.id()),

--- a/fuel-core-interfaces/src/lib.rs
+++ b/fuel-core-interfaces/src/lib.rs
@@ -16,4 +16,6 @@ pub mod common {
     pub use fuel_vm;
     #[doc(no_inline)]
     pub use fuel_vm::*;
+    #[doc(no_inline)]
+    pub use secrecy;
 }

--- a/fuel-core-interfaces/src/model.rs
+++ b/fuel-core-interfaces/src/model.rs
@@ -6,9 +6,12 @@ mod messages;
 mod txpool;
 mod vote;
 
-use crate::common::fuel_types::{
-    Address,
-    Bytes32,
+use crate::common::{
+    fuel_crypto::SecretKey,
+    fuel_types::{
+        Address,
+        Bytes32,
+    },
 };
 pub use block::{
     BlockId,
@@ -31,15 +34,35 @@ pub use coin::{
     CoinStatus,
 };
 pub use da_block_height::DaBlockHeight;
+use derive_more::{
+    Deref,
+    From,
+};
 pub use messages::*;
+use secrecy::{
+    zeroize,
+    CloneableSecret,
+    DebugSecret,
+};
 pub use txpool::{
     ArcTx,
     TxInfo,
 };
 pub use vote::ConsensusVote;
+use zeroize::Zeroize;
 
 /// Validator address used for registration of validator on DA layer
 pub type ValidatorId = Address;
 /// Consensus public key used for Fuel network consensus protocol to
 /// check signatures. ConsensusId is assigned by validator.
 pub type ConsensusId = Bytes32;
+
+/// Wrapper around [`fuel_crypto::SecretKey`] to implement [`secrecy`] marker traits
+#[derive(
+    Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Zeroize, Deref, From,
+)]
+#[repr(transparent)]
+pub struct SecretKeyWrapper(SecretKey);
+
+impl CloneableSecret for SecretKeyWrapper {}
+impl DebugSecret for SecretKeyWrapper {}

--- a/fuel-core-interfaces/src/model.rs
+++ b/fuel-core-interfaces/src/model.rs
@@ -11,6 +11,7 @@ use crate::common::fuel_types::{
     Bytes32,
 };
 pub use block::{
+    BlockId,
     ConsensusType,
     FuelApplicationHeader,
     FuelBlock,

--- a/fuel-core-interfaces/src/model.rs
+++ b/fuel-core-interfaces/src/model.rs
@@ -22,6 +22,7 @@ pub use block::{
     PartialFuelBlock,
     PartialFuelBlockHeader,
     SealedFuelBlock,
+    SealedFuelBlockHeader,
 };
 pub use block_height::BlockHeight;
 pub use coin::{

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -25,9 +25,31 @@ use std::fmt;
 
 #[cfg(any(test, feature = "test-helpers"))]
 use chrono::TimeZone;
+use derive_more::{
+    Display,
+    From,
+    FromStr,
+    LowerHex,
+    UpperHex,
+};
 
 /// A cryptographically secure hash, identifying a block.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
+    FromStr,
+    From,
+    LowerHex,
+    UpperHex,
+    Display,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[repr(transparent)]
@@ -40,25 +62,6 @@ impl BlockId {
         unsafe { fuel_crypto::Message::from_bytes_unchecked(*self.0) }
         // Without this, the signature would be using a hash of the id making it more
         // difficult to verify.
-    }
-}
-
-impl From<Bytes32> for BlockId {
-    fn from(bytes: Bytes32) -> Self {
-        Self(bytes)
-    }
-}
-
-#[allow(clippy::from_over_into)] // Avoids circular dependency
-impl Into<Bytes32> for BlockId {
-    fn into(self) -> Bytes32 {
-        self.0
-    }
-}
-
-impl fmt::LowerHex for BlockId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(&self.0, f)
     }
 }
 

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -16,13 +16,51 @@ use chrono::{
 };
 use core::ops::Deref;
 use fuel_vm::{
+    fuel_crypto,
     fuel_merkle,
     fuel_types::MessageId,
     prelude::Signature,
 };
+use std::fmt;
 
 #[cfg(any(test, feature = "test-helpers"))]
 use chrono::TimeZone;
+
+/// A cryptographically secure hash, identifying a block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[repr(transparent)]
+pub struct BlockId(Bytes32);
+
+impl BlockId {
+    /// Converts the hash into a message having the same bytes.
+    pub fn into_message(self) -> fuel_crypto::Message {
+        // This is safe because BlockId is a cryptographically secure hash.
+        unsafe { fuel_crypto::Message::from_bytes_unchecked(*self.0) }
+        // Without this, the signature would be using a hash of the id making it more
+        // difficult to verify.
+    }
+}
+
+impl From<Bytes32> for BlockId {
+    fn from(bytes: Bytes32) -> Self {
+        Self(bytes)
+    }
+}
+
+#[allow(clippy::from_over_into)] // Avoids circular dependency
+impl Into<Bytes32> for BlockId {
+    fn into(self) -> Bytes32 {
+        self.0
+    }
+}
+
+impl fmt::LowerHex for BlockId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -120,7 +158,7 @@ pub struct GeneratedConsensusFields {
 /// Extra data that is not actually part of the header.
 pub struct HeaderMetadata {
     /// Hash of the header.
-    id: Bytes32,
+    id: BlockId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -182,13 +220,13 @@ impl FuelBlockHeader {
     }
 
     /// Get the hash of the fuel header.
-    pub fn hash(&self) -> Bytes32 {
+    pub fn hash(&self) -> BlockId {
         // This internally hashes the hash of the application header.
         self.consensus.hash()
     }
 
     /// Get the cached fuel header hash.
-    pub fn id(&self) -> Bytes32 {
+    pub fn id(&self) -> BlockId {
         if let Some(ref metadata) = self.metadata {
             metadata.id
         } else {
@@ -299,14 +337,14 @@ impl FuelApplicationHeader<GeneratedApplicationFields> {
 
 impl FuelConsensusHeader<GeneratedConsensusFields> {
     /// Hash the consensus header.
-    fn hash(&self) -> Bytes32 {
+    fn hash(&self) -> BlockId {
         // Order matters and is the same as the spec.
         let mut hasher = Hasher::default();
         hasher.input(self.prev_root.as_ref());
         hasher.input(&self.height.to_bytes()[..]);
         hasher.input(self.time.timestamp_millis().to_be_bytes());
         hasher.input(self.application_hash.as_ref());
-        hasher.digest()
+        BlockId(hasher.digest())
     }
 }
 
@@ -367,7 +405,7 @@ pub struct FuelBlockDb {
 
 impl FuelBlockDb {
     /// Hash of the header.
-    pub fn id(&self) -> Bytes32 {
+    pub fn id(&self) -> BlockId {
         self.header.id()
     }
 
@@ -458,7 +496,7 @@ impl FuelBlock {
     }
 
     /// Get the hash of the header.
-    pub fn id(&self) -> Bytes32 {
+    pub fn id(&self) -> BlockId {
         self.header.id()
     }
 

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -14,7 +14,6 @@ use chrono::{
     DateTime,
     Utc,
 };
-use core::ops::Deref;
 use fuel_vm::{
     fuel_crypto,
     fuel_merkle,
@@ -29,7 +28,7 @@ use crate::common::{
 #[cfg(any(test, feature = "test-helpers"))]
 use chrono::TimeZone;
 use derive_more::{
-    Deref,
+    AsRef,
     Display,
     From,
     FromStr,
@@ -55,7 +54,7 @@ use derive_more::{
     LowerHex,
     UpperHex,
     Display,
-    Deref,
+    AsRef,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
@@ -685,14 +684,6 @@ pub struct SealedFuelBlock {
     pub consensus: FuelBlockConsensus,
 }
 
-impl Deref for SealedFuelBlock {
-    type Target = FuelBlock;
-
-    fn deref(&self) -> &FuelBlock {
-        &self.block
-    }
-}
-
 impl FuelBlockPoAConsensus {
     /// Create a new block consensus.
     pub fn new(signature: Signature) -> Self {
@@ -742,12 +733,4 @@ impl SealedFuelBlock {
 pub struct SealedFuelBlockHeader {
     pub header: FuelBlockHeader,
     pub consensus: FuelBlockConsensus,
-}
-
-impl Deref for SealedFuelBlockHeader {
-    type Target = FuelBlockHeader;
-
-    fn deref(&self) -> &FuelBlockHeader {
-        &self.header
-    }
 }

--- a/fuel-core-interfaces/src/poa_coordinator.rs
+++ b/fuel-core-interfaces/src/poa_coordinator.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use fuel_vm::fuel_tx::Bytes32;
 
 use crate::model::{
     BlockHeight,
+    BlockId,
     FuelBlockConsensus,
 };
 
@@ -12,7 +12,7 @@ pub trait BlockDb: Send + Sync {
     // Returns error if already sealed
     fn seal_block(
         &mut self,
-        block_id: Bytes32,
+        block_id: BlockId,
         consensus: FuelBlockConsensus,
     ) -> Result<()>;
 }

--- a/fuel-core-interfaces/src/poa_coordinator.rs
+++ b/fuel-core-interfaces/src/poa_coordinator.rs
@@ -1,9 +1,20 @@
 use anyhow::Result;
+use fuel_vm::fuel_tx::Bytes32;
 
-use crate::model::BlockHeight;
+use crate::model::{
+    BlockHeight,
+    FuelBlockConsensus,
+};
 
-pub trait BlockHeightDb: Send + Sync {
+pub trait BlockDb: Send + Sync {
     fn block_height(&self) -> Result<BlockHeight>;
+
+    // Returns error if already sealed
+    fn seal_block(
+        &mut self,
+        block_id: Bytes32,
+        consensus: FuelBlockConsensus,
+    ) -> Result<()>;
 }
 
 #[async_trait::async_trait]

--- a/fuel-core/src/cli/run.rs
+++ b/fuel-core/src/cli/run.rs
@@ -6,13 +6,17 @@ use anyhow::Context;
 use clap::Parser;
 use fuel_chain_config::ChainConfig;
 use fuel_core::service::{
+    config::default_consensus_dev_key,
     Config,
     DbType,
     VMConfig,
 };
-use fuel_core_interfaces::common::{
-    prelude::SecretKey,
-    secrecy::Secret,
+use fuel_core_interfaces::{
+    common::{
+        prelude::SecretKey,
+        secrecy::Secret,
+    },
+    model::SecretKeyWrapper,
 };
 use std::{
     env,
@@ -75,8 +79,15 @@ pub struct Command {
     #[clap(long = "min-gas-price", default_value = "0")]
     pub min_gas_price: u64,
 
+    /// The signing key used when producing blocks.
+    /// Setting via the `CONSENSUS_KEY_SECRET` ENV var is preferred.
     #[clap(long = "consensus-key")]
     pub consensus_key: Option<String>,
+
+    /// Use a default insecure consensus key for testing purposes.
+    /// This will not be enabled by default in the future.
+    #[clap(long = "dev-keys", default_value = "true")]
+    pub consensus_dev_key: bool,
 
     #[cfg(feature = "relayer")]
     #[clap(flatten)]
@@ -100,6 +111,7 @@ impl Command {
             utxo_validation,
             min_gas_price,
             consensus_key,
+            consensus_dev_key,
             #[cfg(feature = "relayer")]
             relayer_args,
             #[cfg(feature = "p2p")]
@@ -118,6 +130,20 @@ impl Command {
 
         let chain_conf: ChainConfig = chain_config.as_str().parse()?;
         let consensus_params = chain_conf.transaction_parameters;
+        // if consensus key is not configured, fallback to dev consensus key
+        let consensus_key = load_consensus_key(consensus_key)?.or_else(|| {
+            if consensus_dev_key {
+                let key = default_consensus_dev_key();
+                warn!(
+                    "Fuel Core is using an insecure test key for consensus. Public key: {}",
+                    key.public_key()
+                );
+                Some(Secret::new(key.into()))
+            } else {
+                // if consensus dev key is disabled, use no key
+                None
+            }
+        });
 
         Ok(Config {
             addr,
@@ -145,7 +171,7 @@ impl Command {
             sync: Default::default(),
             #[cfg(feature = "p2p")]
             p2p,
-            consensus_key: load_consensus_key(consensus_key)?,
+            consensus_key,
         })
     }
 }
@@ -166,7 +192,7 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
 // Attempt to load the consensus key from cli arg first, otherwise check the env.
 fn load_consensus_key(
     cli_arg: Option<String>,
-) -> anyhow::Result<Option<Secret<[u8; 32]>>> {
+) -> anyhow::Result<Option<Secret<SecretKeyWrapper>>> {
     let secret_string = if let Some(cli_arg) = cli_arg {
         warn!("Consensus key configured insecurely using cli args. Consider setting the {} env var instead.", CONSENSUS_KEY_ENV);
         Some(cli_arg)

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -361,7 +361,7 @@ impl InterpreterStorage for Database {
                 let block_id = current_block.header.id();
                 let consensus = self
                     .storage::<SealedBlockConsensus>()
-                    .get(&block_id)?
+                    .get(block_id.as_ref())?
                     .ok_or(KvStoreError::NotFound)?;
                 consensus.block_producer(&block_id).map_err(Into::into)
             }

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -21,7 +21,10 @@ pub use fuel_core_interfaces::db::KvStoreError;
 use fuel_core_interfaces::{
     common::{
         fuel_asm::Word,
-        fuel_storage::StorageAsRef,
+        fuel_storage::{
+            StorageAsMut,
+            StorageAsRef,
+        },
         fuel_vm::prelude::{
             Address,
             Bytes32,
@@ -36,7 +39,7 @@ use fuel_core_interfaces::{
         SealedFuelBlock,
     },
     p2p::P2pDb,
-    poa_coordinator::BlockHeightDb,
+    poa_coordinator::BlockDb,
     relayer::RelayerDb,
     txpool::TxPoolDb,
 };
@@ -55,8 +58,11 @@ use std::{
     sync::Arc,
 };
 
+use crate::database::storage::SealedBlockConsensus;
 #[cfg(feature = "rocksdb")]
 use crate::state::rocks_db::RocksDb;
+use anyhow::anyhow;
+use fuel_core_interfaces::model::FuelBlockConsensus;
 #[cfg(feature = "rocksdb")]
 use std::path::Path;
 #[cfg(feature = "rocksdb")]
@@ -71,6 +77,7 @@ mod coin;
 mod contracts;
 mod message;
 mod receipts;
+mod sealed_block;
 mod state;
 
 pub mod metadata;
@@ -117,6 +124,8 @@ pub enum Column {
     Messages = 14,
     /// The column of the table that stores `true` if `owner` owns `Message` with `message_id`
     OwnedMessageIds = 15,
+    /// The column that stores the consensus metadata associated with a finalized fuel block
+    FuelBlockConsensus = 16,
 }
 
 #[derive(Clone, Debug)]
@@ -297,9 +306,27 @@ impl Default for Database {
     }
 }
 
-impl BlockHeightDb for Database {
+impl BlockDb for Database {
     fn block_height(&self) -> anyhow::Result<BlockHeight> {
         Ok(self.get_block_height()?.unwrap_or_default())
+    }
+
+    fn seal_block(
+        &mut self,
+        block_id: Bytes32,
+        consensus: FuelBlockConsensus,
+    ) -> anyhow::Result<()> {
+        if self
+            .storage::<SealedBlockConsensus>()
+            .contains_key(&block_id)?
+        {
+            return Err(anyhow!("block {} is already sealed", &block_id))
+        }
+
+        self.storage::<SealedBlockConsensus>()
+            .insert(&block_id, &consensus)
+            .map(|_| ())
+            .map_err(Into::into)
     }
 }
 
@@ -443,9 +470,15 @@ mod relayer {
 
         async fn get_sealed_block(
             &self,
-            _height: BlockHeight,
+            height: BlockHeight,
         ) -> Option<Arc<SealedFuelBlock>> {
-            Some(Arc::new(SealedFuelBlock::fix_me_default_block()))
+            let block_id = self
+                .get_block_id(height)
+                .unwrap_or_else(|_| panic!("nonexistent block height {}", height))?;
+
+            self.get_sealed_block(&block_id)
+                .expect("expected to find sealed block")
+                .map(Arc::new)
         }
 
         async fn set_finalized_da_height(&self, block: DaBlockHeight) {

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -61,6 +61,7 @@ use std::{
 use crate::database::storage::SealedBlockConsensus;
 #[cfg(feature = "rocksdb")]
 use crate::state::rocks_db::RocksDb;
+use anyhow::Context;
 use fuel_core_interfaces::model::FuelBlockConsensus;
 #[cfg(feature = "rocksdb")]
 use std::path::Path;
@@ -350,7 +351,11 @@ impl InterpreterStorage for Database {
     }
 
     fn coinbase(&self) -> Result<Address, Error> {
-        let current_block = self.get_current_block()?.ok_or(KvStoreError::NotFound)?;
+        let current_block = self
+            .get_current_block()?
+            .ok_or(KvStoreError::NotFound)
+            .with_context(|| "no current block was found")?;
+
         match current_block.consensus_type() {
             ConsensusType::PoA => {
                 let block_id = current_block.header.id();

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -317,13 +317,6 @@ impl BlockDb for Database {
         block_id: BlockId,
         consensus: FuelBlockConsensus,
     ) -> anyhow::Result<()> {
-        if self
-            .storage::<SealedBlockConsensus>()
-            .contains_key(&block_id.into())?
-        {
-            return Err(anyhow!("block {:x} is already sealed", &block_id))
-        }
-
         self.storage::<SealedBlockConsensus>()
             .insert(&block_id.into(), &consensus)
             .map(|_| ())

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -14,14 +14,19 @@ use crate::{
         IterDirection,
     },
 };
-use fuel_core_interfaces::common::{
-    fuel_storage::{
-        StorageInspect,
-        StorageMutate,
+use fuel_core_interfaces::{
+    common::{
+        fuel_storage::{
+            StorageInspect,
+            StorageMutate,
+        },
+        fuel_tx::Bytes32,
+        prelude::StorageAsRef,
     },
-    fuel_tx::Bytes32,
-    prelude::StorageAsRef,
+    db::Transactions,
+    model::FuelBlock,
 };
+use itertools::Itertools;
 use std::{
     borrow::Cow,
     convert::{
@@ -130,5 +135,30 @@ impl Database {
         )
         .next()
         .transpose()
+    }
+
+    /// Retrieve the full block and all associated transactions
+    pub(crate) fn get_full_block(
+        &self,
+        block_id: &Bytes32,
+    ) -> Result<Option<FuelBlock>, Error> {
+        let db_block = self.storage::<FuelBlocks>().get(block_id)?;
+        if let Some(block) = db_block {
+            // fetch all the transactions
+            // TODO: optimize with multi-key get
+            let txs = block
+                .transactions
+                .iter()
+                .map(|tx_id| {
+                    self.storage::<Transactions>()
+                        .get(tx_id)
+                        .and_then(|tx| tx.ok_or(KvStoreError::NotFound))
+                        .map(Cow::into_owned)
+                })
+                .try_collect()?;
+            Ok(Some(FuelBlock::from_db_block(block.into_owned(), txs)))
+        } else {
+            Ok(None)
+        }
     }
 }

--- a/fuel-core/src/database/sealed_block.rs
+++ b/fuel-core/src/database/sealed_block.rs
@@ -1,0 +1,100 @@
+use crate::database::{
+    storage::{
+        FuelBlocks,
+        SealedBlockConsensus,
+    },
+    Column,
+    Database,
+};
+use fuel_core_interfaces::{
+    common::prelude::{
+        Bytes32,
+        StorageAsRef,
+        StorageInspect,
+        StorageMutate,
+    },
+    db::KvStoreError,
+    model::{
+        FuelBlockConsensus,
+        SealedFuelBlock,
+        SealedFuelBlockHeader,
+    },
+};
+use std::borrow::Cow;
+
+impl StorageInspect<SealedBlockConsensus> for Database {
+    type Error = KvStoreError;
+
+    fn get(
+        &self,
+        key: &Bytes32,
+    ) -> Result<Option<Cow<FuelBlockConsensus>>, KvStoreError> {
+        Database::get(self, key.as_ref(), Column::FuelBlockConsensus).map_err(Into::into)
+    }
+
+    fn contains_key(&self, key: &Bytes32) -> Result<bool, KvStoreError> {
+        Database::exists(self, key.as_ref(), Column::FuelBlockConsensus)
+            .map_err(Into::into)
+    }
+}
+
+impl StorageMutate<SealedBlockConsensus> for Database {
+    fn insert(
+        &mut self,
+        key: &Bytes32,
+        value: &FuelBlockConsensus,
+    ) -> Result<Option<FuelBlockConsensus>, KvStoreError> {
+        Database::insert(self, key.as_ref(), Column::FuelBlockConsensus, value)
+            .map_err(Into::into)
+    }
+
+    fn remove(
+        &mut self,
+        key: &Bytes32,
+    ) -> Result<Option<FuelBlockConsensus>, KvStoreError> {
+        Database::remove(self, key.as_ref(), Column::FuelBlockConsensus)
+            .map_err(Into::into)
+    }
+}
+
+impl Database {
+    pub fn get_sealed_block(
+        &self,
+        block_id: &Bytes32,
+    ) -> Result<Option<SealedFuelBlock>, KvStoreError> {
+        // combine the block and consensus metadata into a sealed fuel block type
+
+        let block = self.get_full_block(block_id)?;
+        let consensus = self.storage::<SealedBlockConsensus>().get(block_id)?;
+
+        if let (Some(block), Some(consensus)) = (block, consensus) {
+            let sealed_block = SealedFuelBlock {
+                block,
+                consensus: consensus.into_owned(),
+            };
+
+            Ok(Some(sealed_block))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_sealed_block_header(
+        &self,
+        block_id: &Bytes32,
+    ) -> Result<Option<SealedFuelBlockHeader>, KvStoreError> {
+        let header = self.storage::<FuelBlocks>().get(block_id)?;
+        let consensus = self.storage::<SealedBlockConsensus>().get(block_id)?;
+
+        if let (Some(header), Some(consensus)) = (header, consensus) {
+            let sealed_block = SealedFuelBlockHeader {
+                header: header.into_owned().header,
+                consensus: consensus.into_owned(),
+            };
+
+            Ok(Some(sealed_block))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/fuel-core/src/database/storage.rs
+++ b/fuel-core/src/database/storage.rs
@@ -7,7 +7,10 @@ use fuel_core_interfaces::{
             UtxoId,
         },
     },
-    model::FuelBlockDb,
+    model::{
+        FuelBlockConsensus,
+        FuelBlockDb,
+    },
 };
 use fuel_txpool::types::ContractId;
 
@@ -42,6 +45,15 @@ impl Mappable for Receipts {
     type Key = Bytes32;
     type SetValue = [Receipt];
     type GetValue = Vec<Receipt>;
+}
+
+/// The table of consensus metadata associated with sealed (finalized) blocks
+pub struct SealedBlockConsensus;
+
+impl Mappable for SealedBlockConsensus {
+    type Key = Bytes32;
+    type SetValue = FuelBlockConsensus;
+    type GetValue = Self::SetValue;
 }
 
 // TODO: Add macro to define all common tables to avoid copy/paste of the code.

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -60,6 +60,7 @@ use fuel_core_interfaces::{
         TransactionValidityError,
     },
     model::{
+        BlockId,
         DaBlockHeight,
         Message,
         PartialFuelBlock,
@@ -213,7 +214,7 @@ impl Executor {
         block_db_transaction
             .deref_mut()
             .storage::<FuelBlocks>()
-            .insert(&finalized_block_id, &block.to_db_block())?;
+            .insert(&finalized_block_id.into(), &block.to_db_block())?;
 
         // Commit the database transaction.
         block_db_transaction.commit()?;
@@ -880,7 +881,7 @@ impl Executor {
 
     fn persist_transaction_status(
         &self,
-        finalized_block_id: Bytes32,
+        finalized_block_id: BlockId,
         tx_status: &mut [(Bytes32, TransactionStatus)],
         db: &Database,
     ) -> Result<(), Error> {

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -38,6 +38,7 @@ use fuel_core_interfaces::{
     common::{
         fuel_storage::StorageAsRef,
         fuel_types,
+        prelude::Bytes32,
     },
     db::Transactions,
     executor::{
@@ -62,7 +63,8 @@ pub struct Block(pub(crate) FuelBlockDb);
 #[Object]
 impl Block {
     async fn id(&self) -> BlockId {
-        self.0.id().into()
+        let bytes: Bytes32 = self.0.id().into();
+        bytes.into()
     }
 
     async fn height(&self) -> U64 {

--- a/fuel-core/src/schema/tx/types.rs
+++ b/fuel-core/src/schema/tx/types.rs
@@ -39,7 +39,6 @@ use fuel_core_interfaces::{
     common::{
         fuel_storage::StorageAsRef,
         fuel_tx,
-        fuel_types,
         fuel_types::bytes::SerializableVec,
         fuel_vm::prelude::ProgramState as VmProgramState,
     },
@@ -113,7 +112,7 @@ impl SubmittedStatus {
 }
 
 pub struct SuccessStatus {
-    block_id: fuel_types::Bytes32,
+    block_id: fuel_core_interfaces::model::BlockId,
     time: DateTime<Utc>,
     result: VmProgramState,
 }
@@ -124,7 +123,7 @@ impl SuccessStatus {
         let db = ctx.data_unchecked::<Database>();
         let block = db
             .storage::<FuelBlocks>()
-            .get(&self.block_id)?
+            .get(&self.block_id.into())?
             .ok_or(KvStoreError::NotFound)?
             .into_owned();
         let block = Block(block);
@@ -141,7 +140,7 @@ impl SuccessStatus {
 }
 
 pub struct FailureStatus {
-    block_id: fuel_types::Bytes32,
+    block_id: fuel_core_interfaces::model::BlockId,
     time: DateTime<Utc>,
     reason: String,
     state: Option<VmProgramState>,
@@ -153,7 +152,7 @@ impl FailureStatus {
         let db = ctx.data_unchecked::<Database>();
         let block = db
             .storage::<FuelBlocks>()
-            .get(&self.block_id)?
+            .get(&self.block_id.into())?
             .ok_or(KvStoreError::NotFound)?
             .into_owned();
         let block = Block(block);

--- a/fuel-core/src/service/config.rs
+++ b/fuel-core/src/service/config.rs
@@ -90,6 +90,6 @@ pub enum DbType {
 pub fn default_consensus_dev_key() -> SecretKey {
     const DEV_KEY_PHRASE: &str =
         "winner alley monkey elephant sun off boil hope toward boss bronze dish";
-    SecretKey::new_from_mnemonic_phrase_with_path(&DEV_KEY_PHRASE, "m/44'/60'/0'/0/0")
+    SecretKey::new_from_mnemonic_phrase_with_path(DEV_KEY_PHRASE, "m/44'/60'/0'/0/0")
         .expect("valid key")
 }

--- a/fuel-core/src/service/modules.rs
+++ b/fuel-core/src/service/modules.rs
@@ -96,6 +96,7 @@ pub async fn start_modules(config: &Config, database: &Database) -> Result<Modul
             fuel_poa_coordinator::Service::new(&fuel_poa_coordinator::Config {
                 trigger: *trigger,
                 block_gas_limit: config.chain_conf.block_gas_limit,
+                signing_key: config.consensus_key.clone(),
             }),
         ),
         // TODO: enable when bft config is ready to use

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -2,9 +2,9 @@ use chrono::{
     DateTime,
     Utc,
 };
-use fuel_core_interfaces::common::{
-    fuel_tx::Bytes32,
-    fuel_vm::prelude::ProgramState,
+use fuel_core_interfaces::{
+    common::fuel_vm::prelude::ProgramState,
+    model::BlockId,
 };
 use serde::{
     Deserialize,
@@ -17,12 +17,12 @@ pub enum TransactionStatus {
         time: DateTime<Utc>,
     },
     Success {
-        block_id: Bytes32,
+        block_id: BlockId,
         time: DateTime<Utc>,
         result: ProgramState,
     },
     Failed {
-        block_id: Bytes32,
+        block_id: BlockId,
         time: DateTime<Utc>,
         reason: String,
         result: Option<ProgramState>,

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -835,7 +835,7 @@ mod tests {
                                     let response_message = rx_orchestrator.await;
 
                                     if let Ok(sealed_block) = response_message {
-                                        let _ = tx_test_end.send(*sealed_block.header().height() == 0_u64.into()).await;
+                                        let _ = tx_test_end.send(*sealed_block.block.header().height() == 0_u64.into()).await;
                                     } else {
                                         tracing::error!("Orchestrator failed to receive a message: {:?}", response_message);
                                         panic!("Message not received successfully!")

--- a/fuel-poa-coordinator/src/config.rs
+++ b/fuel-poa-coordinator/src/config.rs
@@ -1,6 +1,9 @@
-use fuel_core_interfaces::common::{
-    prelude::Word,
-    secrecy::Secret,
+use fuel_core_interfaces::{
+    common::{
+        prelude::Word,
+        secrecy::Secret,
+    },
+    model::SecretKeyWrapper,
 };
 use serde::{
     Deserialize,
@@ -12,7 +15,7 @@ use tokio::time::Duration;
 pub struct Config {
     pub trigger: Trigger,
     pub block_gas_limit: Word,
-    pub signing_key: Option<Secret<[u8; 32]>>,
+    pub signing_key: Option<Secret<SecretKeyWrapper>>,
 }
 
 /// Block production trigger for PoA operation

--- a/fuel-poa-coordinator/src/config.rs
+++ b/fuel-poa-coordinator/src/config.rs
@@ -1,4 +1,7 @@
-use fuel_core_interfaces::common::prelude::Word;
+use fuel_core_interfaces::common::{
+    prelude::Word,
+    secrecy::Secret,
+};
 use serde::{
     Deserialize,
     Serialize,
@@ -9,6 +12,7 @@ use tokio::time::Duration;
 pub struct Config {
     pub trigger: Trigger,
     pub block_gas_limit: Word,
+    pub signing_key: Option<Secret<[u8; 32]>>,
 }
 
 /// Block production trigger for PoA operation

--- a/fuel-poa-coordinator/src/service.rs
+++ b/fuel-poa-coordinator/src/service.rs
@@ -332,7 +332,7 @@ where
             // The length of the secret is checked
             let signing_key = key.expose_secret().deref();
 
-            let poa_signature = Signature::sign(&signing_key, &message);
+            let poa_signature = Signature::sign(signing_key, &message);
             let seal = FuelBlockConsensus::PoA(FuelBlockPoAConsensus::new(poa_signature));
             self.db.seal_block(block_hash, seal)
         } else {

--- a/fuel-poa-coordinator/src/service.rs
+++ b/fuel-poa-coordinator/src/service.rs
@@ -14,7 +14,6 @@ use fuel_core_interfaces::{
     block_importer::ImportBlockBroadcast,
     block_producer::BlockProducer,
     common::{
-        fuel_crypto,
         prelude::{
             SecretKey,
             Signature,
@@ -320,11 +319,9 @@ where
     fn seal_block(&mut self, block: &FuelBlock) -> anyhow::Result<()> {
         if let Some(key) = &self.signing_key {
             let block_hash = block.id();
-            // This is safe because block.id() is a cryptographically secure hash.
             // Without this, the signature would be using a hash of the id making it more
             // difficult to verify.
-            let message =
-                unsafe { fuel_crypto::Message::from_bytes_unchecked(*block_hash) };
+            let message = block_hash.into_message();
 
             // The length of the secret is checked
             let signing_key =

--- a/fuel-poa-coordinator/tests/test_trigger.rs
+++ b/fuel-poa-coordinator/tests/test_trigger.rs
@@ -1,5 +1,6 @@
 #![deny(unused_must_use)]
 
+use anyhow::anyhow;
 use fuel_core_interfaces::{
     block_importer::ImportBlockBroadcast,
     block_producer::BlockProducer,
@@ -7,16 +8,21 @@ use fuel_core_interfaces::{
         consts::REG_ZERO,
         fuel_tx::TransactionBuilder,
         prelude::*,
+        secrecy::{
+            ExposeSecret,
+            Secret,
+        },
     },
     model::{
         BlockHeight,
         FuelBlock,
+        FuelBlockConsensus,
         FuelConsensusHeader,
         PartialFuelBlock,
         PartialFuelBlockHeader,
     },
     poa_coordinator::{
-        BlockHeightDb,
+        BlockDb,
         TransactionPool,
     },
     txpool::{
@@ -29,6 +35,7 @@ use fuel_poa_coordinator::{
     Service,
     Trigger,
 };
+use parking_lot::RwLock;
 use rand::{
     prelude::StdRng,
     Rng,
@@ -36,6 +43,7 @@ use rand::{
 };
 use std::{
     cmp::Reverse,
+    collections::HashMap,
     sync::Arc,
 };
 use tokio::{
@@ -145,17 +153,37 @@ fn select_transactions(
 
 #[derive(Clone, Default)]
 pub struct MockDatabase {
-    height: u32,
+    inner: Arc<RwLock<MockDatabaseInner>>,
 }
+
+#[derive(Default)]
+pub struct MockDatabaseInner {
+    height: u32,
+    consensus: HashMap<Bytes32, FuelBlockConsensus>,
+}
+
 impl MockDatabase {
     pub fn new() -> Self {
-        Self { height: 0 }
+        Self::default()
     }
 }
 
-impl BlockHeightDb for MockDatabase {
+impl BlockDb for MockDatabase {
     fn block_height(&self) -> anyhow::Result<BlockHeight> {
-        Ok(BlockHeight::from(self.height))
+        Ok(BlockHeight::from(self.inner.read().height))
+    }
+
+    fn seal_block(
+        &mut self,
+        block_id: Bytes32,
+        consensus: FuelBlockConsensus,
+    ) -> anyhow::Result<()> {
+        if self.inner.read().consensus.contains_key(&block_id) {
+            Err(anyhow!("block already sealed"))
+        } else {
+            self.inner.write().consensus.insert(block_id, consensus);
+            Ok(())
+        }
     }
 }
 
@@ -284,6 +312,12 @@ impl MockTxPoolSender {
     }
 }
 
+fn test_signing_key() -> Secret<[u8; 32]> {
+    let mut rng = StdRng::seed_from_u64(0);
+    let secret_key = SecretKey::random(&mut rng);
+    Secret::new(secret_key.into())
+}
+
 #[async_trait::async_trait]
 impl TransactionPool for MockTxPoolSender {
     async fn total_consumable_gas(&self) -> anyhow::Result<u64> {
@@ -317,6 +351,7 @@ async fn clean_startup_shutdown_each_trigger() -> anyhow::Result<()> {
         let service = Service::new(&Config {
             trigger,
             block_gas_limit: 100_000,
+            signing_key: Some(test_signing_key()),
         });
 
         let (txpool, broadcast_rx) = MockTxPool::spawn();
@@ -391,6 +426,7 @@ async fn never_trigger_never_produces_blocks() -> anyhow::Result<()> {
     let service = Service::new(&Config {
         trigger: Trigger::Never,
         block_gas_limit: 100_000,
+        signing_key: Some(test_signing_key()),
     });
 
     let (mut txpool, broadcast_rx) = MockTxPool::spawn();
@@ -435,6 +471,7 @@ async fn instant_trigger_produces_block_instantly() -> anyhow::Result<()> {
     let service = Service::new(&Config {
         trigger: Trigger::Instant,
         block_gas_limit: 100_000,
+        signing_key: Some(test_signing_key()),
     });
 
     let (mut txpool, broadcast_rx) = MockTxPool::spawn();
@@ -447,7 +484,7 @@ async fn instant_trigger_produces_block_instantly() -> anyhow::Result<()> {
             txpool.sender(),
             txpool.import_block_tx.clone(),
             producer.clone(),
-            db,
+            db.clone(),
         )
         .await;
 
@@ -456,6 +493,31 @@ async fn instant_trigger_produces_block_instantly() -> anyhow::Result<()> {
 
     // Make sure it's produced
     assert_eq!(txpool.wait_block_produced().await, 1);
+
+    // Checked that it's sealed and signature is valid
+    {
+        let db_lock = db.inner.read();
+        let (id, consensus) = db_lock
+            .consensus
+            .iter()
+            .next()
+            .expect("expected sealed block info");
+        match consensus {
+            FuelBlockConsensus::PoA(poa) => {
+                // verify against public key from test config
+                let pk = unsafe {
+                    SecretKey::from_bytes_unchecked(*test_signing_key().expose_secret())
+                }
+                .public_key();
+
+                let message = unsafe { Message::from_bytes_unchecked((*id).into()) };
+
+                poa.signature
+                    .verify(&pk, &message)
+                    .expect("expected signature to be valid");
+            } //_ => panic!("invalid sealed data"),
+        }
+    }
 
     // Stop
     let handle = service.stop().await.expect("Get join handle");
@@ -474,6 +536,7 @@ async fn interval_trigger_produces_blocks_periodically() -> anyhow::Result<()> {
             block_time: Duration::new(2, 0),
         },
         block_gas_limit: 100_000,
+        signing_key: Some(test_signing_key()),
     });
 
     let (mut txpool, broadcast_rx) = MockTxPool::spawn();
@@ -566,6 +629,7 @@ async fn interval_trigger_doesnt_react_to_full_txpool() -> anyhow::Result<()> {
             block_time: Duration::new(2, 0),
         },
         block_gas_limit: 100_000,
+        signing_key: Some(test_signing_key()),
     });
 
     let (mut txpool, broadcast_rx) = MockTxPool::spawn();
@@ -623,6 +687,7 @@ async fn hybrid_trigger_produces_blocks_correctly() -> anyhow::Result<()> {
             max_block_time: Duration::new(10, 0),
         },
         block_gas_limit: 100_000,
+        signing_key: Some(test_signing_key()),
     });
 
     let (mut txpool, broadcast_rx) = MockTxPool::spawn();
@@ -702,6 +767,7 @@ async fn hybrid_trigger_reacts_correctly_to_full_txpool() -> anyhow::Result<()> 
             max_block_time: Duration::new(10, 0),
         },
         block_gas_limit: 100_000,
+        signing_key: Some(test_signing_key()),
     });
 
     let (mut txpool, broadcast_rx) = MockTxPool::spawn();

--- a/fuel-poa-coordinator/tests/test_trigger.rs
+++ b/fuel-poa-coordinator/tests/test_trigger.rs
@@ -21,6 +21,7 @@ use fuel_core_interfaces::{
         FuelConsensusHeader,
         PartialFuelBlock,
         PartialFuelBlockHeader,
+        SecretKeyWrapper,
     },
     poa_coordinator::{
         BlockDb,
@@ -319,7 +320,7 @@ impl MockTxPoolSender {
     }
 }
 
-fn test_signing_key() -> Secret<[u8; 32]> {
+fn test_signing_key() -> Secret<SecretKeyWrapper> {
     let mut rng = StdRng::seed_from_u64(0);
     let secret_key = SecretKey::random(&mut rng);
     Secret::new(secret_key.into())
@@ -512,10 +513,7 @@ async fn instant_trigger_produces_block_instantly() -> anyhow::Result<()> {
         match consensus {
             FuelBlockConsensus::PoA(poa) => {
                 // verify against public key from test config
-                let pk = unsafe {
-                    SecretKey::from_bytes_unchecked(*test_signing_key().expose_secret())
-                }
-                .public_key();
+                let pk = test_signing_key().expose_secret().public_key();
 
                 let message = id.into_message();
 

--- a/fuel-poa-coordinator/tests/test_trigger.rs
+++ b/fuel-poa-coordinator/tests/test_trigger.rs
@@ -15,6 +15,7 @@ use fuel_core_interfaces::{
     },
     model::{
         BlockHeight,
+        BlockId,
         FuelBlock,
         FuelBlockConsensus,
         FuelConsensusHeader,
@@ -165,7 +166,7 @@ pub struct MockDatabase {
 #[derive(Default)]
 pub struct MockDatabaseInner {
     height: u32,
-    consensus: HashMap<Bytes32, FuelBlockConsensus>,
+    consensus: HashMap<BlockId, FuelBlockConsensus>,
 }
 
 impl MockDatabase {
@@ -181,7 +182,7 @@ impl BlockDb for MockDatabase {
 
     fn seal_block(
         &mut self,
-        block_id: Bytes32,
+        block_id: BlockId,
         consensus: FuelBlockConsensus,
     ) -> anyhow::Result<()> {
         if self.inner.read().consensus.contains_key(&block_id) {
@@ -516,7 +517,7 @@ async fn instant_trigger_produces_block_instantly() -> anyhow::Result<()> {
                 }
                 .public_key();
 
-                let message = unsafe { Message::from_bytes_unchecked((*id).into()) };
+                let message = id.into_message();
 
                 poa.signature
                     .verify(&pk, &message)

--- a/fuel-tests/tests/blocks.rs
+++ b/fuel-tests/tests/blocks.rs
@@ -24,11 +24,14 @@ use fuel_core_interfaces::{
     },
     model::FuelConsensusHeader,
 };
-use fuel_gql_client::client::{
-    types::TransactionStatus,
-    FuelClient,
-    PageDirection,
-    PaginationRequest,
+use fuel_gql_client::{
+    client::{
+        types::TransactionStatus,
+        FuelClient,
+        PageDirection,
+        PaginationRequest,
+    },
+    prelude::Bytes32,
 };
 use itertools::{
     rev,
@@ -42,7 +45,9 @@ async fn block() {
     let block = FuelBlockDb::default();
     let id = block.id();
     let mut db = Database::default();
-    db.storage::<FuelBlocks>().insert(&id, &block).unwrap();
+    db.storage::<FuelBlocks>()
+        .insert(&id.into(), &block)
+        .unwrap();
 
     // setup server & client
     let srv = FuelService::from_database(db, Config::local_node())
@@ -51,8 +56,9 @@ async fn block() {
     let client = FuelClient::from(srv.bound_address);
 
     // run test
+    let id_bytes: Bytes32 = id.into();
     let block = client
-        .block(BlockId::from(id).to_string().as_str())
+        .block(BlockId::from(id_bytes).to_string().as_str())
         .await
         .unwrap();
     assert!(block.is_some());
@@ -168,7 +174,9 @@ async fn block_connection_5(
     let mut db = Database::default();
     for block in blocks {
         let id = block.id();
-        db.storage::<FuelBlocks>().insert(&id, &block).unwrap();
+        db.storage::<FuelBlocks>()
+            .insert(&id.into(), &block)
+            .unwrap();
     }
 
     // setup server & client

--- a/fuel-tests/tests/lib.rs
+++ b/fuel-tests/tests/lib.rs
@@ -11,6 +11,7 @@ mod messages;
 #[cfg(feature = "metrics")]
 mod metrics;
 mod node_info;
+mod poa;
 #[cfg(feature = "relayer")]
 mod relayer;
 mod resource;

--- a/fuel-tests/tests/poa.rs
+++ b/fuel-tests/tests/poa.rs
@@ -1,0 +1,88 @@
+use fuel_core::{
+    database::Database,
+    service::{
+        Config,
+        FuelService,
+    },
+};
+use fuel_core_interfaces::{
+    common::secrecy::Secret,
+    model::FuelBlockConsensus,
+};
+use fuel_gql_client::{
+    client::{
+        types::TransactionStatus,
+        FuelClient,
+    },
+    fuel_crypto::Message,
+    fuel_types::Bytes32,
+    prelude::SecretKey,
+};
+use fuel_txpool::types::Transaction;
+use rand::{
+    rngs::StdRng,
+    SeedableRng,
+};
+use std::str::FromStr;
+
+#[tokio::test]
+async fn can_get_sealed_block_from_poa_produced_block() {
+    let mut rng = StdRng::seed_from_u64(10);
+    let poa_secret = SecretKey::random(&mut rng);
+    let poa_public = poa_secret.public_key();
+
+    let db = Database::default();
+    let mut config = Config::local_node();
+    config.consensus_key = Some(Secret::new(poa_secret.into()));
+    let srv = FuelService::from_database(db.clone(), config)
+        .await
+        .unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    let status = client
+        .submit_and_await_commit(&Transaction::default())
+        .await
+        .unwrap();
+    let block_id = match status {
+        TransactionStatus::Success { block_id, .. } => block_id,
+        _ => {
+            panic!("unexpected result")
+        }
+    };
+
+    let block_id = Bytes32::from_str(&block_id).unwrap();
+
+    // check sealed block header is correct
+    let sealed_block_header = db
+        .get_sealed_block_header(&block_id)
+        .unwrap()
+        .expect("expected sealed header to be available");
+
+    // verify signature
+    let block_id = sealed_block_header.header.id();
+    let signature = match sealed_block_header.consensus {
+        FuelBlockConsensus::PoA(poa) => poa.signature,
+    };
+    signature
+        .verify(&poa_public, unsafe {
+            &Message::from_bytes_unchecked(*block_id)
+        })
+        .expect("failed to verify signature");
+
+    // check sealed block is correct
+    let sealed_block = db
+        .get_sealed_block(&block_id)
+        .unwrap()
+        .expect("expected sealed header to be available");
+
+    // verify signature
+    let block_id = sealed_block.block.header().id();
+    let signature = match sealed_block.consensus {
+        FuelBlockConsensus::PoA(poa) => poa.signature,
+    };
+    signature
+        .verify(&poa_public, unsafe {
+            &Message::from_bytes_unchecked(*block_id)
+        })
+        .expect("failed to verify signature");
+}

--- a/fuel-tests/tests/poa.rs
+++ b/fuel-tests/tests/poa.rs
@@ -14,7 +14,6 @@ use fuel_gql_client::{
         types::TransactionStatus,
         FuelClient,
     },
-    fuel_crypto::Message,
     fuel_types::Bytes32,
     prelude::SecretKey,
 };
@@ -64,14 +63,12 @@ async fn can_get_sealed_block_from_poa_produced_block() {
         FuelBlockConsensus::PoA(poa) => poa.signature,
     };
     signature
-        .verify(&poa_public, unsafe {
-            &Message::from_bytes_unchecked(*block_id)
-        })
+        .verify(&poa_public, &block_id.into_message())
         .expect("failed to verify signature");
 
     // check sealed block is correct
     let sealed_block = db
-        .get_sealed_block(&block_id)
+        .get_sealed_block(&block_id.into())
         .unwrap()
         .expect("expected sealed header to be available");
 
@@ -81,8 +78,6 @@ async fn can_get_sealed_block_from_poa_produced_block() {
         FuelBlockConsensus::PoA(poa) => poa.signature,
     };
     signature
-        .verify(&poa_public, unsafe {
-            &Message::from_bytes_unchecked(*block_id)
-        })
+        .verify(&poa_public, &block_id.into_message())
         .expect("failed to verify signature");
 }


### PR DESCRIPTION
Initial implementation of PoA block signing & persistence of fuel consensus data.

Todo:

- [ ] update devops configs to accept a consensus secret (deferred to followup PR)
- [x] (deferrable) safe method to convert block id's into messages for signatures (may require a BlockId newtype)
- [x] (deferrable) update fuel-crypto to support zeroize on secret types

In the future, we should use the keystore traits provided by fuel-crypto to allow for a pluggable signing backend.


closes: #668
closes: #673