### PR TITLE
version 0.16.1 bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,25 +161,25 @@ jobs:
           # TODO: Automate running `verify_tag` only for "publish = true" crates
           curl -sSLf "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 bin/fuel-core/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 bin/fuel-core-client/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 bin/fuel-core-keygen/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/client/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/chain-config/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/database/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/fuel-core/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/types/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/storage/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/metrics/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/executor/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/importer/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/producer/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/p2p/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/sync/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/txpool/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/relayer/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/consensus_module/bft/Cargo.toml
-          ./.github/workflows/scripts/verify_tag.sh 0.16.0 crates/services/consensus_module/poa/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} bin/fuel-core/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} bin/fuel-core-client/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} bin/fuel-core-keygen/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/client/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/chain-config/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/database/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/fuel-core/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/types/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/storage/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/metrics/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/executor/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/importer/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/producer/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/p2p/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/sync/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/txpool/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/relayer/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/consensus_module/bft/Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} crates/services/consensus_module/poa/Cargo.toml
 
       - name: Verify helm chart version
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "parking_lot 0.12.1",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "clap 4.1.4",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "clap 4.1.4",
  "fuel-core-client",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "clap 4.1.4",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "axum",
  "lazy_static",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/benches/benches-outputs/Cargo.toml
+++ b/benches/benches-outputs/Cargo.toml
@@ -6,6 +6,6 @@ license = "BUSL-1.1"
 publish = false
 
 [dependencies]
-fuel-core-types = { path = "../../crates/types", version = "0.16.0", default-features = false, features = ["random", "test-helpers"] }
+fuel-core-types = { path = "../../crates/types", version = "0.16.1", default-features = false, features = ["random", "test-helpers"] }
 
 [workspace]

