### PR TITLE
disable musl binary builds 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,20 +274,10 @@ jobs:
             platform: linux
             target: x86_64-unknown-linux-gnu
             cross_image: x86_64-linux-gnu
-#          libclang incompatible with musl, disabled for now
-#          - os: ubuntu-latest
-#            platform: linux
-#            target: x86_64-unknown-linux-musl
-#            cross_image: x86_64-linux-musl
           - os: ubuntu-latest
             platform: linux-arm
             target: aarch64-unknown-linux-gnu
             cross_image: aarch64-linux-gnu
-#           libclang incompatible with musl, disabled for now
-#          - os: ubuntu-latest
-#            platform: linux-arm
-#            target: aarch64-unknown-linux-musl
-#            cross_image: aarch64-linux-musl
           - os: macos-latest
             platform: darwin
             target: x86_64-apple-darwin
@@ -353,15 +343,6 @@ jobs:
           aarch64-linux-gnu:latest \
           aarch64-linux-gnu-strip \
           /target/aarch64-unknown-linux-gnu/release/fuel-core
-
-      - name: Strip release binary aarch64-linux-musl
-        if: matrix.job.target == 'aarch64-unknown-linux-musl'
-        run: |
-          docker run --rm -v \
-          "$PWD/target:/target:Z" \
-          aarch64-linux-musl:latest \
-          aarch64-linux-musl-strip \
-          /target/aarch64-unknown-linux-musl/release/fuel-core
 
       - name: Strip release binary mac
         if: matrix.job.os == 'macos-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,18 +274,20 @@ jobs:
             platform: linux
             target: x86_64-unknown-linux-gnu
             cross_image: x86_64-linux-gnu
-          - os: ubuntu-latest
-            platform: linux
-            target: x86_64-unknown-linux-musl
-            cross_image: x86_64-linux-musl
+#          libclang incompatible with musl, disabled for now
+#          - os: ubuntu-latest
+#            platform: linux
+#            target: x86_64-unknown-linux-musl
+#            cross_image: x86_64-linux-musl
           - os: ubuntu-latest
             platform: linux-arm
             target: aarch64-unknown-linux-gnu
             cross_image: aarch64-linux-gnu
-          - os: ubuntu-latest
-            platform: linux-arm
-            target: aarch64-unknown-linux-musl
-            cross_image: aarch64-linux-musl
+#           libclang incompatible with musl, disabled for now
+#          - os: ubuntu-latest
+#            platform: linux-arm
+#            target: aarch64-unknown-linux-musl
+#            cross_image: aarch64-linux-musl
           - os: macos-latest
             platform: darwin
             target: x86_64-apple-darwin

--- a/ci/Dockerfile.aarch64-unknown-linux-musl-clang
+++ b/ci/Dockerfile.aarch64-unknown-linux-musl-clang
@@ -1,3 +1,5 @@
+# Currently Unsupported
+
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
 
 RUN dpkg --add-architecture arm64 && \

--- a/ci/Dockerfile.aarch64-unknown-linux-musl-clang
+++ b/ci/Dockerfile.aarch64-unknown-linux-musl-clang
@@ -1,7 +1,0 @@
-# Currently Unsupported
-
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:main
-
-RUN dpkg --add-architecture arm64 && \
-    apt-get update && \
-    apt-get install --assume-yes clang libclang-dev binutils-aarch64-linux-gnu

--- a/ci/Dockerfile.x86_64-unknown-linux-musl-clang
+++ b/ci/Dockerfile.x86_64-unknown-linux-musl-clang
@@ -1,6 +1,0 @@
-# Currently Unsupported
-
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
-
-RUN apt-get update && \
-    apt-get install --assume-yes clang libclang-dev binutils-aarch64-linux-gnu

--- a/ci/Dockerfile.x86_64-unknown-linux-musl-clang
+++ b/ci/Dockerfile.x86_64-unknown-linux-musl-clang
@@ -1,3 +1,5 @@
+# Currently Unsupported
+
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:main
 
 RUN apt-get update && \

--- a/ci/build-images.sh
+++ b/ci/build-images.sh
@@ -2,8 +2,4 @@
 
 docker build -t x86_64-linux-gnu -f Dockerfile.x86_64-unknown-linux-gnu-clang .
 
-docker build -t x86_64-linux-musl -f Dockerfile.x86_64-unknown-linux-musl-clang .
-
 docker build -t aarch64-linux-gnu -f Dockerfile.aarch64-unknown-linux-gnu-clang .
-
-docker build -t aarch64-linux-musl -f Dockerfile.aarch64-unknown-linux-musl-clang .


### PR DESCRIPTION
We are unable to compile rocksdb using musl since it depends on libclang which targets gnu. Disabling musl binaries and removing them since we don't really need to support both musl and gnu unless there's a specific request for it.