### PR TITLE
Return back the "Output Bech32Address for initial accounts" change.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,7 +998,7 @@ checksum = "c94090a6663f224feae66ab01e41a2555a8296ee07b5f20dab8888bdefc9f617"
 dependencies = [
  "base58check",
  "base64 0.12.3",
- "bech32",
+ "bech32 0.7.3",
  "blake2",
  "digest 0.10.6",
  "generic-array 0.14.6",
@@ -2278,6 +2284,7 @@ name = "fuel-core-chain-config"
 version = "0.15.1"
 dependencies = [
  "anyhow",
+ "bech32 0.9.1",
  "bincode",
  "fuel-core-poa",
  "fuel-core-storage",

--- a/crates/chain-config/Cargo.toml
+++ b/crates/chain-config/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel Chain config types"
 
 [dependencies]
 anyhow = "1.0"
+bech32 = "0.9.0"
 bincode = "1.3"
 fuel-core-poa = { path = "../services/consensus_module/poa", version = "0.15.1" }
 fuel-core-storage = { path = "../storage", version = "0.15.1" }


### PR DESCRIPTION
[This change](https://github.com/FuelLabs/fuel-core/pull/594) was done at the same time as moving this file into another place, so during conflict resolution, we missed it.

Closes https://github.com/FuelLabs/fuel-core/issues/593