### PR TITLE
fix bug where txs wouldn't get squeezed if coin state already existed

### DIFF
--- a/fuel-txpool/src/containers/dependency.rs
+++ b/fuel-txpool/src/containers/dependency.rs
@@ -399,7 +399,7 @@ impl Dependency {
                         *utxo_id,
                         CoinState {
                             is_spend_by: Some(tx.id() as TxId),
-                            depth: 0,
+                            depth: max_depth - 1,
                         },
                     );
                     // yey we got our coin

--- a/fuel-txpool/src/containers/dependency.rs
+++ b/fuel-txpool/src/containers/dependency.rs
@@ -392,17 +392,16 @@ impl Dependency {
 
                             Self::check_if_coin_input_can_spend_db_coin(&coin, input)?;
                         }
-
                         max_depth = core::cmp::max(1, max_depth);
-                        db_coins.insert(
-                            *utxo_id,
-                            CoinState {
-                                is_spend_by: Some(tx.id() as TxId),
-                                depth: 0,
-                            },
-                        );
                     }
-
+                    // mark this coin as spent by the current tx
+                    db_coins.insert(
+                        *utxo_id,
+                        CoinState {
+                            is_spend_by: Some(tx.id() as TxId),
+                            depth: 0,
+                        },
+                    );
                     // yey we got our coin
                 }
                 Input::MessagePredicate { message_id, .. }


### PR DESCRIPTION
Found a bug where submitting more than two txs that conflict on the same input would stop squeezing the lower priced txs after the first squeeze.

This would ultimately lead to the tx with the lower price getting skipped by the executor, making this only a minor annoyance. However it causes wasted computation during block production.