### PR TITLE
revert optimistic reserved node reconnect

### DIFF
--- a/crates/services/p2p/src/heartbeat/handler.rs
+++ b/crates/services/p2p/src/heartbeat/handler.rs
@@ -298,11 +298,14 @@ impl ConnectionHandler for HeartbeatHandler {
     }
 }
 
+/// Represents state of the Oubound stream
 enum OutboundState {
     NegotiatingStream,
     Idle(NegotiatedSubstream),
     RequestingBlockHeight {
         stream: NegotiatedSubstream,
+        /// `false` if the BlockHeight has not been requested yet.
+        /// `true` if the BlockHeight has been requested in the current `Heartbeat` cycle.
         requested: bool,
     },
     SendingBlockHeight(OutboundData),

--- a/crates/services/p2p/src/p2p_service.rs
+++ b/crates/services/p2p/src/p2p_service.rs
@@ -461,9 +461,16 @@ impl<Codec: NetworkCodec> FuelP2PService<Codec> {
                     }
                     return Some(FuelP2PEvent::PeerDisconnected(peer_id))
                 }
-                PeerInfoEvent::TooManyPeers { peer_to_disconnect } => {
+                PeerInfoEvent::TooManyPeers {
+                    peer_to_disconnect,
+                    peer_to_connect,
+                } => {
                     // disconnect the surplus peer
                     let _ = self.swarm.disconnect_peer_id(peer_to_disconnect);
+                    // reconnect the reserved peer
+                    if let Some(peer_id) = peer_to_connect {
+                        let _ = self.swarm.dial(peer_id);
+                    }
                 }
             },
             FuelBehaviourEvent::RequestResponse(req_res_event) => match req_res_event {


### PR DESCRIPTION
During #974 optimistic reconnect was removed from the code as being a _duplicate_ work.

It was not a duplicate work, more of an optimistic immediate reconnect if the node is available, while `health_check` tries to reconnect after a certain Interval (e.g. 30-60 seconds) which is there as a backup only if the optimistic reconnect was not successful.

I also added a small description comment to `OutboundState`.