### PR TITLE
fix: Use HttpsConnector for fuel-client's GraphQL subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "fuel-vm",
  "futures",
  "hex",
+ "hyper-rustls 0.22.1",
  "insta",
  "itertools",
  "reqwest",
@@ -3169,6 +3170,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -3883,7 +3885,7 @@ dependencies = [
  "rw-stream-sink",
  "soketto",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.5",
 ]
 
 [[package]]
@@ -5247,7 +5249,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.22.5",
  "winreg",
 ]
 
@@ -6353,7 +6355,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tungstenite",
  "webpki 0.22.0",
- "webpki-roots",
+ "webpki-roots 0.22.5",
 ]
 
 [[package]]
@@ -6963,6 +6965,15 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki 0.21.4",
 ]
 
 [[package]]

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -24,6 +24,8 @@ eventsource-client = "0.10.2"
 fuel-vm = { version = "0.22", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
+# Included to enable webpki in the eventsource client
+hyper-rustls = { version = "0.22", features = ["webpki-tokio"] }
 itertools = "0.10"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -9,6 +9,7 @@ use cynic::{
     QueryBuilder,
     StreamingOperation,
 };
+use eventsource_client::HttpsConnector;
 use fuel_vm::prelude::*;
 use futures::StreamExt;
 use itertools::Itertools;
@@ -192,7 +193,7 @@ impl FuelClient {
                     format!("Failed to add header to client {:?}", e),
                 )
             })?
-            .build_http();
+            .build_with_conn(HttpsConnector::with_native_roots());
 
         let mut last = None;
 

--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -193,7 +193,7 @@ impl FuelClient {
                     format!("Failed to add header to client {:?}", e),
                 )
             })?
-            .build_with_conn(HttpsConnector::with_native_roots());
+            .build_with_conn(HttpsConnector::with_webpki_roots());
 
         let mut last = None;
 


### PR DESCRIPTION
Related issues:
- Closes https://github.com/FuelLabs/fuel-core/issues/793

Currently, `fuel-client` makes calls to the GraphQL subscription endpoint using an `eventsource` client (built on Hyper) with an HTTP-only connector. This connector forbids HTTPs connections and throws an `INVALID_NOT_HTTP` error when it encounters one. When deploying a contract to a node deployed to an HTTPs URL, the connector throws this error. 

I was able to reproduce this error by doing the following:
- Registering the domain brandonvrooman.com 
- Getting an SSL cert for a subdomain (node.brandonvrooman.com) from LetsEncrypt and adding it to my local keychain
- Adding the url (node.brandonvrooman.com) to my `/etc/hosts` and pointing it to localhost
- Configuring NGINX to point this url (node.brandonvrooman.com) to my local node running on localhost:4000 using SSL
- Deploying a contract to https://node.brandonvrooman.com

With this fix, I was able to test that I can deploy to http and https at the respective urls:
- http://localhost:4000
- https://node.brandonvrooman.com 
