### PR TITLE
Use postcard instead of bincode for serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +994,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "coins-bip32"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1219,12 @@ dependencies = [
  "cast",
  "itertools",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -2265,7 +2286,6 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "axum",
- "bincode",
  "clap 4.1.1",
  "derive_more",
  "enum-iterator",
@@ -2291,6 +2311,7 @@ dependencies = [
  "itertools",
  "mockall",
  "num_cpus",
+ "postcard",
  "primitive-types",
  "rand 0.8.5",
  "rocksdb",
@@ -2357,12 +2378,12 @@ version = "0.15.1"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
- "bincode",
  "fuel-core-storage",
  "fuel-core-types",
  "hex",
  "insta",
  "itertools",
+ "postcard",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2477,7 +2498,6 @@ version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode",
  "ctor",
  "fuel-core-chain-config",
  "fuel-core-metrics",
@@ -2502,6 +2522,7 @@ dependencies = [
  "libp2p-tcp",
  "libp2p-websocket",
  "libp2p-yamux",
+ "postcard",
  "prometheus-client",
  "rand 0.8.5",
  "serde",
@@ -3037,6 +3058,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3061,6 +3091,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.4",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4912,6 +4956,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2b180dc0bade59f03fd005cb967d3f1e5f69b13922dad0cd6e047cb8af2363"
+dependencies = [
+ "cobs",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6102,6 +6157,9 @@ name = "spin"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -6112,6 +6170,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"

--- a/crates/chain-config/Cargo.toml
+++ b/crates/chain-config/Cargo.toml
@@ -13,7 +13,6 @@ description = "Fuel Chain config types"
 [dependencies]
 anyhow = "1.0"
 bech32 = "0.9.0"
-postcard = { version = "1.0", features = ["use-std"] }
 fuel-core-storage = { path = "../storage", version = "0.15.1" }
 fuel-core-types = { path = "../types", version = "0.15.1", features = [
     "serde",
@@ -21,6 +20,7 @@ fuel-core-types = { path = "../types", version = "0.15.1", features = [
 ] }
 hex = { version = "0.4", features = ["serde"] }
 itertools = "0.10"
+postcard = { version = "1.0", features = ["use-std"] }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/crates/chain-config/Cargo.toml
+++ b/crates/chain-config/Cargo.toml
@@ -13,7 +13,7 @@ description = "Fuel Chain config types"
 [dependencies]
 anyhow = "1.0"
 bech32 = "0.9.0"
-bincode = "1.3"
+postcard = { version = "1.0", features = ["use-std"] }
 fuel-core-storage = { path = "../storage", version = "0.15.1" }
 fuel-core-types = { path = "../types", version = "0.15.1", features = [
     "serde",

--- a/crates/chain-config/src/config/chain.rs
+++ b/crates/chain-config/src/config/chain.rs
@@ -183,9 +183,7 @@ impl GenesisCommitment for ConsensusParameters {
     fn root(&mut self) -> anyhow::Result<MerkleRoot> {
         // TODO: Define hash algorithm for `ConsensusParameters`
         let bytes = postcard::to_stdvec(&self)?;
-        let params_hash = Hasher::default()
-            .chain(bytes)
-            .finalize();
+        let params_hash = Hasher::default().chain(bytes).finalize();
 
         Ok(params_hash.into())
     }

--- a/crates/chain-config/src/config/chain.rs
+++ b/crates/chain-config/src/config/chain.rs
@@ -182,8 +182,9 @@ impl GenesisCommitment for ChainConfig {
 impl GenesisCommitment for ConsensusParameters {
     fn root(&mut self) -> anyhow::Result<MerkleRoot> {
         // TODO: Define hash algorithm for `ConsensusParameters`
+        let bytes = postcard::to_stdvec(&self)?;
         let params_hash = Hasher::default()
-            .chain(bincode::serialize(&self)?)
+            .chain(bytes)
             .finalize();
 
         Ok(params_hash.into())

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -17,7 +17,7 @@ async-graphql = { version = "4.0", features = [
 ], default-features = false }
 async-trait = "0.1"
 axum = { version = "0.5" }
-bincode = "1.3"
+postcard = { version = "1.0", features = ["use-std"] }
 clap = { version = "4.1", features = ["derive"] }
 derive_more = { version = "0.99" }
 enum-iterator = "1.2"

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -17,7 +17,6 @@ async-graphql = { version = "4.0", features = [
 ], default-features = false }
 async-trait = "0.1"
 axum = { version = "0.5" }
-postcard = { version = "1.0", features = ["use-std"] }
 clap = { version = "4.1", features = ["derive"] }
 derive_more = { version = "0.99" }
 enum-iterator = "1.2"
@@ -43,6 +42,7 @@ hex = { version = "0.4", features = ["serde"] }
 hyper = { version = "0.14" }
 itertools = "0.10"
 num_cpus = "1.13"
+postcard = { version = "1.0", features = ["use-std"] }
 primitive-types = "0.12"
 rand = "0.8"
 rocksdb = { version = "0.19", default-features = false, features = [

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -189,11 +189,11 @@ impl Database {
         let result = self.data.put(
             key.as_ref(),
             column,
-            bincode::serialize(&value).map_err(|_| DatabaseError::Codec)?,
+            postcard::to_stdvec(&value).map_err(|_| DatabaseError::Codec)?,
         )?;
         if let Some(previous) = result {
             Ok(Some(
-                bincode::deserialize(&previous).map_err(|_| DatabaseError::Codec)?,
+                postcard::from_bytes(&previous).map_err(|_| DatabaseError::Codec)?,
             ))
         } else {
             Ok(None)
@@ -207,7 +207,7 @@ impl Database {
     ) -> DatabaseResult<Option<V>> {
         self.data
             .delete(key, column)?
-            .map(|val| bincode::deserialize(&val).map_err(|_| DatabaseError::Codec))
+            .map(|val| postcard::from_bytes(&val).map_err(|_| DatabaseError::Codec))
             .transpose()
     }
 
@@ -218,7 +218,7 @@ impl Database {
     ) -> DatabaseResult<Option<V>> {
         self.data
             .get(key, column)?
-            .map(|val| bincode::deserialize(&val).map_err(|_| DatabaseError::Codec))
+            .map(|val| postcard::from_bytes(&val).map_err(|_| DatabaseError::Codec))
             .transpose()
     }
 
@@ -245,7 +245,7 @@ impl Database {
                 val.and_then(|(key, value)| {
                     let key = K::from(key);
                     let value: V =
-                        bincode::deserialize(&value).map_err(|_| DatabaseError::Codec)?;
+                        postcard::from_bytes(&value).map_err(|_| DatabaseError::Codec)?;
                     Ok((key, value))
                 })
             })

--- a/crates/services/p2p/Cargo.toml
+++ b/crates/services/p2p/Cargo.toml
@@ -13,7 +13,6 @@ description = "Fuel client networking"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-postcard = { version = "1.0", features = ["use-std"] }
 fuel-core-chain-config = { path = "../../chain-config", version = "0.15.1" }
 fuel-core-metrics = { path = "../../metrics", version = "0.15.1" } # TODO make this a feature
 fuel-core-services = { path = "../../services", version = "0.15.1" }
@@ -53,6 +52,7 @@ libp2p-swarm = "=0.41.1"
 libp2p-tcp = "=0.38.0"
 libp2p-websocket = "=0.40.0"
 libp2p-yamux = "=0.42.0"
+postcard = { version = "1.0", features = ["use-std"] }
 prometheus-client = "0.18"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/services/p2p/Cargo.toml
+++ b/crates/services/p2p/Cargo.toml
@@ -13,7 +13,7 @@ description = "Fuel client networking"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-bincode = "1.3"
+postcard = { version = "1.0", features = ["use-std"] }
 fuel-core-chain-config = { path = "../../chain-config", version = "0.15.1" }
 fuel-core-metrics = { path = "../../metrics", version = "0.15.1" } # TODO make this a feature
 fuel-core-services = { path = "../../services", version = "0.15.1" }

--- a/crates/services/p2p/src/codecs.rs
+++ b/crates/services/p2p/src/codecs.rs
@@ -1,4 +1,4 @@
-pub mod bincode;
+pub mod postcard;
 
 use crate::{
     gossipsub::messages::{

--- a/crates/services/p2p/src/codecs/postcard.rs
+++ b/crates/services/p2p/src/codecs/postcard.rs
@@ -283,11 +283,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_request_size_matches() {
+    fn test_request_size_fits() {
         let m = RequestMessage::Transactions(BlockId::default());
-        assert_eq!(
-            bincode::serialized_size(&m).unwrap() as usize,
-            MAX_REQUEST_SIZE
-        );
+        assert!(postcard::to_stdvec(&m).unwrap().len() < MAX_REQUEST_SIZE);
     }
 }

--- a/crates/services/p2p/src/codecs/postcard.rs
+++ b/crates/services/p2p/src/codecs/postcard.rs
@@ -285,6 +285,6 @@ mod tests {
     #[test]
     fn test_request_size_fits() {
         let m = RequestMessage::Transactions(BlockId::default());
-        assert!(postcard::to_stdvec(&m).unwrap().len() < MAX_REQUEST_SIZE);
+        assert!(postcard::to_stdvec(&m).unwrap().len() <= MAX_REQUEST_SIZE);
     }
 }

--- a/crates/services/p2p/src/codecs/postcard.rs
+++ b/crates/services/p2p/src/codecs/postcard.rs
@@ -40,14 +40,14 @@ use serde::{
 use std::io;
 
 #[derive(Debug, Clone)]
-pub struct BincodeCodec {
+pub struct PostcardCodec {
     /// Used for `max_size` parameter when reading Response Message
     /// Necessary in order to avoid DoS attacks
     /// Currently the size mostly depends on the max size of the Block
     max_response_size: usize,
 }
 
-impl BincodeCodec {
+impl PostcardCodec {
     pub fn new(max_block_size: usize) -> Self {
         Self {
             max_response_size: max_block_size,
@@ -70,7 +70,7 @@ impl BincodeCodec {
     }
 }
 
-/// Since Bincode does not support async reads or writes out of the box
+/// Since Postcard does not support async reads or writes out of the box
 /// We prefix Request & Response Messages with the length of the data in bytes
 /// We expect the substream to be properly closed when response channel is dropped.
 /// Since the request protocol used here expects a response, the sender considers this
@@ -78,8 +78,8 @@ impl BincodeCodec {
 /// If the substream was not properly closed when dropped, the sender would instead
 /// run into a timeout waiting for the response.
 #[async_trait]
-impl RequestResponseCodec for BincodeCodec {
-    type Protocol = MessageExchangeBincodeProtocol;
+impl RequestResponseCodec for PostcardCodec {
+    type Protocol = MessageExchangePostcardProtocol;
     type Request = RequestMessage;
     type Response = NetworkResponse;
 
@@ -150,7 +150,7 @@ impl RequestResponseCodec for BincodeCodec {
     }
 }
 
-impl GossipsubCodec for BincodeCodec {
+impl GossipsubCodec for PostcardCodec {
     type RequestMessage = GossipsubBroadcastRequest;
     type ResponseMessage = GossipsubMessage;
 
@@ -185,7 +185,7 @@ impl GossipsubCodec for BincodeCodec {
     }
 }
 
-impl RequestResponseConverter for BincodeCodec {
+impl RequestResponseConverter for PostcardCodec {
     type NetworkResponse = NetworkResponse;
     type OutboundResponse = OutboundResponse;
     type ResponseMessage = ResponseMessage;
@@ -261,16 +261,16 @@ impl RequestResponseConverter for BincodeCodec {
     }
 }
 
-impl NetworkCodec for BincodeCodec {
+impl NetworkCodec for PostcardCodec {
     fn get_req_res_protocol(&self) -> <Self as RequestResponseCodec>::Protocol {
-        MessageExchangeBincodeProtocol {}
+        MessageExchangePostcardProtocol {}
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct MessageExchangeBincodeProtocol;
+pub struct MessageExchangePostcardProtocol;
 
-impl ProtocolName for MessageExchangeBincodeProtocol {
+impl ProtocolName for MessageExchangePostcardProtocol {
     fn protocol_name(&self) -> &[u8] {
         REQUEST_RESPONSE_PROTOCOL_ID
     }

--- a/crates/services/p2p/src/p2p_service.rs
+++ b/crates/services/p2p/src/p2p_service.rs
@@ -545,7 +545,7 @@ impl<Codec: NetworkCodec> FuelP2PService<Codec> {
 mod tests {
     use super::FuelP2PService;
     use crate::{
-        codecs::bincode::BincodeCodec,
+        codecs::postcard::PostcardCodec,
         config::Config,
         gossipsub::{
             messages::{
@@ -613,12 +613,14 @@ mod tests {
     use tracing_attributes::instrument;
 
     /// helper function for building FuelP2PService
-    fn build_service_from_config(mut p2p_config: Config) -> FuelP2PService<BincodeCodec> {
+    fn build_service_from_config(
+        mut p2p_config: Config,
+    ) -> FuelP2PService<PostcardCodec> {
         p2p_config.keypair = Keypair::generate_secp256k1(); // change keypair for each Node
         let max_block_size = p2p_config.max_block_size;
 
         let mut service =
-            FuelP2PService::new(p2p_config, BincodeCodec::new(max_block_size));
+            FuelP2PService::new(p2p_config, PostcardCodec::new(max_block_size));
         service.start().unwrap();
         service
     }
@@ -665,19 +667,22 @@ mod tests {
         }
 
         /// Combines `NodeData` with `P2pConfig` to create a `FuelP2PService`
-        fn create_service(&self, mut p2p_config: Config) -> FuelP2PService<BincodeCodec> {
+        fn create_service(
+            &self,
+            mut p2p_config: Config,
+        ) -> FuelP2PService<PostcardCodec> {
             let max_block_size = p2p_config.max_block_size;
             p2p_config.tcp_port = self.tcp_port;
             p2p_config.keypair = self.keypair.clone();
 
             let mut service =
-                FuelP2PService::new(p2p_config, BincodeCodec::new(max_block_size));
+                FuelP2PService::new(p2p_config, PostcardCodec::new(max_block_size));
             service.start().unwrap();
             service
         }
     }
 
-    fn spawn(stop: &watch::Sender<()>, mut node: FuelP2PService<BincodeCodec>) {
+    fn spawn(stop: &watch::Sender<()>, mut node: FuelP2PService<PostcardCodec>) {
         let mut stop = stop.subscribe();
         tokio::spawn(async move {
             loop {

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -1,6 +1,6 @@
 use crate::{
     codecs::{
-        bincode::BincodeCodec,
+        postcard::PostcardCodec,
         NetworkCodec,
     },
     config::Config,
@@ -104,7 +104,7 @@ impl Debug for TaskRequest {
 /// Orchestrates various p2p-related events between the inner `P2pService`
 /// and the top level `NetworkService`.
 pub struct Task<D> {
-    p2p_service: FuelP2PService<BincodeCodec>,
+    p2p_service: FuelP2PService<PostcardCodec>,
     db: Arc<D>,
     next_block_height: BoxStream<BlockHeight>,
     /// Receive internal Task Requests
@@ -123,7 +123,7 @@ impl<D> Task<D> {
         let (block_height_broadcast, _) = broadcast::channel(100);
         let next_block_height = block_importer.next_block_height();
         let max_block_size = config.max_block_size;
-        let p2p_service = FuelP2PService::new(config, BincodeCodec::new(max_block_size));
+        let p2p_service = FuelP2PService::new(config, PostcardCodec::new(max_block_size));
 
         Self {
             p2p_service,


### PR DESCRIPTION
[Postcard](https://github.com/jamesmunns/postcard) is a drop-in replacement for bincode. It has [almost identical performance characteristics, but it's bit a more comact](https://github.com/djkoloski/rust_serialization_benchmark) and [stable across Rust versions](https://github.com/jamesmunns/postcard#format-stability). It recently reached 1.0 and is considered rather stable.

This PR simply replaces all invocations to bincode with their postcard equivalents. Closes #905 and closes #776 