### PR TITLE
fuel authentication with connection state

### DIFF
--- a/crates/services/p2p/src/behavior.rs
+++ b/crates/services/p2p/src/behavior.rs
@@ -1,3 +1,8 @@
+use std::sync::{
+    Arc,
+    RwLock,
+};
+
 use crate::{
     codecs::NetworkCodec,
     config::Config,
@@ -11,6 +16,7 @@ use crate::{
         topics::GossipTopic,
     },
     peer_manager::{
+        ConnectionState,
         PeerInfo,
         PeerInfoEvent,
         PeerManagerBehaviour,
@@ -71,7 +77,11 @@ pub struct FuelBehaviour<Codec: NetworkCodec> {
 }
 
 impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
-    pub fn new(p2p_config: &Config, codec: Codec) -> Self {
+    pub(crate) fn new(
+        p2p_config: &Config,
+        codec: Codec,
+        connection_state: Arc<RwLock<ConnectionState>>,
+    ) -> Self {
         let local_public_key = p2p_config.keypair.public();
         let local_peer_id = PeerId::from_public_key(&local_public_key);
 
@@ -98,7 +108,7 @@ impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
             discovery_config
         };
 
-        let peer_manager = PeerManagerBehaviour::new(p2p_config);
+        let peer_manager = PeerManagerBehaviour::new(p2p_config, connection_state);
 
         let req_res_protocol =
             std::iter::once((codec.get_req_res_protocol(), ProtocolSupport::Full));

--- a/crates/services/p2p/src/config/connection_tracker.rs
+++ b/crates/services/p2p/src/config/connection_tracker.rs
@@ -1,0 +1,50 @@
+use super::{
+    fuel_authenticated::Approver,
+    peer_ids_set_from,
+};
+use crate::peer_manager::ConnectionState;
+use libp2p::{
+    Multiaddr,
+    PeerId,
+};
+use std::{
+    collections::HashSet,
+    sync::{
+        Arc,
+        RwLock,
+    },
+};
+
+/// A `ConnectionTracker` allows either Reserved Peers or other peers if there is an available slot.
+/// It is synced with `PeerManager` which keeps track of the `ConnectionState`.
+#[derive(Debug, Clone)]
+pub(crate) struct ConnectionTracker {
+    reserved_nodes: HashSet<PeerId>,
+    connection_state: Arc<RwLock<ConnectionState>>,
+}
+
+impl ConnectionTracker {
+    pub(crate) fn new(
+        reserved_nodes: &[Multiaddr],
+        connection_state: Arc<RwLock<ConnectionState>>,
+    ) -> Self {
+        Self {
+            reserved_nodes: peer_ids_set_from(reserved_nodes),
+            connection_state,
+        }
+    }
+}
+
+impl Approver for ConnectionTracker {
+    fn allow_peer(&self, peer_id: &PeerId) -> bool {
+        if self.reserved_nodes.contains(peer_id) {
+            return true
+        }
+
+        if let Ok(connection_state) = self.connection_state.read() {
+            return connection_state.available_slot()
+        }
+
+        false
+    }
+}

--- a/crates/services/p2p/src/config/fuel_authenticated.rs
+++ b/crates/services/p2p/src/config/fuel_authenticated.rs
@@ -1,0 +1,114 @@
+use fuel_core_types::secrecy::Zeroize;
+use futures::{
+    future,
+    AsyncRead,
+    AsyncWrite,
+    Future,
+    TryFutureExt,
+};
+use libp2p::{
+    core::UpgradeInfo,
+    noise::{
+        NoiseAuthenticated,
+        NoiseError,
+        NoiseOutput,
+        Protocol,
+    },
+    InboundUpgrade,
+    OutboundUpgrade,
+    PeerId,
+};
+use std::pin::Pin;
+
+pub(crate) trait Approver {
+    /// Allows Peer connection based on it's PeerId and the Approver's knowledge of the Connection State
+    fn allow_peer(&self, peer_id: &PeerId) -> bool;
+}
+
+#[derive(Clone)]
+pub(crate) struct FuelAuthenticated<A: Approver, P, C: Zeroize, R> {
+    noise_authenticated: NoiseAuthenticated<P, C, R>,
+    approver: A,
+}
+
+impl<A: Approver, P, C: Zeroize, R> FuelAuthenticated<A, P, C, R> {
+    pub(crate) fn new(
+        noise_authenticated: NoiseAuthenticated<P, C, R>,
+        approver: A,
+    ) -> Self {
+        Self {
+            noise_authenticated,
+            approver,
+        }
+    }
+}
+
+impl<A: Approver, P, C: Zeroize, R> UpgradeInfo for FuelAuthenticated<A, P, C, R>
+where
+    NoiseAuthenticated<P, C, R>: UpgradeInfo,
+{
+    type Info = <NoiseAuthenticated<P, C, R> as UpgradeInfo>::Info;
+    type InfoIter = <NoiseAuthenticated<P, C, R> as UpgradeInfo>::InfoIter;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        self.noise_authenticated.protocol_info()
+    }
+}
+
+impl<A, T, P, C, R> InboundUpgrade<T> for FuelAuthenticated<A, P, C, R>
+where
+    NoiseAuthenticated<P, C, R>: UpgradeInfo
+        + InboundUpgrade<T, Output = (PeerId, NoiseOutput<T>), Error = NoiseError>
+        + 'static,
+    <NoiseAuthenticated<P, C, R> as InboundUpgrade<T>>::Future: Send,
+    T: AsyncRead + AsyncWrite + Send + 'static,
+    C: Protocol<C> + AsRef<[u8]> + Zeroize + Send + 'static,
+    A: Approver + Send + 'static,
+{
+    type Output = (PeerId, NoiseOutput<T>);
+    type Error = NoiseError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
+
+    fn upgrade_inbound(self, socket: T, info: Self::Info) -> Self::Future {
+        Box::pin(
+            self.noise_authenticated
+                .upgrade_inbound(socket, info)
+                .and_then(move |(remote_peer_id, io)| {
+                    if self.approver.allow_peer(&remote_peer_id) {
+                        future::ok((remote_peer_id, io))
+                    } else {
+                        future::err(NoiseError::AuthenticationFailed)
+                    }
+                }),
+        )
+    }
+}
+
+impl<A, T, P, C, R> OutboundUpgrade<T> for FuelAuthenticated<A, P, C, R>
+where
+    NoiseAuthenticated<P, C, R>: UpgradeInfo
+        + OutboundUpgrade<T, Output = (PeerId, NoiseOutput<T>), Error = NoiseError>
+        + 'static,
+    <NoiseAuthenticated<P, C, R> as OutboundUpgrade<T>>::Future: Send,
+    T: AsyncRead + AsyncWrite + Send + 'static,
+    C: Protocol<C> + AsRef<[u8]> + Zeroize + Send + 'static,
+    A: Approver + Send + 'static,
+{
+    type Output = (PeerId, NoiseOutput<T>);
+    type Error = NoiseError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
+
+    fn upgrade_outbound(self, socket: T, info: Self::Info) -> Self::Future {
+        Box::pin(
+            self.noise_authenticated
+                .upgrade_outbound(socket, info)
+                .and_then(move |(remote_peer_id, io)| {
+                    if self.approver.allow_peer(&remote_peer_id) {
+                        future::ok((remote_peer_id, io))
+                    } else {
+                        future::err(NoiseError::AuthenticationFailed)
+                    }
+                }),
+        )
+    }
+}

--- a/crates/services/p2p/src/config/fuel_upgrade.rs
+++ b/crates/services/p2p/src/config/fuel_upgrade.rs
@@ -1,0 +1,132 @@
+use futures::{
+    AsyncRead,
+    AsyncWrite,
+    Future,
+    FutureExt,
+};
+use libp2p::{
+    InboundUpgrade,
+    OutboundUpgrade,
+};
+use libp2p_core::{
+    upgrade::{
+        read_length_prefixed,
+        write_length_prefixed,
+    },
+    UpgradeInfo,
+};
+use std::{
+    error::Error,
+    fmt,
+    io,
+    pin::Pin,
+};
+
+/// Sha256 hash of ChainConfig
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Checksum([u8; 32]);
+
+impl From<[u8; 32]> for Checksum {
+    fn from(value: [u8; 32]) -> Self {
+        Self(value)
+    }
+}
+
+/// When two nodes want to establish a connection they need to
+/// exchange the Hash of their respective Chain Id and Chain Config.
+/// The connection is only accepted if their hashes match.
+/// This is used to aviod peers having same network name but different configurations connecting to each other.
+#[derive(Debug, Clone)]
+pub(crate) struct FuelUpgrade {
+    checksum: Checksum,
+}
+
+impl FuelUpgrade {
+    pub(crate) fn new(checksum: Checksum) -> Self {
+        Self { checksum }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum FuelUpgradeError {
+    IncorrectChecksum,
+    Io(io::Error),
+}
+
+impl fmt::Display for FuelUpgradeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FuelUpgradeError::Io(e) => write!(f, "{}", e),            
+            FuelUpgradeError::IncorrectChecksum => f.write_str("Fuel node checksum does not match, either ChainId or ChainConfig are not the same, or both."),            
+        }
+    }
+}
+
+impl From<io::Error> for FuelUpgradeError {
+    fn from(e: io::Error) -> Self {
+        FuelUpgradeError::Io(e)
+    }
+}
+
+impl Error for FuelUpgradeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            FuelUpgradeError::Io(e) => Some(e),
+            FuelUpgradeError::IncorrectChecksum => None,
+        }
+    }
+}
+
+impl UpgradeInfo for FuelUpgrade {
+    type Info = &'static [u8];
+    type InfoIter = std::iter::Once<Self::Info>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        std::iter::once(b"/fuel/upgrade/0")
+    }
+}
+
+impl<C> InboundUpgrade<C> for FuelUpgrade
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Output = C;
+    type Error = FuelUpgradeError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
+
+    fn upgrade_inbound(self, mut socket: C, _: Self::Info) -> Self::Future {
+        async move {
+            // Inbound node receives the checksum and compares it to its own checksum.
+            // If they do not match the connection is rejected.
+            let res = read_length_prefixed(&mut socket, self.checksum.0.len()).await?;
+            if res != self.checksum.0 {
+                return Err(FuelUpgradeError::IncorrectChecksum)
+            }
+
+            Ok(socket)
+        }
+        .boxed()
+    }
+}
+
+impl<C> OutboundUpgrade<C> for FuelUpgrade
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Output = C;
+    type Error = FuelUpgradeError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
+
+    fn upgrade_outbound(self, mut socket: C, _: Self::Info) -> Self::Future {
+        async move {
+            // Outbound node sends their own checksum for comparison with the inbound node.
+            write_length_prefixed(&mut socket, &self.checksum.0).await?;
+
+            // Note: outbound node does not need to receive the checksum from the inbound node,
+            // since inbound node will reject the connection if the two don't match on its side.
+
+            Ok(socket)
+        }
+        .boxed()
+    }
+}

