### PR TITLE
prep fuel-core 0.15 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "data-encoding-macro"
@@ -1573,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-executor"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-importer"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-producer"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-chain-config"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-interfaces"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gql-client"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-metrics"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "axum",
  "lazy_static",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-p2p"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-poa-coordinator"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-relayer"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,7 +2581,7 @@ checksum = "b0f895423d18472d60eb078cf949608ff3fe6e42e91d41b85993b11528d2c4c3"
 
 [[package]]
 name = "fuel-sync"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-txpool"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2755,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "futures-locks"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb42d4fb72227be5778429f9ef5240a38a358925a49f05b5cf702ce7c7e558a"
+checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
 dependencies = [
  "futures-channel",
  "futures-task",
@@ -3175,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper",
@@ -3320,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261bf85ed492cd1c47c9ba675e48649682a9d2d2e77f515c5386d7726fb0ba76"
+checksum = "197f4e300af8b23664d4077bf5c40e0afa9ba66a567bb5a51d3def3c7b287d1c"
 dependencies = [
  "console",
  "lazy_static",
@@ -3382,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "ec947b7a4ce12e3b87e353abae7ce124d025b6c7d6c5aea5cc0bcf92e9510ded"
 
 [[package]]
 name = "itertools"
@@ -3464,9 +3464,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libloading"
@@ -4302,9 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4632,9 +4632,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -4798,9 +4798,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6bd09a7f7e68f3f0bf710fb7ab9c4615a488b58b5f653382a687701e458c92"
+checksum = "f54fc5dc63ed3bbf19494623db4f3af16842c0d975818e469022d09e53f0aa05"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -4928,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
+checksum = "276470f7f281b0ed53d2ae42dd52b4a8d08853a3c70e7fe95882acbb98a6ae94"
 dependencies = [
  "bytes",
  "heck",
@@ -5003,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57098b1a3d2159d13dc3a98c0e3a5f8ab91ac3dd2471e52b1d712ea0c1085555"
+checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -5229,7 +5229,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.23.1",
+ "hyper-rustls 0.23.2",
  "ipnet",
  "js-sys",
  "log",
@@ -5513,9 +5513,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8a765117b237ef233705cc2cc4c6a27fccd46eea6ef0c8c6dae5f3ef407f8"
+checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -5525,9 +5525,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcd47b380d8c4541044e341dcd9475f55ba37ddc50c908d945fc036a8642496"
+checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5637,9 +5637,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
  "rand 0.8.5",
  "secp256k1-sys",
@@ -5703,9 +5703,9 @@ checksum = "930c0acf610d3fdb5e2ab6213019aaa04e227ebe9547b0649ba599b16d788bd7"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
@@ -5722,9 +5722,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6036,9 +6036,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6269,9 +6269,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
@@ -6284,7 +6284,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -6299,9 +6299,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6400,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
  "bitflags",
  "bytes",
@@ -6646,9 +6646,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -7543,9 +7543,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-core
 description: Fuel Core Helm Chart
 type: application
-appVersion: "0.14.1"
+appVersion: "0.15.0"
 version: 0.1.0

--- a/fuel-block-executor/Cargo.toml
+++ b/fuel-block-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-executor"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,5 +11,5 @@ description = "Fuel Block Executor"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0" }
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-block-importer/Cargo.toml
+++ b/fuel-block-importer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-importer"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Block Importer"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0" }
 parking_lot = "0.12"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-block-producer/Cargo.toml
+++ b/fuel-block-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-block-producer"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,7 +12,7 @@ description = "Fuel Block Producer"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0" }
 parking_lot = "0.12"
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-chain-config/Cargo.toml
+++ b/fuel-chain-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-chain-config"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -12,10 +12,10 @@ description = "Fuel Chain config types"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1", features = [
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0", features = [
     "serde",
 ] }
-fuel-poa-coordinator = { path = "../fuel-poa-coordinator", version = "0.14.1" }
+fuel-poa-coordinator = { path = "../fuel-poa-coordinator", version = "0.15.0" }
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"
 rand = "0.8"

