### PR TITLE
Bugfix: Use the same `ChainConfig` during initialization of `Config`

### DIFF
--- a/fuel-core/src/cli/run.rs
+++ b/fuel-core/src/cli/run.rs
@@ -180,17 +180,13 @@ impl Command {
             addr,
             database_path,
             database_type,
-            chain_conf,
+            chain_conf: chain_conf.clone(),
             utxo_validation,
             manual_blocks_enabled,
             vm: VMConfig {
                 backtrace: vm_backtrace,
             },
-            txpool: fuel_txpool::Config {
-                min_gas_price,
-                utxo_validation,
-                ..Default::default()
-            },
+            txpool: fuel_txpool::Config::new(chain_conf, min_gas_price, utxo_validation),
             block_importer: Default::default(),
             block_producer: fuel_block_producer::Config {
                 utxo_validation,

--- a/fuel-core/src/service.rs
+++ b/fuel-core/src/service.rs
@@ -6,6 +6,7 @@ use std::{
     panic,
 };
 use tokio::task::JoinHandle;
+use tracing::log::warn;
 
 pub use config::{
     Config,
@@ -30,7 +31,8 @@ pub struct FuelService {
 impl FuelService {
     /// Create a fuel node instance from service config
     #[tracing::instrument(skip(config))]
-    pub async fn new_node(config: Config) -> Result<Self, AnyError> {
+    pub async fn new_node(mut config: Config) -> Result<Self, AnyError> {
+        Self::make_config_consistent(&mut config);
         // initialize database
         let database = match config.database_type {
             #[cfg(feature = "rocksdb")]
@@ -41,6 +43,22 @@ impl FuelService {
         };
         // initialize service
         Self::init_service(database, config).await
+    }
+
+    // TODO: Rework our configs system to avoid nesting of the same configs.
+    fn make_config_consistent(config: &mut Config) {
+        if config.txpool.chain_config != config.chain_conf {
+            warn!("The `ChainConfig` of `TxPool` was inconsistent");
+            config.txpool.chain_config = config.chain_conf.clone();
+        }
+        if config.txpool.utxo_validation != config.utxo_validation {
+            warn!("The `utxo_validation` of `TxPool` was inconsistent");
+            config.txpool.utxo_validation = config.utxo_validation;
+        }
+        if config.block_producer.utxo_validation != config.utxo_validation {
+            warn!("The `utxo_validation` of `BlockProducer` was inconsistent");
+            config.block_producer.utxo_validation = config.utxo_validation;
+        }
     }
 
     /// Used to initialize a service with a pre-existing database

--- a/fuel-core/src/service/config.rs
+++ b/fuel-core/src/service/config.rs
@@ -47,7 +47,8 @@ pub struct Config {
 impl Config {
     pub fn local_node() -> Self {
         let chain_conf = ChainConfig::local_testnet();
-
+        let utxo_validation = false;
+        let min_gas_price = 0;
         Self {
             addr: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
             database_path: Default::default(),
@@ -55,12 +56,8 @@ impl Config {
             chain_conf: chain_conf.clone(),
             manual_blocks_enabled: false,
             vm: Default::default(),
-            utxo_validation: false,
-            txpool: fuel_txpool::Config {
-                utxo_validation: false,
-                chain_config: chain_conf,
-                ..Default::default()
-            },
+            utxo_validation,
+            txpool: fuel_txpool::Config::new(chain_conf, min_gas_price, utxo_validation),
             block_importer: Default::default(),
             block_producer: Default::default(),
             block_executor: Default::default(),

--- a/fuel-tests/tests/helpers.rs
+++ b/fuel-tests/tests/helpers.rs
@@ -128,20 +128,23 @@ impl TestSetupBuilder {
 
     // setup chainspec and spin up a fuel-node
     pub async fn finalize(&mut self) -> TestContext {
+        let chain_config = ChainConfig {
+            initial_state: Some(StateConfig {
+                coins: Some(self.initial_coins.clone()),
+                contracts: Some(self.contracts.values().cloned().collect_vec()),
+                ..StateConfig::default()
+            }),
+            ..ChainConfig::local_testnet()
+        };
+        let utxo_validation = true;
         let config = Config {
-            utxo_validation: true,
-            txpool: fuel_txpool::Config {
-                min_gas_price: self.min_gas_price,
-                ..Default::default()
-            },
-            chain_conf: ChainConfig {
-                initial_state: Some(StateConfig {
-                    coins: Some(self.initial_coins.clone()),
-                    contracts: Some(self.contracts.values().cloned().collect_vec()),
-                    ..StateConfig::default()
-                }),
-                ..ChainConfig::local_testnet()
-            },
+            utxo_validation,
+            txpool: fuel_txpool::Config::new(
+                chain_config.clone(),
+                self.min_gas_price,
+                utxo_validation,
+            ),
+            chain_conf: chain_config,
             ..Config::local_node()
         };
 

--- a/fuel-txpool/src/config.rs
+++ b/fuel-txpool/src/config.rs
@@ -19,12 +19,26 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
+        let min_gas_price = 0;
+        let utxo_validation = true;
+        Self::new(ChainConfig::default(), min_gas_price, utxo_validation)
+    }
+}
+
+impl Config {
+    pub fn new(
+        chain_config: ChainConfig,
+        min_gas_price: u64,
+        utxo_validation: bool,
+    ) -> Self {
+        // # Dev-note: If you add a new field, be sure that this field is propagated correctly
+        //  in all places where `new` is used.
         Self {
             max_tx: 4064,
             max_depth: 10,
-            min_gas_price: 0,
-            utxo_validation: true,
-            chain_config: ChainConfig::default(),
+            min_gas_price,
+            utxo_validation,
+            chain_config,
             metrics: false,
         }
     }


### PR DESCRIPTION
`Config` used default `ChainConfig` for `TxPoolConfig` instead of parsed chain config from cli. 