### PR TITLE
unify chain id generation and usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "ctor",
+ "fuel-chain-config",
  "fuel-core-interfaces",
  "fuel-metrics",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,7 @@ name = "fuel-block-executor"
 version = "0.14.1"
 dependencies = [
  "anyhow",
+ "fuel-chain-config",
  "fuel-core-interfaces",
  "tokio",
 ]
@@ -2317,6 +2318,7 @@ name = "fuel-chain-config"
 version = "0.14.1"
 dependencies = [
  "anyhow",
+ "bincode",
  "fuel-core-interfaces",
  "fuel-poa-coordinator",
  "hex",

--- a/fuel-block-executor/Cargo.toml
+++ b/fuel-block-executor/Cargo.toml
@@ -12,4 +12,5 @@ description = "Fuel Block Executor"
 [dependencies]
 anyhow = "1.0"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1" }
+fuel-chain-config = { path = "../fuel-chain-config", version = "0.14.1" }
 tokio = { version = "1.21", features = ["full"] }

--- a/fuel-block-executor/src/refs.rs
+++ b/fuel-block-executor/src/refs.rs
@@ -1,3 +1,6 @@
 mod contract;
 
-pub use contract::ContractRef;
+pub use contract::{
+    ContractRef,
+    ContractStorageTrait,
+};

--- a/fuel-block-executor/src/refs/contract.rs
+++ b/fuel-block-executor/src/refs/contract.rs
@@ -113,17 +113,17 @@ where
     }
 }
 
+pub trait ContractStorageTrait<'a>:
+    StorageInspect<ContractsLatestUtxo, Error = Self::InnerError>
+    + MerkleRootStorage<ContractId, ContractsState<'a>, Error = Self::InnerError>
+    + MerkleRootStorage<ContractId, ContractsAssets<'a>, Error = Self::InnerError>
+{
+    type InnerError: StdError + Send + Sync + 'static;
+}
+
 impl<'a, Database> GenesisCommitment for ContractRef<&'a mut Database>
 where
-    for<'b> Database: StorageInspect<ContractsLatestUtxo>
-        + MerkleRootStorage<ContractId, ContractsState<'a>>
-        + MerkleRootStorage<ContractId, ContractsAssets<'a>>,
-    <Database as StorageInspect<ContractsLatestUtxo>>::Error:
-        StdError + Send + Sync + 'static,
-    <Database as StorageInspect<ContractsState<'a>>>::Error:
-        StdError + Send + Sync + 'static,
-    <Database as StorageInspect<ContractsAssets<'a>>>::Error:
-        StdError + Send + Sync + 'static,
+    for<'b> Database: ContractStorageTrait<'a>,
 {
     fn root(&mut self) -> anyhow::Result<MerkleRoot> {
         let contract_id = *self.contract_id();

--- a/fuel-chain-config/Cargo.toml
+++ b/fuel-chain-config/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel Chain config types"
 
 [dependencies]
 anyhow = "1.0"
+bincode = "1.3"
 fuel-core-interfaces = { path = "../fuel-core-interfaces", version = "0.14.1", features = [
     "serde",
 ] }

--- a/fuel-chain-config/src/config/chain.rs
+++ b/fuel-chain-config/src/config/chain.rs
@@ -136,7 +136,6 @@ impl GenesisCommitment for ChainConfig {
             .chain(self.block_gas_limit.to_be_bytes())
             .chain(self.transaction_parameters.root()?)
             .chain(self.chain_name.as_bytes())
-            .chain(bincode::serialize(&self.initial_state)?)
             .finalize();
 
         Ok(config_hash)

--- a/fuel-chain-config/src/config/chain.rs
+++ b/fuel-chain-config/src/config/chain.rs
@@ -4,6 +4,10 @@ use fuel_core_interfaces::common::{
         Address,
         AssetId,
     },
+    prelude::{
+        Hasher,
+        MerkleRoot,
+    },
 };
 use itertools::Itertools;
 use rand::{
@@ -21,6 +25,8 @@ use std::{
     path::PathBuf,
     str::FromStr,
 };
+
+use crate::GenesisCommitment;
 
 use super::{
     coin::CoinConfig,
@@ -120,6 +126,31 @@ impl FromStr for ChainConfig {
                 })
             }
         }
+    }
+}
+
+impl GenesisCommitment for ChainConfig {
+    fn root(&mut self) -> anyhow::Result<MerkleRoot> {
+        // TODO: Hash settlement configuration, consensus block production
+        let config_hash = *Hasher::default()
+            .chain(self.block_gas_limit.to_be_bytes())
+            .chain(self.transaction_parameters.root()?)
+            .chain(self.chain_name.as_bytes())
+            .chain(bincode::serialize(&self.initial_state)?)
+            .finalize();
+
+        Ok(config_hash)
+    }
+}
+
+impl GenesisCommitment for ConsensusParameters {
+    fn root(&mut self) -> anyhow::Result<MerkleRoot> {
+        // TODO: Define hash algorithm for `ConsensusParameters`
+        let params_hash = Hasher::default()
+            .chain(bincode::serialize(&self)?)
+            .finalize();
+
+        Ok(params_hash.into())
     }
 }
 