--- a/fuel-client/Cargo.toml
+++ b/fuel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-gql-client"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"

--- a/fuel-core-bft/Cargo.toml
+++ b/fuel-core-bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-bft"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Core BFT"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0" }
 parking_lot = "0.12"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-core-interfaces/Cargo.toml
+++ b/fuel-core-interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-interfaces"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/fuel-core/Cargo.toml
+++ b/fuel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -29,20 +29,20 @@ clap = { version = "3.2", features = ["env", "derive"] }
 derive_more = { version = "0.99" }
 dirs = "4.0"
 enum-iterator = "1.2"
-fuel-block-executor = { path = "../fuel-block-executor", version = "0.14.1" }
-fuel-block-importer = { path = "../fuel-block-importer", version = "0.14.1" }
-fuel-block-producer = { path = "../fuel-block-producer", version = "0.14.1" }
-fuel-chain-config = { path = "../fuel-chain-config", version = "0.14.1" }
-fuel-core-bft = { path = "../fuel-core-bft", version = "0.14.1" }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1", features = [
+fuel-block-executor = { path = "../fuel-block-executor", version = "0.15.0" }
+fuel-block-importer = { path = "../fuel-block-importer", version = "0.15.0" }
+fuel-block-producer = { path = "../fuel-block-producer", version = "0.15.0" }
+fuel-chain-config = { path = "../fuel-chain-config", version = "0.15.0" }
+fuel-core-bft = { path = "../fuel-core-bft", version = "0.15.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0", features = [
     "serde",
 ] }
-fuel-metrics = { path = "../fuel-metrics", version = "0.14.1", optional = true }
-fuel-p2p = { path = "../fuel-p2p", version = "0.14.1", optional = true }
-fuel-poa-coordinator = { path = "../fuel-poa-coordinator", version = "0.14.1" }
-fuel-relayer = { path = "../fuel-relayer", version = "0.14.1", optional = true }
-fuel-sync = { path = "../fuel-sync", version = "0.14.1" }
-fuel-txpool = { path = "../fuel-txpool", version = "0.14.1" }
+fuel-metrics = { path = "../fuel-metrics", version = "0.15.0", optional = true }
+fuel-p2p = { path = "../fuel-p2p", version = "0.15.0", optional = true }
+fuel-poa-coordinator = { path = "../fuel-poa-coordinator", version = "0.15.0" }
+fuel-relayer = { path = "../fuel-relayer", version = "0.15.0", optional = true }
+fuel-sync = { path = "../fuel-sync", version = "0.15.0" }
+fuel-txpool = { path = "../fuel-txpool", version = "0.15.0" }
 futures = "0.3"
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"

--- a/fuel-metrics/Cargo.toml
+++ b/fuel-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-metrics"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-p2p"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 edition = "2021"
@@ -16,8 +16,8 @@ async-trait = "0.1"
 bincode = "1.3"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", features = [
     "serde",
-], version = "0.14.1" }
-fuel-metrics = { path = "../fuel-metrics", version = "0.14.1" } # TODO make this a feature
+], version = "0.15.0" }
+fuel-metrics = { path = "../fuel-metrics", version = "0.15.0" } # TODO make this a feature
 futures = "0.3"
 futures-timer = "3.0"
 ip_network = "0.4"
@@ -65,7 +65,7 @@ ctor = "0.1"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", features = [
     "serde",
     "test-helpers",
-], version = "0.14.1" }
+], version = "0.15.0" }
 rand = "0.8"
 tokio = { version = "1.21", features = ["full"] }
 tracing-appender = "0.2"

--- a/fuel-poa-coordinator/Cargo.toml
+++ b/fuel-poa-coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-poa-coordinator"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -12,7 +12,7 @@ description = "Fuel Core PoA Coordinator"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0" }
 humantime-serde = "1.1.1"
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }

