### PR TITLE
avoid compiling usued deps when --no-default-features is used

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -9,9 +9,7 @@ version = "0.0.0"
 clap = { workspace = true, features = ["derive"] }
 criterion = { version = "0.4", features = ["html_reports"] }
 ctrlc = "3.2.3"
-fuel-core = { path = "../crates/fuel-core", default-features = false, features = [
-    "rocksdb",
-] }
+fuel-core = { path = "../crates/fuel-core", default-features = false }
 fuel-core-storage = { path = "./../crates/storage" }
 fuel-core-types = { path = "./../crates/types", features = ["test-helpers"] }
 rand = { workspace = true }
@@ -22,3 +20,6 @@ serde_yaml = "0.9.13"
 [[bench]]
 harness = false
 name = "vm"
+
+[features]
+default = ["fuel-core/rocksdb"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -28,11 +28,11 @@ required-features = ["metrics"]
 ethers = "1.0.2"
 fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["test-helpers"] }
 fuel-core-client = { path = "../crates/client", features = ["test-helpers"] }
-fuel-core-p2p = { path = "../crates/services/p2p", features = ["test-helpers"] }
+fuel-core-p2p = { path = "../crates/services/p2p", features = ["test-helpers"], optional = true }
 fuel-core-poa = { path = "../crates/services/consensus_module/poa" }
 fuel-core-relayer = { path = "../crates/services/relayer", features = [
     "test-helpers",
-] }
+], optional = true }
 fuel-core-storage = { path = "../crates/storage", features = ["test-helpers"] }
 fuel-core-trace = { path = "../crates/trace" }
 fuel-core-txpool = { path = "../crates/services/txpool", features = ["test-helpers"] }
@@ -59,5 +59,5 @@ tokio = { workspace = true, features = [
 debug = ["fuel-core-types/debug"]
 default = ["fuel-core/default", "metrics", "relayer"]
 metrics = ["fuel-core/metrics", "fuel-core/rocksdb"]
-p2p = ["fuel-core/p2p"]
-relayer = ["fuel-core/relayer"]
+p2p = ["fuel-core/p2p", "fuel-core-p2p"]
+relayer = ["fuel-core/relayer", "fuel-core-relayer"]


### PR DESCRIPTION
speedup builds using `--no-default-features` by disabling extra deps that aren't used