### PR TITLE
Leave `dap.rs` in the `fuel-core` level for now

### DIFF
--- a/crates/fuel-core/src/graphql_api/service.rs
+++ b/crates/fuel-core/src/graphql_api/service.rs
@@ -2,9 +2,8 @@ use crate::{
     fuel_core_graphql_api::ports::DatabasePort,
     graphql_api::Config,
     schema::{
-        build_schema,
-        dap,
         CoreSchema,
+        CoreSchemaBuilder,
     },
     service::metrics::metrics,
 };
@@ -67,11 +66,7 @@ use tower_http::{
 
 pub type Service = fuel_core_services::ServiceRunner<NotInitializedTask>;
 
-// TODO: When the port of DB will exist we need to replace it with `Box<dyn DatabasePort>
-pub type Database = crate::database::Database;
-// TODO: When all ports will be ready, we need to remove `Database`(and related code)
-//  and rename `DatabaseTemp` into `Database`
-pub type DatabaseTemp = Box<dyn DatabasePort>;
+pub type Database = Box<dyn DatabasePort>;
 // TODO: When the port for `Executor` will exist we need to replace it with `Box<dyn ExecutorPort>
 pub type Executor = crate::service::adapters::ExecutorAdapter;
 // TODO: When the port of BlockProducer will exist we need to replace it with
@@ -145,21 +140,20 @@ impl RunnableTask for Task {
 pub fn new_service(
     config: Config,
     database: Database,
+    schema: CoreSchemaBuilder,
     producer: BlockProducer,
     txpool: TxPool,
     executor: Executor,
 ) -> anyhow::Result<Service> {
-    let database_temp: DatabaseTemp = Box::new(database.clone());
     let network_addr = config.addr;
-    let params = config.transaction_parameters;
-    let schema = build_schema()
+    let schema = schema
         .data(config)
         .data(database)
-        .data(database_temp)
         .data(producer)
         .data(txpool)
-        .data(executor);
-    let schema = dap::init(schema, params).extension(Tracing).finish();
+        .data(executor)
+        .extension(Tracing)
+        .finish();
 
     let router = Router::new()
         .route("/playground", get(graphql_playground))

--- a/crates/fuel-core/src/query/balance.rs
+++ b/crates/fuel-core/src/query/balance.rs
@@ -1,5 +1,5 @@
 use crate::{
-    fuel_core_graphql_api::service::DatabaseTemp,
+    fuel_core_graphql_api::service::Database,
     state::IterDirection,
 };
 use asset_query::{
@@ -23,7 +23,7 @@ use std::{
 
 pub mod asset_query;
 
-pub struct BalanceQueryContext<'a>(pub &'a DatabaseTemp);
+pub struct BalanceQueryContext<'a>(pub &'a Database);
 
 impl BalanceQueryContext<'_> {
     pub fn balance(

--- a/crates/fuel-core/src/query/balance/asset_query.rs
+++ b/crates/fuel-core/src/query/balance/asset_query.rs
@@ -1,5 +1,5 @@
 use crate::{
-    fuel_core_graphql_api::service::DatabaseTemp,
+    fuel_core_graphql_api::service::Database,
     query::{
         CoinQueryContext,
         MessageQueryContext,
@@ -71,7 +71,7 @@ pub struct AssetsQuery<'a> {
     pub owner: &'a Address,
     pub assets: Option<HashSet<&'a AssetId>>,
     pub exclude: Option<&'a Exclude>,
-    pub database: &'a DatabaseTemp,
+    pub database: &'a Database,
 }
 
 impl<'a> AssetsQuery<'a> {
@@ -79,7 +79,7 @@ impl<'a> AssetsQuery<'a> {
         owner: &'a Address,
         assets: Option<HashSet<&'a AssetId>>,
         exclude: Option<&'a Exclude>,
-        database: &'a DatabaseTemp,
+        database: &'a Database,
     ) -> Self {
         Self {
             owner,
@@ -161,7 +161,7 @@ pub struct AssetQuery<'a> {
     pub owner: &'a Address,
     pub asset: &'a AssetSpendTarget,
     pub exclude: Option<&'a Exclude>,
-    pub database: &'a DatabaseTemp,
+    pub database: &'a Database,
     query: AssetsQuery<'a>,
 }
 
@@ -170,7 +170,7 @@ impl<'a> AssetQuery<'a> {
         owner: &'a Address,
         asset: &'a AssetSpendTarget,
         exclude: Option<&'a Exclude>,
-        database: &'a DatabaseTemp,
+        database: &'a Database,
     ) -> Self {
         let mut allowed = HashSet::new();
         allowed.insert(&asset.id);

--- a/crates/fuel-core/src/query/block.rs
+++ b/crates/fuel-core/src/query/block.rs
@@ -1,5 +1,5 @@
 use crate::{
-    fuel_core_graphql_api::service::DatabaseTemp,
+    fuel_core_graphql_api::service::Database,
     state::IterDirection,
 };
 use fuel_core_storage::{
@@ -20,7 +20,7 @@ use fuel_core_types::blockchain::{
     },
 };
 
-pub struct BlockQueryContext<'a>(pub &'a DatabaseTemp);
+pub struct BlockQueryContext<'a>(pub &'a Database);
 
 impl BlockQueryContext<'_> {
     pub fn block(&self, id: &BlockId) -> StorageResult<CompressedBlock> {

--- a/crates/fuel-core/src/query/chain.rs
+++ b/crates/fuel-core/src/query/chain.rs
@@ -1,7 +1,7 @@
-use crate::fuel_core_graphql_api::service::DatabaseTemp;
+use crate::fuel_core_graphql_api::service::Database;
 use fuel_core_storage::Result as StorageResult;
 
-pub struct ChainQueryContext<'a>(pub &'a DatabaseTemp);
+pub struct ChainQueryContext<'a>(pub &'a Database);
 
 impl ChainQueryContext<'_> {
     pub fn name(&self) -> StorageResult<String> {

--- a/crates/fuel-core/src/query/coin.rs
+++ b/crates/fuel-core/src/query/coin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    graphql_api::service::DatabaseTemp,
+    graphql_api::service::Database,
     state::IterDirection,
 };
 use fuel_core_storage::{
@@ -14,7 +14,7 @@ use fuel_core_types::{
     fuel_types::Address,
 };
 
-pub struct CoinQueryContext<'a>(pub &'a DatabaseTemp);
+pub struct CoinQueryContext<'a>(pub &'a Database);
 
 impl<'a> CoinQueryContext<'a> {
     pub fn coin(&self, utxo_id: UtxoId) -> StorageResult<Coin> {

--- a/crates/fuel-core/src/query/contract.rs
+++ b/crates/fuel-core/src/query/contract.rs
@@ -1,5 +1,5 @@
 use crate::{
-    graphql_api::service::DatabaseTemp,
+    graphql_api::service::Database,
     state::IterDirection,
 };
 use fuel_core_storage::{
@@ -21,7 +21,7 @@ use fuel_core_types::{
     services::graphql_api::ContractBalance,
 };
 
-pub struct ContractQueryContext<'a>(pub &'a DatabaseTemp);
+pub struct ContractQueryContext<'a>(pub &'a Database);
 
 impl ContractQueryContext<'_> {
     pub fn contract_id(&self, id: ContractId) -> StorageResult<ContractId> {

--- a/crates/fuel-core/src/query/message_proof.rs
+++ b/crates/fuel-core/src/query/message_proof.rs
@@ -1,6 +1,6 @@
 use crate::{
     fuel_core_graphql_api::{
-        service::DatabaseTemp,
+        service::Database,
         IntoApiResult,
     },
     query::{
@@ -48,7 +48,7 @@ use std::borrow::Cow;
 #[cfg(test)]
 mod test;
 
-pub struct MessageQueryContext<'a>(pub &'a DatabaseTemp);
+pub struct MessageQueryContext<'a>(pub &'a Database);
 
 impl<'a> MessageQueryContext<'a> {
     pub fn message(&self, message_id: &MessageId) -> StorageResult<Message> {

--- a/crates/fuel-core/src/query/tx.rs
+++ b/crates/fuel-core/src/query/tx.rs
@@ -1,5 +1,5 @@
 use crate::{
-    fuel_core_graphql_api::service::DatabaseTemp,
+    fuel_core_graphql_api::service::Database,
     state::IterDirection,
 };
 use fuel_core_storage::{
@@ -22,7 +22,7 @@ use fuel_core_types::{
     services::txpool::TransactionStatus,
 };
 
-pub struct TransactionQueryContext<'a>(pub &'a DatabaseTemp);
+pub struct TransactionQueryContext<'a>(pub &'a Database);
 
 impl TransactionQueryContext<'_> {
     pub fn transaction(&self, tx_id: &TxId) -> StorageResult<Transaction> {

--- a/crates/fuel-core/src/schema.rs
+++ b/crates/fuel-core/src/schema.rs
@@ -53,8 +53,9 @@ pub struct Mutation(dap::DapMutation, tx::TxMutation, block::BlockMutation);
 pub struct Subscription(tx::TxStatusSubscription);
 
 pub type CoreSchema = Schema<Query, Mutation, Subscription>;
+pub type CoreSchemaBuilder = SchemaBuilder<Query, Mutation, Subscription>;
 
-pub fn build_schema() -> SchemaBuilder<Query, Mutation, Subscription> {
+pub fn build_schema() -> CoreSchemaBuilder {
     Schema::build_with_ignore_name_conflicts(
         Query::default(),
         Mutation::default(),

--- a/crates/fuel-core/src/schema/dap.rs
+++ b/crates/fuel-core/src/schema/dap.rs
@@ -2,8 +2,8 @@ use crate::{
     database::{
         transactional::DatabaseTransaction,
         vm_database::VmDatabase,
+        Database,
     },
-    fuel_core_graphql_api::service::Database,
     schema::scalars::U64,
 };
 use async_graphql::{

--- a/crates/fuel-core/src/schema/resource.rs
+++ b/crates/fuel-core/src/schema/resource.rs
@@ -1,6 +1,6 @@
 use crate::{
     fuel_core_graphql_api::{
-        service::DatabaseTemp,
+        service::Database,
         Config as GraphQLConfig,
     },
     query::asset_query::AssetSpendTarget,
@@ -112,7 +112,7 @@ impl ResourceQuery {
 
         let spend_query = SpendQuery::new(owner, &query_per_asset, excluded_ids)?;
 
-        let db = ctx.data_unchecked::<DatabaseTemp>();
+        let db = ctx.data_unchecked::<Database>();
 
         let resources = random_improve(db, &spend_query)?
             .into_iter()

--- a/crates/fuel-core/src/schema/scalars.rs
+++ b/crates/fuel-core/src/schema/scalars.rs
@@ -1,4 +1,3 @@
-use crate::database::transactions::OwnedTransactionIndexCursor;
 use async_graphql::{
     connection::CursorType,
     InputValueError,
@@ -148,18 +147,6 @@ impl CursorType for HexString {
 
     fn encode_cursor(&self) -> String {
         self.to_string()
-    }
-}
-
-impl From<HexString> for OwnedTransactionIndexCursor {
-    fn from(string: HexString) -> Self {
-        string.0.into()
-    }
-}
-
-impl From<OwnedTransactionIndexCursor> for HexString {
-    fn from(cursor: OwnedTransactionIndexCursor) -> Self {
-        HexString(cursor.into())
     }
 }
 

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -2,7 +2,7 @@ use crate::{
     fuel_core_graphql_api::{
         service::{
             BlockProducer,
-            DatabaseTemp,
+            Database,
             TxPool,
         },
         IntoApiResult,
@@ -224,7 +224,7 @@ pub struct TxStatusSubscription;
 
 struct StreamState<'a> {
     txpool: TxPool,
-    db: &'a DatabaseTemp,
+    db: &'a Database,
 }
 
 #[Subscription]
@@ -247,7 +247,7 @@ impl TxStatusSubscription {
         #[graphql(desc = "The ID of the transaction")] id: TransactionId,
     ) -> impl Stream<Item = async_graphql::Result<TransactionStatus>> + 'a {
         let txpool = ctx.data_unchecked::<TxPool>().clone();
-        let db = ctx.data_unchecked::<DatabaseTemp>();
+        let db = ctx.data_unchecked::<Database>();
         let rx = BroadcastStream::new(txpool.shared.tx_update_subscribe());
         let state = StreamState { txpool, db };
 

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -122,7 +122,8 @@ pub fn init_sub_services(
     };
 
     // TODO: Figure out on how to move it into `fuel-core-graphql-api`.
-    let schema = dap::init(build_schema(), config.chain_conf.transaction_parameters);
+    let schema = dap::init(build_schema(), config.chain_conf.transaction_parameters)
+        .data(database.clone());
     let graph_ql = crate::fuel_core_graphql_api::service::new_service(
         GraphQLConfig {
             addr: config.addr,

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -4,6 +4,10 @@ use crate::{
     chain_config::BlockProduction,
     database::Database,
     fuel_core_graphql_api::Config as GraphQLConfig,
+    schema::{
+        build_schema,
+        dap,
+    },
     service::{
         adapters::{
             BlockImportAdapter,
@@ -117,6 +121,8 @@ pub fn init_sub_services(
         ),
     };
 
+    // TODO: Figure out on how to move it into `fuel-core-graphql-api`.
+    let schema = dap::init(build_schema(), config.chain_conf.transaction_parameters);
     let graph_ql = crate::fuel_core_graphql_api::service::new_service(
         GraphQLConfig {
             addr: config.addr,
@@ -129,7 +135,8 @@ pub fn init_sub_services(
             transaction_parameters: config.chain_conf.transaction_parameters,
             consensus_key: config.consensus_key.clone(),
         },
-        database.clone(),
+        Box::new(database.clone()),
+        schema,
         block_producer,
         txpool.clone(),
         executor,


### PR DESCRIPTION
Removed unused `OwnedTransactionIndexCursor` from the schema.
Extracted `dap.rs` into the `fuel-core` level.
Renamed `TempDatabase` into `Database`.