### PR TITLE
Enable p2p in docker

### DIFF
--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -41,4 +41,4 @@ relayer = ["fuel-core/relayer", "dep:url", "dep:serde_json"]
 rocksdb = ["fuel-core/rocksdb"]
 rocksdb-production = ["fuel-core/rocksdb-production"]
 # features to enable in production, but increase build times
-production = ["metrics", "relayer", "rocksdb-production"]
+production = ["metrics", "relayer", "rocksdb-production", "p2p"]

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
     lld \
     clang \
     libclang-dev \
+    protobuf-compiler \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -32,6 +32,7 @@ FROM ubuntu:22.04 as run
 
 ARG IP=0.0.0.0
 ARG PORT=4000
+ARG P2P_PORT=30333
 ARG DB_PATH=./mnt/db/
 
 ENV IP="${IP}"
@@ -51,6 +52,7 @@ COPY --from=builder /build/target/release/fuel-core .
 COPY --from=builder /build/target/release/fuel-core.d .
 
 EXPOSE ${PORT}
+EXPOSE ${P2P_PORT}
 
 # https://stackoverflow.com/a/44671685
 # https://stackoverflow.com/a/40454758


### PR DESCRIPTION
Enables libp2p in the standard docker container for fuel-core.