### PR TITLE
Fix Windows Compilation

### DIFF
--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -263,6 +263,6 @@ async fn shutdown_signal(stop_graphql_api: oneshot::Sender<()>) {
             .await
             .expect("failed to install CTRL+C signal handler");
         let _ = stop_graphql_api.send(());
-        info!("CTRL+C received");
+        tracing::log::info!("CTRL+C received");
     }
 }


### PR DESCRIPTION
Windows would just not compile because a missed import

Closes #463 

Clearer Protoc instructions are still needed but now there is nothing technically blocking it. Although I would actually be in favor of just distributing a windows binary in the future and telling people to vendor it