### PR TITLE
Fix database version serialization

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -28,8 +28,13 @@ pub enum Error {
     #[error("Chain is not yet initialized")]
     ChainUninitialized,
     /// The version of database or data is invalid (possibly not migrated).
-    #[error("Invalid database version")]
-    InvalidDatabaseVersion,
+    #[error("Invalid database version, expected {expected:#x}, found {found:#x}")]
+    InvalidDatabaseVersion {
+        /// the current database version
+        found: u32,
+        /// the database version expected by this build of fuel-core
+        expected: u32,
+    },
     /// Not related to database error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -65,6 +65,7 @@ impl FuelService {
     /// Creates a `FuelService` instance from service config
     #[tracing::instrument(skip_all, fields(name = %config.name))]
     pub fn new(database: Database, mut config: Config) -> anyhow::Result<Self> {
+        database.init(&config.chain_conf)?;
         Self::make_config_consistent(&mut config);
         let task = Task::new(database, config)?;
         let runner = ServiceRunner::new(task);

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -71,7 +71,7 @@ pub fn maybe_initialize_state(
     database: &Database,
 ) -> anyhow::Result<()> {
     // check if chain is initialized
-    if database.get_chain_name()?.is_none() {
+    if database.ids_of_latest_block()?.is_none() {
         import_genesis_block(config, database)?;
     }
 
@@ -87,7 +87,6 @@ fn import_genesis_block(
 
     let database = database_transaction.as_mut();
     // Initialize the chain id and height.
-    database.init(&config.chain_conf)?;
 
     let chain_config_hash = config.chain_conf.root()?.into();
     let coins_root = init_coin_state(database, &config.chain_conf.initial_state)?.into();

--- a/tests/tests/health.rs
+++ b/tests/tests/health.rs
@@ -1,14 +1,43 @@
-use fuel_core::service::{
-    Config,
-    FuelService,
+use fuel_core::{
+    database::Database,
+    service::{
+        Config,
+        FuelService,
+        ServiceTrait,
+    },
 };
 use fuel_core_client::client::FuelClient;
+use tempfile::TempDir;
 
 #[tokio::test]
 async fn health() {
-    let srv = FuelService::new_node(Config::local_node()).await.unwrap();
+    let srv = FuelService::from_database(Database::default(), Config::local_node())
+        .await
+        .unwrap();
     let client = FuelClient::from(srv.bound_address);
 
     let health = client.health().await.unwrap();
     assert!(health);
+}
+
+#[cfg(feature = "default")]
+#[tokio::test]
+async fn can_restart_node() {
+    let tmp_dir = TempDir::new().unwrap();
+
+    // start node once
+    {
+        let database = Database::open(tmp_dir.path()).unwrap();
+        let first_startup = FuelService::from_database(database, Config::local_node())
+            .await
+            .unwrap();
+        first_startup.stop_and_await().await.unwrap();
+    }
+
+    {
+        let database = Database::open(tmp_dir.path()).unwrap();
+        let _second_startup = FuelService::from_database(database, Config::local_node())
+            .await
+            .unwrap();
+    }
 }


### PR DESCRIPTION
The database version was being double initialized between `Database::init` and `RocksDB`. However, the `Database` was using postcard, and `RocksDB` was using manual byte serialization. This was causing version conflicts when restarting a fuel-core node off of an existing database, as the serialization methods were mismatched.

This PR resolves the issue by ensuring the database metadata is only managed by the database itself, and not by RocksDb.

This is a blocker for beta3.