### PR TITLE
Fixed Request Body Limit Size

### DIFF
--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -54,7 +54,7 @@ tempfile = "3.3"
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tower-http = { version = "0.3", features = ["set-header", "trace"] }
+tower-http = { version = "0.3", features = ["set-header", "trace", "limit"] }
 tracing = "0.1"
 uuid = { version = "1.1", features = ["v4"] }
 

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -84,6 +84,13 @@ impl P2PAdapter {
 }
 
 #[cfg(not(feature = "p2p"))]
+impl Default for P2PAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(not(feature = "p2p"))]
 impl P2PAdapter {
     pub fn new() -> Self {
         Self {}

--- a/crates/fuel-core/src/service/graph_api.rs
+++ b/crates/fuel-core/src/service/graph_api.rs
@@ -21,7 +21,10 @@ use async_graphql::{
     Response,
 };
 use axum::{
-    extract::Extension,
+    extract::{
+        DefaultBodyLimit,
+        Extension,
+    },
     http::{
         header::{
             ACCESS_CONTROL_ALLOW_HEADERS,
@@ -101,7 +104,8 @@ pub async fn start_server(
         .layer(SetResponseHeaderLayer::<_>::overriding(
             ACCESS_CONTROL_ALLOW_HEADERS,
             HeaderValue::from_static("*"),
-        ));
+        ))
+        .layer(DefaultBodyLimit::disable());
 
     let (tx, rx) = tokio::sync::oneshot::channel();
     let listener = TcpListener::bind(network_addr)?;

--- a/deployment/ingress/eks/fuel-core-ingress.yaml
+++ b/deployment/ingress/eks/fuel-core-ingress.yaml
@@ -4,6 +4,8 @@ metadata:
   name: ${k8s_namespace}-ingress
   namespace: ${k8s_namespace}
   annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "7m"
+    nginx.org/client-max-body-size: "7m"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /


### PR DESCRIPTION
Fixed a common error of 
```
thread 'test' panicked at 'called `Result::unwrap()` on an `Err` value: ProviderError("Server returned 413: Failed to buffer the request body: length limit exceeded")', 
```

Removed the default request body limit, and instead pushed it to the nginx configuration to handle request body size limiting. Local nodes will now allow unbounded size for API requests, which should now be handled at a proxy level

Based off of refactor branch because changes aren't needed in prod (where it's fine if limit persists), but can still trickle down through tooling so developers are unblocked locally.