### PR TITLE
add missing ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,6 +2351,8 @@ name = "fuel-core-importer"
 version = "0.15.1"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "fuel-core-types",
  "parking_lot 0.12.1",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,6 +2482,7 @@ name = "fuel-core-sync"
 version = "0.15.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "fuel-core-types",
  "parking_lot 0.12.1",
  "tokio",

--- a/crates/services/importer/Cargo.toml
+++ b/crates/services/importer/Cargo.toml
@@ -11,5 +11,9 @@ description = "Fuel Block Importer"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
+fuel-core-types = { path = "../../types", features = [
+    "serde",
+], version = "0.15.1" }
 parking_lot = "0.12"
-tokio = { version = "1.21", features = ["full"] }
+tokio = { version = "1.21", features = ["sync", "rt"] }

--- a/crates/services/importer/src/lib.rs
+++ b/crates/services/importer/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unused_crate_dependencies)]
 
 pub mod config;
+pub mod ports;
 pub mod service;
 
 pub use config::Config;

--- a/crates/services/importer/src/ports.rs
+++ b/crates/services/importer/src/ports.rs
@@ -1,0 +1,41 @@
+use async_trait::async_trait;
+use fuel_core_types::{
+    blockchain::{
+        block::Block,
+        primitives::DaBlockHeight,
+        SealedBlock,
+        SealedBlockHeader,
+    },
+    fuel_tx::TxId,
+};
+
+#[async_trait]
+pub trait Relayer {
+    // wait until the relayer is synced with ethereum
+    async fn await_synced() -> anyhow::Result<()>;
+    // wait until a specific da_height is reached
+    async fn await_da_height(da_height: DaBlockHeight) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+pub trait Executor {
+    async fn validate_and_store_block(block: &Block) -> anyhow::Result<()>;
+}
+
+pub trait TransactionPool {
+    // remove a set of txs from the pool after a block is committed
+    fn drop_txs(txs: Vec<TxId>) -> anyhow::Result<()>;
+}
+
+pub trait Database {
+    // insert consensus information associated with a sealed block
+    fn insert_consensus_data(sealed_block: &SealedBlock) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+pub trait PeerToPeer {
+    // broadcast the finalized header to peers who may need to sync
+    async fn broadcast_sealed_header(
+        sealed_block_header: SealedBlockHeader,
+    ) -> anyhow::Result<()>;
+}

--- a/crates/services/sync/Cargo.toml
+++ b/crates/services/sync/Cargo.toml
@@ -11,6 +11,7 @@ description = "Fuel Synchronizer"
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 fuel-core-types = { path = "../../types", version = "0.15.1" }
 parking_lot = "0.12"
-tokio = { version = "1.21", features = ["full"] }
+tokio = { version = "1.21", features = ["rt", "sync"] }

--- a/crates/services/sync/src/lib.rs
+++ b/crates/services/sync/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unused_crate_dependencies)]
 
 pub mod config;
+pub mod ports;
 pub mod service;
 
 pub use config::Config;

--- a/crates/services/sync/src/ports.rs
+++ b/crates/services/sync/src/ports.rs
@@ -1,0 +1,64 @@
+use std::ops::Range;
+
+use async_trait::async_trait;
+use fuel_core_types::{
+    blockchain::{
+        primitives::BlockHeight,
+        SealedBlock,
+        SealedBlockHeader,
+    },
+    services::p2p::{
+        GossipsubMessageAcceptance,
+        NetworkData,
+    },
+};
+
+#[async_trait]
+trait PeerToPeer {
+    type SealedHeaderResponse: NetworkData<SealedBlockHeader>;
+    type BlockResponse: NetworkData<Vec<SealedBlock>>;
+    type GossipedBlockHeader: NetworkData<SealedBlockHeader>;
+
+    async fn fetch_best_network_block_header(
+    ) -> anyhow::Result<Option<Self::SealedHeaderResponse>>;
+
+    async fn fetch_blocks(
+        query: Range<BlockHeight>,
+    ) -> anyhow::Result<Self::BlockResponse>;
+
+    // punish the sender for providing an invalid block header
+    fn report_invalid_block_header(
+        invalid_header: &Self::SealedHeaderResponse,
+    ) -> anyhow::Result<()>;
+
+    // punish the sender for providing a set of blocks that aren't valid
+    fn report_invalid_blocks(invalid_blocks: &Self::BlockResponse) -> anyhow::Result<()>;
+
+    // await a newly produced block from the network (similar to stream.next())
+    async fn next_gossiped_block_header() -> anyhow::Result<Self::SealedHeaderResponse>;
+
+    // notify the p2p network whether to continue gossiping this message to others or
+    // punish the peer that sent it
+    fn notify_gossip_block_validity(
+        message: &Self::GossipedBlockHeader,
+        validity: GossipsubMessageAcceptance,
+    );
+}
+
+#[async_trait]
+trait BlockImporter {
+    // commit a sealed block to the chain
+    async fn commit(block: SealedBlock) -> anyhow::Result<()>;
+}
+
+#[async_trait]
+trait Consensus {
+    // check with the consensus layer whether a block header passes consensus rules
+    async fn validate_sealed_block_header(block: SealedBlockHeader)
+        -> anyhow::Result<()>;
+}
+
+trait Database {
+    // get current fuel blockchain height
+    fn get_current_height() -> anyhow::Result<BlockHeight>;
+}


### PR DESCRIPTION
Adding ports for following crates:
- sync 
- importer

The ports/traits are not referenced currently in their respective crates not implemented in fuel-core/adapters.