--- a/bin/fuel-core-client/Cargo.toml
+++ b/bin/fuel-core-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-client-bin"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -16,8 +16,8 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.1", features = ["derive"] }
-fuel-core-client = { version = "0.16.0", path = "../../crates/client" }
-fuel-core-types = { version = "0.16.0", path = "../../crates/types", features = ["serde"] }
+fuel-core-client = { version = "0.16.1", path = "../../crates/client" }
+fuel-core-types = { version = "0.16.1", path = "../../crates/types", features = ["serde"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.21", features = ["macros"] }
 

--- a/bin/fuel-core-keygen/Cargo.toml
+++ b/bin/fuel-core-keygen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-keygen"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
@@ -12,5 +12,5 @@ description = "Command line utilities for fuel-core key management"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.1", features = ["derive", "env"] }
-fuel-core-types = { version = "0.16.0", path = "../../crates/types", features = ["serde", "random"] }
+fuel-core-types = { version = "0.16.1", path = "../../crates/types", features = ["serde", "random"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -7,7 +7,7 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 name = "fuel-core-bin"
 publish = false
 
@@ -19,7 +19,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 clap = { version = "4.1", features = ["derive", "env"] }
 dirs = "4.0"
-fuel-core = { path = "../../crates/fuel-core", version = "0.16.0" }
+fuel-core = { path = "../../crates/fuel-core", version = "0.16.1" }
 humantime = "2.1"
 lazy_static = "1.4"
 serde_json = { version = "1.0", features = ["raw_value"], optional = true }

--- a/crates/chain-config/Cargo.toml
+++ b/crates/chain-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-chain-config"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -13,8 +13,8 @@ description = "Fuel Chain config types"
 [dependencies]
 anyhow = "1.0"
 bech32 = "0.9.0"
-fuel-core-storage = { path = "../storage", version = "0.16.0" }
-fuel-core-types = { path = "../types", version = "0.16.0", features = [
+fuel-core-storage = { path = "../storage", version = "0.16.1" }
+fuel-core-types = { path = "../types", version = "0.16.1", features = [
     "serde",
     "random",
 ] }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-client"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["concurrency", "cryptography::cryptocurrencies", "emulators"]
 edition = "2021"
@@ -15,7 +15,7 @@ anyhow = "1.0"
 cynic = { version = "2.2.1", features = ["http-reqwest"] }
 derive_more = { version = "0.99" }
 eventsource-client = "0.10.2"
-fuel-core-types = { version = "0.16.0", path = "../types", features = ["serde"] }
+fuel-core-types = { version = "0.16.1", path = "../types", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
 # Included to enable webpki in the eventsource client

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-database"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -12,8 +12,8 @@ description = "The crates contains databases used by Fuel core protocol."
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-storage = { path = "../storage", version = "0.16.0" }
-fuel-core-types = { path = "../types", version = "0.16.0" }
+fuel-core-storage = { path = "../storage", version = "0.16.1" }
+fuel-core-types = { path = "../types", version = "0.16.1" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 name = "fuel-core"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 
 [dependencies]
 anyhow = "1.0"
@@ -20,21 +20,21 @@ axum = { version = "0.5" }
 clap = { version = "4.1", features = ["derive"] }
 derive_more = { version = "0.99" }
 enum-iterator = "1.2"
-fuel-core-chain-config = { path = "../chain-config", version = "0.16.0" }
-fuel-core-consensus-module = { path = "../../crates/services/consensus_module", version = "0.16.0" }
-fuel-core-database = { path = "../database", version = "0.16.0" }
-fuel-core-executor = { path = "../services/executor", version = "0.16.0" }
-fuel-core-importer = { path = "../services/importer", version = "0.16.0" }
-fuel-core-metrics = { path = "../metrics", version = "0.16.0", optional = true }
-fuel-core-p2p = { path = "../services/p2p", version = "0.16.0", optional = true }
-fuel-core-poa = { path = "../services/consensus_module/poa", version = "0.16.0" }
-fuel-core-producer = { path = "../services/producer", version = "0.16.0" }
-fuel-core-relayer = { path = "../services/relayer", version = "0.16.0", optional = true }
-fuel-core-services = { path = "../services", version = "0.16.0" }
-fuel-core-storage = { path = "../storage", version = "0.16.0" }
-fuel-core-sync = { path = "../services/sync", version = "0.16.0", optional = true }
-fuel-core-txpool = { path = "../services/txpool", version = "0.16.0" }
-fuel-core-types = { path = "../types", version = "0.16.0", features = [
+fuel-core-chain-config = { path = "../chain-config", version = "0.16.1" }
+fuel-core-consensus-module = { path = "../../crates/services/consensus_module", version = "0.16.1" }
+fuel-core-database = { path = "../database", version = "0.16.1" }
+fuel-core-executor = { path = "../services/executor", version = "0.16.1" }
+fuel-core-importer = { path = "../services/importer", version = "0.16.1" }
+fuel-core-metrics = { path = "../metrics", version = "0.16.1", optional = true }
+fuel-core-p2p = { path = "../services/p2p", version = "0.16.1", optional = true }
+fuel-core-poa = { path = "../services/consensus_module/poa", version = "0.16.1" }
+fuel-core-producer = { path = "../services/producer", version = "0.16.1" }
+fuel-core-relayer = { path = "../services/relayer", version = "0.16.1", optional = true }
+fuel-core-services = { path = "../services", version = "0.16.1" }
+fuel-core-storage = { path = "../storage", version = "0.16.1" }
+fuel-core-sync = { path = "../services/sync", version = "0.16.1", optional = true }
+fuel-core-txpool = { path = "../services/txpool", version = "0.16.1" }
+fuel-core-types = { path = "../types", version = "0.16.1", features = [
     "serde",
 ] }
 futures = "0.3"

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-metrics"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["bft", "blockchain", "consensus", "fuel"]
 license = "BUSL-1.1"
 name = "fuel-core-services"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/services/consensus_module/Cargo.toml
+++ b/crates/services/consensus_module/Cargo.toml
@@ -7,13 +7,13 @@ keywords = ["blockchain", "consensus", "fuel"]
 license = "BUSL-1.1"
 name = "fuel-core-consensus-module"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-chain-config = { version = "0.16.0", path = "../../chain-config" }
-fuel-core-poa = { version = "0.16.0", path = "poa" }
-fuel-core-types = { version = "0.16.0", path = "../../types" }
+fuel-core-chain-config = { version = "0.16.1", path = "../../chain-config" }
+fuel-core-poa = { version = "0.16.1", path = "poa" }
+fuel-core-types = { version = "0.16.1", path = "../../types" }
 
 [dev-dependencies]
 fuel-core-types = { path = "../../types", features = ["test-helpers"] }

--- a/crates/services/consensus_module/bft/Cargo.toml
+++ b/crates/services/consensus_module/bft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-bft"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"

--- a/crates/services/consensus_module/poa/Cargo.toml
+++ b/crates/services/consensus_module/poa/Cargo.toml
@@ -7,15 +7,15 @@ keywords = ["blockchain", "consensus", "fuel"]
 license = "BUSL-1.1"
 name = "fuel-core-poa"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-core-chain-config = { version = "0.16.0", path = "../../../chain-config" }
-fuel-core-services = { path = "../..", version = "0.16.0" }
-fuel-core-storage = { path = "../../../storage", version = "0.16.0" }
-fuel-core-types = { path = "../../../types", version = "0.16.0" }
+fuel-core-chain-config = { version = "0.16.1", path = "../../../chain-config" }
+fuel-core-services = { path = "../..", version = "0.16.1" }
+fuel-core-storage = { path = "../../../storage", version = "0.16.1" }
+fuel-core-types = { path = "../../../types", version = "0.16.1" }
 tokio = { version = "1.21", features = ["full"] }
 tokio-stream = "0.1"
 tracing = "0.1"

--- a/crates/services/executor/Cargo.toml
+++ b/crates/services/executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-executor"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,9 +11,9 @@ description = "Fuel Block Executor"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-chain-config = { path = "../../chain-config", version = "0.16.0" }
-fuel-core-storage = { path = "../../storage", version = "0.16.0" }
-fuel-core-types = { path = "../../types", version = "0.16.0" }
+fuel-core-chain-config = { path = "../../chain-config", version = "0.16.1" }
+fuel-core-storage = { path = "../../storage", version = "0.16.1" }
+fuel-core-types = { path = "../../types", version = "0.16.1" }
 
 [dev-dependencies]
 fuel-core-trace = { path = "../../trace" }

--- a/crates/services/importer/Cargo.toml
+++ b/crates/services/importer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-importer"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -11,8 +11,8 @@ description = "Fuel Block Importer"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-storage = { path = "../../storage", version = "0.16.0" }
-fuel-core-types = { path = "../../types", version = "0.16.0" }
+fuel-core-storage = { path = "../../storage", version = "0.16.1" }
+fuel-core-types = { path = "../../types", version = "0.16.1" }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }
 tracing = "0.1"

--- a/crates/services/p2p/Cargo.toml
+++ b/crates/services/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-p2p"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "network-programming"]
 edition = "2021"
@@ -13,13 +13,13 @@ description = "Fuel client networking"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-core-chain-config = { path = "../../chain-config", version = "0.16.0" }
-fuel-core-metrics = { path = "../../metrics", version = "0.16.0" } # TODO make this a feature
-fuel-core-services = { path = "../../services", version = "0.16.0" }
-fuel-core-storage = { path = "../../storage", version = "0.16.0" }
+fuel-core-chain-config = { path = "../../chain-config", version = "0.16.1" }
+fuel-core-metrics = { path = "../../metrics", version = "0.16.1" } # TODO make this a feature
+fuel-core-services = { path = "../../services", version = "0.16.1" }
+fuel-core-storage = { path = "../../storage", version = "0.16.1" }
 fuel-core-types = { path = "../../types", features = [
     "serde",
-], version = "0.16.0" }
+], version = "0.16.1" }
 futures = "0.3"
 futures-timer = "3.0"
 ip_network = "0.4"
@@ -67,7 +67,7 @@ fuel-core-trace = { path = "../../trace" }
 fuel-core-types = { path = "../../types", features = [
     "serde",
     "test-helpers"
-], version = "0.16.0" }
+], version = "0.16.1" }
 rand = "0.8"
 tokio = { version = "1.21", features = ["full"] }
 tracing-attributes = "0.1"

--- a/crates/services/producer/Cargo.toml
+++ b/crates/services/producer/Cargo.toml
@@ -7,13 +7,13 @@ keywords = ["blockchain", "fuel", "fuel-vm"]
 license = "BUSL-1.1"
 name = "fuel-core-producer"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-core-storage = { path = "../../storage", version = "0.16.0" }
-fuel-core-types = { path = "../../types", version = "0.16.0" }
+fuel-core-storage = { path = "../../storage", version = "0.16.1" }
+fuel-core-types = { path = "../../types", version = "0.16.1" }
 thiserror = "1.0"
 tokio = { version = "1.21", features = ["full"] }
 tracing = { version = "0.1" }

--- a/crates/services/relayer/Cargo.toml
+++ b/crates/services/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-relayer"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"
@@ -21,9 +21,9 @@ ethers-providers = { version = "1.0.2", default-features = false, features = [
     "ws",
     "rustls",
 ] }
-fuel-core-services = { path = "..", version = "0.16.0" }
-fuel-core-storage = { path = "../../storage", version = "0.16.0" }
-fuel-core-types = { path = "../../types", version = "0.16.0" }
+fuel-core-services = { path = "..", version = "0.16.1" }
+fuel-core-storage = { path = "../../storage", version = "0.16.1" }
+fuel-core-types = { path = "../../types", version = "0.16.1" }
 futures = "0.3"
 once_cell = "1.4"
 parking_lot = { version = "0.12", optional = true }

--- a/crates/services/sync/Cargo.toml
+++ b/crates/services/sync/Cargo.toml
@@ -7,13 +7,13 @@ keywords = ["blockchain", "fuel", "fuel-vm"]
 license = "BUSL-1.1"
 name = "fuel-core-sync"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.60"
 fuel-core-services = { path = "../" }
-fuel-core-types = { path = "../../types", version = "0.16.0" }
+fuel-core-types = { path = "../../types", version = "0.16.1" }
 futures = "0.3.25"
 tokio = { version = "1.21", features = ["full"] }
 tracing = "0.1"

--- a/crates/services/txpool/Cargo.toml
+++ b/crates/services/txpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-core-txpool"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies"]
 edition = "2021"
@@ -13,11 +13,11 @@ description = "Transaction pool"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-fuel-core-chain-config = { path = "../../chain-config", version = "0.16.0" }
-fuel-core-metrics = { path = "../../metrics", version = "0.16.0" }
-fuel-core-services = { path = "..", version = "0.16.0" }
-fuel-core-storage = { path = "../../storage", version = "0.16.0" }
-fuel-core-types = { path = "../../types", version = "0.16.0" }
+fuel-core-chain-config = { path = "../../chain-config", version = "0.16.1" }
+fuel-core-metrics = { path = "../../metrics", version = "0.16.1" }
+fuel-core-services = { path = "..", version = "0.16.1" }
+fuel-core-storage = { path = "../../storage", version = "0.16.1" }
+fuel-core-types = { path = "../../types", version = "0.16.1" }
 parking_lot = "0.12"
 tokio = { version = "1.21", default-features = false, features = ["sync"] }
 tokio-stream = "0.1"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -14,11 +14,11 @@ keywords = [
 license = "BUSL-1.1"
 name = "fuel-core-storage"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 
 [dependencies]
 anyhow = "1.0"
-fuel-core-types = { path = "../types", version = "0.16.0" }
+fuel-core-types = { path = "../types", version = "0.16.1" }
 fuel-vm-private = { version = "0.25", package = "fuel-vm" }
 thiserror = "1.0"
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [
 license = "BUSL-1.1"
 name = "fuel-core-types"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.16.0"
+version = "0.16.1"
 
 [dependencies]
 anyhow = "1.0"

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fuel-core
 description: Fuel Core Helm Chart
 type: application
-appVersion: "0.16.0"
+appVersion: "0.16.1"
 version: 0.1.0


### PR DESCRIPTION
Re-attempt publishing of 0.16.x

- fix hardcoding of version numbers for tag validation
- bump versions to v0.16.1