### PR TITLE
Graceful Shutdown for all services

### DIFF
--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -63,6 +63,7 @@ uuid = { version = "1.1", features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
+fuel-core-services = { path = "./../services", features = ["test-helpers"] }
 fuel-core-storage = { path = "./../storage", features = ["test-helpers"] }
 fuel-core-trace = { path = "./../trace" }
 fuel-core-types = { path = "./../types", features = ["test-helpers"] }

--- a/crates/fuel-core/src/graphql_api/service.rs
+++ b/crates/fuel-core/src/graphql_api/service.rs
@@ -132,6 +132,13 @@ impl RunnableTask for Task {
         // error or stop signal.
         Ok(false /* should_continue */)
     }
+
+    async fn shutdown(self) -> anyhow::Result<()> {
+        // Nothing to shut down because we don't have any temporary state that should be dumped,
+        // and we don't spawn any sub-tasks that we need to finish or await.
+        // The `axum::Server` was already gracefully shutdown at this point.
+        Ok(())
+    }
 }
 
 pub fn new_service(

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -19,3 +19,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }
+
+[features]
+test-helpers = []

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -435,6 +435,12 @@ where
         }
         Ok(should_continue)
     }
+
+    async fn shutdown(self) -> anyhow::Result<()> {
+        // Nothing to shut down because we don't have any temporary state that should be dumped,
+        // and we don't spawn any sub-tasks that we need to finish or await.
+        Ok(())
+    }
 }
 
 pub fn new_service<D, T, B, I>(

--- a/crates/services/relayer/Cargo.toml
+++ b/crates/services/relayer/Cargo.toml
@@ -36,6 +36,7 @@ url = "2.2"
 
 [dev-dependencies]
 fuel-core-relayer = { path = "", features = ["test-helpers"] }
+fuel-core-services = { path = "../../services", features = ["test-helpers"] }
 fuel-core-storage = { path = "../../storage", features = ["test-helpers"] }
 fuel-core-trace = { path = "../../trace" }
 mockall = { workspace = true }

--- a/crates/services/relayer/src/service/get_logs.rs
+++ b/crates/services/relayer/src/service/get_logs.rs
@@ -5,12 +5,12 @@ use futures::TryStreamExt;
 mod test;
 
 /// Download the logs from the DA layer.
-pub(crate) fn download_logs<P>(
+pub(crate) fn download_logs<'a, P>(
     eth_sync_gap: &state::EthSyncGap,
     contracts: Vec<H160>,
-    eth_node: Arc<P>,
+    eth_node: &'a P,
     page_size: u64,
-) -> impl futures::Stream<Item = Result<(u64, Vec<Log>), ProviderError>>
+) -> impl futures::Stream<Item = Result<(u64, Vec<Log>), ProviderError>> + 'a
 where
     P: Middleware<Error = ProviderError> + 'static,
 {
@@ -19,7 +19,6 @@ where
         eth_sync_gap.page(page_size),
         move |page: Option<state::EthSyncPage>| {
             let contracts = contracts.clone();
-            let eth_node = eth_node.clone();
             async move {
                 match page {
                     None => Ok(None),

--- a/crates/services/relayer/src/service/get_logs/test.rs
+++ b/crates/services/relayer/src/service/get_logs/test.rs
@@ -118,7 +118,7 @@ async fn can_paginate_logs(input: Input) -> Expected {
         data.best_block.number =
             Some((eth_gap.end() + Config::DEFAULT_DA_FINALIZATION).into());
     });
-    let count = Arc::new(AtomicUsize::new(0));
+    let count = std::sync::Arc::new(AtomicUsize::new(0));
     let num_calls = count.clone();
     eth_node.set_after_event(move |_, evt| {
         if let TriggerType::GetLogs(_) = evt {
@@ -129,7 +129,7 @@ async fn can_paginate_logs(input: Input) -> Expected {
     let result = download_logs(
         &EthSyncGap::new(*eth_gap.start(), *eth_gap.end()),
         contracts,
-        Arc::new(eth_node),
+        &eth_node,
         Config::DEFAULT_LOG_PAGE_SIZE,
     )
     .map_ok(|(_, l)| l)

--- a/crates/services/relayer/src/service/test.rs
+++ b/crates/services/relayer/src/service/test.rs
@@ -31,7 +31,7 @@ async fn can_download_logs() {
     let result = download_logs(
         &eth_state.needs_to_sync_eth().unwrap(),
         contracts,
-        Arc::new(eth_node),
+        &eth_node,
         Config::DEFAULT_LOG_PAGE_SIZE,
     )
     .map_ok(|(_, l)| l)
@@ -53,9 +53,8 @@ async fn deploy_height_does_not_override() {
         ..Default::default()
     };
     let eth_node = MockMiddleware::default();
-    let (tx, _) = watch::channel(None);
-    let mut relayer = Task::new(tx, eth_node, mock_db.clone(), config);
-    relayer.set_deploy_height();
+    let relayer = NotInitializedTask::new(eth_node, mock_db.clone(), config);
+    let _ = relayer.into_task(&Default::default()).await;
 
     assert_eq!(*mock_db.get_finalized_da_height().unwrap(), 50);
 }
@@ -72,9 +71,8 @@ async fn deploy_height_does_override() {
         ..Default::default()
     };
     let eth_node = MockMiddleware::default();
-    let (tx, _) = watch::channel(None);
-    let mut relayer = Task::new(tx, eth_node, mock_db.clone(), config);
-    relayer.set_deploy_height();
+    let relayer = NotInitializedTask::new(eth_node, mock_db.clone(), config);
+    let _ = relayer.into_task(&Default::default()).await;
 
     assert_eq!(*mock_db.get_finalized_da_height().unwrap(), 52);
 }

--- a/crates/services/relayer/src/test_helpers/middleware.rs
+++ b/crates/services/relayer/src/test_helpers/middleware.rs
@@ -240,6 +240,7 @@ impl Middleware for MockMiddleware {
 
     /// Needs for initial sync of relayer
     async fn syncing(&self) -> Result<SyncingStatus, Self::Error> {
+        tokio::task::yield_now().await;
         self.before_event(TriggerType::Syncing);
         let r = Ok(self.update_data(|data| data.is_syncing.clone()));
         self.after_event(TriggerType::Syncing);
@@ -248,6 +249,7 @@ impl Middleware for MockMiddleware {
 
     /// Used in initial sync to get current best eth block
     async fn get_block_number(&self) -> Result<U64, Self::Error> {
+        tokio::task::yield_now().await;
         let this = self;
         let _ = this.before_event(TriggerType::GetBlockNumber);
         let r = Ok(self.update_data(|data| data.best_block.number.unwrap()));
@@ -257,6 +259,7 @@ impl Middleware for MockMiddleware {
 
     /// used for initial sync to get logs of already finalized diffs
     async fn get_logs(&self, filter: &Filter) -> Result<Vec<Log>, Self::Error> {
+        tokio::task::yield_now().await;
         self.before_event(TriggerType::GetLogs(filter));
         let r = self.update_data(|data| {
             data.logs_batch
@@ -292,6 +295,7 @@ impl Middleware for MockMiddleware {
         &self,
         block_hash_or_number: T,
     ) -> Result<Option<Block<TxHash>>, Self::Error> {
+        tokio::task::yield_now().await;
         let block_id = block_hash_or_number.into();
         self.before_event(TriggerType::GetBlock(block_id));
         let r = Ok(Some(self.update_data(|data| data.best_block.clone())));

--- a/crates/services/src/service.rs
+++ b/crates/services/src/service.rs
@@ -3,10 +3,8 @@ use crate::state::{
     StateWatcher,
 };
 use anyhow::anyhow;
-use tokio::{
-    sync::watch,
-    task::JoinHandle,
-};
+use futures::FutureExt;
+use tokio::sync::watch;
 use tracing::Instrument;
 
 /// Alias for Arc<T>
@@ -53,6 +51,9 @@ pub trait Service {
 
     /// The current state of the service (i.e. `Started`, `Stopped`, etc..)
     fn state(&self) -> State;
+
+    /// Returns the state watcher of the service.
+    fn state_watcher(&self) -> StateWatcher;
 }
 
 /// Trait used by `ServiceRunner` to encapsulate the business logic tasks for a service.
@@ -94,6 +95,9 @@ pub trait RunnableTask: Send {
     /// will stop. If the service should react to the state change earlier, it should handle it in
     /// the `run` loop on its own. See [`StateWatcher::while_started`].
     async fn run(&mut self, watcher: &mut StateWatcher) -> anyhow::Result<bool>;
+
+    /// Gracefully shutdowns the task after the end of the execution cycle.
+    async fn shutdown(self) -> anyhow::Result<()>;
 }
 
 /// The service runner manages the lifecycle, execution and error handling of a `RunnableService`.
@@ -213,6 +217,10 @@ where
     fn state(&self) -> State {
         self.state.borrow().clone()
     }
+
+    fn state_watcher(&self) -> StateWatcher {
+        self.state.subscribe().into()
+    }
 }
 
 #[tracing::instrument(skip_all, fields(service = S::NAME))]
@@ -228,12 +236,13 @@ where
     tokio::task::spawn(
         async move {
             tracing::debug!("running");
-            let join_handler = run(service, stop_sender.clone());
+            let run = std::panic::AssertUnwindSafe(run(service, stop_sender.clone()));
             tracing::debug!("awaiting run");
-            let result = join_handler.await;
+            let result = run.catch_unwind().await;
 
             let stopped_state = if let Err(e) = result {
-                State::StoppedWithError(e.to_string())
+                let panic_information = panic_to_string(e);
+                State::StoppedWithError(panic_information)
             } else {
                 State::Stopped
             };
@@ -256,61 +265,85 @@ where
     state
 }
 
-/// Spawns a task for the main background run loop.
-fn run<S>(service: S, sender: Shared<watch::Sender<State>>) -> JoinHandle<()>
+/// Runs the main loop.
+async fn run<S>(service: S, sender: Shared<watch::Sender<State>>)
 where
     S: RunnableService + 'static,
 {
     let mut state: StateWatcher = sender.subscribe().into();
-    tokio::task::spawn(
-        async move {
-            if state.borrow_and_update().not_started() {
-                // We can panic here, because it is inside of the task.
-                state.changed().await.expect("The service is destroyed");
-            }
+    if state.borrow_and_update().not_started() {
+        // We can panic here, because it is inside of the task.
+        state.changed().await.expect("The service is destroyed");
+    }
 
-            // If the state after update is not `Starting` then return to stop the service.
-            if !state.borrow().starting() {
-                return
-            }
+    // If the state after update is not `Starting` then return to stop the service.
+    if !state.borrow().starting() {
+        return
+    }
 
-            // We can panic here, because it is inside of the task.
-            let mut task = service
-                .into_task(&state)
-                .await
-                .expect("The initialization of the service failed.");
+    // We can panic here, because it is inside of the task.
+    let mut task = service
+        .into_task(&state)
+        .await
+        .expect("The initialization of the service failed.");
 
-            let started = sender.send_if_modified(|s| {
-                if s.starting() {
-                    *s = State::Started;
-                    true
-                } else {
-                    false
+    sender.send_if_modified(|s| {
+        if s.starting() {
+            *s = State::Started;
+            true
+        } else {
+            false
+        }
+    });
+
+    let mut got_panic = None;
+
+    while state.borrow_and_update().started() {
+        let task = std::panic::AssertUnwindSafe(task.run(&mut state));
+        let panic_result = task.catch_unwind().await;
+
+        match panic_result {
+            Ok(Ok(should_continue)) => {
+                if !should_continue {
+                    tracing::debug!("stopping");
+                    break
                 }
-            });
-
-            if !started {
-                return
+                tracing::debug!("run loop");
             }
-
-            while state.borrow_and_update().started() {
-                match task.run(&mut state).await {
-                    Ok(should_continue) => {
-                        if !should_continue {
-                            tracing::debug!("stopping");
-                            return
-                        }
-                        tracing::debug!("run loop");
-                    }
-                    Err(e) => {
-                        let e: &dyn std::error::Error = &*e;
-                        tracing::error!(e);
-                    }
-                }
+            Ok(Err(e)) => {
+                let e: &dyn std::error::Error = &*e;
+                tracing::error!(e);
+            }
+            Err(panic) => {
+                tracing::debug!("got a panic");
+                got_panic = Some(panic);
+                break
             }
         }
-        .in_current_span(),
-    )
+    }
+
+    let shutdown = std::panic::AssertUnwindSafe(task.shutdown());
+    match shutdown.catch_unwind().await {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => {
+            tracing::error!("Go an error during shutdown of the task: {e}");
+        }
+        Err(e) => {
+            if got_panic.is_some() {
+                let panic_information = panic_to_string(e);
+                tracing::error!(
+                    "Go a panic during execution and shutdown of the task. \
+                    The error during shutdown: {panic_information}"
+                );
+            } else {
+                got_panic = Some(e);
+            }
+        }
+    }
+
+    if let Some(panic) = got_panic {
+        std::panic::resume_unwind(panic)
+    }
 }
 
 impl<T> SharedMutex<T> {
@@ -326,7 +359,17 @@ impl<T> SharedMutex<T> {
     }
 }
 
-// TODO: Add tests
+fn panic_to_string(e: Box<dyn core::any::Any + Send>) -> String {
+    let panic_information = match e.downcast::<String>() {
+        Ok(v) => *v,
+        Err(e) => match e.downcast::<&str>() {
+            Ok(v) => v.to_string(),
+            _ => "Unknown Source of Error".to_owned(),
+        },
+    };
+    panic_information
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -361,6 +404,8 @@ mod tests {
                 '_self: 'a,
                 '_state: 'a,
                 Self: Sync + 'a;
+
+            async fn shutdown(self) -> anyhow::Result<()>;
         }
     }
 
@@ -374,9 +419,11 @@ mod tests {
                     let mut watcher = watcher.clone();
                     Box::pin(async move {
                         watcher.while_started().await.unwrap();
-                        Ok(false)
+                        let should_continue = false;
+                        Ok(should_continue)
                     })
                 });
+                mock.expect_shutdown().times(1).returning(|| Ok(()));
                 Ok(mock)
             });
             mock
@@ -389,7 +436,7 @@ mod tests {
         let state = service.start_and_await().await.unwrap();
         assert!(state.started());
         let state = service.stop_and_await().await.unwrap();
-        assert!(state.stopped());
+        assert!(matches!(state, State::Stopped));
     }
 
     #[tokio::test]
@@ -410,6 +457,7 @@ mod tests {
     async fn stop_without_start() {
         let service = ServiceRunner::new(MockService::new_empty());
         service.stop_and_await().await.unwrap();
+        assert!(matches!(service.state(), State::Stopped));
     }
 
     #[tokio::test]
@@ -419,14 +467,44 @@ mod tests {
         mock.expect_into_task().returning(|_| {
             let mut mock = MockTask::default();
             mock.expect_run().returning(|_| panic!("Should fail"));
+            mock.expect_shutdown().times(1).returning(|| Ok(()));
             Ok(mock)
         });
         let service = ServiceRunner::new(mock);
         let state = service.start_and_await().await.unwrap();
-        assert!(matches!(state, State::StoppedWithError(_)));
+        assert!(matches!(state, State::StoppedWithError(s) if s.contains("Should fail")));
 
         let state = service.await_stop().await.unwrap();
-        assert!(matches!(state, State::StoppedWithError(_)));
+        assert!(matches!(state, State::StoppedWithError(s) if s.contains("Should fail")));
+    }
+
+    #[tokio::test]
+    async fn panic_during_shutdown() {
+        let mut mock = MockService::default();
+        mock.expect_shared_data().returning(|| EmptyShared);
+        mock.expect_into_task().returning(|_| {
+            let mut mock = MockTask::default();
+            mock.expect_run().returning(|_| {
+                Box::pin(async move {
+                    let should_continue = false;
+                    Ok(should_continue)
+                })
+            });
+            mock.expect_shutdown()
+                .times(1)
+                .returning(|| panic!("Shutdown should fail"));
+            Ok(mock)
+        });
+        let service = ServiceRunner::new(mock);
+        let state = service.start_and_await().await.unwrap();
+        assert!(
+            matches!(state, State::StoppedWithError(s) if s.contains("Shutdown should fail"))
+        );
+
+        let state = service.await_stop().await.unwrap();
+        assert!(
+            matches!(state, State::StoppedWithError(s) if s.contains("Shutdown should fail"))
+        );
     }
 
     #[tokio::test]
@@ -436,9 +514,9 @@ mod tests {
         service.stop();
 
         let state = service.await_stop().await.unwrap();
-        assert!(state.stopped());
+        assert!(matches!(state, State::Stopped));
         let state = service.await_stop().await.unwrap();
-        assert!(state.stopped());
+        assert!(matches!(state, State::Stopped));
     }
 
     #[tokio::test]
@@ -447,9 +525,9 @@ mod tests {
         service.start().unwrap();
 
         let state = service.stop_and_await().await.unwrap();
-        assert!(state.stopped());
+        assert!(matches!(state, State::Stopped));
         let state = service.stop_and_await().await.unwrap();
-        assert!(state.stopped());
+        assert!(matches!(state, State::Stopped));
     }
 
     #[tokio::test]
@@ -464,6 +542,6 @@ mod tests {
         receiver.changed().await.unwrap();
         assert!(matches!(receiver.borrow().clone(), State::Stopping));
         receiver.changed().await.unwrap();
-        assert!(receiver.borrow().stopped());
+        assert!(matches!(receiver.borrow().clone(), State::Stopped));
     }
 }

--- a/crates/services/src/service.rs
+++ b/crates/services/src/service.rs
@@ -251,7 +251,7 @@ where
 
             let _ = stop_sender.send_if_modified(|state| {
                 if !state.stopped() {
-                    *state = stopped_state;
+                    *state = stopped_state.clone();
                     tracing::debug!("Wasn't stopped, so sent stop.");
                     true
                 } else {
@@ -259,6 +259,10 @@ where
                     false
                 }
             });
+
+            if let State::StoppedWithError(err) = stopped_state {
+                std::panic::resume_unwind(Box::new(err));
+            }
         }
         .in_current_span(),
     );

--- a/crates/services/src/state.rs
+++ b/crates/services/src/state.rs
@@ -46,6 +46,14 @@ impl State {
 #[derive(Clone)]
 pub struct StateWatcher(watch::Receiver<State>);
 
+#[cfg(feature = "test-helpers")]
+impl Default for StateWatcher {
+    fn default() -> Self {
+        let (_, receiver) = watch::channel(State::NotStarted);
+        Self(receiver)
+    }
+}
+
 impl StateWatcher {
     /// See [`watch::Receiver::borrow`].
     pub fn borrow(&self) -> watch::Ref<'_, State> {

--- a/crates/services/sync/src/service/tests.rs
+++ b/crates/services/sync/src/service/tests.rs
@@ -50,6 +50,7 @@ async fn test_new_service() {
     consensus
         .expect_check_sealed_header()
         .returning(|_| Ok(true));
+    consensus.expect_await_da_height().returning(|_| Ok(()));
     let params = Config {
         max_get_header_requests: 10,
         max_get_txns_requests: 10,
@@ -60,12 +61,15 @@ async fn test_new_service() {
         s.start_and_await().await.unwrap(),
         fuel_core_services::State::Started
     );
+    let mut last_value = 0;
     while let Some(h) = rx.recv().await {
+        last_value = h;
         if h == 16 {
             break
         }
     }
 
+    assert_eq!(last_value, 16);
     assert_eq!(
         s.stop_and_await().await.unwrap(),
         fuel_core_services::State::Stopped

--- a/crates/services/txpool/src/service.rs
+++ b/crates/services/txpool/src/service.rs
@@ -186,6 +186,14 @@ where
         }
         Ok(should_continue)
     }
+
+    async fn shutdown(self) -> anyhow::Result<()> {
+        // Nothing to shut down because we don't have any temporary state that should be dumped,
+        // and we don't spawn any sub-tasks that we need to finish or await.
+        // Maybe we will save and load the previous list of transactions in the future to
+        // avoid losing them.
+        Ok(())
+    }
 }
 
 // TODO: Remove `find` and `find_one` methods from `txpool`. It is used only by GraphQL.

--- a/tests/tests/health.rs
+++ b/tests/tests/health.rs
@@ -3,11 +3,9 @@ use fuel_core::{
     service::{
         Config,
         FuelService,
-        ServiceTrait,
     },
 };
 use fuel_core_client::client::FuelClient;
-use tempfile::TempDir;
 
 #[tokio::test]
 async fn health() {
@@ -23,10 +21,12 @@ async fn health() {
 #[cfg(feature = "default")]
 #[tokio::test]
 async fn can_restart_node() {
+    use tempfile::TempDir;
     let tmp_dir = TempDir::new().unwrap();
 
     // start node once
     {
+        use fuel_core::service::ServiceTrait;
         let database = Database::open(tmp_dir.path()).unwrap();
         let first_startup = FuelService::from_database(database, Config::local_node())
             .await


### PR DESCRIPTION
- Closes https://github.com/FuelLabs/fuel-core/issues/949
- Closes https://github.com/FuelLabs/fuel-core/issues/897

Removed second spawned task for `fuel_core_services::service::run` function.

Instead, wrapped it into `catch_unwind`.
Added a `shutdown` method for the task that allows doing some cleanup for methods. For, almost, all services, it does nothing, but can be reused in the future. Added handling of the shutdown for `Relayer` to act immediately instead of waiting for the synchronization's end. Improved handling of the stop signal for `fuel-core-sync`.