### PR TITLE
expose get_peers_ids() from Network Service

### DIFF
--- a/fuel-core/src/service/modules.rs
+++ b/fuel-core/src/service/modules.rs
@@ -132,7 +132,6 @@ pub async fn start_modules(config: &Config, database: &Database) -> Result<Modul
         fuel_p2p::orchestrator::Service::new(
             config.p2p.clone(),
             p2p_db,
-            p2p_request_event_sender.clone(),
             p2p_request_event_receiver,
             tx_consensus,
             incoming_tx_sender,

--- a/fuel-p2p/src/orchestrator.rs
+++ b/fuel-p2p/src/orchestrator.rs
@@ -241,7 +241,7 @@ pub struct Service {
     network_orchestrator: Arc<Mutex<Option<NetworkOrchestrator>>>,
     /// Holds the spawned task when Netowrk Orchestrator is started
     join: Mutex<Option<JoinHandle<Result<NetworkOrchestrator, anyhow::Error>>>>,
-    /// Used for comminicating with the Orchestrator
+    /// Used for communicating with the Orchestrator
     tx_service_request: Sender<ServiceToOrchestratorRequest>,
 }
 

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -216,10 +216,18 @@ impl<Codec: NetworkCodec> FuelP2PService<Codec> {
     pub fn send_response_msg(
         &mut self,
         request_id: RequestId,
-        message: OutboundResponse,
+        message: Option<OutboundResponse>,
     ) -> Result<(), ResponseError> {
+        // if the response message wasn't successfully prepared
+        // we still need to remove the `request_id` from `inbound_requests_table`
+        if message.is_none() {
+            self.inbound_requests_table.remove(&request_id);
+            return Ok(())
+        }
+
         match (
-            self.network_codec.convert_to_intermediate(&message),
+            self.network_codec
+                .convert_to_intermediate(&message.unwrap()),
             self.inbound_requests_table.remove(&request_id),
         ) {
             (Ok(message), Some(channel)) => {
@@ -862,7 +870,7 @@ mod tests {
                             consensus: FuelBlockConsensus::PoA(FuelBlockPoAConsensus::new(Default::default())),
                         };
 
-                        let _ = node_b.send_response_msg(request_id, OutboundResponse::ResponseBlock(Arc::new(sealed_block)));
+                        let _ = node_b.send_response_msg(request_id, Some(OutboundResponse::ResponseBlock(Arc::new(sealed_block))));
                     }
 
                     tracing::info!("Node B Event: {:?}", node_b_event);

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -155,8 +155,12 @@ impl<Codec: NetworkCodec> FuelP2PService<Codec> {
         })
     }
 
-    pub fn get_peers(&self) -> &HashMap<PeerId, PeerInfo> {
+    pub fn get_peers_info(&self) -> &HashMap<PeerId, PeerInfo> {
         self.swarm.behaviour().get_peers()
+    }
+
+    pub fn get_peers_ids(&self) -> Vec<PeerId> {
+        self.get_peers_info().iter().map(|(id, _)| *id).collect()
     }
 
     pub fn publish_message(
@@ -188,7 +192,7 @@ impl<Codec: NetworkCodec> FuelP2PService<Codec> {
         let peer_id = match peer_id {
             Some(peer_id) => peer_id,
             _ => {
-                let connected_peers = self.get_peers();
+                let connected_peers = self.get_peers_info();
                 if connected_peers.is_empty() {
                     return Err(RequestError::NoPeersConnected)
                 }


### PR DESCRIPTION
part of the #649 

with this initial commit we have:
- exposed p2p get peer ids
- refactored certain parts of the Orchestrator
- added few comments to clarify the channel usage

I achieved this by slightly refactoring Network Service & Orchestrator, 
separated _external_ p2p requests from _internal_ Orchestrator requests.

I have also added checking and clearing of `request_id`s in inbound response table if response wasn't properly constructed.

