### PR TITLE
Use ascending order for blocks

### DIFF
--- a/fuel-core/src/schema/block.rs
+++ b/fuel-core/src/schema/block.rs
@@ -347,10 +347,7 @@ where
             true
         })
         .take(records_to_fetch);
-    let mut blocks: Vec<(BlockHeight, fuel_types::Bytes32)> = blocks.try_collect()?;
-    if direction == IterDirection::Forward {
-        blocks.reverse();
-    }
+    let blocks: Vec<(BlockHeight, fuel_types::Bytes32)> = blocks.try_collect()?;
 
     // TODO: do a batch get instead
     let blocks: Vec<Cow<FuelBlockDb>> = blocks

--- a/fuel-tests/tests/blocks.rs
+++ b/fuel-tests/tests/blocks.rs
@@ -314,7 +314,10 @@ async fn block_connection_5(
 
     assert!(!blocks.results.is_empty());
     assert!(blocks.cursor.is_some());
-    // assert "first" 5 blocks are returned in descending order (latest first)
+
+    // Blocks are typically requested in descending order (latest
+    // first), but we're returning them in ascending order to keep
+    // this query in line with the GraphQL API specs and other queries.
     match pagination_direction {
         PageDirection::Forward => {
             assert_eq!(
@@ -323,7 +326,7 @@ async fn block_connection_5(
                     .into_iter()
                     .map(|b| b.header.height.0)
                     .collect_vec(),
-                rev(0..5).collect_vec()
+                (0..5).collect_vec()
             );
         }
         PageDirection::Backward => {


### PR DESCRIPTION
Closes #795.

## Changelog
- Use ascending order for `blocks()` query

## Testing Plan
Adjusted `PageDirection::Forward` assertion to match against the first five elements of the iterator. Tests should pass.