### PR TITLE
avoid pulling protoc via github api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,9 @@ jobs:
         with:
           version: "0.36.4"
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1.1.2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
       - uses: Swatinem/rust-cache@v2
         with:
           key: '${{ matrix.command }} ${{ matrix.args }}'
@@ -203,9 +203,9 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1.1.2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
 
       - name: Publish crate
         uses: katyo/publish-crates@v2


### PR DESCRIPTION
use `sudo apt-get` to fetch protoc instead of downloading the binary from github to avoid rate limiting