### PR TITLE
Use `fuel-core` `0.15` in compatibility tests

### DIFF
--- a/version-compatibility/0.14.1-0.15.0/fuel-core:0.14.1-client:0.15.0/Cargo.toml
+++ b/version-compatibility/0.14.1-0.15.0/fuel-core:0.14.1-client:0.15.0/Cargo.toml
@@ -10,6 +10,5 @@ path = "test.rs"
 
 [dev-dependencies]
 f_core = { version = "=0.14.1", package = "fuel-core" }
-# TODO: Use `0.15.0` when it is released
-fuel-gql-client = { path = "../../../fuel-client", features = ["test-helpers"] }
+fuel-gql-client = { version = "=0.15", features = ["test-helpers"] }
 tokio = { version = "1.21", features = ["macros", "rt-multi-thread"] }

--- a/version-compatibility/0.14.1-0.15.0/fuel-core:0.15.0-client:0.14.1/Cargo.toml
+++ b/version-compatibility/0.14.1-0.15.0/fuel-core:0.15.0-client:0.14.1/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 path = "test.rs"
 
 [dev-dependencies]
-# TODO: Use `0.15.0` when it is released
 f-client = { version = "=0.14.1", package = "fuel-gql-client", features = ["test-helpers"] }
-fuel-core = { path = "../../../fuel-core" }
+fuel-core = { version = "=0.15" }
 tokio = { version = "1.21", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
After releasing `fuel-core` `0.15`, we can use it from crates.io in compatibility tests