--- a/crates/services/p2p/src/config/guarded_node.rs
+++ b/crates/services/p2p/src/config/guarded_node.rs
@@ -1,0 +1,31 @@
+use super::{
+    fuel_authenticated::Approver,
+    peer_ids_set_from,
+};
+use libp2p::{
+    Multiaddr,
+    PeerId,
+};
+use std::collections::HashSet;
+
+/// A `GuardedNode` only accepts connections from the set of the reserved nodes
+#[derive(Debug, Clone)]
+pub(crate) struct GuardedNode {
+    reserved_nodes: HashSet<PeerId>,
+}
+
+impl GuardedNode {
+    pub(crate) fn new(reserved_nodes: &[Multiaddr]) -> Self {
+        Self {
+            reserved_nodes: peer_ids_set_from(reserved_nodes),
+        }
+    }
+}
+
+impl Approver for GuardedNode {
+    /// Checks if PeerId of the remote node is contained within the reserved nodes.
+    /// It rejects the connection otherwise.
+    fn allow_peer(&self, peer_id: &PeerId) -> bool {
+        self.reserved_nodes.contains(peer_id)
+    }
+}

--- a/crates/services/p2p/src/p2p_service.rs
+++ b/crates/services/p2p/src/p2p_service.rs
@@ -740,7 +740,7 @@ mod tests {
                         // create and insert it, to be polled with rest of the nodes
                         if all_node_services
                         .iter()
-                        .find(|service| service.local_peer_id == reserved_node_peer_id).is_none() {
+                        .any(|service| service.local_peer_id == reserved_node_peer_id) {
                             all_node_services.push(reserved_node.create_service(p2p_config.clone()));
                         }
                     }

--- a/crates/services/p2p/src/p2p_service.rs
+++ b/crates/services/p2p/src/p2p_service.rs
@@ -128,8 +128,8 @@ impl<Codec: NetworkCodec> FuelP2PService<Codec> {
         let local_peer_id = PeerId::from(config.keypair.public());
 
         // configure and build P2P Service
-        let transport = build_transport(&config);
-        let behaviour = FuelBehaviour::new(&config, codec.clone());
+        let (transport, connection_state) = build_transport(&config);
+        let behaviour = FuelBehaviour::new(&config, codec.clone(), connection_state);
 
         let total_connections = {
             // Reserved nodes do not count against the configured peer input/output limits.

--- a/crates/services/p2p/src/peer_manager.rs
+++ b/crates/services/p2p/src/peer_manager.rs
@@ -150,7 +150,7 @@ impl PeerManagerBehaviour {
 
     pub fn insert_peer_addresses(&mut self, peer_id: &PeerId, addresses: Vec<Multiaddr>) {
         self.peer_manager
-            .inser_peer_info(peer_id, PeerInfoInsert::Addresses(addresses));
+            .insert_peer_info(peer_id, PeerInfoInsert::Addresses(addresses));
     }
 }
 
@@ -377,7 +377,7 @@ impl NetworkBehaviour for PeerManagerBehaviour {
                     result: Ok(PingSuccess::Ping { rtt }),
                 })) => {
                     self.peer_manager
-                        .inser_peer_info(&peer, PeerInfoInsert::LatestPing(rtt));
+                        .insert_peer_info(&peer, PeerInfoInsert::LatestPing(rtt));
 
                     let event = PeerInfoEvent::PeerInfoUpdated { peer_id: peer };
                     return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event))
