### PR TITLE
replace usage of futures-timer to avoid extra helper threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,6 @@ dependencies = [
  "fuel-core-trace",
  "fuel-core-types",
  "futures",
- "futures-timer",
  "ip_network",
  "libp2p",
  "libp2p-core",

--- a/crates/services/p2p/Cargo.toml
+++ b/crates/services/p2p/Cargo.toml
@@ -21,7 +21,6 @@ fuel-core-types = { path = "../../types", features = [
     "serde",
 ], version = "0.16.1" }
 futures = "0.3"
-futures-timer = "3.0"
 ip_network = "0.4"
 libp2p = { version = "=0.50.0", default-features = false, features = [
     "dns",

--- a/crates/services/p2p/src/discovery/discovery_config.rs
+++ b/crates/services/p2p/src/discovery/discovery_config.rs
@@ -2,7 +2,6 @@ use crate::discovery::{
     mdns::MdnsWrapper,
     DiscoveryBehaviour,
 };
-use futures_timer::Delay;
 use libp2p::{
     kad::{
         store::MemoryStore,
@@ -161,7 +160,9 @@ impl DiscoveryConfig {
         }
 
         let next_kad_random_walk = {
-            let random_walk = self.random_walk.map(Delay::new);
+            let random_walk = self
+                .random_walk
+                .map(|duration| Box::pin(tokio::time::sleep(duration)));
 
             // no need to preferm random walk if we don't want the node to connect to non-whitelisted peers
             if !reserved_nodes_only_mode {


### PR DESCRIPTION
futures-timer was being used in p2p, however it makes use of helper threads which are unnecessary since we use a tokio runtime.