### PR TITLE
Avoid feature unification during testing of --no-default-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,9 @@ jobs:
             args: check --locked
           - command: test
             args: --all-features --workspace
-          - command: test
-            args: --no-default-features --workspace
+          # use cargo make test to avoid workspace feature unification
+          - command: make
+            args: test --no-default-features --workspace
           - command: test
             args: --manifest-path version-compatibility/Cargo.toml --workspace
     # disallow any job that takes longer than 45 minutes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
             args: --all-features --workspace
           # use cargo make test to avoid workspace feature unification
           - command: make
-            args: test --no-default-features --workspace
+            args: test --no-default-features
           - command: test
             args: --manifest-path version-compatibility/Cargo.toml --workspace
     # disallow any job that takes longer than 45 minutes

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -7,5 +7,5 @@ cargo clippy --all-targets --all-features &&
 cargo make check --locked &&
 cargo make check --all-features --locked &&
 cargo test --all-features --workspace &&
-cargo test --no-default-features --workspace &&
+cargo make test --no-default-features --workspace &&
 cargo test --manifest-path version-compatibility/Cargo.toml --workspace

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -7,5 +7,5 @@ cargo clippy --all-targets --all-features &&
 cargo make check --locked &&
 cargo make check --all-features --locked &&
 cargo test --all-features --workspace &&
-cargo make test --no-default-features --workspace &&
+cargo make test --no-default-features &&
 cargo test --manifest-path version-compatibility/Cargo.toml --workspace

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -6,7 +6,6 @@ use crate::{
         IterDirection,
     },
 };
-use anyhow::Context;
 use fuel_core_chain_config::{
     ChainConfigDb,
     CoinConfig,
@@ -42,7 +41,6 @@ type DatabaseError = Error;
 type DatabaseResult<T> = Result<T>;
 
 // TODO: Extract `Database` and all belongs into `fuel-core-database`.
-
 #[cfg(feature = "rocksdb")]
 use crate::state::rocks_db::RocksDb;
 #[cfg(feature = "rocksdb")]
@@ -163,6 +161,7 @@ unsafe impl Sync for Database {}
 impl Database {
     #[cfg(feature = "rocksdb")]
     pub fn open(path: &Path) -> DatabaseResult<Self> {
+        use anyhow::Context;
         let db = RocksDb::default_open(path).context("Failed to open rocksdb, you may need to wipe a pre-existing incompatible db `rm -rf ~/.fuel/db`")?;
 
         Ok(Database {


### PR DESCRIPTION
our --no-default-features testing wasn't working as expected due to feature unification. This change ensures each crate is tested in isolation with no extra features enabled.