### PR TITLE
added a comma value delimiter for clap arguments

### DIFF
--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -54,12 +54,12 @@ pub struct P2PArgs {
 
     /// Addresses of the bootstrap nodes
     /// They should contain PeerId within their `Multiaddr`
-    #[clap(long = "bootstrap_nodes", env)]
+    #[clap(long = "bootstrap_nodes", value_delimiter = ',', env)]
     pub bootstrap_nodes: Vec<Multiaddr>,
 
     /// Addresses of the reserved nodes
     /// They should contain PeerId within their `Multiaddr`
-    #[clap(long = "reserved_nodes", env)]
+    #[clap(long = "reserved_nodes", value_delimiter = ',', env)]
     pub reserved_nodes: Vec<Multiaddr>,
 
     /// With this set to `true` you create a guarded node that is only ever connected to trusted, reserved nodes.    
@@ -107,7 +107,7 @@ pub struct P2PArgs {
     pub identify_interval: u64,
 
     /// Choose which topics to subscribe to via gossipsub protocol
-    #[clap(long = "topics", default_values = &["new_tx", "new_block", "consensus_vote"], env)]
+    #[clap(long = "topics", value_delimiter = ',', default_values = &["new_tx", "new_block", "consensus_vote"], env)]
     pub topics: Vec<String>,
 
     /// Choose max mesh size for gossipsub protocol

--- a/bin/fuel-core/src/cli/run/relayer.rs
+++ b/bin/fuel-core/src/cli/run/relayer.rs
@@ -21,7 +21,7 @@ pub struct RelayerArgs {
     pub eth_v2_listening_contracts: Vec<H160>,
 
     /// Number of da block after which messages/stakes/validators become finalized.
-    #[clap(long = "relayer-da-finalization", default_value_t = Config::DEFAULT_DA_FINALIZATION, env)]
+    #[clap(long = "relayer-da-finalization", value_delimiter = ',', default_value_t = Config::DEFAULT_DA_FINALIZATION, env)]
     pub da_finalization: u64,
 
     /// Number of da block that the contract is deployed at.

--- a/bin/fuel-core/src/cli/run/relayer.rs
+++ b/bin/fuel-core/src/cli/run/relayer.rs
@@ -21,7 +21,7 @@ pub struct RelayerArgs {
     pub eth_v2_listening_contracts: Vec<H160>,
 
     /// Number of da block after which messages/stakes/validators become finalized.
-    #[clap(long = "relayer-da-finalization", value_delimiter = ',', default_value_t = Config::DEFAULT_DA_FINALIZATION, env)]
+    #[clap(long = "relayer-da-finalization", default_value_t = Config::DEFAULT_DA_FINALIZATION, env)]
     pub da_finalization: u64,
 
     /// Number of da block that the contract is deployed at.


### PR DESCRIPTION
some of our CLI arguments require array of values, we had issues parsing them, adding a comma delimiter helps in parsing the values like:

```bash
RESERVED_NODES="/dns4/my-fuel-sentry-0/tcp/30333/p2p/16Uiu2HAmKTu2oFwqhcRQ9fyyCy5bh5vReh8nWfbZRQ991MzEVwWw,/dns4/my-fuel-sentry-1/tcp/30333/p2p/16Uiu2HAmLFKkEYZFE86JZszmoMTCw4XJF7P4jxoDG7RJgtKV8ZNN"
```