--- a/fuel-chain-config/src/config/coin.rs
+++ b/fuel-chain-config/src/config/coin.rs
@@ -1,14 +1,26 @@
-use crate::serialization::{
-    HexNumber,
-    HexType,
+use crate::{
+    serialization::{
+        HexNumber,
+        HexType,
+    },
+    GenesisCommitment,
 };
 use fuel_core_interfaces::{
-    common::fuel_types::{
-        Address,
-        AssetId,
-        Bytes32,
+    common::{
+        fuel_types::{
+            Address,
+            AssetId,
+            Bytes32,
+        },
+        prelude::{
+            Hasher,
+            MerkleRoot,
+        },
     },
-    model::BlockHeight,
+    model::{
+        BlockHeight,
+        Coin,
+    },
 };
 
 use serde::{
@@ -44,4 +56,19 @@ pub struct CoinConfig {
     pub amount: u64,
     #[serde_as(as = "HexType")]
     pub asset_id: AssetId,
+}
+
+impl GenesisCommitment for Coin {
+    fn root(&mut self) -> anyhow::Result<MerkleRoot> {
+        let coin_hash = *Hasher::default()
+            .chain(self.owner)
+            .chain(self.amount.to_be_bytes())
+            .chain(self.asset_id)
+            .chain((*self.maturity).to_be_bytes())
+            .chain([self.status as u8])
+            .chain((*self.block_created).to_be_bytes())
+            .finalize();
+
+        Ok(coin_hash)
+    }
 }

--- a/fuel-chain-config/src/config/message.rs
+++ b/fuel-chain-config/src/config/message.rs
@@ -1,10 +1,14 @@
-use crate::serialization::{
-    HexNumber,
-    HexType,
+use crate::{
+    serialization::{
+        HexNumber,
+        HexType,
+    },
+    GenesisCommitment,
 };
 use fuel_core_interfaces::{
     common::prelude::{
         Address,
+        MerkleRoot,
         Word,
     },
     model::{
@@ -51,5 +55,11 @@ impl From<MessageConfig> for Message {
             da_height: msg.da_height,
             fuel_block_spend: None,
         }
+    }
+}
+
+impl GenesisCommitment for Message {
+    fn root(&mut self) -> anyhow::Result<MerkleRoot> {
+        Ok(self.id().into())
     }
 }

--- a/fuel-chain-config/src/genesis.rs
+++ b/fuel-chain-config/src/genesis.rs
@@ -14,10 +14,10 @@ pub trait GenesisCommitment {
 impl GenesisCommitment for Genesis {
     fn root(&mut self) -> anyhow::Result<MerkleRoot> {
         let genesis_hash = *Hasher::default()
+            .chain(self.chain_config_hash)
             .chain(self.coins_root)
             .chain(self.contracts_root)
             .chain(self.messages_root)
-            .chain(self.chain_config_hash)
             .finalize();
 
         Ok(genesis_hash)

--- a/fuel-chain-config/src/genesis.rs
+++ b/fuel-chain-config/src/genesis.rs
@@ -1,0 +1,25 @@
+use fuel_core_interfaces::{
+    common::prelude::{
+        Hasher,
+        MerkleRoot,
+    },
+    model::Genesis,
+};
+
+pub trait GenesisCommitment {
+    /// Calculates the merkle root of the state of the entity.
+    fn root(&mut self) -> anyhow::Result<MerkleRoot>;
+}
+
+impl GenesisCommitment for Genesis {
+    fn root(&mut self) -> anyhow::Result<MerkleRoot> {
+        let genesis_hash = *Hasher::default()
+            .chain(self.coins_root)
+            .chain(self.contracts_root)
+            .chain(self.messages_root)
+            .chain(self.chain_config_hash)
+            .finalize();
+
+        Ok(genesis_hash)
+    }
+}

--- a/fuel-chain-config/src/lib.rs
+++ b/fuel-chain-config/src/lib.rs
@@ -2,3 +2,9 @@ pub mod config;
 mod serialization;
 
 pub use config::*;
+use fuel_core_interfaces::common::prelude::MerkleRoot;
+
+pub trait GenesisCommitment {
+    /// Calculates the merkle root of the state of the entity.
+    fn root(&mut self) -> anyhow::Result<MerkleRoot>;
+}

--- a/fuel-chain-config/src/lib.rs
+++ b/fuel-chain-config/src/lib.rs
@@ -1,10 +1,6 @@
 pub mod config;
+mod genesis;
 mod serialization;
 
 pub use config::*;
-use fuel_core_interfaces::common::prelude::MerkleRoot;
-
-pub trait GenesisCommitment {
-    /// Calculates the merkle root of the state of the entity.
-    fn root(&mut self) -> anyhow::Result<MerkleRoot>;
-}
+pub use genesis::GenesisCommitment;

--- a/fuel-core-interfaces/src/model/block.rs
+++ b/fuel-core-interfaces/src/model/block.rs
@@ -592,7 +592,7 @@ impl From<FuelBlock> for PartialFuelBlock {
 /// network - contracts states, contracts balances, unspent coins, and messages. It also contains
 /// the hash on the initial config of the network that defines the consensus rules for following
 /// blocks.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Genesis {
     /// The chain config define what consensus type to use, what settlement layer to use,

--- a/fuel-core/src/cli/run.rs
+++ b/fuel-core/src/cli/run.rs
@@ -110,7 +110,7 @@ pub struct Command {
 
     #[cfg(feature = "p2p")]
     #[clap(flatten)]
-    pub p2p_args: p2p::P2pArgs,
+    pub p2p_args: p2p::P2PArgs,
 
     #[clap(long = "metrics")]
     pub metrics: bool,
@@ -140,17 +140,10 @@ impl Command {
 
         let addr = net::SocketAddr::new(ip, port);
 
-        let mut chain_conf: ChainConfig = chain_config.as_str().parse()?;
+        let chain_conf: ChainConfig = chain_config.as_str().parse()?;
 
         #[cfg(feature = "p2p")]
-        let p2p_cfg = {
-            let mut p2p = match p2p_args.into_config(&mut chain_conf) {
-                Ok(value) => value,
-                Err(e) => return Err(e),
-            };
-            p2p.metrics = metrics;
-            p2p
-        };
+        let p2p_cfg = p2p_args.into_config(metrics)?;
 
         // if consensus key is not configured, fallback to dev consensus key
         let consensus_key = load_consensus_key(consensus_key)?.or_else(|| {

--- a/fuel-core/src/cli/run.rs
+++ b/fuel-core/src/cli/run.rs
@@ -140,11 +140,11 @@ impl Command {
 
         let addr = net::SocketAddr::new(ip, port);
 
-        let chain_conf: ChainConfig = chain_config.as_str().parse()?;
+        let mut chain_conf: ChainConfig = chain_config.as_str().parse()?;
 
         #[cfg(feature = "p2p")]
         let p2p_cfg = {
-            let mut p2p = match p2p_args.into_config(&chain_conf) {
+            let mut p2p = match p2p_args.into_config(&mut chain_conf) {
                 Ok(value) => value,
                 Err(e) => return Err(e),
             };

--- a/fuel-core/src/cli/run/p2p.rs
+++ b/fuel-core/src/cli/run/p2p.rs
@@ -9,7 +9,10 @@ use std::{
 
 use clap::Args;
 
-use fuel_chain_config::ChainConfig;
+use fuel_chain_config::{
+    ChainConfig,
+    GenesisCommitment,
+};
 use fuel_core_interfaces::common::fuel_crypto;
 use fuel_p2p::{
     config::P2PConfig,
@@ -133,10 +136,11 @@ pub struct P2pArgs {
 }
 
 impl P2pArgs {
-    pub fn into_config(self, chain_config: &ChainConfig) -> anyhow::Result<P2PConfig> {
-        let checksum = *fuel_crypto::Hasher::default()
-            .chain(bincode::serialize(chain_config)?)
-            .finalize();
+    pub fn into_config(
+        self,
+        chain_config: &mut ChainConfig,
+    ) -> anyhow::Result<P2PConfig> {
+        let checksum = chain_config.root()?.into();
 
         let local_keypair = {
             match self.keypair {

--- a/fuel-core/src/database.rs
+++ b/fuel-core/src/database.rs
@@ -8,6 +8,7 @@ use crate::{
     },
 };
 use async_trait::async_trait;
+use fuel_block_executor::refs::ContractStorageTrait;
 use fuel_block_producer::ports::BlockProducerDatabase;
 use fuel_chain_config::{
     ChainConfigDb,
@@ -264,6 +265,11 @@ impl AsRef<Database> for Database {
     fn as_ref(&self) -> &Database {
         self
     }
+}
+
+/// Implemented to satisfy: `GenesisCommitment for ContractRef<&'a mut Database>`
+impl ContractStorageTrait<'_> for Database {
+    type InnerError = Error;
 }
 
 /// Construct an ephemeral database

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -149,8 +149,8 @@ impl Database {
         .next()
         .ok_or(not_found!("Genesis block height"))?
         .map(|(height, id): (Vec<u8>, Bytes32)| {
-            // safety: we know that all block heights are stored with the correct amount of bytes
-            let bytes = <[u8; 4]>::try_from(height.as_slice()).unwrap();
+            let bytes = <[u8; 4]>::try_from(height.as_slice())
+                .expect("all block heights are stored with the correct amount of bytes");
             (u32::from_be_bytes(bytes).into(), id)
         })
     }

--- a/fuel-core/src/database/block.rs
+++ b/fuel-core/src/database/block.rs
@@ -139,6 +139,22 @@ impl Database {
             })
     }
 
+    pub fn genesis_block_ids(&self) -> Result<(BlockHeight, Bytes32), Error> {
+        self.iter_all(
+            Column::FuelBlockIds,
+            None,
+            None,
+            Some(IterDirection::Forward),
+        )
+        .next()
+        .ok_or(not_found!("Genesis block height"))?
+        .map(|(height, id): (Vec<u8>, Bytes32)| {
+            // safety: we know that all block heights are stored with the correct amount of bytes
+            let bytes = <[u8; 4]>::try_from(height.as_slice()).unwrap();
+            (u32::from_be_bytes(bytes).into(), id)
+        })
+    }
+
     fn latest_block(&self) -> Result<Option<(Vec<u8>, Bytes32)>, Error> {
         self.iter_all(
             Column::FuelBlockIds,

--- a/fuel-core/src/database/sealed_block.rs
+++ b/fuel-core/src/database/sealed_block.rs
@@ -16,9 +16,11 @@ use fuel_core_interfaces::{
     },
     model::{
         FuelBlockConsensus,
+        Genesis,
         SealedFuelBlock,
         SealedFuelBlockHeader,
     },
+    not_found,
 };
 use std::borrow::Cow;
 
@@ -76,6 +78,20 @@ impl Database {
             Ok(Some(sealed_block))
         } else {
             Ok(None)
+        }
+    }
+
+    pub fn get_genesis(&self) -> Result<Genesis, KvStoreError> {
+        let (_, genesis_block_id) = self.genesis_block_ids()?;
+        let consensus = self
+            .storage::<SealedBlockConsensus>()
+            .get(&genesis_block_id)?
+            .map(|c| c.into_owned());
+
+        if let Some(FuelBlockConsensus::Genesis(genesis)) = consensus {
+            Ok(genesis)
+        } else {
+            Err(not_found!(SealedBlockConsensus))
         }
     }
 

--- a/fuel-core/src/service/config.rs
+++ b/fuel-core/src/service/config.rs
@@ -20,7 +20,10 @@ use strum_macros::{
 };
 
 #[cfg(feature = "p2p")]
-use fuel_p2p;
+use fuel_p2p::config::{
+    NotInitialized,
+    P2PConfig,
+};
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -40,7 +43,7 @@ pub struct Config {
     #[cfg(feature = "relayer")]
     pub relayer: fuel_relayer::Config,
     #[cfg(feature = "p2p")]
-    pub p2p: fuel_p2p::config::P2PConfig,
+    pub p2p: P2PConfig<NotInitialized>,
     pub consensus_key: Option<Secret<SecretKeyWrapper>>,
 }
 
@@ -65,7 +68,7 @@ impl Config {
             #[cfg(feature = "relayer")]
             relayer: Default::default(),
             #[cfg(feature = "p2p")]
-            p2p: fuel_p2p::config::P2PConfig::default_with_network("test_network"),
+            p2p: P2PConfig::<NotInitialized>::default("test_network"),
             consensus_key: Some(Secret::new(default_consensus_dev_key().into())),
         }
     }

--- a/fuel-p2p/Cargo.toml
+++ b/fuel-p2p/Cargo.toml
@@ -14,6 +14,7 @@ description = "Fuel client networking"
 anyhow = "1.0"
 async-trait = "0.1"
 bincode = "1.3"
+fuel-chain-config = { path = "../fuel-chain-config", version = "0.15.0" }
 fuel-core-interfaces = { path = "../fuel-core-interfaces", features = [
     "serde",
 ], version = "0.15.0" }

--- a/fuel-p2p/src/behavior.rs
+++ b/fuel-p2p/src/behavior.rs
@@ -72,7 +72,7 @@ pub struct FuelBehaviour<Codec: NetworkCodec> {
 
 impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
     pub fn new(p2p_config: &P2PConfig, codec: Codec) -> Self {
-        let local_public_key = p2p_config.local_keypair.public();
+        let local_public_key = p2p_config.keypair.public();
         let local_peer_id = PeerId::from_public_key(&local_public_key);
 
         let discovery_config = {

--- a/fuel-p2p/src/config.rs
+++ b/fuel-p2p/src/config.rs
@@ -6,8 +6,10 @@ use crate::gossipsub::{
         NEW_TX_GOSSIP_TOPIC,
     },
 };
-
-use fuel_core_interfaces::common::secrecy::Zeroize;
+use fuel_core_interfaces::{
+    common::secrecy::Zeroize,
+    model::Genesis,
+};
 use futures::{
     future,
     AsyncRead,
@@ -26,6 +28,7 @@ use libp2p::{
         },
         UpgradeInfo,
     },
+    gossipsub::GossipsubConfig,
     identity::{
         secp256k1::SecretKey,
         Keypair,
@@ -49,7 +52,6 @@ use libp2p::{
     PeerId,
     Transport,
 };
-
 use std::{
     collections::HashSet,
     error::Error,
@@ -63,8 +65,6 @@ use std::{
     time::Duration,
 };
 
-use libp2p::gossipsub::GossipsubConfig;
-
 const REQ_RES_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Maximum number of frames buffered per substream.
@@ -75,7 +75,7 @@ const MAX_NUM_OF_FRAMES_BUFFERED: usize = 256;
 const TRANSPORT_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Sha256 hash of ChainConfig
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Checksum([u8; 32]);
 
 impl From<[u8; 32]> for Checksum {
@@ -85,13 +85,14 @@ impl From<[u8; 32]> for Checksum {
 }
 
 #[derive(Clone, Debug)]
-pub struct P2PConfig {
-    pub local_keypair: Keypair,
+pub struct P2PConfig<State = Initialized> {
+    /// The keypair used for for handshake during communication with other p2p nodes.
+    pub keypair: Keypair,
 
     /// Name of the Network
     pub network_name: String,
 
-    /// Checksum (sha256) of Chain ID + Chain Config
+    /// Checksum is a hash(sha256) of [`Genesis`](fuel_core_interfaces::model::Genesis) - chain id.
     pub checksum: Checksum,
 
     /// IP address for Swarm to listen on
@@ -140,6 +141,51 @@ pub struct P2PConfig {
 
     /// Enables prometheus metrics for this fuel-service
     pub metrics: bool,
+
+    /// It is the state of the config initialization. Everyone can create an instance of the `Self`
+    /// with the `NotInitialized` state. But it can be set into the `Initialized` state only with
+    /// the `init` method.
+    pub state: State,
+}
+
+/// The initialized state can be achieved only by the `init` function because `()` is private.
+#[derive(Clone, Debug)]
+pub struct Initialized(());
+
+#[derive(Clone, Debug)]
+pub struct NotInitialized;
+
+impl P2PConfig<NotInitialized> {
+    /// Inits the `P2PConfig` with some lazily loaded data.
+    pub fn init(self, mut genesis: Genesis) -> anyhow::Result<P2PConfig<Initialized>> {
+        use fuel_chain_config::GenesisCommitment;
+
+        Ok(P2PConfig {
+            keypair: self.keypair,
+            network_name: self.network_name,
+            checksum: genesis.root()?.into(),
+            address: self.address,
+            public_address: self.public_address,
+            tcp_port: self.tcp_port,
+            max_block_size: self.max_block_size,
+            bootstrap_nodes: self.bootstrap_nodes,
+            enable_mdns: self.enable_mdns,
+            max_peers_connected: self.max_peers_connected,
+            allow_private_addresses: self.allow_private_addresses,
+            random_walk: self.random_walk,
+            connection_idle_timeout: self.connection_idle_timeout,
+            reserved_nodes: self.reserved_nodes,
+            reserved_nodes_only_mode: self.reserved_nodes_only_mode,
+            identify_interval: self.identify_interval,
+            info_interval: self.info_interval,
+            gossipsub_config: self.gossipsub_config,
+            topics: self.topics,
+            set_request_timeout: self.set_request_timeout,
+            set_connection_keep_alive: self.set_connection_keep_alive,
+            metrics: self.metrics,
+            state: Initialized(()),
+        })
+    }
 }
 
 /// Takes secret key bytes generated outside of libp2p.
@@ -152,14 +198,14 @@ pub fn convert_to_libp2p_keypair(
     Ok(Keypair::Secp256k1(secret_key.into()))
 }
 
-impl P2PConfig {
-    pub fn default_with_network(network_name: &str) -> Self {
-        let local_keypair = Keypair::generate_secp256k1();
+impl P2PConfig<NotInitialized> {
+    pub fn default(network_name: &str) -> Self {
+        let keypair = Keypair::generate_secp256k1();
 
-        P2PConfig {
-            local_keypair,
+        Self {
+            keypair,
             network_name: network_name.into(),
-            checksum: [0u8; 32].into(),
+            checksum: Default::default(),
             address: IpAddr::V4(Ipv4Addr::from([0, 0, 0, 0])),
             public_address: None,
             tcp_port: 0,
@@ -183,7 +229,17 @@ impl P2PConfig {
             info_interval: Some(Duration::from_secs(3)),
             identify_interval: Some(Duration::from_secs(5)),
             metrics: false,
+            state: NotInitialized,
         }
+    }
+}
+
+#[cfg(any(feature = "test-helpers", test))]
+impl P2PConfig<Initialized> {
+    pub fn default_initialized(network_name: &str) -> Self {
+        P2PConfig::<NotInitialized>::default(network_name)
+            .init(Default::default())
+            .expect("Expected correct initialization of config")
     }
 }
 
@@ -207,7 +263,7 @@ pub(crate) fn build_transport(p2p_config: &P2PConfig) -> Boxed<(PeerId, StreamMu
 
     let noise_authenticated = {
         let dh_keys = noise::Keypair::<noise::X25519Spec>::new()
-            .into_authentic(&p2p_config.local_keypair)
+            .into_authentic(&p2p_config.keypair)
             .expect("Noise key generation failed");
 
         noise::NoiseConfig::xx(dh_keys).into_authenticated()

--- a/fuel-p2p/src/gossipsub/config.rs
+++ b/fuel-p2p/src/gossipsub/config.rs
@@ -60,7 +60,7 @@ pub(crate) fn build_gossipsub_behaviour(p2p_config: &P2PConfig) -> Gossipsub {
         let metrics_config = MetricsConfig::default();
 
         let mut gossipsub = Gossipsub::new_with_metrics(
-            MessageAuthenticity::Signed(p2p_config.local_keypair.clone()),
+            MessageAuthenticity::Signed(p2p_config.keypair.clone()),
             p2p_config.gossipsub_config.clone(),
             &mut p2p_registry,
             metrics_config,
@@ -80,7 +80,7 @@ pub(crate) fn build_gossipsub_behaviour(p2p_config: &P2PConfig) -> Gossipsub {
         gossipsub
     } else {
         let mut gossipsub = Gossipsub::new(
-            MessageAuthenticity::Signed(p2p_config.local_keypair.clone()),
+            MessageAuthenticity::Signed(p2p_config.keypair.clone()),
             p2p_config.gossipsub_config.clone(),
         )
         .expect("gossipsub initialized");

--- a/fuel-p2p/src/orchestrator.rs
+++ b/fuel-p2p/src/orchestrator.rs
@@ -370,7 +370,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn start_stop_works() {
-        let p2p_config = P2PConfig::default_with_network("start_stop_works");
+        let p2p_config = P2PConfig::default_initialized("start_stop_works");
         let db: Arc<dyn P2pDb> = Arc::new(FakeDb);
 
         let (_, rx_request_event) = tokio::sync::mpsc::channel(100);

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -119,7 +119,7 @@ pub enum FuelP2PEvent {
 
 impl<Codec: NetworkCodec> FuelP2PService<Codec> {
     pub fn new(config: P2PConfig, codec: Codec) -> anyhow::Result<Self> {
-        let local_peer_id = PeerId::from(config.local_keypair.public());
+        let local_peer_id = PeerId::from(config.keypair.public());
 
         // configure and build P2P Service
         let transport = build_transport(&config);
@@ -531,7 +531,7 @@ mod tests {
     fn build_service_from_config(
         mut p2p_config: P2PConfig,
     ) -> FuelP2PService<BincodeCodec> {
-        p2p_config.local_keypair = Keypair::generate_secp256k1(); // change keypair for each Node
+        p2p_config.keypair = Keypair::generate_secp256k1(); // change keypair for each Node
         let max_block_size = p2p_config.max_block_size;
 
         FuelP2PService::new(p2p_config, BincodeCodec::new(max_block_size)).unwrap()
@@ -585,7 +585,7 @@ mod tests {
         ) -> FuelP2PService<BincodeCodec> {
             let max_block_size = p2p_config.max_block_size;
             p2p_config.tcp_port = self.tcp_port;
-            p2p_config.local_keypair = self.keypair.clone();
+            p2p_config.keypair = self.keypair.clone();
 
             FuelP2PService::new(p2p_config, BincodeCodec::new(max_block_size)).unwrap()
         }
@@ -595,7 +595,7 @@ mod tests {
     #[instrument]
     async fn p2p_service_works() {
         let mut fuel_p2p_service = build_service_from_config(
-            P2PConfig::default_with_network("p2p_service_works"),
+            P2PConfig::default_initialized("p2p_service_works"),
         );
 
         loop {
@@ -621,7 +621,7 @@ mod tests {
         let reserved_nodes_size = 4;
         let double_reserved_nodes_size = reserved_nodes_size * 2;
 
-        let mut p2p_config = P2PConfig::default_with_network("sentry_nodes_working");
+        let mut p2p_config = P2PConfig::default_initialized("sentry_nodes_working");
         // enable mdns for faster discovery of nodes
         p2p_config.enable_mdns = true;
 
@@ -738,7 +738,7 @@ mod tests {
     #[instrument]
     async fn nodes_connected_via_mdns() {
         // Node A
-        let mut p2p_config = P2PConfig::default_with_network("nodes_connected_via_mdns");
+        let mut p2p_config = P2PConfig::default_initialized("nodes_connected_via_mdns");
         p2p_config.enable_mdns = true;
         let mut node_a = build_service_from_config(p2p_config.clone());
 
@@ -772,7 +772,7 @@ mod tests {
             TransportError,
         };
         // Node A
-        let mut p2p_config = P2PConfig::default_with_network(
+        let mut p2p_config = P2PConfig::default_initialized(
             "nodes_cannot_connect_due_to_different_checksum",
         );
         p2p_config.enable_mdns = true;
@@ -812,7 +812,7 @@ mod tests {
     async fn nodes_connected_via_identify() {
         // Node A
         let mut p2p_config =
-            P2PConfig::default_with_network("nodes_connected_via_identify");
+            P2PConfig::default_initialized("nodes_connected_via_identify");
 
         let node_a_data = NodeData::random();
         let mut node_a = node_a_data.create_service(p2p_config.clone());
@@ -851,7 +851,7 @@ mod tests {
     #[tokio::test]
     #[instrument]
     async fn peer_info_updates_work() {
-        let mut p2p_config = P2PConfig::default_with_network("peer_info_updates_work");
+        let mut p2p_config = P2PConfig::default_initialized("peer_info_updates_work");
 
         // Node A
         let node_a_data = NodeData::random();
@@ -915,7 +915,7 @@ mod tests {
     /// Reusable helper function for Broadcasting Gossipsub requests
     async fn gossipsub_broadcast(broadcast_request: GossipsubBroadcastRequest) {
         let mut p2p_config =
-            P2PConfig::default_with_network("gossipsub_exchanges_messages");
+            P2PConfig::default_initialized("gossipsub_exchanges_messages");
 
         let selected_topic: GossipTopic = {
             let topic = match broadcast_request {
@@ -1009,7 +1009,7 @@ mod tests {
             },
         };
 
-        let mut p2p_config = P2PConfig::default_with_network("request_response_works");
+        let mut p2p_config = P2PConfig::default_initialized("request_response_works");
 
         // Node A
         let node_a_data = NodeData::random();
@@ -1085,7 +1085,7 @@ mod tests {
     #[instrument]
     async fn req_res_outbound_timeout_works() {
         let mut p2p_config =
-            P2PConfig::default_with_network("req_res_outbound_timeout_works");
+            P2PConfig::default_initialized("req_res_outbound_timeout_works");
 
         // Node A
         // setup request timeout to 0 in order for the Request to fail

--- a/fuel-p2p/src/service.rs
+++ b/fuel-p2p/src/service.rs
@@ -779,7 +779,7 @@ mod tests {
         let mut node_a = build_service_from_config(p2p_config.clone());
 
         // different checksum
-        p2p_config.checksum = [1u8; 32];
+        p2p_config.checksum = [1u8; 32].into();
         // Node B
         let mut node_b = build_service_from_config(p2p_config);
 

--- a/version-compatibility/Cargo.lock
+++ b/version-compatibility/Cargo.lock
@@ -1493,6 +1493,7 @@ name = "fuel-block-executor"
 version = "0.15.0"
 dependencies = [
  "anyhow",
+ "fuel-chain-config 0.15.0",
  "fuel-core-interfaces 0.15.0",
  "tokio",
 ]
@@ -1570,6 +1571,7 @@ name = "fuel-chain-config"
 version = "0.15.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "fuel-core-interfaces 0.15.0",
  "fuel-poa-coordinator 0.15.0",
  "hex",


### PR DESCRIPTION
closes #824 

I renamed `Merklization` trait to `GenesisCommitment` and moved it to `chain-config` module.
Moved the implementations of the trait to their respective files.

Included few extra fields in `ChainConfig` hash calculation.
Implemented `GenesisCommitment` for `Genesis` within `chain-config` module.

Made a wrapper struct Checksum([u8; 32]).