--- a/fuel-relayer/Cargo.toml
+++ b/fuel-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-relayer"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -21,7 +21,7 @@ ethers-providers = { version = "1.0.2", default-features = false, features = [
     "ws",
     "rustls",
 ] }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.14.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", package = "fuel-core-interfaces", version = "0.15.0" }
 futures = "0.3"
 hex = "0.4"
 once_cell = "1.4"

--- a/fuel-sync/Cargo.toml
+++ b/fuel-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-sync"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,6 +11,6 @@ description = "Fuel Synchronizer"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0" }
 parking_lot = "0.12"
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-txpool/Cargo.toml
+++ b/fuel-txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-txpool"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -13,9 +13,9 @@ description = "Transaction pool"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-chain-config = { path = "../fuel-chain-config", version = "0.14.1" }
-fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1" }
-fuel-metrics = { path = "../fuel-metrics", version = "0.14.1"}
+fuel-chain-config = { path = "../fuel-chain-config", version = "0.15.0" }
+fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.15.0" }
+fuel-metrics = { path = "../fuel-metrics", version = "0.15.0"}
 parking_lot = "0.12"
 thiserror = "1.0"
 tokio = { version = "1.21", default-features = false, features = ["sync"] }

--- a/version-compatibility/Cargo.lock
+++ b/version-compatibility/Cargo.lock
@@ -1480,6 +1480,8 @@ dependencies = [
 [[package]]
 name = "fuel-block-executor"
 version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c33fdcbe2dae0de5f0d948de5fbd5e7fbcc82d29141dd75674a66dba93ee15"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces 0.14.1",
@@ -1488,22 +1490,10 @@ dependencies = [
 
 [[package]]
 name = "fuel-block-executor"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c33fdcbe2dae0de5f0d948de5fbd5e7fbcc82d29141dd75674a66dba93ee15"
+version = "0.15.0"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio",
-]
-
-[[package]]
-name = "fuel-block-importer"
-version = "0.14.1"
-dependencies = [
- "anyhow",
- "fuel-core-interfaces 0.14.1",
- "parking_lot 0.12.1",
+ "fuel-core-interfaces 0.15.0",
  "tokio",
 ]
 
@@ -1514,22 +1504,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b2338b8568545ad3abe2e46243072b0d4580e8aded2cc3d4e3f9d915aebbe0"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuel-core-interfaces 0.14.1",
  "parking_lot 0.12.1",
  "tokio",
 ]
 
 [[package]]
