### PR TITLE
Change timestamps from chrono to tai64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,12 +870,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "serde",
- "time 0.1.44",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -2275,7 +2271,6 @@ version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
  "fuel-block-producer",
  "fuel-core-interfaces",
  "fuel-txpool",
@@ -2317,7 +2312,6 @@ dependencies = [
  "bech32 0.9.1",
  "bincode",
  "byteorder",
- "chrono",
  "clap",
  "derive_more",
  "dirs",
@@ -2385,7 +2379,6 @@ version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
  "derive_more",
  "fuel-vm",
  "futures",
@@ -2422,7 +2415,6 @@ name = "fuel-gql-client"
 version = "0.13.2"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
  "cynic",
  "derive_more",
@@ -2509,7 +2501,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "chrono",
  "env_logger",
  "ethers-contract",
  "ethers-core",
@@ -2558,7 +2549,6 @@ name = "fuel-tests"
 version = "0.0.0"
 dependencies = [
  "async-std",
- "chrono",
  "ethers",
  "fuel-core",
  "fuel-core-interfaces",
@@ -2604,7 +2594,6 @@ version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
  "fuel-chain-config",
  "fuel-core-interfaces",
  "fuel-txpool",
@@ -6102,17 +6091,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
@@ -6750,12 +6728,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,15 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,8 +238,6 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes",
- "chrono",
- "chrono-tz",
  "fnv",
  "futures-util",
  "http",
@@ -869,32 +858,8 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "iana-time-zone",
  "num-integer",
  "num-traits",
- "winapi",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c39203181991a7dd4343b8005bd804e7a9a37afb8ac070e43771e8c820bbde"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f509c3a87b33437b05e2458750a0700e5bdd6956176773e6c7d6dd15a283a0c"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -990,16 +955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
 ]
 
 [[package]]
@@ -1384,50 +1339,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3155,30 +3066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,15 +3766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4401,15 +4279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "password-hash"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,45 +4367,6 @@ checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
  "rustc_version 0.4.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
-dependencies = [
- "siphasher",
- "uncased",
 ]
 
 [[package]]
@@ -5381,12 +5211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
-
-[[package]]
 name = "scrypt"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5710,12 +5534,6 @@ checksum = "38aabbeafa6f6dead8cebf246fe9fae1f9215c8d29b3a69f93bd62a9e4a3dcd6"
 dependencies = [
  "event-listener",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "slab"
@@ -6538,15 +6356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uncased"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6575,12 +6384,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "secrecy",
  "serde",
+ "tai64",
  "thiserror",
  "tokio",
  "zeroize",
@@ -2435,6 +2436,7 @@ dependencies = [
  "serde",
  "serde_json",
  "surf",
+ "tai64",
  "thiserror",
 ]
 
@@ -5981,6 +5983,9 @@ name = "tai64"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7401421025f4132e6c1f7af5e7f8287383969f36e6628016cd509b8d3da9dc"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "tap"

--- a/fuel-block-producer/Cargo.toml
+++ b/fuel-block-producer/Cargo.toml
@@ -12,7 +12,6 @@ description = "Fuel Block Producer"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-chrono = "0.4"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.13.2" }
 parking_lot = "0.12"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-block-producer/src/block_producer.rs
+++ b/fuel-block-producer/src/block_producer.rs
@@ -8,10 +8,6 @@ use anyhow::{
     Context,
     Result,
 };
-use chrono::{
-    TimeZone,
-    Utc,
-};
 use fuel_core_interfaces::{
     block_producer::{
         BlockProducer as Trait,
@@ -162,7 +158,7 @@ impl Producer {
                 // TODO: this needs to be updated using a proper BMT MMR
                 prev_root: previous_block_info.prev_root,
                 height,
-                time: Utc.timestamp(Tai64::now().to_unix(), 0),
+                time: Tai64::now(),
                 generated: Default::default(),
             },
             metadata: None,

--- a/fuel-block-producer/src/block_producer.rs
+++ b/fuel-block-producer/src/block_producer.rs
@@ -8,7 +8,10 @@ use anyhow::{
     Context,
     Result,
 };
-use chrono::Utc;
+use chrono::{
+    TimeZone,
+    Utc,
+};
 use fuel_core_interfaces::{
     block_producer::{
         BlockProducer as Trait,
@@ -27,6 +30,7 @@ use fuel_core_interfaces::{
             Word,
         },
         fuel_types::Bytes32,
+        tai64::Tai64,
     },
     executor::{
         ExecutionBlock,
@@ -158,7 +162,7 @@ impl Producer {
                 // TODO: this needs to be updated using a proper BMT MMR
                 prev_root: previous_block_info.prev_root,
                 height,
-                time: Utc::now(),
+                time: Utc.timestamp(Tai64::now().to_unix(), 0),
                 generated: Default::default(),
             },
             metadata: None,

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.1", features = ["derive"] }
 cynic = { version = "1.0", features = ["surf"] }
 derive_more = { version = "0.99" }

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 surf = { version = "2.2", default-features = false, features = ["h1-client-rustls"] }
+tai64 = {version = "4.0", features = ["serde"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -241,13 +241,6 @@ type ContractOutput {
 	stateRoot: Bytes32!
 }
 
-"""
-Implement the DateTime<Utc> scalar
-
-The input/output is a string in RFC3339 format.
-"""
-scalar DateTime
-
 input ExcludeInput {
 	"""
 	Utxos to exclude from the selection.
@@ -261,7 +254,7 @@ input ExcludeInput {
 
 type FailureStatus {
 	block: Block!
-	time: DateTime!
+	time: U64!
 	reason: String!
 	programState: ProgramState
 }
@@ -303,11 +296,7 @@ type Header {
 	"""
 	The block producer time.
 	"""
-	time: DateTime!
-	"""
-	The block producer time in tai64 format
-	"""
-	timeTai64: U64!
+	time: U64!
 	"""
 	Hash of the application header.
 	"""
@@ -604,12 +593,12 @@ input SpendQueryElementInput {
 
 
 type SubmittedStatus {
-	time: DateTime!
+	time: U64!
 }
 
 type SuccessStatus {
 	block: Block!
-	time: DateTime!
+	time: U64!
 	programState: ProgramState
 }
 

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -254,7 +254,7 @@ input ExcludeInput {
 
 type FailureStatus {
 	block: Block!
-	time: U64!
+	time: Tai64Timestamp!
 	reason: String!
 	programState: ProgramState
 }
@@ -296,7 +296,7 @@ type Header {
 	"""
 	The block producer time.
 	"""
-	time: U64!
+	time: Tai64Timestamp!
 	"""
 	Hash of the application header.
 	"""
@@ -593,14 +593,16 @@ input SpendQueryElementInput {
 
 
 type SubmittedStatus {
-	time: U64!
+	time: Tai64Timestamp!
 }
 
 type SuccessStatus {
 	block: Block!
-	time: U64!
+	time: Tai64Timestamp!
 	programState: ProgramState
 }
+
+scalar Tai64Timestamp
 
 input TimeParameters {
 	"""

--- a/fuel-client/assets/schema.sdl
+++ b/fuel-client/assets/schema.sdl
@@ -305,6 +305,10 @@ type Header {
 	"""
 	time: DateTime!
 	"""
+	The block producer time in tai64 format
+	"""
+	timeTai64: U64!
+	"""
 	Hash of the application header.
 	"""
 	applicationHash: Bytes32!

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -4,6 +4,7 @@ use crate::client::{
         BlockId,
         ConnectionArgs,
         PageInfo,
+        Tai64Timestamp,
         U64,
     },
     PaginatedResult,
@@ -115,7 +116,7 @@ pub struct Header {
     pub output_messages_root: Bytes32,
     pub height: U64,
     pub prev_root: Bytes32,
-    pub time: U64,
+    pub time: Tai64Timestamp,
     pub application_hash: Bytes32,
 }
 

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -1,6 +1,5 @@
 use crate::client::{
     schema::{
-        primitives::DateTime,
         schema,
         BlockId,
         ConnectionArgs,
@@ -116,8 +115,7 @@ pub struct Header {
     pub output_messages_root: Bytes32,
     pub height: U64,
     pub prev_root: Bytes32,
-    pub time: DateTime,
-    pub time_tai64: U64,
+    pub time: U64,
     pub application_hash: Bytes32,
 }
 

--- a/fuel-client/src/client/schema/block.rs
+++ b/fuel-client/src/client/schema/block.rs
@@ -117,6 +117,7 @@ pub struct Header {
     pub height: U64,
     pub prev_root: Bytes32,
     pub time: DateTime,
+    pub time_tai64: U64,
     pub application_hash: Bytes32,
 }
 

--- a/fuel-client/src/client/schema/primitives.rs
+++ b/fuel-client/src/client/schema/primitives.rs
@@ -24,9 +24,6 @@ use std::{
     str::FromStr,
 };
 
-pub type DateTime = chrono::DateTime<chrono::Utc>;
-impl_scalar!(DateTime, schema::DateTime);
-
 #[derive(Debug, Clone, Default)]
 pub struct HexFormatted<T: Debug + Clone + Default>(pub T);
 

--- a/fuel-client/src/client/schema/primitives.rs
+++ b/fuel-client/src/client/schema/primitives.rs
@@ -23,6 +23,7 @@ use std::{
     ops::Deref,
     str::FromStr,
 };
+use tai64::Tai64;
 
 #[derive(Debug, Clone, Default)]
 pub struct HexFormatted<T: Debug + Clone + Default>(pub T);
@@ -264,5 +265,31 @@ impl From<usize> for U64 {
 impl From<U64> for InstructionResult {
     fn from(s: U64) -> Self {
         s.0.into()
+    }
+}
+
+#[derive(
+    Debug, Clone, derive_more::Into, derive_more::From, PartialOrd, Eq, PartialEq,
+)]
+pub struct Tai64Timestamp(pub Tai64);
+impl_scalar!(Tai64Timestamp, schema::Tai64Timestamp);
+
+impl Serialize for Tai64Timestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = self.0 .0.to_string();
+        serializer.serialize_str(s.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Tai64Timestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        Ok(Self(Tai64(s.parse().map_err(D::Error::custom)?)))
     }
 }

--- a/fuel-client/src/client/schema/tx.rs
+++ b/fuel-client/src/client/schema/tx.rs
@@ -8,6 +8,7 @@ use crate::client::{
         HexString,
         PageInfo,
         TransactionId,
+        U64,
     },
     types::TransactionResponse,
     PageDirection,
@@ -175,14 +176,14 @@ pub enum TransactionStatus {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct SubmittedStatus {
-    pub time: super::DateTime,
+    pub time: U64,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct SuccessStatus {
     pub block: BlockIdFragment,
-    pub time: super::DateTime,
+    pub time: U64,
     pub program_state: Option<ProgramState>,
 }
 
@@ -190,7 +191,7 @@ pub struct SuccessStatus {
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct FailureStatus {
     pub block: BlockIdFragment,
-    pub time: super::DateTime,
+    pub time: U64,
     pub reason: String,
     pub program_state: Option<ProgramState>,
 }

--- a/fuel-client/src/client/schema/tx.rs
+++ b/fuel-client/src/client/schema/tx.rs
@@ -7,8 +7,8 @@ use crate::client::{
         ConversionError,
         HexString,
         PageInfo,
+        Tai64Timestamp,
         TransactionId,
-        U64,
     },
     types::TransactionResponse,
     PageDirection,
@@ -176,14 +176,14 @@ pub enum TransactionStatus {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct SubmittedStatus {
-    pub time: U64,
+    pub time: Tai64Timestamp,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct SuccessStatus {
     pub block: BlockIdFragment,
-    pub time: U64,
+    pub time: Tai64Timestamp,
     pub program_state: Option<ProgramState>,
 }
 
@@ -191,7 +191,7 @@ pub struct SuccessStatus {
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct FailureStatus {
     pub block: BlockIdFragment,
-    pub time: U64,
+    pub time: Tai64Timestamp,
     pub reason: String,
     pub program_state: Option<ProgramState>,
 }

--- a/fuel-client/src/client/types.rs
+++ b/fuel-client/src/client/types.rs
@@ -5,10 +5,6 @@ use crate::client::schema::{
     },
     ConversionError,
 };
-use chrono::{
-    DateTime,
-    Utc,
-};
 use fuel_vm::{
     fuel_tx::Transaction,
     fuel_types::bytes::Deserializable,
@@ -18,6 +14,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use tai64::Tai64;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionResponse {
@@ -28,16 +25,16 @@ pub struct TransactionResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TransactionStatus {
     Submitted {
-        submitted_at: DateTime<Utc>,
+        submitted_at: Tai64,
     },
     Success {
         block_id: String,
-        time: DateTime<Utc>,
+        time: Tai64,
         program_state: Option<ProgramState>,
     },
     Failure {
         block_id: String,
-        time: DateTime<Utc>,
+        time: Tai64,
         reason: String,
         program_state: Option<ProgramState>,
     },
@@ -49,16 +46,16 @@ impl TryFrom<SchemaTxStatus> for TransactionStatus {
     fn try_from(status: SchemaTxStatus) -> Result<Self, Self::Error> {
         Ok(match status {
             SchemaTxStatus::SubmittedStatus(s) => TransactionStatus::Submitted {
-                submitted_at: s.time,
+                submitted_at: Tai64(s.time.0),
             },
             SchemaTxStatus::SuccessStatus(s) => TransactionStatus::Success {
                 block_id: s.block.id.0.to_string(),
-                time: s.time,
+                time: Tai64(s.time.0),
                 program_state: s.program_state.map(TryInto::try_into).transpose()?,
             },
             SchemaTxStatus::FailureStatus(s) => TransactionStatus::Failure {
                 block_id: s.block.id.0.to_string(),
-                time: s.time,
+                time: Tai64(s.time.0),
                 reason: s.reason,
                 program_state: s.program_state.map(TryInto::try_into).transpose()?,
             },

--- a/fuel-client/src/client/types.rs
+++ b/fuel-client/src/client/types.rs
@@ -46,16 +46,16 @@ impl TryFrom<SchemaTxStatus> for TransactionStatus {
     fn try_from(status: SchemaTxStatus) -> Result<Self, Self::Error> {
         Ok(match status {
             SchemaTxStatus::SubmittedStatus(s) => TransactionStatus::Submitted {
-                submitted_at: Tai64(s.time.0),
+                submitted_at: s.time.0,
             },
             SchemaTxStatus::SuccessStatus(s) => TransactionStatus::Success {
                 block_id: s.block.id.0.to_string(),
-                time: Tai64(s.time.0),
+                time: s.time.0,
                 program_state: s.program_state.map(TryInto::try_into).transpose()?,
             },
             SchemaTxStatus::FailureStatus(s) => TransactionStatus::Failure {
                 block_id: s.block.id.0.to_string(),
-                time: Tai64(s.time.0),
+                time: s.time.0,
                 reason: s.reason,
                 program_state: s.program_state.map(TryInto::try_into).transpose()?,
             },

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "1.4"
 parking_lot = "0.12"
 secrecy = "0.8"
 serde = { version = "1.0", features = ["derive"], optional = true }
+tai64 = {version = "4.0", features = ["serde"] }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }
 zeroize = "1.5"

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -13,7 +13,6 @@ description = "Fuel core interfaces"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-chrono = { version = "0.4" }
 derive_more = { version = "0.99" }
 fuel-vm = { version = "0.22", default-features = false, features = ["random"] }
 futures = "0.3"
@@ -30,5 +29,5 @@ zeroize = "1.5"
 test-helpers = [
     "fuel-vm/random", "fuel-vm/test-helpers",
 ]
-serde = ["dep:serde", "fuel-vm/serde", "chrono/serde"]
+serde = ["dep:serde", "fuel-vm/serde"]
 debug = ["fuel-vm/debug"]

--- a/fuel-core-interfaces/src/lib.rs
+++ b/fuel-core-interfaces/src/lib.rs
@@ -18,4 +18,6 @@ pub mod common {
     pub use fuel_vm::*;
     #[doc(no_inline)]
     pub use secrecy;
+    #[doc(no_inline)]
+    pub use tai64;
 }

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -188,8 +188,8 @@ impl FuelBlockHeader {
         &self.as_ref().height
     }
     /// The block producer time.
-    pub fn time(&self) -> &Tai64 {
-        &self.as_ref().time
+    pub fn time(&self) -> Tai64 {
+        self.as_ref().time
     }
     /// The hash of the application header.
     pub fn application_hash(&self) -> &Bytes32 {

--- a/fuel-core-interfaces/src/model/txpool.rs
+++ b/fuel-core-interfaces/src/model/txpool.rs
@@ -1,26 +1,23 @@
 use crate::txpool::PoolTransaction;
-use chrono::{
-    DateTime,
-    Utc,
-};
 use std::{
     ops::Deref,
     sync::Arc,
 };
+use tai64::Tai64;
 
 pub type ArcPoolTx = Arc<PoolTransaction>;
 
 #[derive(Debug, Clone)]
 pub struct TxInfo {
     tx: ArcPoolTx,
-    submitted_time: DateTime<Utc>,
+    submitted_time: Tai64,
 }
 
 impl TxInfo {
     pub fn new(tx: ArcPoolTx) -> Self {
         Self {
             tx,
-            submitted_time: Utc::now(),
+            submitted_time: Tai64::now(),
         }
     }
 
@@ -28,7 +25,7 @@ impl TxInfo {
         &self.tx
     }
 
-    pub fn submitted_time(&self) -> DateTime<Utc> {
+    pub fn submitted_time(&self) -> Tai64 {
         self.submitted_time
     }
 }

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -29,7 +29,6 @@ axum = { version = "0.5" }
 bech32 = "0.9.0"
 bincode = "1.3"
 byteorder = "1.4.3"
-chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "3.2", features = ["env", "derive"] }
 derive_more = { version = "0.99" }
 dirs = "4.0"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -19,11 +19,7 @@ test = false
 
 [dependencies]
 anyhow = "1.0"
-async-graphql = { version = "4.0", features = [
-    "chrono",
-    "chrono-tz",
-    "tracing",
-], default-features = false }
+async-graphql = { version = "4.0", features = ["tracing"], default-features = false }
 async-trait = "0.1"
 axum = { version = "0.5" }
 bech32 = "0.9.0"

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -14,10 +14,6 @@ use crate::{
         IterDirection,
     },
 };
-use chrono::{
-    DateTime,
-    Utc,
-};
 use fuel_core_interfaces::{
     common::{
         fuel_storage::{
@@ -109,22 +105,13 @@ impl Database {
         }
     }
 
-    pub fn block_time(&self, height: u32) -> Result<DateTime<Utc>, Error> {
+    pub fn block_time(&self, height: u32) -> Result<Tai64, Error> {
         let id = self.get_block_id(height.into())?.unwrap_or_default();
         let block = self
             .storage::<FuelBlocks>()
             .get(&id)?
             .ok_or(Error::ChainUninitialized)?;
         Ok(block.header.time().to_owned())
-    }
-
-    pub fn block_time_tai64(&self, height: u32) -> Result<Tai64, Error> {
-        let id = self.get_block_id(height.into())?.unwrap_or_default();
-        let block = self
-            .storage::<FuelBlocks>()
-            .get(&id)?
-            .ok_or(Error::ChainUninitialized)?;
-        Ok(block.header.time_tai64())
     }
 
     pub fn get_block_id(&self, height: BlockHeight) -> Result<Option<Bytes32>, Error> {

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -26,6 +26,7 @@ use fuel_core_interfaces::{
         },
         fuel_tx::Bytes32,
         prelude::StorageAsRef,
+        tai64::Tai64,
     },
     db::Transactions,
     model::FuelBlock,
@@ -115,6 +116,15 @@ impl Database {
             .get(&id)?
             .ok_or(Error::ChainUninitialized)?;
         Ok(block.header.time().to_owned())
+    }
+
+    pub fn block_time_tai64(&self, height: u32) -> Result<Tai64, Error> {
+        let id = self.get_block_id(height.into())?.unwrap_or_default();
+        let block = self
+            .storage::<FuelBlocks>()
+            .get(&id)?
+            .ok_or(Error::ChainUninitialized)?;
+        Ok(block.header.time_tai64())
     }
 
     pub fn get_block_id(&self, height: BlockHeight) -> Result<Option<Bytes32>, Error> {

--- a/fuel-core/src/database/vm_database.rs
+++ b/fuel-core/src/database/vm_database.rs
@@ -54,7 +54,7 @@ impl VmDatabase {
     ) -> Self {
         Self {
             current_block_height: header.height.into(),
-            current_timestamp: header.time_tai64(),
+            current_timestamp: header.time,
             coinbase,
             database,
         }
@@ -120,7 +120,7 @@ impl InterpreterStorage for VmDatabase {
                 return Err(anyhow!("block height too high for timestamp").into())
             }
             height if height == self.current_block_height => self.current_timestamp,
-            height => self.database.block_time_tai64(height)?,
+            height => self.database.block_time(height)?,
         };
         Ok(timestamp.0)
     }

--- a/fuel-core/src/executor.rs
+++ b/fuel-core/src/executor.rs
@@ -1206,10 +1206,6 @@ impl Fee for CreateCheckedMetadata {
 mod tests {
     use super::*;
     use crate::model::FuelBlock;
-    use chrono::{
-        TimeZone,
-        Utc,
-    };
     use fuel_core_interfaces::{
         common::{
             fuel_asm::Opcode,
@@ -1247,6 +1243,7 @@ mod tests {
                 script_with_data_offset,
                 util::test_helpers::TestBuilder as TxBuilder,
             },
+            tai64::Tai64,
         },
         executor::ExecutionTypes,
         model::{
@@ -3175,7 +3172,7 @@ mod tests {
 
         // setup block
         let block_height = rng.gen_range(5u32..1000u32);
-        let time = Utc.timestamp(rng.gen_range(1u32..u32::MAX) as i64, 0);
+        let time = Tai64(rng.gen_range(1u32..u32::MAX) as u64);
 
         let block = PartialFuelBlock {
             header: PartialFuelBlockHeader {
@@ -3227,6 +3224,6 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(time.timestamp_millis() as Word, receipts[0].val().unwrap());
+        assert_eq!(time.0, receipts[0].val().unwrap());
     }
 }

--- a/fuel-core/src/query/message_proof/test.rs
+++ b/fuel-core/src/query/message_proof/test.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use fuel_core_interfaces::{
-    common::fuel_tx::Script,
+    common::{
+        fuel_tx::Script,
+        tai64::Tai64,
+    },
     model::{
         FuelApplicationHeader,
         FuelConsensusHeader,
@@ -113,7 +116,7 @@ async fn can_build_message_proof() {
         .returning(|_| {
             Ok(Some(TransactionStatus::Success {
                 block_id: Default::default(),
-                time: Default::default(),
+                time: Tai64::UNIX_EPOCH,
                 result: None,
             }))
         });
@@ -143,7 +146,7 @@ async fn can_build_message_proof() {
         consensus: FuelConsensusHeader {
             prev_root: Bytes32::zeroed(),
             height: 1u64.into(),
-            time: Default::default(),
+            time: Tai64::UNIX_EPOCH,
             generated: Default::default(),
         },
         metadata: None,

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -31,15 +31,11 @@ use async_graphql::{
     InputObject,
     Object,
 };
-use chrono::{
-    DateTime,
-    NaiveDateTime,
-    Utc,
-};
 use fuel_core_interfaces::{
     common::{
         fuel_storage::StorageAsRef,
         fuel_types,
+        tai64::Tai64,
     },
     db::Transactions,
     executor::{
@@ -144,13 +140,8 @@ impl Header {
     }
 
     /// The block producer time.
-    async fn time(&self) -> DateTime<Utc> {
-        *self.0.time()
-    }
-
-    /// The block producer time in tai64 format
-    async fn time_tai64(&self) -> U64 {
-        U64(self.0.time_tai64().0)
+    async fn time(&self) -> U64 {
+        U64(self.0.time().0)
     }
 
     /// Hash of the application header.
@@ -414,7 +405,7 @@ fn get_time_closure(
     db: &Database,
     time_parameters: Option<TimeParameters>,
     blocks_to_produce: u64,
-) -> anyhow::Result<Box<dyn Fn(u64) -> DateTime<Utc> + Send>> {
+) -> anyhow::Result<Box<dyn Fn(u64) -> Tai64 + Send>> {
     if let Some(params) = time_parameters {
         check_start_after_latest_block(db, params.start_time.0)?;
         check_block_time_overflow(&params, blocks_to_produce)?;
@@ -424,13 +415,11 @@ fn get_time_closure(
                 .start_time
                 .0
                 .overflowing_add(params.block_time_interval.0.overflowing_mul(idx).0);
-            let naive = NaiveDateTime::from_timestamp(timestamp as i64, 0);
-
-            DateTime::from_utc(naive, Utc)
+            Tai64(timestamp)
         }))
     };
 
-    Ok(Box::new(|_| Utc::now()))
+    Ok(Box::new(|_| Tai64::now()))
 }
 
 fn check_start_after_latest_block(db: &Database, start_time: u64) -> anyhow::Result<()> {
@@ -440,7 +429,7 @@ fn check_start_after_latest_block(db: &Database, start_time: u64) -> anyhow::Res
         return Ok(())
     }
 
-    let latest_time = db.block_time(current_height.into())?.timestamp();
+    let latest_time = db.block_time(current_height.into())?.0;
     if latest_time as u64 > start_time {
         return Err(anyhow!(
             "The start time must be set after the latest block time: {}",

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -1,3 +1,7 @@
+use super::scalars::{
+    Bytes32,
+    Tai64Timestamp,
+};
 use crate::{
     database::{
         storage::FuelBlocks,
@@ -55,8 +59,6 @@ use std::{
     borrow::Cow,
     convert::TryInto,
 };
-
-use super::scalars::Bytes32;
 
 pub struct Block {
     pub(crate) header: Header,
@@ -140,8 +142,8 @@ impl Header {
     }
 
     /// The block producer time.
-    async fn time(&self) -> U64 {
-        U64(self.0.time().0)
+    async fn time(&self) -> Tai64Timestamp {
+        Tai64Timestamp(self.0.time())
     }
 
     /// Hash of the application header.

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -148,6 +148,11 @@ impl Header {
         *self.0.time()
     }
 
+    /// The block producer time in tai64 format
+    async fn time_tai64(&self) -> U64 {
+        U64(self.0.time_tai64().0)
+    }
+
     /// Hash of the application header.
     async fn application_hash(&self) -> Bytes32 {
         (*self.0.application_hash()).into()

--- a/fuel-core/src/schema/scalars.rs
+++ b/fuel-core/src/schema/scalars.rs
@@ -10,7 +10,10 @@ use async_graphql::{
     ScalarType,
     Value,
 };
-use fuel_core_interfaces::common::fuel_types;
+use fuel_core_interfaces::common::{
+    fuel_types,
+    tai64::Tai64,
+};
 use std::{
     convert::TryInto,
     fmt::{
@@ -55,6 +58,26 @@ impl From<BlockHeight> for U64 {
 impl From<U64> for usize {
     fn from(u: U64) -> Self {
         u.0 as usize
+    }
+}
+
+/// Need our own u64 type since GraphQL integers are restricted to i32.
+#[derive(Copy, Clone, Debug, derive_more::Into, derive_more::From)]
+pub struct Tai64Timestamp(pub Tai64);
+
+#[Scalar(name = "Tai64Timestamp")]
+impl ScalarType for Tai64Timestamp {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        if let Value::String(value) = &value {
+            let num: u64 = value.parse().map_err(InputValueError::custom)?;
+            Ok(Tai64Timestamp(Tai64(num)))
+        } else {
+            Err(InputValueError::expected_type(value))
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.0 .0.to_string())
     }
 }
 

--- a/fuel-core/src/schema/tx/types.rs
+++ b/fuel-core/src/schema/tx/types.rs
@@ -32,10 +32,6 @@ use async_graphql::{
     Object,
     Union,
 };
-use chrono::{
-    DateTime,
-    Utc,
-};
 use fuel_core_interfaces::{
     common::{
         fuel_storage::StorageAsRef,
@@ -61,6 +57,7 @@ use fuel_core_interfaces::{
         },
         fuel_types::bytes::SerializableVec,
         fuel_vm::prelude::ProgramState as VmProgramState,
+        tai64::Tai64,
     },
     db::KvStoreError,
     txpool::TxPoolMpsc,
@@ -122,18 +119,18 @@ pub enum TransactionStatus {
     Failed(FailureStatus),
 }
 
-pub struct SubmittedStatus(DateTime<Utc>);
+pub struct SubmittedStatus(Tai64);
 
 #[Object]
 impl SubmittedStatus {
-    async fn time(&self) -> DateTime<Utc> {
-        self.0
+    async fn time(&self) -> U64 {
+        U64(self.0 .0)
     }
 }
 
 pub struct SuccessStatus {
     block_id: fuel_core_interfaces::model::BlockId,
-    time: DateTime<Utc>,
+    time: Tai64,
     result: Option<VmProgramState>,
 }
 
@@ -150,8 +147,8 @@ impl SuccessStatus {
         Ok(block)
     }
 
-    async fn time(&self) -> DateTime<Utc> {
-        self.time
+    async fn time(&self) -> U64 {
+        U64(self.time.0)
     }
 
     async fn program_state(&self) -> Option<ProgramState> {
@@ -161,7 +158,7 @@ impl SuccessStatus {
 
 pub struct FailureStatus {
     block_id: fuel_core_interfaces::model::BlockId,
-    time: DateTime<Utc>,
+    time: Tai64,
     reason: String,
     state: Option<VmProgramState>,
 }
@@ -179,8 +176,8 @@ impl FailureStatus {
         Ok(block)
     }
 
-    async fn time(&self) -> DateTime<Utc> {
-        self.time
+    async fn time(&self) -> U64 {
+        U64(self.time.0)
     }
 
     async fn reason(&self) -> String {

--- a/fuel-core/src/schema/tx/types.rs
+++ b/fuel-core/src/schema/tx/types.rs
@@ -19,6 +19,7 @@ use crate::{
             Bytes32,
             HexString,
             Salt,
+            Tai64Timestamp,
             TransactionId,
             TxPointer,
             U64,
@@ -123,8 +124,8 @@ pub struct SubmittedStatus(Tai64);
 
 #[Object]
 impl SubmittedStatus {
-    async fn time(&self) -> U64 {
-        U64(self.0 .0)
+    async fn time(&self) -> Tai64Timestamp {
+        Tai64Timestamp(self.0)
     }
 }
 
@@ -147,8 +148,8 @@ impl SuccessStatus {
         Ok(block)
     }
 
-    async fn time(&self) -> U64 {
-        U64(self.time.0)
+    async fn time(&self) -> Tai64Timestamp {
+        Tai64Timestamp(self.time)
     }
 
     async fn program_state(&self) -> Option<ProgramState> {
@@ -176,8 +177,8 @@ impl FailureStatus {
         Ok(block)
     }
 
-    async fn time(&self) -> U64 {
-        U64(self.time.0)
+    async fn time(&self) -> Tai64Timestamp {
+        Tai64Timestamp(self.time)
     }
 
     async fn reason(&self) -> String {

--- a/fuel-core/src/tx_pool.rs
+++ b/fuel-core/src/tx_pool.rs
@@ -1,9 +1,8 @@
-use chrono::{
-    DateTime,
-    Utc,
-};
 use fuel_core_interfaces::{
-    common::fuel_vm::prelude::ProgramState,
+    common::{
+        fuel_vm::prelude::ProgramState,
+        tai64::Tai64,
+    },
     model::BlockId,
 };
 use serde::{
@@ -14,16 +13,16 @@ use serde::{
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TransactionStatus {
     Submitted {
-        time: DateTime<Utc>,
+        time: Tai64,
     },
     Success {
         block_id: BlockId,
-        time: DateTime<Utc>,
+        time: Tai64,
         result: Option<ProgramState>,
     },
     Failed {
         block_id: BlockId,
-        time: DateTime<Utc>,
+        time: Tai64,
         reason: String,
         result: Option<ProgramState>,
     },

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -13,7 +13,6 @@ description = "Fuel Relayer"
 anyhow = "1.0"
 async-trait = "0.1"
 bytes = "1.1"
-chrono = "0.4"
 env_logger = "0.9"
 ethers-contract = { version = "0.17", default-features = false, features = [
     "abigen",

--- a/fuel-tests/Cargo.toml
+++ b/fuel-tests/Cargo.toml
@@ -18,7 +18,6 @@ harness = true
 
 [dependencies]
 async-std = "1.12"
-chrono = { version = "0.4", features = ["serde"] }
 ethers = "0.17"
 fuel-core = { path = "../fuel-core", default-features = false }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", features = ["test-helpers"] }

--- a/fuel-tests/tests/blocks.rs
+++ b/fuel-tests/tests/blocks.rs
@@ -1,7 +1,3 @@
-use chrono::{
-    TimeZone,
-    Utc,
-};
 use fuel_core::{
     database::{
         storage::FuelBlocks,
@@ -22,6 +18,7 @@ use fuel_core_interfaces::{
         fuel_storage::StorageAsMut,
         fuel_tx,
         fuel_tx::UniqueIdentifier,
+        tai64::Tai64,
     },
     model::FuelConsensusHeader,
 };
@@ -178,11 +175,11 @@ async fn produce_block_custom_time() {
 
     assert_eq!(5, new_height);
 
-    assert_eq!(db.block_time(1).unwrap().timestamp(), 100);
-    assert_eq!(db.block_time(2).unwrap().timestamp(), 110);
-    assert_eq!(db.block_time(3).unwrap().timestamp(), 120);
-    assert_eq!(db.block_time(4).unwrap().timestamp(), 130);
-    assert_eq!(db.block_time(5).unwrap().timestamp(), 140);
+    assert_eq!(db.block_time(1).unwrap().0, 100);
+    assert_eq!(db.block_time(2).unwrap().0, 110);
+    assert_eq!(db.block_time(3).unwrap().0, 120);
+    assert_eq!(db.block_time(4).unwrap().0, 130);
+    assert_eq!(db.block_time(5).unwrap().0, 140);
 }
 
 #[tokio::test]
@@ -259,7 +256,7 @@ async fn block_connection_5(
             header: FuelBlockHeader {
                 consensus: FuelConsensusHeader {
                     height: i.into(),
-                    time: Utc.timestamp(i.into(), 0),
+                    time: Tai64(i.into()),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/fuel-tests/tests/messages.rs
+++ b/fuel-tests/tests/messages.rs
@@ -452,7 +452,7 @@ async fn can_get_message_proof() {
             hasher.input(Bytes32::from(result.header.prev_root).as_ref());
             hasher
                 .input(&u32::try_from(result.header.height.0).unwrap().to_be_bytes()[..]);
-            hasher.input(result.header.time.timestamp_millis().to_be_bytes());
+            hasher.input(result.header.time.0.to_be_bytes());
             hasher.input(Bytes32::from(result.header.application_hash).as_ref());
             let block_id = hasher.digest();
             assert_eq!(block_id, Bytes32::from(result.header.id));

--- a/fuel-tests/tests/messages.rs
+++ b/fuel-tests/tests/messages.rs
@@ -452,7 +452,7 @@ async fn can_get_message_proof() {
             hasher.input(Bytes32::from(result.header.prev_root).as_ref());
             hasher
                 .input(&u32::try_from(result.header.height.0).unwrap().to_be_bytes()[..]);
-            hasher.input(result.header.time.0.to_be_bytes());
+            hasher.input(result.header.time.0 .0.to_be_bytes());
             hasher.input(Bytes32::from(result.header.application_hash).as_ref());
             let block_id = hasher.digest();
             assert_eq!(block_id, Bytes32::from(result.header.id));

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -1,5 +1,4 @@
 use crate::helpers::TestContext;
-use chrono::Utc;
 use fuel_core::{
     database::Database,
     executor::Executor,
@@ -15,6 +14,7 @@ use fuel_core_interfaces::{
             consts::*,
             prelude::*,
         },
+        tai64::Tai64,
     },
     executor::{
         ExecutionBlock,
@@ -403,7 +403,7 @@ async fn get_transactions_from_manual_blocks() {
         header: PartialFuelBlockHeader {
             consensus: FuelConsensusHeader {
                 height: 1u32.into(),
-                time: Utc::now(),
+                time: Tai64::now(),
                 ..Default::default()
             },
             ..Default::default()
@@ -418,7 +418,7 @@ async fn get_transactions_from_manual_blocks() {
         header: PartialFuelBlockHeader {
             consensus: FuelConsensusHeader {
                 height: 2u32.into(),
-                time: Utc::now(),
+                time: Tai64::now(),
                 ..Default::default()
             },
             ..Default::default()

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -13,7 +13,6 @@ description = "Transaction pool"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-chrono = "0.4"
 fuel-chain-config = { path = "../fuel-chain-config", version = "0.13.2" }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.13.2" }
 futures = "0.3"


### PR DESCRIPTION
We were incorrectly using unix time in blocks when we should be using tai64. This was causing issues for the solidity proofs when trying to verify the block hash and signature.

This is a breaking change that will require a new breaking release of fuel-core (0.14). However, this upgrade should be much easier than 0.13 and will be backward compatible with forc 0.30.