### PR TITLE
Use spawn_blocking for dry-run requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "mockall",
+ "num_cpus",
  "rand 0.8.5",
  "rocksdb",
  "serde",

--- a/fuel-block-producer/src/mocks.rs
+++ b/fuel-block-producer/src/mocks.rs
@@ -1,7 +1,6 @@
 use super::db::BlockProducerDatabase;
 use crate::ports::TxPool;
 use anyhow::Result;
-use async_trait::async_trait;
 use fuel_core_interfaces::{
     block_producer::Relayer,
     common::{
@@ -70,12 +69,8 @@ impl TxPool for MockTxPool {
 #[derive(Default)]
 pub struct MockExecutor(pub MockDb);
 
-#[async_trait]
 impl Executor for MockExecutor {
-    async fn execute(
-        &self,
-        block: ExecutionBlock,
-    ) -> Result<ExecutionResult, ExecutorError> {
+    fn execute(&self, block: ExecutionBlock) -> Result<ExecutionResult, ExecutorError> {
         let block = match block {
             ExecutionBlock::Production(block) => block.generate(&[]),
             ExecutionBlock::Validation(block) => block,
@@ -89,7 +84,7 @@ impl Executor for MockExecutor {
         })
     }
 
-    async fn dry_run(
+    fn dry_run(
         &self,
         _block: ExecutionBlock,
         _utxo_validation: Option<bool>,
@@ -100,12 +95,8 @@ impl Executor for MockExecutor {
 
 pub struct FailingMockExecutor(pub Mutex<Option<ExecutorError>>);
 
-#[async_trait]
 impl Executor for FailingMockExecutor {
-    async fn execute(
-        &self,
-        block: ExecutionBlock,
-    ) -> Result<ExecutionResult, ExecutorError> {
+    fn execute(&self, block: ExecutionBlock) -> Result<ExecutionResult, ExecutorError> {
         // simulate an execution failure
         let mut err = self.0.lock().unwrap();
         if let Some(err) = err.take() {
@@ -122,7 +113,7 @@ impl Executor for FailingMockExecutor {
         }
     }
 
-    async fn dry_run(
+    fn dry_run(
         &self,
         _block: ExecutionBlock,
         _utxo_validation: Option<bool>,

--- a/fuel-block-producer/tests/integration.rs
+++ b/fuel-block-producer/tests/integration.rs
@@ -56,6 +56,7 @@ use std::sync::Arc;
 use tokio::sync::{
     broadcast,
     mpsc,
+    Semaphore,
 };
 
 const COIN_AMOUNT: u64 = 1_000_000_000;
@@ -157,9 +158,10 @@ async fn block_producer() -> Result<()> {
         txpool: Box::new(TxPoolAdapter {
             sender: txpool.sender().clone(),
         }),
-        executor: Box::new(MockExecutor(mock_db.clone())),
+        executor: Arc::new(MockExecutor(mock_db.clone())),
         relayer: Box::new(MockRelayer::default()),
         lock: Default::default(),
+        dry_run_semaphore: Semaphore::new(1),
     };
 
     // Add new transactions

--- a/fuel-core-interfaces/src/executor.rs
+++ b/fuel-core-interfaces/src/executor.rs
@@ -20,7 +20,6 @@ use crate::{
         PartialFuelBlock,
     },
 };
-use async_trait::async_trait;
 use fuel_vm::fuel_tx::Transaction;
 use std::error::Error as StdError;
 use thiserror::Error;
@@ -62,11 +61,10 @@ pub enum ExecutionKind {
     Validation,
 }
 
-#[async_trait]
 pub trait Executor: Sync + Send {
-    async fn execute(&self, block: ExecutionBlock) -> Result<ExecutionResult, Error>;
+    fn execute(&self, block: ExecutionBlock) -> Result<ExecutionResult, Error>;
 
-    async fn dry_run(
+    fn dry_run(
         &self,
         block: ExecutionBlock,
         utxo_validation: Option<bool>,

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -48,6 +48,7 @@ futures = "0.3"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"
 lazy_static = "1.4"
+num_cpus = "1.13"
 rand = "0.8"
 rocksdb = { version = "0.19", default-features = false, features = [
     "lz4",

--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -368,7 +368,7 @@ impl BlockMutation {
 
         let executor = Executor {
             database: db.clone(),
-            config: cfg.clone(),
+            config: cfg,
         };
 
         let block_time = get_time_closure(db, time, blocks_to_produce.0)?;
@@ -394,7 +394,7 @@ impl BlockMutation {
                 vec![],
             );
 
-            executor.execute(ExecutionBlock::Production(block)).await?;
+            executor.execute(ExecutionBlock::Production(block))?;
         }
 
         db.get_block_height()?

--- a/fuel-tests/tests/tx.rs
+++ b/fuel-tests/tests/tx.rs
@@ -430,11 +430,9 @@ async fn get_transactions_from_manual_blocks() {
     // process blocks and save block height
     executor
         .execute(ExecutionBlock::Production(first_test_block))
-        .await
         .unwrap();
     executor
         .execute(ExecutionBlock::Production(second_test_block))
-        .await
         .unwrap();
 
     // Query for first 4: [coinbase_tx1, 0, 1, 2]


### PR DESCRIPTION
fixes: #752

### Moves dry_run to a tokio::spawn_blocking call

Since the executor is mostly blocking code, issuing too many dry-run requests could impact more critical functions of the node (such as block production) if executed directly on the main worker pool.

### Limits the number of concurrent dry_run requests by the CPU count
This is because in the worst case we will be CPU bound. While some txs may be state-access heavy and I/O bound, other txs could be CPU bound by using lots of crypto ops like hashing and ecrecover. To ensure we don't grind the system to a halt with hundreds of CPU intensive blocking threads, semaphore permits are used to rate limit the number of dry_run requests.

### Removes async from the executor
Previously the executor methods were marked as async, even though there were no async calls. This posed a risk when calling the executor within spawn_blocking, as spawn_blocking is a sync context and must use `block_on` to call any futures. Using `block_on` is risky because it can easily lead to deadlocks when using async code. While block_on  likely would've been safe to use in this one case, it could be the source of difficult-to-debug issues if more asynchronous code is added to the executor in the future.