-name = "fuel-block-producer"
-version = "0.14.1"
+name = "fuel-block-importer"
+version = "0.15.0"
 dependencies = [
  "anyhow",
- "async-trait",
- "fuel-core-interfaces 0.14.1",
+ "fuel-core-interfaces 0.15.0",
  "parking_lot 0.12.1",
- "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1540,25 +1527,22 @@ checksum = "d5fa36e7d0ff0d8417462e13cfc4200490b42358b2356d3abbfea50f7591da1e"
 dependencies = [
  "anyhow",
  "async-trait",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuel-core-interfaces 0.14.1",
  "parking_lot 0.12.1",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "fuel-chain-config"
-version = "0.14.1"
+name = "fuel-block-producer"
+version = "0.15.0"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces 0.14.1",
- "fuel-poa-coordinator 0.14.1",
- "hex",
- "itertools",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "serde_with",
+ "async-trait",
+ "fuel-core-interfaces 0.15.0",
+ "parking_lot 0.12.1",
+ "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -1569,8 +1553,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56056dc76e152c92f82d35a5ed2354f6d0f1a306daf5ec26d970a72879edbce"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-poa-coordinator 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuel-core-interfaces 0.14.1",
+ "fuel-poa-coordinator 0.14.1",
  "hex",
  "itertools",
  "rand 0.8.5",
@@ -1582,8 +1566,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuel-chain-config"
+version = "0.15.0"
+dependencies = [
+ "anyhow",
+ "fuel-core-interfaces 0.15.0",
+ "fuel-poa-coordinator 0.15.0",
+ "hex",
+ "itertools",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+]
+
+[[package]]
 name = "fuel-core"
 version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a7f750a7ca612ce7ded3647e193211326e8b8051920fdf7bbd965f66427b8e7"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1596,6 +1598,7 @@ dependencies = [
  "derive_more",
  "dirs",
  "enum-iterator",
+ "env_logger",
  "fuel-block-executor 0.14.1",
  "fuel-block-importer 0.14.1",
  "fuel-block-producer 0.14.1",
@@ -1632,9 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7f750a7ca612ce7ded3647e193211326e8b8051920fdf7bbd965f66427b8e7"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1647,17 +1648,16 @@ dependencies = [
  "derive_more",
  "dirs",
  "enum-iterator",
- "env_logger",
- "fuel-block-executor 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-block-importer 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-block-producer 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-chain-config 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-core-bft 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-metrics 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-poa-coordinator 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-sync 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-txpool 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuel-block-executor 0.15.0",
+ "fuel-block-importer 0.15.0",
+ "fuel-block-producer 0.15.0",
+ "fuel-chain-config 0.15.0",
+ "fuel-core-bft 0.15.0",
+ "fuel-core-interfaces 0.15.0",
+ "fuel-metrics 0.15.0",
+ "fuel-poa-coordinator 0.15.0",
+ "fuel-sync 0.15.0",
+ "fuel-txpool 0.15.0",
  "futures",
  "hex",
  "itertools",
@@ -1686,8 +1686,8 @@ dependencies = [
 name = "fuel-core-0_14_1-client-0_15_0"
 version = "0.0.0"
 dependencies = [
- "fuel-core 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-gql-client 0.14.1",
+ "fuel-core 0.14.1",
+ "fuel-gql-client 0.15.0",
  "tokio",
 ]
 
@@ -1695,18 +1695,8 @@ dependencies = [
 name = "fuel-core-0_15_0-client-0_14_1"
 version = "0.0.0"
 dependencies = [
- "fuel-core 0.14.1",
- "fuel-gql-client 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio",
-]
-
-[[package]]
-name = "fuel-core-bft"
-version = "0.14.1"
-dependencies = [
- "anyhow",
- "fuel-core-interfaces 0.14.1",
- "parking_lot 0.12.1",
+ "fuel-core 0.15.0",
+ "fuel-gql-client 0.14.1",
  "tokio",
 ]
 
@@ -1717,27 +1707,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de74a06987fe916daa761151fc5a6c945a3d3601ccc3e30c9303f136e2cbd7f"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuel-core-interfaces 0.14.1",
  "parking_lot 0.12.1",
  "tokio",
 ]
 
 [[package]]
-name = "fuel-core-interfaces"
-version = "0.14.1"
+name = "fuel-core-bft"
+version = "0.15.0"
 dependencies = [
  "anyhow",
- "async-trait",
- "derive_more",
- "fuel-vm",
- "lazy_static",
+ "fuel-core-interfaces 0.15.0",
  "parking_lot 0.12.1",
- "secrecy",
- "serde",
- "tai64",
- "thiserror",
  "tokio",
- "zeroize",
 ]
 
 [[package]]
@@ -1751,6 +1733,24 @@ dependencies = [
  "derive_more",
  "fuel-vm",
  "futures",
+ "lazy_static",
+ "parking_lot 0.12.1",
+ "secrecy",
+ "serde",
+ "tai64",
+ "thiserror",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "fuel-core-interfaces"
+version = "0.15.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "derive_more",
+ "fuel-vm",
  "lazy_static",
  "parking_lot 0.12.1",
  "secrecy",
@@ -1782,26 +1782,6 @@ dependencies = [
 [[package]]
 name = "fuel-gql-client"
 version = "0.14.1"
-dependencies = [
- "anyhow",
- "clap",
- "cynic 2.2.1",
- "derive_more",
- "eventsource-client",
- "fuel-vm",
- "futures",
- "hex",
- "itertools",
- "reqwest",
- "serde",
- "serde_json",
- "tai64",
- "thiserror",
-]
-
-[[package]]
-name = "fuel-gql-client"
-version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c4c4a52e2dee7e026307877d79b0bdacbb02cb155a01c2da2e56dc7838459a"
 dependencies = [
@@ -1823,6 +1803,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuel-gql-client"
+version = "0.15.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "cynic 2.2.1",
+ "derive_more",
+ "eventsource-client",
+ "fuel-vm",
+ "futures",
+ "hex",
+ "hyper-rustls 0.22.1",
+ "itertools",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tai64",
+ "thiserror",
+]
+
+[[package]]
 name = "fuel-merkle"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,16 +1840,6 @@ dependencies = [
 [[package]]
 name = "fuel-metrics"
 version = "0.14.1"
-dependencies = [
- "axum",
- "lazy_static",
- "once_cell",
- "prometheus-client",
-]
-
-[[package]]
-name = "fuel-metrics"
-version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61077b7459292ddf72dad4a9bbf0f961779a83c6fc228947503c2aea5851d988"
 dependencies = [
@@ -1860,11 +1851,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuel-metrics"
+version = "0.15.0"
+dependencies = [
+ "axum",
+ "lazy_static",
+ "once_cell",
+ "prometheus-client",
+]
+
+[[package]]
 name = "fuel-poa-coordinator"
 version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49262d99abab91616534a9ef2bab5d55b72c9076f1c8555c93cfdba293a14a23"
 dependencies = [
  "anyhow",
- "async-trait",
  "fuel-core-interfaces 0.14.1",
  "humantime-serde",
  "parking_lot 0.12.1",
@@ -1875,12 +1877,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-poa-coordinator"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49262d99abab91616534a9ef2bab5d55b72c9076f1c8555c93cfdba293a14a23"
+version = "0.15.0"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait",
+ "fuel-core-interfaces 0.15.0",
  "humantime-serde",
  "parking_lot 0.12.1",
  "serde",
@@ -1897,6 +1898,8 @@ checksum = "b0f895423d18472d60eb078cf949608ff3fe6e42e91d41b85993b11528d2c4c3"
 [[package]]
 name = "fuel-sync"
 version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a59af943f25281ceb6771c37f531bfc691d9fe4b38eedadb9933d2de18abb17"
 dependencies = [
  "anyhow",
  "fuel-core-interfaces 0.14.1",
@@ -1906,12 +1909,10 @@ dependencies = [
 
 [[package]]
 name = "fuel-sync"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a59af943f25281ceb6771c37f531bfc691d9fe4b38eedadb9933d2de18abb17"
+version = "0.15.0"
 dependencies = [
  "anyhow",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuel-core-interfaces 0.15.0",
  "parking_lot 0.12.1",
  "tokio",
 ]
@@ -1938,13 +1939,17 @@ dependencies = [
 [[package]]
 name = "fuel-txpool"
 version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22721a7c9f3cbcfeeea939d90e1a56dd24d6066ef5b9a3ffd3780f3240491a6"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "fuel-chain-config 0.14.1",
  "fuel-core-interfaces 0.14.1",
  "fuel-metrics 0.14.1",
- "parking_lot 0.12.1",
+ "futures",
+ "parking_lot 0.11.2",
  "thiserror",
  "tokio",
  "tracing",
@@ -1952,18 +1957,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-txpool"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22721a7c9f3cbcfeeea939d90e1a56dd24d6066ef5b9a3ffd3780f3240491a6"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
- "fuel-chain-config 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-core-interfaces 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuel-metrics 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures",
- "parking_lot 0.11.2",
+ "fuel-chain-config 0.15.0",
+ "fuel-core-interfaces 0.15.0",
+ "fuel-metrics 0.15.0",
+ "parking_lot 0.12.1",
  "thiserror",
  "tokio",
  "tracing",
@@ -2429,6 +2430,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -4589,6 +4591,15 @@ name = "webpki-roots"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+dependencies = [
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki 0.21.4",
 ]


### PR DESCRIPTION
This release while breaking, is backwards compatible with fuel-client 0.14.1. E.g. existing usages of the fuels-rs SDK targeting the beta-2 environment will continue operating as normal.

It mainly includes bug fixes discovered from beta2.