@@ -444,11 +444,11 @@ impl NetworkBehaviour for PeerManagerBehaviour {
                                 listen_addrs.truncate(MAX_IDENTIFY_ADDRESSES);
                             }
 
-                            self.peer_manager.inser_peer_info(
+                            self.peer_manager.insert_peer_info(
                                 &peer_id,
                                 PeerInfoInsert::ClientVersion(agent_version),
                             );
-                            self.peer_manager.inser_peer_info(
+                            self.peer_manager.insert_peer_info(
                                 &peer_id,
                                 PeerInfoInsert::Addresses(listen_addrs.clone()),
                             );
@@ -550,7 +550,7 @@ impl PeerManager {
         self.non_reserved_connected_peers.get(peer_id)
     }
 
-    fn inser_peer_info(&mut self, peer_id: &PeerId, data: PeerInfoInsert) {
+    fn insert_peer_info(&mut self, peer_id: &PeerId, data: PeerInfoInsert) {
         let peers = if self.reserved_peers.contains(peer_id) {
             &mut self.reserved_connected_peers
         } else {

--- a/crates/services/p2p/src/peer_manager.rs
+++ b/crates/services/p2p/src/peer_manager.rs
@@ -121,8 +121,8 @@ impl PeerManagerBehaviour {
 
         let peer_manager = PeerManager::new(
             reserved_peers,
-            config.max_peers_connected as usize,
             connection_state,
+            config.max_peers_connected as usize,
         );
 
         Self {
@@ -136,20 +136,21 @@ impl PeerManagerBehaviour {
     }
 
     pub fn total_peers_connected(&self) -> usize {
-        self.peer_manager.connected_peers.len()
+        self.peer_manager.total_peers_connected()
     }
 
     /// returns an iterator over the connected peers
     pub fn get_peers_ids(&self) -> impl Iterator<Item = &PeerId> {
-        self.peer_manager.connected_peers.keys()
+        self.peer_manager.get_peers_ids()
     }
 
     pub fn get_peer_info(&self, peer_id: &PeerId) -> Option<&PeerInfo> {
-        self.peer_manager.connected_peers.get(peer_id)
+        self.peer_manager.get_peer_info(peer_id)
     }
 
     pub fn insert_peer_addresses(&mut self, peer_id: &PeerId, addresses: Vec<Multiaddr>) {
-        self.peer_manager.insert_peer_addresses(peer_id, addresses)
+        self.peer_manager
+            .inser_peer_info(peer_id, PeerInfoInsert::Addresses(addresses));
     }
 }
 
@@ -375,7 +376,9 @@ impl NetworkBehaviour for PeerManagerBehaviour {
                     peer,
                     result: Ok(PingSuccess::Ping { rtt }),
                 })) => {
-                    self.peer_manager.insert_latest_ping(&peer, rtt);
+                    self.peer_manager
+                        .inser_peer_info(&peer, PeerInfoInsert::LatestPing(rtt));
+
                     let event = PeerInfoEvent::PeerInfoUpdated { peer_id: peer };
                     return Poll::Ready(NetworkBehaviourAction::GenerateEvent(event))
                 }
@@ -441,11 +444,14 @@ impl NetworkBehaviour for PeerManagerBehaviour {
                                 listen_addrs.truncate(MAX_IDENTIFY_ADDRESSES);
                             }
 
-                            self.peer_manager
-                                .insert_client_version(&peer_id, agent_version);
-
-                            self.peer_manager
-                                .insert_peer_addresses(&peer_id, listen_addrs.clone());
+                            self.peer_manager.inser_peer_info(
+                                &peer_id,
+                                PeerInfoInsert::ClientVersion(agent_version),
+                            );
+                            self.peer_manager.inser_peer_info(
+                                &peer_id,
+                                PeerInfoInsert::Addresses(listen_addrs.clone()),
+                            );
 
                             let event = PeerInfoEvent::PeerIdentified {
                                 peer_id,
@@ -494,94 +500,96 @@ pub struct PeerInfo {
     pub latest_ping: Option<Duration>,
 }
 
+enum PeerInfoInsert {
+    Addresses(Vec<Multiaddr>),
+    ClientVersion(String),
+    LatestPing(Duration),
+}
+
 /// Manages Peers and their events
 #[derive(Debug, Default, Clone)]
 struct PeerManager {
     pending_events: VecDeque<PeerInfoEvent>,
-    connected_peers: HashMap<PeerId, PeerInfo>,
+    non_reserved_connected_peers: HashMap<PeerId, PeerInfo>,
+    reserved_connected_peers: HashMap<PeerId, PeerInfo>,
     reserved_peers: HashSet<PeerId>,
-    number_of_non_reserved_peers_allowed: usize,
     connection_state: Arc<RwLock<ConnectionState>>,
+    max_non_reserved_peers: usize,
 }
 
 impl PeerManager {
     fn new(
         reserved_peers: HashSet<PeerId>,
-        max_connections_allowed: usize,
         connection_state: Arc<RwLock<ConnectionState>>,
+        max_non_reserved_peers: usize,
     ) -> Self {
         Self {
             pending_events: VecDeque::default(),
-            connected_peers: HashMap::with_capacity(max_connections_allowed),
+            non_reserved_connected_peers: HashMap::with_capacity(max_non_reserved_peers),
+            reserved_connected_peers: HashMap::with_capacity(reserved_peers.len()),
             reserved_peers,
-            number_of_non_reserved_peers_allowed: max_connections_allowed,
             connection_state,
+            max_non_reserved_peers,
         }
     }
 
-    fn insert_peer_addresses(&mut self, peer_id: &PeerId, addresses: Vec<Multiaddr>) {
-        if let Some(peer) = self.connected_peers.get_mut(peer_id) {
-            for address in addresses {
-                peer.peer_addresses.insert(address);
+    fn total_peers_connected(&self) -> usize {
+        self.reserved_connected_peers.len() + self.non_reserved_connected_peers.len()
+    }
+
+    fn get_peers_ids(&self) -> impl Iterator<Item = &PeerId> {
+        self.non_reserved_connected_peers
+            .keys()
+            .chain(self.reserved_connected_peers.keys())
+    }
+
+    fn get_peer_info(&self, peer_id: &PeerId) -> Option<&PeerInfo> {
+        if self.reserved_peers.contains(peer_id) {
+            return self.reserved_connected_peers.get(peer_id)
+        }
+        self.non_reserved_connected_peers.get(peer_id)
+    }
+
+    fn inser_peer_info(&mut self, peer_id: &PeerId, data: PeerInfoInsert) {
+        let peers = if self.reserved_peers.contains(peer_id) {
+            &mut self.reserved_connected_peers
+        } else {
+            &mut self.non_reserved_connected_peers
+        };
+        match data {
+            PeerInfoInsert::Addresses(addresses) => {
+                insert_peer_addresses(peers, peer_id, addresses)
             }
-        } else {
-            log_missing_peer(peer_id);
-        }
-    }
-
-    fn insert_latest_ping(&mut self, peer_id: &PeerId, duration: Duration) {
-        if let Some(peer) = self.connected_peers.get_mut(peer_id) {
-            peer.latest_ping = Some(duration);
-        } else {
-            log_missing_peer(peer_id);
-        }
-    }
-
-    fn insert_client_version(&mut self, peer_id: &PeerId, client_version: String) {
-        if let Some(peer) = self.connected_peers.get_mut(peer_id) {
-            peer.client_version = Some(client_version);
-        } else {
-            log_missing_peer(peer_id);
+            PeerInfoInsert::ClientVersion(client_version) => {
+                insert_client_version(peers, peer_id, client_version)
+            }
+            PeerInfoInsert::LatestPing(duration) => {
+                insert_latest_ping(peers, peer_id, duration)
+            }
         }
     }
 
     fn get_disconnected_reserved_peers(&self) -> impl Iterator<Item = &PeerId> {
         self.reserved_peers
             .iter()
-            .filter(|peer_id| !self.connected_peers.contains_key(peer_id))
-    }
-
-    fn reserved_peers_connected_count(&self) -> usize {
-        self.reserved_peers.iter().fold(0, |count, peer_id| {
-            if self.connected_peers.contains_key(peer_id) {
-                count + 1
-            } else {
-                count
-            }
-        })
+            .filter(|peer_id| !self.reserved_connected_peers.contains_key(peer_id))
     }
 
     fn find_disconnected_reserved_peer(&self) -> Option<PeerId> {
         self.reserved_peers
             .iter()
-            .find(|peer_id| self.connected_peers.contains_key(peer_id))
+            .find(|peer_id| self.reserved_connected_peers.contains_key(peer_id))
             .cloned()
     }
 
     /// Handles the first connnection established with a Peer
     fn handle_initial_connection(&mut self, peer_id: PeerId) {
+        let non_reserved_peers_connected = self.non_reserved_connected_peers.len();
+
         // if the connected Peer is not from the reserved peers
         if !self.reserved_peers.contains(&peer_id) {
-            let number_of_non_reserved_peers_connected =
-                self.connected_peers.len() - self.reserved_peers_connected_count();
-
-            // check if there is no more space for non-resereved peers
-            if number_of_non_reserved_peers_connected
-                >= self.number_of_non_reserved_peers_allowed
-            {
-                // todo/potential improvement: once `Peer Reputation` is implemented we could check if there are peers
-                // with poor reputation and disconnect them instead?
-
+            // check if all the slots are already taken
+            if non_reserved_peers_connected >= self.max_non_reserved_peers {
                 // Too many peers already connected, disconnect the Peer
                 self.pending_events.push_back(PeerInfoEvent::TooManyPeers {
                     peer_to_disconnect: peer_id,
@@ -592,21 +600,22 @@ impl PeerManager {
                 // nor insert it in `connected_peers`
                 // since we're going to disconnect it anyways
                 return
-            } else if self.number_of_non_reserved_peers_allowed
-                - number_of_non_reserved_peers_connected
-                == 1
-            {
-                // this is the last peer allowed no more!
-                self.connection_state
-                    .write()
-                    .unwrap()
-                    .non_reserved_peers_allowed = false;
             }
+
+            if self.max_non_reserved_peers - non_reserved_peers_connected == 1 {
+                // this is the last non-reserved peer allowed
+                if let Ok(mut connection_state) = self.connection_state.write() {
+                    connection_state.deny_new_peers();
+                }
+            }
+
+            self.non_reserved_connected_peers
+                .insert(peer_id, PeerInfo::default());
+        } else {
+            self.reserved_connected_peers
+                .insert(peer_id, PeerInfo::default());
         }
 
-        // insert and report on new Peer Connection
-        // for either, reserved peer or non-reserved
-        self.connected_peers.insert(peer_id, PeerInfo::default());
         self.pending_events
             .push_back(PeerInfoEvent::PeerConnected(peer_id));
     }
@@ -614,44 +623,92 @@ impl PeerManager {
     /// Handles on peer's last connection getting disconnected
     fn handle_peer_disconnect(&mut self, peer_id: PeerId) {
         // try immediate reconnect if it's a reserved peer
-        let should_reconnect = self.reserved_peers.contains(&peer_id);
-        self.connected_peers.remove(&peer_id);
+        let is_reserved = self.reserved_peers.contains(&peer_id);
 
-        if !should_reconnect
-            && !self
-                .connection_state
-                .read()
-                .unwrap()
-                .non_reserved_peers_allowed
-        {
-            self.connection_state
-                .write()
-                .unwrap()
-                .non_reserved_peers_allowed = true;
+        if !is_reserved {
+            // check were all the slots full prior to this disconnect
+            if self.max_non_reserved_peers - self.non_reserved_connected_peers.len() == 0
+            {
+                // since all the slots were full prior to this disconnect
+                // let's allow new peer non-reserved peers connections
+                if let Ok(mut connection_state) = self.connection_state.write() {
+                    connection_state.allow_new_peers();
+                }
+            }
+
+            self.non_reserved_connected_peers.remove(&peer_id);
+        } else {
+            self.reserved_connected_peers.remove(&peer_id);
         }
 
         self.pending_events
             .push_back(PeerInfoEvent::PeerDisconnected {
                 peer_id,
-                should_reconnect,
+                should_reconnect: is_reserved,
             })
     }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct ConnectionState {
-    non_reserved_peers_allowed: bool,
+    peers_allowed: bool,
 }
 
 impl ConnectionState {
     pub fn new() -> Arc<RwLock<Self>> {
         Arc::new(RwLock::new(Self {
-            non_reserved_peers_allowed: true,
+            peers_allowed: true,
         }))
     }
 
     pub fn available_slot(&self) -> bool {
-        self.non_reserved_peers_allowed
+        self.peers_allowed
+    }
+
+    fn allow_new_peers(&mut self) {
+        self.peers_allowed = true;
+    }
+
+    fn deny_new_peers(&mut self) {
+        self.peers_allowed = false;
+    }
+}
+
+fn insert_peer_addresses(
+    peers: &mut HashMap<PeerId, PeerInfo>,
+    peer_id: &PeerId,
+    addresses: Vec<Multiaddr>,
+) {
+    if let Some(peer) = peers.get_mut(peer_id) {
+        for address in addresses {
+            peer.peer_addresses.insert(address);
+        }
+    } else {
+        log_missing_peer(peer_id);
+    }
+}
+
+fn insert_latest_ping(
+    peers: &mut HashMap<PeerId, PeerInfo>,
+    peer_id: &PeerId,
+    duration: Duration,
+) {
+    if let Some(peer) = peers.get_mut(peer_id) {
+        peer.latest_ping = Some(duration);
+    } else {
+        log_missing_peer(peer_id);
+    }
+}
+
+fn insert_client_version(
+    peers: &mut HashMap<PeerId, PeerInfo>,
+    peer_id: &PeerId,
+    client_version: String,
+) {
+    if let Some(peer) = peers.get_mut(peer_id) {
+        peer.client_version = Some(client_version);
+    } else {
+        log_missing_peer(peer_id);
     }
 }
 
@@ -679,8 +736,8 @@ mod tests {
 
         let mut peer_manager = PeerManager::new(
             reserved_peers.clone().into_iter().collect(),
-            max_non_reserved_allowed,
             connection_state,
+            max_non_reserved_allowed,
         );
 
         // try connecting only random peers
@@ -690,11 +747,14 @@ mod tests {
 
         // only amount of non-reserved peers allowed should be connected
         assert_eq!(
-            peer_manager.connected_peers.len(),
-            peer_manager.number_of_non_reserved_peers_allowed
+            peer_manager.non_reserved_connected_peers.len(),
+            peer_manager.max_non_reserved_peers
         );
         // or in other words:
-        assert_eq!(peer_manager.connected_peers.len(), random_peers.len() / 2);
+        assert_eq!(
+            peer_manager.non_reserved_connected_peers.len(),
+            random_peers.len() / 2
+        );
 
         // connect resereved peers
         for peer_id in &reserved_peers {
@@ -702,15 +762,15 @@ mod tests {
         }
 
         // the connections should be at max now
-        assert_eq!(peer_manager.connected_peers.len(), total_connections);
+        assert_eq!(peer_manager.total_peers_connected(), total_connections);
 
         // disconnect a reserved peer
         peer_manager.handle_peer_disconnect(*reserved_peers.first().unwrap());
-        assert_eq!(peer_manager.connected_peers.len(), total_connections - 1);
+        assert_eq!(peer_manager.total_peers_connected(), total_connections - 1);
 
         // assert that the last random peer is not already connected
         assert!(!peer_manager
-            .connected_peers
+            .non_reserved_connected_peers
             .contains_key(random_peers.last().unwrap()));
 
         // try to connect the last random peer in the list
@@ -718,21 +778,21 @@ mod tests {
 
         // the connection count should remain the same as when the reserved peer disconnected
         // that is, the connection has been refused
-        assert_eq!(peer_manager.connected_peers.len(), total_connections - 1);
+        assert_eq!(peer_manager.total_peers_connected(), total_connections - 1);
 
         // reconnect the first reserved peer that was disconnected
         peer_manager.handle_initial_connection(*reserved_peers.first().unwrap());
-        assert_eq!(peer_manager.connected_peers.len(), total_connections);
+        assert_eq!(peer_manager.total_peers_connected(), total_connections);
 
         // disconnect a single non-reserved peer
         peer_manager.handle_peer_disconnect(*random_peers.first().unwrap());
-        assert_eq!(peer_manager.connected_peers.len(), total_connections - 1);
+        assert_eq!(peer_manager.total_peers_connected(), total_connections - 1);
 
         // connect a different non-reserved peer
         peer_manager.handle_initial_connection(*random_peers.last().unwrap());
 
         // the connection should be successful,
         // and we should be up to our max connections count again
-        assert_eq!(peer_manager.connected_peers.len(), total_connections);
+        assert_eq!(peer_manager.total_peers_connected(), total_connections);
     }
 }


### PR DESCRIPTION
following @Voxelot 's [comment](https://github.com/FuelLabs/fuel-core/pull/876#discussion_r1065400628) this is a prototype of how would we move checking of peer slot availability during handshake instead of after the connection is established.

The approach is that we share a state between PeerManager and Fuel Authenticator (that does the handshake), we update the state only on PeerManager side, but we read the state from Fuel Authenticator every time we want to establish a connection with a peer