### PR TITLE
make in-memory iteration match rocksdb behavior

### DIFF
--- a/crates/fuel-core/src/state/in_memory/memory_store.rs
+++ b/crates/fuel-core/src/state/in_memory/memory_store.rs
@@ -63,7 +63,10 @@ impl MemoryStore {
 
         let until_start_reached = |(key, _): &(Vec<u8>, Vec<u8>)| {
             if let Some(start) = start {
-                key.as_slice() != start
+                match direction {
+                    IterDirection::Forward => key.as_slice() < start,
+                    IterDirection::Reverse => key.as_slice() > start,
+                }
             } else {
                 false
             }


### PR DESCRIPTION
fixes bug introduced in #643 

this bug can be demonstrated on master by running all tests with `--no-default-features`

actually this bug might've existed earlier, we just didn't notice it due to feature unification