### PR TITLE
Added removal of skipped transactions from `TxPool`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,7 @@ dependencies = [
  "async-trait",
  "fuel-core-interfaces",
  "humantime-serde",
+ "mockall",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "serde",

--- a/fuel-block-producer/src/block_producer/tests.rs
+++ b/fuel-block-producer/src/block_producer/tests.rs
@@ -38,7 +38,7 @@ async fn cant_produce_at_genesis_height() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_block(0u32.into(), 1_000_000_000)
+        .produce_and_execute_block(0u32.into(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 
@@ -55,7 +55,9 @@ async fn can_produce_initial_block() {
     let ctx = TestContext::default();
     let producer = ctx.producer();
 
-    let result = producer.produce_block(1u32.into(), 1_000_000_000).await;
+    let result = producer
+        .produce_and_execute_block(1u32.into(), 1_000_000_000)
+        .await;
 
     assert!(result.is_ok());
 }
@@ -88,7 +90,7 @@ async fn can_produce_next_block() {
     let ctx = TestContext::default_from_db(db);
     let producer = ctx.producer();
     let result = producer
-        .produce_block(prev_height + 1u32.into(), 1_000_000_000)
+        .produce_and_execute_block(prev_height + 1u32.into(), 1_000_000_000)
         .await;
 
     assert!(result.is_ok());
@@ -101,7 +103,7 @@ async fn cant_produce_if_no_previous_block() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_block(100u32.into(), 1_000_000_000)
+        .produce_and_execute_block(100u32.into(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 
@@ -152,7 +154,7 @@ async fn cant_produce_if_previous_block_da_height_too_high() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_block(prev_height + 1u32.into(), 1_000_000_000)
+        .produce_and_execute_block(prev_height + 1u32.into(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 
@@ -183,7 +185,7 @@ async fn production_fails_on_execution_error() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_block(1u32.into(), 1_000_000_000)
+        .produce_and_execute_block(1u32.into(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 

--- a/fuel-block-producer/tests/integration.rs
+++ b/fuel-block-producer/tests/integration.rs
@@ -35,6 +35,7 @@ use fuel_core_interfaces::{
         prelude::StorageAsMut,
     },
     db::Coins,
+    executor::ExecutionResult,
     model::{
         Coin,
         CoinStatus,
@@ -197,8 +198,11 @@ async fn block_producer() -> Result<()> {
     assert_eq!(results[2].removed, vec![]);
 
     // Trigger block production
-    let generated_block = block_producer
-        .produce_block(1u32.into(), max_gas_per_block)
+    let ExecutionResult {
+        block: generated_block,
+        ..
+    } = block_producer
+        .produce_and_execute_block(1u32.into(), max_gas_per_block)
         .await
         .expect("Failed to generate block");
 
@@ -228,8 +232,11 @@ async fn block_producer() -> Result<()> {
         .expect("Failed to import the generated block");
 
     // Trigger block production again
-    let generated_block = block_producer
-        .produce_block(2u32.into(), max_gas_per_block)
+    let ExecutionResult {
+        block: generated_block,
+        ..
+    } = block_producer
+        .produce_and_execute_block(2u32.into(), max_gas_per_block)
         .await
         .expect("Failed to generate block");
 
@@ -251,8 +258,11 @@ async fn block_producer() -> Result<()> {
         .expect("Failed to import the generated block");
 
     // Trigger block production once more, now the block should be empty
-    let generated_block = block_producer
-        .produce_block(3u32.into(), max_gas_per_block)
+    let ExecutionResult {
+        block: generated_block,
+        ..
+    } = block_producer
+        .produce_and_execute_block(3u32.into(), max_gas_per_block)
         .await
         .expect("Failed to generate block");
 

--- a/fuel-core-interfaces/src/block_producer.rs
+++ b/fuel-core-interfaces/src/block_producer.rs
@@ -3,6 +3,7 @@ use crate::{
         Receipt,
         Transaction,
     },
+    executor::ExecutionResult,
     model::{
         BlockHeight,
         DaBlockHeight,
@@ -32,11 +33,13 @@ pub enum BlockProducerBroadcast {
 
 #[async_trait::async_trait]
 pub trait BlockProducer: Send + Sync {
-    async fn produce_block(
+    // TODO: Right now production and execution of the block is one step, but in the future,
+    //  `produce_block` should only produce a block without affecting the blockchain state.
+    async fn produce_and_execute_block(
         &self,
         height: BlockHeight,
         max_gas: Word,
-    ) -> Result<FuelBlock>;
+    ) -> Result<ExecutionResult>;
 
     async fn dry_run(
         &self,

--- a/fuel-core-interfaces/src/poa_coordinator.rs
+++ b/fuel-core-interfaces/src/poa_coordinator.rs
@@ -1,10 +1,13 @@
-use anyhow::Result;
-
-use crate::model::{
-    BlockHeight,
-    BlockId,
-    FuelBlockConsensus,
+use crate::{
+    common::fuel_tx::TxId,
+    model::{
+        ArcPoolTx,
+        BlockHeight,
+        BlockId,
+        FuelBlockConsensus,
+    },
 };
+use anyhow::Result;
 
 pub trait BlockDb: Send + Sync {
     fn block_height(&self) -> Result<BlockHeight>;
@@ -20,4 +23,6 @@ pub trait BlockDb: Send + Sync {
 #[async_trait::async_trait]
 pub trait TransactionPool {
     async fn total_consumable_gas(&self) -> Result<u64>;
+
+    async fn remove_txs(&mut self, tx_ids: Vec<TxId>) -> Result<Vec<ArcPoolTx>>;
 }

--- a/fuel-core-interfaces/src/txpool.rs
+++ b/fuel-core-interfaces/src/txpool.rs
@@ -268,6 +268,12 @@ impl super::poa_coordinator::TransactionPool for Sender {
         self.send(TxPoolMpsc::ConsumableGas { response }).await?;
         receiver.await.map_err(Into::into)
     }
+
+    async fn remove_txs(&mut self, ids: Vec<TxId>) -> anyhow::Result<Vec<ArcPoolTx>> {
+        let (response, receiver) = oneshot::channel();
+        self.send(TxPoolMpsc::Remove { ids, response }).await?;
+        receiver.await.map_err(Into::into)
+    }
 }
 
 /// RPC commands that can be sent to the TxPool through an MPSC channel.

--- a/fuel-poa-coordinator/Cargo.toml
+++ b/fuel-poa-coordinator/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel Core PoA Coordinator"
 [dependencies]
 anyhow = "1.0"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.13.2" }
+mockall = "0.11"
 humantime-serde = "1.1.1"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Added removal of skipped transactions from `TxPool` on the `PoACoordinator` level instead of the `BlockProducer` level.
Added unit test for this case to check that skipped transactions are propagated to `TxPool`.
Renamed `produce_block` into `produce_and_execute_block` to clarify current behavior.