### PR TITLE
Bugfix: set prefix extractor for all columns that need it

### DIFF
--- a/crates/fuel-core/src/schema/contract.rs
+++ b/crates/fuel-core/src/schema/contract.rs
@@ -9,6 +9,7 @@ use crate::{
         U64,
     },
 };
+use anyhow::anyhow;
 use async_graphql::{
     connection::{
         Connection,
@@ -133,6 +134,14 @@ impl ContractBalanceQuery {
         Connection<AssetId, ContractBalance, EmptyFields, EmptyFields>,
     > {
         let query = ContractQueryContext(ctx.data_unchecked());
+
+        // Rocksdb doesn't support reverse iteration over a prefix
+        if matches!(last, Some(last) if last > 0) {
+            return Err(
+                anyhow!("reverse pagination isn't supported for this resource").into(),
+            )
+        }
+
         crate::schema::query_pagination(after, before, first, last, |start, direction| {
             let balances = query
                 .contract_balances(

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     state::IterDirection,
 };
+use anyhow::anyhow;
 use async_graphql::{
     connection::{
         Connection,
@@ -153,6 +154,13 @@ impl TxQuery {
         before: Option<String>,
     ) -> async_graphql::Result<Connection<TxPointer, Transaction, EmptyFields, EmptyFields>>
     {
+        // Rocksdb doesn't support reverse iteration over a prefix
+        if matches!(last, Some(last) if last > 0) {
+            return Err(
+                anyhow!("reverse pagination isn't supported for this resource").into(),
+            )
+        }
+
         let query = TransactionQueryContext(ctx.data_unchecked());
         let owner = fuel_types::Address::from(owner);
 

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -82,7 +82,17 @@ impl FuelService {
         // initialize database
         let database = match config.database_type {
             #[cfg(feature = "rocksdb")]
-            DbType::RocksDb => Database::open(&config.database_path)?,
+            DbType::RocksDb => {
+                // use a default tmp rocksdb if no path is provided
+                if config.database_path.as_os_str().is_empty() {
+                    warn!(
+                        "No RocksDB path configured, initializing database with a tmp directory"
+                    );
+                    Database::default()
+                } else {
+                    Database::open(&config.database_path)?
+                }
+            }
             DbType::InMemory => Database::in_memory(),
             #[cfg(not(feature = "rocksdb"))]
             _ => Database::in_memory(),

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -62,6 +62,9 @@ impl Config {
         Self {
             addr: SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 0),
             database_path: Default::default(),
+            #[cfg(feature = "rocksdb")]
+            database_type: DbType::RocksDb,
+            #[cfg(not(feature = "rocksdb"))]
             database_type: DbType::InMemory,
             chain_conf: chain_conf.clone(),
             manual_blocks_enabled: false,

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -126,8 +126,13 @@ impl RocksDb {
         opts.create_if_missing(true);
         opts.set_compression_type(DBCompressionType::Lz4);
 
+        // All double-keys should be configured here
         match column {
-            Column::OwnedCoins | Column::TransactionsByOwnerBlockIdx => {
+            Column::OwnedCoins
+            | Column::TransactionsByOwnerBlockIdx
+            | Column::OwnedMessageIds
+            | Column::ContractsAssets
+            | Column::ContractsState => {
                 // prefix is address length
                 opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(32))
             }

--- a/tests/tests/contract.rs
+++ b/tests/tests/contract.rs
@@ -68,7 +68,12 @@ async fn test_contract_balance(
 #[rstest]
 #[tokio::test]
 async fn test_5_contract_balances(
-    #[values(PageDirection::Forward, PageDirection::Backward)] direction: PageDirection,
+    #[values(PageDirection::Forward)] direction: PageDirection,
+    // #[values(PageDirection::Forward, PageDirection::Backward)] direction: PageDirection,
+    // Rocksdb doesn't support reverse seeks using a prefix, we'd need to implement a custom
+    // comparator to support this usecase.
+    // > One common bug of using prefix iterating is to use prefix mode to iterate in reverse order. But it is not yet supported.
+    // https://github.com/facebook/rocksdb/wiki/Prefix-Seek#limitation
 ) {
     let mut test_builder = TestSetupBuilder::new(SEED);
     let (_, contract_id) = test_builder.setup_contract(

--- a/tests/tests/messages.rs
+++ b/tests/tests/messages.rs
@@ -77,6 +77,7 @@ async fn messages_by_owner_returns_messages_for_the_given_owner() {
     // create some owners
     let owner_a = Address::new([1; 32]);
     let owner_b = Address::new([2; 32]);
+    let owner_c = Address::new([3; 32]);
 
     // create some messages for owner A
     let first_msg = MessageConfig {
@@ -138,12 +139,23 @@ async fn messages_by_owner_returns_messages_for_the_given_owner() {
     assert_eq!(result.results.len(), 1);
 
     assert_eq!(result.results[0].recipient.0 .0, owner_b);
+
+    // get the messages from Owner C
+    let result = client
+        .messages(Some(&owner_c.to_string()), request.clone())
+        .await
+        .unwrap();
+
+    // verify that Owner C has no messages
+    assert_eq!(result.results.len(), 0);
 }
 
 #[rstest]
 #[tokio::test]
 async fn messages_empty_results_for_owner_with_no_messages(
-    #[values(PageDirection::Forward, PageDirection::Backward)] direction: PageDirection,
+    #[values(PageDirection::Forward)] direction: PageDirection,
+    //#[values(PageDirection::Forward, PageDirection::Backward)] direction: PageDirection,
+    // reverse iteration with prefix not supported by rocksdb
     #[values(Address::new([16; 32]), Address::new([0; 32]))] owner: Address,
 ) {
     let srv = FuelService::new_node(Config::local_node()).await.unwrap();


### PR DESCRIPTION
- Fixes column settings for all APIs that seek using a prefix
- Enables rocksdb in integration_tests when using default features
- Disables backwards pagination for APIs where a prefix is used, as rocksdb doesn't support it