### PR TITLE
peer reputation framework

### DIFF
--- a/crates/services/p2p/src/behavior.rs
+++ b/crates/services/p2p/src/behavior.rs
@@ -26,7 +26,10 @@ use crate::{
         RequestMessage,
     },
 };
-use fuel_core_types::blockchain::primitives::BlockHeight;
+use fuel_core_types::{
+    blockchain::primitives::BlockHeight,
+    services::p2p::peer_reputation::PeerReport,
+};
 use libp2p::{
     gossipsub::{
         error::{
@@ -211,6 +214,16 @@ impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
 
     pub fn peer_manager(&self) -> &PeerManagerBehaviour {
         &self.peer_manager
+    }
+
+    pub fn report_peer<T: PeerReport>(
+        &mut self,
+        peer_id: PeerId,
+        report: T,
+        reporting_service: &str,
+    ) {
+        self.peer_manager
+            .report_peer(peer_id, report, reporting_service)
     }
 }
 

--- a/crates/services/p2p/src/p2p_service.rs
+++ b/crates/services/p2p/src/p2p_service.rs
@@ -488,7 +488,7 @@ impl<Codec: NetworkCodec> FuelP2PService<Codec> {
                 }
                 PeerInfoEvent::BanPeer { peer_id } => {
                     info!(target: "fuel-libp2p", "Banning {peer_id}");
-                    let _ = self.swarm.ban_peer_id(peer_id);
+                    self.swarm.ban_peer_id(peer_id);
                 }
             },
             FuelBehaviourEvent::RequestResponse(req_res_event) => match req_res_event {

--- a/crates/services/p2p/src/peer_manager.rs
+++ b/crates/services/p2p/src/peer_manager.rs
@@ -11,6 +11,7 @@ use fuel_core_types::{
         PeerReport,
         PeerScore,
         DEFAULT_PEER_SCORE,
+        MAX_PEER_SCORE,
         MIN_PEER_SCORE,
     },
 };
@@ -606,7 +607,8 @@ impl PeerManager {
         score: PeerScore,
     ) -> Option<PeerScore> {
         if let Some(peer) = self.non_reserved_connected_peers.get_mut(peer_id) {
-            peer.score += score;
+            // score should not go over `MAX_PEER_SCORE`
+            peer.score = MAX_PEER_SCORE.min(peer.score + score);
             Some(peer.score)
         } else {
             log_missing_peer(peer_id);

--- a/crates/services/p2p/src/peer_manager.rs
+++ b/crates/services/p2p/src/peer_manager.rs
@@ -608,7 +608,8 @@ impl PeerManager {
     ) -> Option<PeerScore> {
         if let Some(peer) = self.non_reserved_connected_peers.get_mut(peer_id) {
             // score should not go over `MAX_PEER_SCORE`
-            peer.score = MAX_PEER_SCORE.min(peer.score + score);
+            let new_score = peer.score.saturating_add(score);
+            peer.score = MAX_PEER_SCORE.min(new_score);
             Some(peer.score)
         } else {
             log_missing_peer(peer_id);

--- a/crates/types/src/services/p2p.rs
+++ b/crates/types/src/services/p2p.rs
@@ -5,6 +5,8 @@ use crate::{
     fuel_tx::Transaction,
 };
 use std::fmt::Debug;
+/// Contains types and logic for Peer Reputation
+pub mod peer_reputation;
 
 /// Lightweight representation of gossipped data that only includes IDs
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/types/src/services/p2p/peer_reputation.rs
+++ b/crates/types/src/services/p2p/peer_reputation.rs
@@ -1,0 +1,54 @@
+/// PeerScore type used for Peer Reputation
+pub type PeerScore = i8;
+
+/// Minimum allowed peer score before peer is banned
+pub const MIN_PEER_SCORE: PeerScore = 0;
+/// Default value for peer score
+pub const DEFAULT_PEER_SCORE: PeerScore = 50;
+/// Maximum value a Peer can reach with its PeerScore
+pub const MAX_PEER_SCORE: PeerScore = 100;
+
+/// Types implementing this can report new PeerScore
+pub trait PeerReport {
+    /// Extracts PeerScore from the Report
+    fn get_score_from_report(&self) -> PeerScore;
+}
+
+/// Example of negative PeerReport
+#[derive(Debug, Clone)]
+pub enum NegativePeerReport {
+    /// Worst offense, peer should likely be banned after this
+    Fatal,
+    /// Minor offense, deduct few points
+    Minor,
+    /// Major offense, deduct reasonable amount of points
+    Major,
+}
+
+impl PeerReport for NegativePeerReport {
+    fn get_score_from_report(&self) -> PeerScore {
+        match self {
+            Self::Fatal => -MAX_PEER_SCORE - 10,
+            Self::Major => -10,
+            Self::Minor => -5,
+        }
+    }
+}
+
+/// Example of positive PeerReport
+#[derive(Debug, Clone)]
+pub enum PositivePeerReport {
+    /// Minor positive feedback, increase reputation slightly
+    Minor,
+    /// Major positive feedback, increase reputation
+    Major,
+}
+
+impl PeerReport for PositivePeerReport {
+    fn get_score_from_report(&self) -> PeerScore {
+        match self {
+            Self::Major => 5,
+            Self::Minor => 1,
+        }
+    }
+}


### PR DESCRIPTION
This is the initial setup for PeerReputation #943 

The approach was to provide a simple framework where if some of the scoring logic changes,
the API should remain the same, only changes should be done within `types/p2p/peer_reputation`.

Todo:
- [ ] implement unban peers after certain period (?)
- [ ] integrate gossipsub scoring (?)
- [ ] decide what to do with reserved peers and their reputation
- [ ] libp2p can internally also:
     - [ ] increase reputation
     - [ ] decrease reputation