### PR TITLE
fix p2p `max_peers_connected_works` test

### DIFF
--- a/crates/services/p2p/src/p2p_service.rs
+++ b/crates/services/p2p/src/p2p_service.rs
@@ -829,8 +829,8 @@ mod tests {
         stop_sender.send(()).unwrap();
     }
 
-    // We start with two nodes, node_5 and node_10, bootstrapped with 100 other nodes
-    // yet node_5 is only allowed to connect to 5 other nodes, and node_10 to 10
+    // We start with two nodes, node_a and node_b, bootstrapped with `bootstrap_nodes_count` other nodes.
+    // Yet node_a and node_b are only allowed to connect to specified amount of nodes.
     #[tokio::test]
     #[instrument]
     async fn max_peers_connected_works() {
@@ -838,24 +838,30 @@ mod tests {
         // enable mdns for faster discovery of nodes
         p2p_config.enable_mdns = true;
 
-        let nodes: Vec<NodeData> = (0..100).map(|_| NodeData::random()).collect();
+        let bootstrap_nodes_count = 20;
+        let node_a_max_peers_allowed = 3;
+        let node_b_max_peers_allowed = 5;
 
-        // this node is allowed to only connect to 5 other nodes
-        let mut node_5 = {
+        let nodes: Vec<NodeData> = (0..bootstrap_nodes_count)
+            .map(|_| NodeData::random())
+            .collect();
+
+        // this node is allowed to only connect to `node_a_max_peers_allowed` other nodes
+        let mut node_a = {
             let mut p2p_config = p2p_config.clone();
-            p2p_config.max_peers_connected = 5;
-            // it still tries to dial all 100 nodes!
+            p2p_config.max_peers_connected = node_a_max_peers_allowed;
+            // it still tries to dial all nodes!
             p2p_config.bootstrap_nodes =
                 nodes.iter().map(|node| node.multiaddr.clone()).collect();
 
             NodeData::random().create_service(p2p_config)
         };
 
-        // this node is allowed to only connect to 10 other nodes
-        let mut node_10 = {
+        // this node is allowed to only connect to `node_b_max_peers_allowed` other nodes
+        let mut node_b = {
             let mut p2p_config = p2p_config.clone();
-            p2p_config.max_peers_connected = 10;
-            // it still tries to dial all 100 nodes!
+            p2p_config.max_peers_connected = node_b_max_peers_allowed;
+            // it still tries to dial all nodes!
             p2p_config.bootstrap_nodes =
                 nodes.iter().map(|node| node.multiaddr.clone()).collect();
 
@@ -867,7 +873,7 @@ mod tests {
             .map(|node| node.create_service(p2p_config.clone()))
             .collect();
 
-        // this node will only connect to node_5 and node_10 at the beginning
+        // this node will only connect to node_a and node_b at the beginning
         // then it will slowly discover other nodes in the network
         // it serves as our exit from the loop
         let mut bootstrapped_node = node_services.pop().unwrap();
@@ -876,7 +882,7 @@ mod tests {
         let jh = tokio::spawn(async move {
             while rx.try_recv().is_err() {
                 futures::stream::iter(node_services.iter_mut())
-                    .for_each_concurrent(20, |node| async move {
+                    .for_each_concurrent(4, |node| async move {
                         node.next_event().await;
                     })
                     .await;
@@ -885,27 +891,27 @@ mod tests {
 
         loop {
             tokio::select! {
-                event_from_node_5 = node_5.next_event() => {
-                    if let Some(FuelP2PEvent::PeerConnected(_)) = event_from_node_5 {
-                        if node_5.swarm.connected_peers().count() > 5 {
-                            panic!("The node should only connect to max 5 peers");
+                event_from_node_a = node_a.next_event() => {
+                    if let Some(FuelP2PEvent::PeerConnected(_)) = event_from_node_a {
+                        if node_a.peer_manager().total_peers_connected() > node_a_max_peers_allowed as usize {
+                            panic!("The node should only connect to max {node_a_max_peers_allowed} peers");
                         }
                     }
-                    tracing::info!("Event from the node_5: {:?}", event_from_node_5);
+                    tracing::info!("Event from the node_a: {:?}", event_from_node_a);
                 },
-                event_from_node_10 = node_10.next_event() => {
-                    if let Some(FuelP2PEvent::PeerConnected(_)) = event_from_node_10 {
-                        if node_10.swarm.connected_peers().count() > 10 {
-                            panic!("The node should only connect to max 10 peers");
+                event_from_node_b = node_b.next_event() => {
+                    if let Some(FuelP2PEvent::PeerConnected(_)) = event_from_node_b {
+                        if node_b.peer_manager().total_peers_connected() > node_b_max_peers_allowed as usize {
+                            panic!("The node should only connect to max {node_b_max_peers_allowed} peers");
                         }
                     }
-                    tracing::info!("Event from the node_10: {:?}", event_from_node_10);
+                    tracing::info!("Event from the node_b: {:?}", event_from_node_b);
                 },
                 event_from_bootstrapped_node = bootstrapped_node.next_event() => {
                     if let Some(FuelP2PEvent::PeerConnected(_)) = event_from_bootstrapped_node {
                         // if the test was broken, it would panic! by the time this node discovers more peers
                         // and connects to them
-                        if bootstrapped_node.swarm.connected_peers().count() > 20 {
+                        if bootstrapped_node.peer_manager().total_peers_connected() > bootstrap_nodes_count / 2 {
                             break
                         }
                     }


### PR DESCRIPTION
We've been having certain issues with this test especially in the CI,
here's the analysis and the fix.

First problem is the assertion put on the swarm itself instead of our PeerManager:
```rust
if p2p_service.swarm.connected_peers().count() > peer_limit { panic!() }
```
While generally this should not return more peers than allowed, one of the reasons we have PeerManager is to actually contain number of peers connected logic, so moving the assertion to
```rust
if p2p_service.peer_manager().total_peers_connected() > peer_limit { panic!() }
```
should suffice since PeerManager is the one disconnecting surplus peers.

Other, and bigger, issue with the test was the amount of simulated nodes we used in our example.
Having 100+ nodes running makes the test itself unnecessarily slow.
This became even more evident now that we made our Heartbeat protocol ask for a disconnect from a node that did not reply within 2 seconds with a Block Height. So nodes started disconnecting from each other and the test would never hit its exit point.

Actually there is no need to have that amount of nodes, instead same assertion can be achieved with a smaller amount, so I have decreased the amount of nodes in the test.