### PR TITLE
VmDatabase for proper transaction execution

### DIFF
--- a/fuel-benches/src/lib.rs
+++ b/fuel-benches/src/lib.rs
@@ -1,3 +1,4 @@
+use fuel_core::database::vm_database::VmDatabase;
 pub use fuel_core::database::Database;
 use fuel_core_interfaces::common::fuel_tx::{
     StorageSlot,
@@ -13,9 +14,9 @@ use std::{
     iter,
 };
 
-fn new_db() -> Database {
+fn new_db() -> VmDatabase {
     // when rocksdb is enabled, this creates a new db instance with a temporary path
-    Database::default()
+    VmDatabase::default()
 }
 
 pub struct ContractCode {
@@ -65,17 +66,17 @@ pub struct VmBench {
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
     pub witnesses: Vec<Witness>,
-    pub db: Option<Database>,
+    pub db: Option<VmDatabase>,
     pub instruction: Opcode,
     pub prepare_call: Option<PrepareCall>,
     pub dummy_contract: Option<ContractId>,
     pub contract_code: Option<ContractCode>,
-    pub prepare_db: Option<Box<dyn FnMut(Database) -> io::Result<Database>>>,
+    pub prepare_db: Option<Box<dyn FnMut(VmDatabase) -> io::Result<VmDatabase>>>,
 }
 
 #[derive(Debug, Clone)]
 pub struct VmBenchPrepared {
-    pub vm: Interpreter<Database, Script>,
+    pub vm: Interpreter<VmDatabase, Script>,
     pub instruction: Instruction,
 }
 
@@ -165,7 +166,7 @@ impl VmBench {
             .with_prepare_call(prepare_call))
     }
 
-    pub fn with_db(mut self, db: Database) -> Self {
+    pub fn with_db(mut self, db: VmDatabase) -> Self {
         self.db.replace(db);
         self
     }
@@ -237,7 +238,7 @@ impl VmBench {
 
     pub fn with_prepare_db<F>(mut self, prepare_db: F) -> Self
     where
-        F: FnMut(Database) -> io::Result<Database> + 'static,
+        F: FnMut(VmDatabase) -> io::Result<VmDatabase> + 'static,
     {
         self.prepare_db.replace(Box::new(prepare_db));
         self

--- a/fuel-core/src/database/contracts.rs
+++ b/fuel-core/src/database/contracts.rs
@@ -3,7 +3,6 @@ use crate::{
         storage::ContractsLatestUtxo,
         Column,
         Database,
-        InterpreterStorage,
     },
     state::{
         Error,
@@ -30,7 +29,10 @@ use fuel_core_interfaces::{
             ContractId,
         },
     },
-    db::ContractsRawCode,
+    db::{
+        ContractsInfo,
+        ContractsRawCode,
+    },
 };
 use std::borrow::Cow;
 
@@ -123,10 +125,12 @@ impl Database {
                     .into_owned()
                     .into();
 
-                let salt = InterpreterStorage::storage_contract_root(self, &contract_id)?
+                let (salt, _) = self
+                    .storage::<ContractsInfo>()
+                    .get(&contract_id)
                     .unwrap()
-                    .into_owned()
-                    .0;
+                    .expect("Contract does not exist")
+                    .into_owned();
 
                 let state = Some(
                     self.iter_all::<Vec<u8>, Bytes32>(

--- a/fuel-core/src/database/vm_database.rs
+++ b/fuel-core/src/database/vm_database.rs
@@ -54,6 +54,10 @@ impl VmDatabase {
             database,
         }
     }
+
+    pub fn block_height(&self) -> u32 {
+        self.current_block_height
+    }
 }
 
 impl<M: Mappable> StorageInspect<M> for VmDatabase

--- a/fuel-core/src/database/vm_database.rs
+++ b/fuel-core/src/database/vm_database.rs
@@ -1,0 +1,166 @@
+use crate::database::Database;
+use anyhow::{
+    anyhow,
+    Context,
+};
+use chrono::{
+    DateTime,
+    Utc,
+};
+use fuel_core_interfaces::{
+    common::{
+        fuel_storage::{
+            Mappable,
+            MerkleRoot,
+            StorageInspect,
+            StorageMutate,
+        },
+        fuel_tx::Bytes32,
+        prelude::{
+            Address,
+            ContractId,
+            InterpreterStorage,
+            MerkleRootStorage,
+            Word,
+        },
+    },
+    db::{
+        Error,
+        KvStoreError,
+    },
+    model::FuelConsensusHeader,
+};
+use std::borrow::Cow;
+
+/// Used to store metadata relevant during the execution of a transaction
+#[derive(Clone, Debug, Default)]
+pub struct VmDatabase {
+    current_block_height: u32,
+    current_timestamp: DateTime<Utc>,
+    coinbase: Address,
+    database: Database,
+}
+
+impl VmDatabase {
+    pub fn new<T>(
+        database: Database,
+        header: &FuelConsensusHeader<T>,
+        coinbase: Address,
+    ) -> Self {
+        Self {
+            current_block_height: header.height.into(),
+            current_timestamp: header.time,
+            coinbase,
+            database,
+        }
+    }
+}
+
+impl<M: Mappable> StorageInspect<M> for VmDatabase
+where
+    Database: StorageInspect<M, Error = Error>,
+{
+    type Error = Error;
+
+    fn get(&self, key: &M::Key) -> Result<Option<Cow<M::GetValue>>, Error> {
+        StorageInspect::<M>::get(&self.database, key)
+    }
+
+    fn contains_key(&self, key: &M::Key) -> Result<bool, Error> {
+        StorageInspect::<M>::contains_key(&self.database, key)
+    }
+}
+
+impl<M: Mappable> StorageMutate<M> for VmDatabase
+where
+    Database: StorageMutate<M, Error = Error>,
+{
+    fn insert(
+        &mut self,
+        key: &M::Key,
+        value: &M::SetValue,
+    ) -> Result<Option<M::GetValue>, Self::Error> {
+        StorageMutate::<M>::insert(&mut self.database, key, value)
+    }
+
+    fn remove(&mut self, key: &M::Key) -> Result<Option<M::GetValue>, Self::Error> {
+        StorageMutate::<M>::remove(&mut self.database, key)
+    }
+}
+
+impl<K, M: Mappable> MerkleRootStorage<K, M> for VmDatabase
+where
+    Database: MerkleRootStorage<K, M, Error = Error>,
+{
+    fn root(&mut self, key: &K) -> Result<MerkleRoot, Self::Error> {
+        MerkleRootStorage::<K, M>::root(&mut self.database, key)
+    }
+}
+
+impl InterpreterStorage for VmDatabase {
+    type DataError = Error;
+
+    fn block_height(&self) -> Result<u32, Self::DataError> {
+        Ok(self.current_block_height)
+    }
+
+    fn timestamp(&self, height: u32) -> Result<Word, Self::DataError> {
+        let timestamp = match height {
+            // panic if $rB is greater than the current block height.
+            height if height > self.current_block_height => {
+                return Err(anyhow!("block height too high for timestamp").into())
+            }
+            height if height == self.current_block_height => self.current_timestamp,
+            height => self.database.block_time(height)?,
+        };
+        timestamp
+            .timestamp_millis()
+            .try_into()
+            .context("invalid timestamp")
+            .map_err(Into::into)
+    }
+
+    fn block_hash(&self, block_height: u32) -> Result<Bytes32, Self::DataError> {
+        // Block header hashes for blocks with height greater than or equal to current block height are zero (0x00**32).
+        // https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/instruction_set.md#bhsh-block-hash
+        if block_height >= self.current_block_height || block_height == 0 {
+            Ok(Bytes32::zeroed())
+        } else {
+            // this will return 0x00**32 for block height 0 as well
+            self.database
+                .get_block_id(block_height.into())?
+                .ok_or_else(|| KvStoreError::NotFound.into())
+        }
+    }
+
+    fn coinbase(&self) -> Result<Address, Self::DataError> {
+        Ok(self.coinbase)
+    }
+
+    fn merkle_contract_state_range(
+        &self,
+        _id: &ContractId,
+        _start_key: &Bytes32,
+        _range: Word,
+    ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError> {
+        unimplemented!()
+    }
+
+    fn merkle_contract_state_insert_range(
+        &mut self,
+        _contract: &ContractId,
+        _start_key: &Bytes32,
+        _values: &[Bytes32],
+    ) -> Result<Option<()>, Self::DataError> {
+        unimplemented!()
+    }
+
+    fn merkle_contract_state_remove_range(
+        &mut self,
+        _contract: &ContractId,
+        _start_key: &Bytes32,
+        _range: Word,
+    ) -> Result<Option<()>, Self::DataError> {
+        unimplemented!()
+    }
+}

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -292,6 +292,9 @@ impl Executor {
 
         // Temporary insert coinbase into the storage because `InterpreterStorage::coinbase`
         // gets coinbase transaction from the storage during execution of `Script`.
+        //
+        // # Dev-note: in production mode, the `id` of the temporary coinbase is not the same as
+        // the `id ` of the final coinbase.
         let coinbase_id = coinbase_tx.id();
         if block_db_transaction
             .deref_mut()
@@ -369,7 +372,7 @@ impl Executor {
             };
         }
 
-        // Remove temporary added coinbase.
+        // Remove temporary added coinbase with `coinbase_id`.
         block_db_transaction
             .deref_mut()
             .storage::<Transactions>()

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -1694,13 +1694,19 @@ mod tests {
 
         #[tokio::test]
         async fn invalidate_more_than_one_mint_is_not_allowed() {
-            let mint = Transaction::mint(
-                TxPointer::new(0, 0),
-                vec![Output::coin(Address::zeroed(), 0, AssetId::BASE)],
-            );
-
             let mut block = FuelBlock::default();
-            *block.transactions_mut() = vec![mint.clone().into(), mint.clone().into()];
+            *block.transactions_mut() = vec![
+                Transaction::mint(
+                    TxPointer::new(0, 0),
+                    vec![Output::coin(Address::from([1u8; 32]), 0, AssetId::BASE)],
+                )
+                .into(),
+                Transaction::mint(
+                    TxPointer::new(0, 0),
+                    vec![Output::coin(Address::from([2u8; 32]), 0, AssetId::BASE)],
+                )
+                .into(),
+            ];
 
             let validator = Executor {
                 database: Default::default(),

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -282,15 +282,6 @@ impl Executor {
             }
         };
 
-        // Insert the current headers (including time, block height into the db tx)
-        block_db_transaction
-            .deref_mut()
-            .storage::<FuelBlocks>()
-            .insert(
-                &Bytes32::zeroed(), // use id of zero as current block
-                &block.to_partial_db_block(),
-            )?;
-
         // Temporary insert coinbase into the storage because `InterpreterStorage::coinbase`
         // gets coinbase transaction from the storage during execution of `Script`.
         //
@@ -396,13 +387,6 @@ impl Executor {
             Some(execution_data.coinbase),
         )?;
         self.apply_coinbase(coinbase_tx, block, execution_data, block_db_transaction)?;
-
-        // Clean up unfinalized headers (block height + time + producer) that we inserted above
-        // for transaction execution.
-        block_db_transaction
-            .deref_mut()
-            .storage::<FuelBlocks>()
-            .remove(&Bytes32::zeroed())?;
 
         Ok(data)
     }

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -493,7 +493,7 @@ impl Executor {
         // execute transaction
         // setup database view that only lives for the duration of vm execution
         let mut sub_block_db_commit = block_db_transaction.transaction();
-        let sub_db_view = sub_block_db_commit.deref_mut();
+        let sub_db_view = sub_block_db_commit.as_mut();
         // execution vm
         let vm_db = VmDatabase::new(
             sub_db_view.clone(),

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -65,13 +65,13 @@ impl Contract {
         let contract_id = self.0;
 
         let db = ctx.data_unchecked::<Database>().clone();
-        let salt = db
+        let (salt, _) = db
             .storage::<ContractsInfo>()
-            .get(&contract_id)
-            .unwrap()
-            .expect("Contract does not exist");
+            .get(&contract_id)?
+            .ok_or(anyhow!("Contract does not exist"))?
+            .into_owned();
 
-        let cleaned_salt: Salt = salt.clone().0.into();
+        let cleaned_salt: Salt = salt.into();
 
         Ok(cleaned_salt)
     }

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -29,9 +29,12 @@ use fuel_core_interfaces::{
         fuel_storage::StorageAsRef,
         fuel_tx,
         fuel_types,
-        fuel_vm,
     },
-    db::ContractsRawCode,
+    db::{
+        ContractsAssets,
+        ContractsInfo,
+        ContractsRawCode,
+    },
 };
 use std::iter::IntoIterator;
 
@@ -62,12 +65,11 @@ impl Contract {
         let contract_id = self.0;
 
         let db = ctx.data_unchecked::<Database>().clone();
-        let salt = fuel_vm::storage::InterpreterStorage::storage_contract_root(
-            &db,
-            &contract_id,
-        )
-        .unwrap()
-        .expect("Contract does not exist");
+        let salt = db
+            .storage::<ContractsInfo>()
+            .get(&contract_id)
+            .unwrap()
+            .expect("Contract does not exist");
 
         let cleaned_salt: Salt = salt.clone().0.into();
 
@@ -140,13 +142,10 @@ impl ContractBalanceQuery {
 
         let asset_id: fuel_types::AssetId = asset.into();
 
-        let result =
-            fuel_vm::storage::InterpreterStorage::merkle_contract_asset_id_balance(
-                &db,
-                &contract_id,
-                &asset_id,
-            );
-        let balance = result.unwrap().unwrap_or_default();
+        let result = db
+            .storage::<ContractsAssets>()
+            .get(&(&contract_id, &asset_id))?;
+        let balance = result.unwrap_or_default().into_owned();
 
         Ok(ContractBalance {
             contract: contract.into(),

--- a/fuel-core/src/schema/contract.rs
+++ b/fuel-core/src/schema/contract.rs
@@ -68,7 +68,7 @@ impl Contract {
         let (salt, _) = db
             .storage::<ContractsInfo>()
             .get(&contract_id)?
-            .ok_or(anyhow!("Contract does not exist"))?
+            .ok_or_else(|| anyhow!("Contract does not exist"))?
             .into_owned();
 
         let cleaned_salt: Salt = salt.into();

--- a/fuel-core/src/schema/dap.rs
+++ b/fuel-core/src/schema/dap.rs
@@ -70,21 +70,10 @@ impl ConcreteStorage {
         let id = Uuid::new_v4();
         let id = ID::from(id);
 
-        let block = storage
-            .get_current_block()?
-            .unwrap_or_default()
-            .into_owned();
-        let current_block_height = block.header.consensus.height.into();
-
-        let vm_database = VmDatabase::new(
-            storage.as_ref().clone(),
-            &block.header.consensus,
-            // TODO: Use a real coinbase address
-            Address::zeroed(),
-        );
-
+        let vm_database = Self::vm_database(&storage)?;
         let tx = Script::default();
-        let checked_tx = tx.into_checked_basic(current_block_height, &self.params)?;
+        let checked_tx =
+            tx.into_checked_basic(vm_database.block_height() as Word, &self.params)?;
         self.tx
             .get_mut(&id)
             .map(|tx| tx.extend_from_slice(txs))
@@ -107,19 +96,7 @@ impl ConcreteStorage {
     }
 
     pub fn reset(&mut self, id: &ID, storage: DatabaseTransaction) -> anyhow::Result<()> {
-        let block = storage
-            .get_current_block()?
-            .unwrap_or_default()
-            .into_owned();
-        let current_block_height = block.header.consensus.height.into();
-
-        let vm_database = VmDatabase::new(
-            storage.as_ref().clone(),
-            &block.header.consensus,
-            // TODO: Use a real coinbase address
-            Address::zeroed(),
-        );
-
+        let vm_database = Self::vm_database(&storage)?;
         let tx = self
             .tx
             .get(id)
@@ -127,7 +104,8 @@ impl ConcreteStorage {
             .cloned()
             .unwrap_or_default();
 
-        let checked_tx = tx.into_checked_basic(current_block_height, &self.params)?;
+        let checked_tx =
+            tx.into_checked_basic(vm_database.block_height() as Word, &self.params)?;
 
         let mut vm = Interpreter::with_storage(vm_database, self.params);
         vm.transact(checked_tx)?;
@@ -153,6 +131,24 @@ impl ConcreteStorage {
                     "The VM instance was not found",
                 ))
             })
+    }
+
+    fn vm_database(
+        storage: &DatabaseTransaction,
+    ) -> Result<VmDatabase, InterpreterError> {
+        let block = storage
+            .get_current_block()?
+            .unwrap_or_default()
+            .into_owned();
+
+        let vm_database = VmDatabase::new(
+            storage.as_ref().clone(),
+            &block.header.consensus,
+            // TODO: Use a real coinbase address
+            Address::zeroed(),
+        );
+
+        Ok(vm_database)
     }
 }
 


### PR DESCRIPTION
related to #730
fixes: https://github.com/FuelLabs/fuel-core/pull/729

Instead of creating a temporary block during execution for certain opcodes, this PR adds a new database wrapper that implements the InterpreterStorage trait. This wrapper can be initialized directly with the values the VM needs to retrieve, so that we don't have to simulate useless parts of the unfinalized block or coinbase tx to satisfy the VM storage API.
