### PR TITLE
Simplify BMT push error

### DIFF
--- a/crates/fuel-core/src/database/block.rs
+++ b/crates/fuel-core/src/database/block.rs
@@ -96,8 +96,7 @@ impl StorageMutate<FuelBlocks> for Database {
             MerkleTree::load(storage, prev_metadata.version)
                 .map_err(|err| StorageError::Other(err.into()))?;
         let data = key.as_slice();
-        tree.push(data)
-            .map_err(|err| StorageError::Other(err.into()))?;
+        tree.push(data)?;
 
         // Generate new metadata for the updated tree
         let version = tree.leaves_count();


### PR DESCRIPTION
Follow up to https://github.com/FuelLabs/fuel-vm/pull/328.

Now that `push` returns `StorageError` rather than `MerkleTree<StorageError>` we no longer need to map the error to `Other`.