### PR TITLE
Bugfix: Support script txs with empty script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d4cbdd4d7d937e7a0abe8be9508c8480b4ef2ba2534ba169ff56e3ecdaf93b"
+checksum = "1521a9ecf42e1d133b29e3785ca6f46bf74ae9bf2509fc3daed49b731f530560"
 dependencies = [
  "anyhow",
  "fuel-asm",


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/794.

Bump `fuel-vm` to `0.22.6` to fix the bug with an empty `Script` transaction by https://github.com/FuelLabs/fuel-vm/pull/284