### PR TITLE
Remove comment referencing previous defensive programming

### DIFF
--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -268,8 +268,6 @@ where
         if let Some(pre_exec_block_id) = pre_exec_block_id {
             // The block id comparison compares the whole blocks including all fields.
             if pre_exec_block_id != finalized_block_id {
-                // In theory this shouldn't happen since any deviance in the block should've already
-                // been checked by now.
                 return Err(ExecutorError::InvalidBlockId)
             }
         }


### PR DESCRIPTION
A recent change led to a collapsing of the block validation logic to check and compare the final block id instead of the transactions root and messages root separately beforehand. This check was redundant and thus this comment was relevant until @xgreenx recently simplified the checks.