### PR TITLE
Add support for custom timestamps

### DIFF
--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -424,7 +424,7 @@ type Mutation {
 	Submits transaction to the txpool
 	"""
 	submit(tx: HexString!): Transaction!
-	produceBlocks(blocksToProduce: U64!): U64!
+	produceBlocks(blocksToProduce: U64!, time: TimeParameters): U64!
 }
 
 type NodeInfo {
@@ -607,6 +607,17 @@ type SuccessStatus {
 	block: Block!
 	time: DateTime!
 	programState: ProgramState!
+}
+
+input TimeParameters {
+	"""
+	The time to set on the first block
+	"""
+	startTime: U64!
+	"""
+	The time interval between subsequent blocks
+	"""
+	blockTimeInterval: U64!
 }
 
 type Transaction {

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -74,7 +74,10 @@ pub use schema::{
 };
 
 use self::schema::{
-    block::ProduceBlockArgs,
+    block::{
+        ProduceBlockArgs,
+        TimeParameters,
+    },
     message::MessageProofArgs,
 };
 
@@ -419,9 +422,14 @@ impl FuelClient {
         Ok(receipts?)
     }
 
-    pub async fn produce_blocks(&self, blocks_to_produce: u64) -> io::Result<u64> {
+    pub async fn produce_blocks(
+        &self,
+        blocks_to_produce: u64,
+        time: Option<TimeParameters>,
+    ) -> io::Result<u64> {
         let query = schema::block::BlockMutation::build(&ProduceBlockArgs {
             blocks_to_produce: blocks_to_produce.into(),
+            time,
         });
 
         let new_height = self.query(query).await?.produce_blocks;

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -81,9 +81,17 @@ pub struct BlockIdFragment {
     pub id: BlockId,
 }
 
+#[derive(cynic::InputObject, Clone, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct TimeParameters {
+    pub start_time: U64,
+    pub block_time_interval: U64,
+}
+
 #[derive(cynic::FragmentArguments, Debug)]
 pub struct ProduceBlockArgs {
     pub blocks_to_produce: U64,
+    pub time: Option<TimeParameters>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -93,7 +101,7 @@ pub struct ProduceBlockArgs {
     graphql_type = "Mutation"
 )]
 pub struct BlockMutation {
-    #[arguments(blocks_to_produce = &args.blocks_to_produce)]
+    #[arguments(blocks_to_produce = &args.blocks_to_produce, time = &args.time)]
     pub produce_blocks: U64,
 }
 
@@ -130,6 +138,7 @@ mod tests {
         use cynic::MutationBuilder;
         let operation = BlockMutation::build(ProduceBlockArgs {
             blocks_to_produce: U64(0),
+            time: None,
         });
         insta::assert_snapshot!(operation.query)
     }

--- a/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_mutation_query_gql_output.snap
+++ b/fuel-client/src/client/schema/snapshots/fuel_gql_client__client__schema__block__tests__block_mutation_query_gql_output.snap
@@ -2,7 +2,7 @@
 source: fuel-client/src/client/schema/block.rs
 expression: operation.query
 ---
-mutation Mutation($_0: U64!) {
-  produceBlocks(blocksToProduce: $_0)
+mutation Mutation($_0: U64!, $_1: TimeParameters) {
+  produceBlocks(blocksToProduce: $_0, time: $_1)
 }
 

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -332,15 +332,7 @@ impl InterpreterStorage for Database {
     }
 
     fn timestamp(&self, height: u32) -> Result<Word, Self::DataError> {
-        let id = self.block_hash(height)?;
-        let block = self
-            .storage::<FuelBlocks>()
-            .get(&id)?
-            .ok_or(Error::ChainUninitialized)?;
-        block
-            .header
-            .time()
-            .timestamp_millis()
+        self.timestamp(height)?
             .try_into()
             .map_err(|e| Self::DataError::DatabaseError(Box::new(e)))
     }

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -332,7 +332,8 @@ impl InterpreterStorage for Database {
     }
 
     fn timestamp(&self, height: u32) -> Result<Word, Self::DataError> {
-        self.timestamp(height)?
+        self.block_time(height)?
+            .timestamp_millis()
             .try_into()
             .map_err(|e| Self::DataError::DatabaseError(Box::new(e)))
     }

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -108,6 +108,15 @@ impl Database {
         Database::get(self, &height.to_bytes()[..], Column::FuelBlockIds)
     }
 
+    pub fn timestamp(&self, height: u32) -> Result<i64, Error> {
+        let id = self.get_block_id(height.into())?.unwrap_or_default();
+        let block = self
+            .storage::<FuelBlocks>()
+            .get(&id)?
+            .ok_or(Error::ChainUninitialized)?;
+        Ok(block.header.time().timestamp())
+    }
+
     pub fn all_block_ids(
         &self,
         start: Option<BlockHeight>,

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -14,6 +14,10 @@ use crate::{
         IterDirection,
     },
 };
+use chrono::{
+    DateTime,
+    Utc,
+};
 use fuel_core_interfaces::{
     common::{
         fuel_storage::{
@@ -104,17 +108,17 @@ impl Database {
         }
     }
 
-    pub fn get_block_id(&self, height: BlockHeight) -> Result<Option<Bytes32>, Error> {
-        Database::get(self, &height.to_bytes()[..], Column::FuelBlockIds)
-    }
-
-    pub fn timestamp(&self, height: u32) -> Result<i64, Error> {
+    pub fn block_time(&self, height: u32) -> Result<DateTime<Utc>, Error> {
         let id = self.get_block_id(height.into())?.unwrap_or_default();
         let block = self
             .storage::<FuelBlocks>()
             .get(&id)?
             .ok_or(Error::ChainUninitialized)?;
-        Ok(block.header.time().timestamp())
+        Ok(block.header.time().to_owned())
+    }
+
+    pub fn get_block_id(&self, height: BlockHeight) -> Result<Option<Bytes32>, Error> {
+        Database::get(self, &height.to_bytes()[..], Column::FuelBlockIds)
     }
 
     pub fn all_block_ids(

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -28,10 +28,12 @@ use async_graphql::{
         EmptyFields,
     },
     Context,
+    InputObject,
     Object,
 };
 use chrono::{
     DateTime,
+    NaiveDateTime,
     Utc,
 };
 use fuel_core_interfaces::{
@@ -340,12 +342,21 @@ where
 #[derive(Default)]
 pub struct BlockMutation;
 
+#[derive(InputObject)]
+struct TimeParameters {
+    /// The time to set on the first block
+    start_time: U64,
+    /// The time interval between subsequent blocks
+    block_time_interval: U64,
+}
+
 #[Object]
 impl BlockMutation {
     async fn produce_blocks(
         &self,
         ctx: &Context<'_>,
         blocks_to_produce: U64,
+        time: Option<TimeParameters>,
     ) -> async_graphql::Result<U64> {
         let db = ctx.data_unchecked::<Database>();
         let cfg = ctx.data_unchecked::<Config>().clone();
@@ -362,7 +373,9 @@ impl BlockMutation {
             config: cfg.clone(),
         };
 
-        for _ in 0..blocks_to_produce.0 {
+        let block_time = get_time_closure(db, time, blocks_to_produce.0).await?;
+
+        for idx in 0..blocks_to_produce.0 {
             let current_height = db.get_block_height()?.unwrap_or_default();
             let new_block_height = current_height + 1u32.into();
 
@@ -370,7 +383,7 @@ impl BlockMutation {
                 PartialFuelBlockHeader {
                     consensus: FuelConsensusHeader {
                         height: new_block_height,
-                        time: Utc::now(),
+                        time: block_time(idx),
                         prev_root: Default::default(),
                         generated: Default::default(),
                     },
@@ -390,6 +403,67 @@ impl BlockMutation {
             .map(|new_height| Ok(new_height.into()))
             .ok_or("Block height not found")?
     }
+}
+
+async fn get_time_closure(
+    db: &Database,
+    time_parameters: Option<TimeParameters>,
+    blocks_to_produce: u64,
+) -> anyhow::Result<Box<dyn Fn(u64) -> DateTime<Utc> + Send>> {
+    if let Some(params) = time_parameters {
+        check_start_after_latest_block(db, params.start_time.0).await?;
+        check_block_time_overflow(&params, blocks_to_produce).await?;
+
+        return Ok(Box::new(move |idx: u64| {
+            let (timestamp, _) = params
+                .start_time
+                .0
+                .overflowing_add(params.block_time_interval.0.overflowing_mul(idx).0);
+            let naive = NaiveDateTime::from_timestamp(timestamp as i64, 0);
+
+            DateTime::from_utc(naive, Utc)
+        }))
+    };
+
+    Ok(Box::new(|_| Utc::now()))
+}
+
+async fn check_start_after_latest_block(
+    db: &Database,
+    start_time: u64,
+) -> anyhow::Result<()> {
+    let current_height = db.get_block_height()?.unwrap_or_default();
+
+    if current_height.as_usize() == 0 {
+        return Ok(())
+    }
+
+    let latest_time = db.timestamp(current_height.into())?;
+    if latest_time as u64 > start_time {
+        return Err(anyhow!(
+            "The start time must be set after the latest block time: {}",
+            latest_time
+        ))
+    }
+
+    Ok(())
+}
+
+async fn check_block_time_overflow(
+    params: &TimeParameters,
+    blocks_to_produce: u64,
+) -> anyhow::Result<()> {
+    let (final_offset, overflow_mul) = params
+        .block_time_interval
+        .0
+        .overflowing_mul(blocks_to_produce);
+    let (_, overflow_add) = params.start_time.0.overflowing_add(final_offset);
+
+    if overflow_mul || overflow_add {
+        return Err(anyhow!("The provided time parameters lead to an overflow"))
+    };
+
+    Ok(())
 }
 
 impl From<FuelBlockDb> for Block {

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -438,7 +438,7 @@ async fn check_start_after_latest_block(
         return Ok(())
     }
 
-    let latest_time = db.timestamp(current_height.into())?;
+    let latest_time = db.block_time(current_height.into())?.timestamp();
     if latest_time as u64 > start_time {
         return Err(anyhow!(
             "The start time must be set after the latest block time: {}",

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -373,7 +373,7 @@ impl BlockMutation {
             config: cfg.clone(),
         };
 
-        let block_time = get_time_closure(db, time, blocks_to_produce.0).await?;
+        let block_time = get_time_closure(db, time, blocks_to_produce.0)?;
 
         for idx in 0..blocks_to_produce.0 {
             let current_height = db.get_block_height()?.unwrap_or_default();
@@ -405,14 +405,14 @@ impl BlockMutation {
     }
 }
 
-async fn get_time_closure(
+fn get_time_closure(
     db: &Database,
     time_parameters: Option<TimeParameters>,
     blocks_to_produce: u64,
 ) -> anyhow::Result<Box<dyn Fn(u64) -> DateTime<Utc> + Send>> {
     if let Some(params) = time_parameters {
-        check_start_after_latest_block(db, params.start_time.0).await?;
-        check_block_time_overflow(&params, blocks_to_produce).await?;
+        check_start_after_latest_block(db, params.start_time.0)?;
+        check_block_time_overflow(&params, blocks_to_produce)?;
 
         return Ok(Box::new(move |idx: u64| {
             let (timestamp, _) = params
@@ -428,10 +428,7 @@ async fn get_time_closure(
     Ok(Box::new(|_| Utc::now()))
 }
 
-async fn check_start_after_latest_block(
-    db: &Database,
-    start_time: u64,
-) -> anyhow::Result<()> {
+fn check_start_after_latest_block(db: &Database, start_time: u64) -> anyhow::Result<()> {
     let current_height = db.get_block_height()?.unwrap_or_default();
 
     if current_height.as_usize() == 0 {
@@ -449,7 +446,7 @@ async fn check_start_after_latest_block(
     Ok(())
 }
 
-async fn check_block_time_overflow(
+fn check_block_time_overflow(
     params: &TimeParameters,
     blocks_to_produce: u64,
 ) -> anyhow::Result<()> {

--- a/fuel-tests/tests/blocks.rs
+++ b/fuel-tests/tests/blocks.rs
@@ -26,6 +26,10 @@ use fuel_core_interfaces::{
 };
 use fuel_gql_client::{
     client::{
+        schema::{
+            block::TimeParameters,
+            U64,
+        },
         types::TransactionStatus,
         FuelClient,
         PageDirection,
@@ -76,7 +80,7 @@ async fn produce_block() {
 
     let client = FuelClient::from(srv.bound_address);
 
-    let new_height = client.produce_blocks(5).await.unwrap();
+    let new_height = client.produce_blocks(5, None).await.unwrap();
 
     assert_eq!(5, new_height);
 
@@ -117,7 +121,7 @@ async fn produce_block_negative() {
 
     let client = FuelClient::from(srv.bound_address);
 
-    let new_height = client.produce_blocks(5).await;
+    let new_height = client.produce_blocks(5, None).await;
 
     assert_eq!(
         "Response errors; Manual Blocks must be enabled to use this endpoint",
@@ -149,6 +153,68 @@ async fn produce_block_negative() {
     } else {
         panic!("Wrong tx status");
     };
+}
+
+#[tokio::test]
+async fn produce_block_custom_time() {
+    let db = Database::default();
+
+    let mut config = Config::local_node();
+
+    config.manual_blocks_enabled = true;
+
+    let srv = FuelService::from_database(db.clone(), config)
+        .await
+        .unwrap();
+
+    let client = FuelClient::from(srv.bound_address);
+
+    // produce block with current timestamp
+    let _ = client.produce_blocks(1, None).await.unwrap();
+
+    // try producing block with an ealier timestamp
+    let time = TimeParameters {
+        start_time: U64::from(100u64),
+        block_time_interval: U64::from(10u64),
+    };
+    let err = client
+        .produce_blocks(1, Some(time))
+        .await
+        .expect_err("Completed unexpectedly");
+    assert!(err.to_string().starts_with(
+        "Response errors; The start time must be set after the latest block time"
+    ));
+}
+
+#[tokio::test]
+async fn produce_block_overflow_time() {
+    let db = Database::default();
+
+    let mut config = Config::local_node();
+
+    config.manual_blocks_enabled = true;
+
+    let srv = FuelService::from_database(db.clone(), config)
+        .await
+        .unwrap();
+
+    let client = FuelClient::from(srv.bound_address);
+
+    // produce block with current timestamp
+    let _ = client.produce_blocks(1, None).await.unwrap();
+
+    // try producing block with an ealier timestamp
+    let time = TimeParameters {
+        start_time: U64::from(u64::MAX),
+        block_time_interval: U64::from(1u64),
+    };
+    let err = client
+        .produce_blocks(1, Some(time))
+        .await
+        .expect_err("Completed unexpectedly");
+    assert!(err.to_string().starts_with(
+        "Response errors; The provided time parameters lead to an overflow"
+    ));
 }
 
 #[rstest]

--- a/fuel-tests/tests/blocks.rs
+++ b/fuel-tests/tests/blocks.rs
@@ -169,6 +169,35 @@ async fn produce_block_custom_time() {
 
     let client = FuelClient::from(srv.bound_address);
 
+    let time = TimeParameters {
+        start_time: U64::from(100u64),
+        block_time_interval: U64::from(10u64),
+    };
+    let new_height = client.produce_blocks(5, Some(time)).await.unwrap();
+
+    assert_eq!(5, new_height);
+
+    assert_eq!(db.block_time(1).unwrap().timestamp(), 100);
+    assert_eq!(db.block_time(2).unwrap().timestamp(), 110);
+    assert_eq!(db.block_time(3).unwrap().timestamp(), 120);
+    assert_eq!(db.block_time(4).unwrap().timestamp(), 130);
+    assert_eq!(db.block_time(5).unwrap().timestamp(), 140);
+}
+
+#[tokio::test]
+async fn produce_block_bad_start_time() {
+    let db = Database::default();
+
+    let mut config = Config::local_node();
+
+    config.manual_blocks_enabled = true;
+
+    let srv = FuelService::from_database(db.clone(), config)
+        .await
+        .unwrap();
+
+    let client = FuelClient::from(srv.bound_address);
+
     // produce block with current timestamp
     let _ = client.produce_blocks(1, None).await.unwrap();
 


### PR DESCRIPTION
Closes #639

This PR adds `TimeParameters` to the produce_block mutation, as described in the issue. The provided time is checked to confirm that it is set after the latest block time, and that the addition of `block_time_interval` does not lead to an overflow.
Three tests are added to verify the normal behaviour + the two error cases.
