### PR TITLE
Don't startup p2p or sync services if p2p isn't configured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -35,7 +35,7 @@ pub struct SharedState {
     pub txpool: fuel_core_txpool::service::SharedState<P2PAdapter, Database>,
     /// The P2P network shared state.
     #[cfg(feature = "p2p")]
-    pub network: fuel_core_p2p::service::SharedState,
+    pub network: Option<fuel_core_p2p::service::SharedState>,
     #[cfg(feature = "relayer")]
     /// The Relayer shared state.
     pub relayer: Option<fuel_core_relayer::SharedState<Database>>,

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -67,7 +67,7 @@ pub struct BlockImporterAdapter {
 #[cfg(feature = "p2p")]
 #[derive(Clone)]
 pub struct P2PAdapter {
-    service: fuel_core_p2p::service::SharedState,
+    service: Option<fuel_core_p2p::service::SharedState>,
 }
 
 #[cfg(not(feature = "p2p"))]
@@ -76,7 +76,7 @@ pub struct P2PAdapter;
 
 #[cfg(feature = "p2p")]
 impl P2PAdapter {
-    pub fn new(service: fuel_core_p2p::service::SharedState) -> Self {
+    pub fn new(service: Option<fuel_core_p2p::service::SharedState>) -> Self {
         Self { service }
     }
 }

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -46,7 +46,7 @@ pub struct Config {
     #[cfg(feature = "relayer")]
     pub relayer: fuel_core_relayer::Config,
     #[cfg(feature = "p2p")]
-    pub p2p: P2PConfig<NotInitialized>,
+    pub p2p: Option<P2PConfig<NotInitialized>>,
     #[cfg(feature = "p2p")]
     pub sync: fuel_core_sync::Config,
     pub consensus_key: Option<Secret<SecretKeyWrapper>>,
@@ -82,7 +82,7 @@ impl Config {
             #[cfg(feature = "relayer")]
             relayer: Default::default(),
             #[cfg(feature = "p2p")]
-            p2p: P2PConfig::<NotInitialized>::default("test_network"),
+            p2p: Some(P2PConfig::<NotInitialized>::default("test_network")),
             #[cfg(feature = "p2p")]
             sync: fuel_core_sync::Config::default(),
             consensus_key: Some(Secret::new(default_consensus_dev_key().into())),

--- a/tests/tests/sync/helpers.rs
+++ b/tests/tests/sync/helpers.rs
@@ -265,7 +265,7 @@ pub async fn make_nodes(
 
         let mut test_txs = Vec::with_capacity(0);
         node_config.block_production = Trigger::Instant;
-        node_config.p2p.bootstrap_nodes = boots.clone();
+        node_config.p2p.as_mut().unwrap().bootstrap_nodes = boots.clone();
 
         if let Some((ProducerSetup { secret, .. }, txs)) = s {
             let pub_key = secret.public_key();
@@ -295,7 +295,7 @@ pub async fn make_nodes(
             chain_config.clone(),
         );
         node_config.block_production = Trigger::Never;
-        node_config.p2p.bootstrap_nodes = boots.clone();
+        node_config.p2p.as_mut().unwrap().bootstrap_nodes = boots.clone();
 
         if let Some(ValidatorSetup { pub_key, .. }) = s {
             match &mut node_config.chain_conf.consensus {
@@ -343,7 +343,10 @@ fn extract_p2p_config(node_config: &Config) -> fuel_core_p2p::config::Config {
     let bootstrap_config = node_config.p2p.clone();
     let db = Database::in_memory();
     maybe_initialize_state(node_config, &db).unwrap();
-    bootstrap_config.init(db.get_genesis().unwrap()).unwrap()
+    bootstrap_config
+        .unwrap()
+        .init(db.get_genesis().unwrap())
+        .unwrap()
 }
 
 impl Node {

--- a/tests/tests/tx_gossip.rs
+++ b/tests/tests/tx_gossip.rs
@@ -60,7 +60,7 @@ fn create_node_config_from_inputs(inputs: &[Input]) -> Config {
     initial_state.coins = Some(coin_configs);
     node_config.chain_conf.initial_state = Some(initial_state);
     node_config.utxo_validation = true;
-    node_config.p2p.enable_mdns = true;
+    node_config.p2p.as_mut().unwrap().enable_mdns = true;
     node_config
 }
 


### PR DESCRIPTION
resolves: #1019

Disables p2p and sync services from starting if no peering key or network name is configured.