### PR TITLE
add p2p connection limits

### DIFF
--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -160,7 +160,7 @@ impl P2PArgs {
         };
 
         // Reserved nodes do not count against the configured peer input/output limits.
-        let max_peers_allowed =
+        let max_peers_connected =
             self.max_peers_connected + self.reserved_nodes.len() as u32;
 
         let gossipsub_config = default_gossipsub_builder()
@@ -194,7 +194,7 @@ impl P2PArgs {
             reserved_nodes: self.reserved_nodes,
             reserved_nodes_only_mode: self.reserved_nodes_only_mode,
             enable_mdns: self.enable_mdns,
-            max_peers_connected: max_peers_allowed,
+            max_peers_connected,
             allow_private_addresses: self.allow_private_addresses,
             random_walk,
             connection_idle_timeout: Some(Duration::from_secs(

--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -160,7 +160,8 @@ impl P2PArgs {
         };
 
         // Reserved nodes do not count against the configured peer input/output limits.
-        let max_peers_allowed = self.max_peers_connected + self.reserved_nodes.len();
+        let max_peers_allowed =
+            self.max_peers_connected + self.reserved_nodes.len() as u32;
 
         let gossipsub_config = default_gossipsub_builder()
             .mesh_n(self.ideal_mesh_size)

--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -67,7 +67,7 @@ pub struct P2PArgs {
 
     /// Maximum amount of allowed connected peers
     #[clap(long = "max_peers_connected", default_value = "50")]
-    pub max_peers_connected: usize,
+    pub max_peers_connected: u32,
 
     /// Set the delay between random walks for p2p node discovery in seconds.
     /// If it's not set the random walk will be disabled.
@@ -160,12 +160,12 @@ impl P2PArgs {
         };
 
         // Reserved nodes do not count against the configured peer input/output limits.
-        let reserved_nodes_count = self.reserved_nodes.len();
+        let max_peers_allowed = self.max_peers_connected + self.reserved_nodes.len();
 
         let gossipsub_config = default_gossipsub_builder()
-            .mesh_n(self.ideal_mesh_size + reserved_nodes_count)
-            .mesh_n_low(self.min_mesh_size + reserved_nodes_count)
-            .mesh_n_high(self.max_mesh_size + reserved_nodes_count)
+            .mesh_n(self.ideal_mesh_size)
+            .mesh_n_low(self.min_mesh_size)
+            .mesh_n_high(self.max_mesh_size)
             .history_length(self.history_length)
             .history_gossip(self.history_gossip)
             .heartbeat_interval(Duration::from_secs(self.heartbeat_interval))
@@ -193,7 +193,7 @@ impl P2PArgs {
             reserved_nodes: self.reserved_nodes,
             reserved_nodes_only_mode: self.reserved_nodes_only_mode,
             enable_mdns: self.enable_mdns,
-            max_peers_connected: self.max_peers_connected,
+            max_peers_connected: max_peers_allowed,
             allow_private_addresses: self.allow_private_addresses,
             random_walk,
             connection_idle_timeout: Some(Duration::from_secs(

--- a/crates/services/p2p/src/behavior.rs
+++ b/crates/services/p2p/src/behavior.rs
@@ -81,7 +81,7 @@ impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
 
             discovery_config
                 .enable_mdns(p2p_config.enable_mdns)
-                .discovery_limit(p2p_config.max_peers_connected)
+                .discovery_limit(p2p_config.max_peers_connected as usize)
                 .allow_private_addresses(p2p_config.allow_private_addresses)
                 .with_bootstrap_nodes(p2p_config.bootstrap_nodes.clone())
                 .with_reserved_nodes(p2p_config.reserved_nodes.clone())
@@ -98,7 +98,7 @@ impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
             discovery_config
         };
 
-        let peer_info = PeerInfoBehaviour::new(local_public_key, p2p_config);
+        let peer_info = PeerInfoBehaviour::new(p2p_config);
 
         let req_res_protocol =
             std::iter::once((codec.get_req_res_protocol(), ProtocolSupport::Full));

--- a/crates/services/p2p/src/config.rs
+++ b/crates/services/p2p/src/config.rs
@@ -110,7 +110,7 @@ pub struct Config<State = Initialized> {
     // `DiscoveryBehaviour` related fields
     pub bootstrap_nodes: Vec<Multiaddr>,
     pub enable_mdns: bool,
-    pub max_peers_connected: usize,
+    pub max_peers_connected: u32,
     pub allow_private_addresses: bool,
     pub random_walk: Option<Duration>,
     pub connection_idle_timeout: Option<Duration>,

--- a/crates/services/p2p/src/discovery.rs
+++ b/crates/services/p2p/src/discovery.rs
@@ -26,6 +26,7 @@ use libp2p::{
 use libp2p_swarm::derive_prelude::{
     ConnectionClosed,
     ConnectionEstablished,
+    FromSwarm,
 };
 use std::{
     collections::{
@@ -121,18 +122,13 @@ impl NetworkBehaviour for DiscoveryBehaviour {
             .on_connection_handler_event(peer_id, connection, event);
     }
 
-    fn on_swarm_event(
-        &mut self,
-        event: libp2p_swarm::derive_prelude::FromSwarm<Self::ConnectionHandler>,
-    ) {
+    fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
         match &event {
-            libp2p_swarm::derive_prelude::FromSwarm::ConnectionEstablished(
-                ConnectionEstablished {
-                    peer_id,
-                    other_established,
-                    ..
-                },
-            ) => {
+            FromSwarm::ConnectionEstablished(ConnectionEstablished {
+                peer_id,
+                other_established,
+                ..
+            }) => {
                 if *other_established == 0 {
                     self.connected_peers.insert(*peer_id);
                     let addresses = self.addresses_of_peer(peer_id);
@@ -143,13 +139,11 @@ impl NetworkBehaviour for DiscoveryBehaviour {
                     trace!("Connected to a peer {:?}", peer_id);
                 }
             }
-            libp2p_swarm::derive_prelude::FromSwarm::ConnectionClosed(
-                ConnectionClosed {
-                    peer_id,
-                    remaining_established,
-                    ..
-                },
-            ) => {
+            FromSwarm::ConnectionClosed(ConnectionClosed {
+                peer_id,
+                remaining_established,
+                ..
+            }) => {
                 if *remaining_established == 0 {
                     self.connected_peers.remove(peer_id);
                     self.events

--- a/crates/services/p2p/src/peer_info.rs
+++ b/crates/services/p2p/src/peer_info.rs
@@ -4,7 +4,6 @@ use libp2p::{
         connection::ConnectionId,
         either::EitherOutput,
         ConnectedPoint,
-        PublicKey,
     },
     identify::{
         Behaviour as Identify,
@@ -91,10 +90,10 @@ pub struct PeerInfoBehaviour {
 }
 
 impl PeerInfoBehaviour {
-    pub fn new(local_public_key: PublicKey, config: &Config) -> Self {
+    pub fn new(config: &Config) -> Self {
         let identify = {
             let identify_config =
-                IdentifyConfig::new("/fuel/1.0".to_string(), local_public_key);
+                IdentifyConfig::new("/fuel/1.0".to_string(), config.keypair.public());
             if let Some(interval) = config.identify_interval {
                 Identify::new(identify_config.with_interval(interval))
             } else {


### PR DESCRIPTION
While working on #460
I realized we never configured connection limits for the `Swarm`, so this fixes that issue.
plus some cleanup