### PR TITLE
Close Tx Status SSE stream before EOF is encountered

### DIFF
--- a/fuel-client/src/client.rs
+++ b/fuel-client/src/client.rs
@@ -48,6 +48,7 @@ use schema::{
 };
 use std::{
     convert::TryInto,
+    future,
     io::{
         self,
         ErrorKind,
@@ -470,13 +471,25 @@ impl FuelClient {
         &self,
         id: &str,
     ) -> io::Result<TransactionStatus> {
-        let mut outcomes: Vec<_> = futures::TryStreamExt::try_collect(
-            self.subscribe_transaction_status(id).await?,
-        )
-        .await?;
-        outcomes.pop().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "Failed to get status for transaction")
-        })
+        // skip until we've reached a final status and then stop consuming the stream
+        // to avoid an EOF which the eventsource client considers as an error.
+        let status_result = self
+            .subscribe_transaction_status(id)
+            .await?
+            .skip_while(|status| {
+                future::ready(matches!(status, Ok(TransactionStatus::Submitted { .. })))
+            })
+            .next()
+            .await;
+
+        if let Some(Ok(status)) = status_result {
+            Ok(status)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Failed to get status for transaction",
+            ))
+        }
     }
 
     /// returns a paginated set of transactions sorted by block height


### PR DESCRIPTION
# Problem

SSE doesn't provide a built-in way to gracefully terminate a stream from the server side. Our existing behavior was to return a `None` value when the stream has closed. While this does end up closing the SSE stream, the eventsource client reads this `None` value as an [EOF](https://github.com/launchdarkly/rust-eventsource-client/blob/97794ff4a668b8decfb728d3bcb3e2d98449c2aa/eventsource-client/src/client.rs#L534) which is considered retryable error.

This meant that anyone using the new SSE API was seeing error logs from eventsource like `Waiting 1s before retrying` whenever the stream was about to close.

For example, this has been showing up in the faucet API logs:
![image](https://user-images.githubusercontent.com/794823/206622332-16d852f3-d512-4d37-ac76-4d0977514b97.png)

These log messages also appeared in forc-deploy.

# Solution

The fix is to stop consuming the stream on the client side once a non-null terminal value has been reached (e.g. SqueezedOut or Success), to avoid triggering an EOF.

I also verified in local testing that the stream is immediately closed on the server side once the fuel client stops polling the stream, by attaching a drop logger to the server side stream state (this change is not committed though):

![image](https://user-images.githubusercontent.com/794823/206623243-967101d2-522d-49ee-a652-3598b43d5391.png)

# Future Work

We may want to find a way to generically end all types of SSE subscriptions without an EOF issue by using a generic event wrapper that indicates when it is the last event in the stream. Then client side subscriptions can check the generic event `is_last` flag to close their connection without special logic based on each endpoint.