### PR TITLE
Fixing `CB` command for coinbase

### DIFF
--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -292,6 +292,9 @@ impl Executor {
 
         // Temporary insert coinbase into the storage because `InterpreterStorage::coinbase`
         // gets coinbase transaction from the storage during execution of `Script`.
+        //
+        // # Dev-note: in production mode, the `id` of the temporary coinbase is not the same as
+        // the `id ` of the final coinbase.
         let coinbase_id = coinbase_tx.id();
         if block_db_transaction
             .deref_mut()
@@ -369,7 +372,7 @@ impl Executor {
             };
         }
 
-        // Remove temporary added coinbase.
+        // Remove temporary added coinbase with `coinbase_id`.
         block_db_transaction
             .deref_mut()
             .storage::<Transactions>()

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -1694,13 +1694,19 @@ mod tests {
 
         #[tokio::test]
         async fn invalidate_more_than_one_mint_is_not_allowed() {
-            let mint = Transaction::mint(
-                TxPointer::new(0, 0),
-                vec![Output::coin(Address::zeroed(), 0, AssetId::BASE)],
-            );
-
             let mut block = FuelBlock::default();
-            *block.transactions_mut() = vec![mint.clone().into(), mint.clone().into()];
+            *block.transactions_mut() = vec![
+                Transaction::mint(
+                    TxPointer::new(0, 0),
+                    vec![Output::coin(Address::from([1u8; 32]), 0, AssetId::BASE)],
+                )
+                .into(),
+                Transaction::mint(
+                    TxPointer::new(0, 0),
+                    vec![Output::coin(Address::from([2u8; 32]), 0, AssetId::BASE)],
+                )
+                .into(),
+            ];
 
             let validator = Executor {
                 database: Default::default(),


### PR DESCRIPTION
Bug: `InterpreterStorage::coinbase` expects that the coinbase transaction for the current block is available in the storage.
<img width="634" alt="image" src="https://user-images.githubusercontent.com/18346821/198187707-b40f0bbb-dde7-4a37-bdfb-f48346ce6741.png">

But it was not. Added temporary coinbase into the storage and after replaced with actual.
Added unit test for this case.