### PR TITLE
Add RUST_LOG option to deployment charts & increase max_transmit_size

### DIFF
--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -136,8 +136,8 @@ pub struct P2PArgs {
     #[clap(long = "gossip_heartbeat_interval", default_value = "1", env)]
     pub gossip_heartbeat_interval: u64,
 
-    /// The maximum byte size for each gossip
-    #[clap(long = "max_transmit_size", default_value = "2048", env)]
+    /// The maximum byte size for each gossip (default is 7.5 MiB)
+    #[clap(long = "max_transmit_size", default_value = "7864320", env)]
     pub max_transmit_size: usize,
 
     /// Choose timeout for sent requests in RequestResponse protocol

--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -218,6 +218,10 @@ spec:
             - name: BOOTSTRAP_NODES
               value: {{ .Values.app.bootstrap_nodes | quote }}
             {{- end }}
+            {{- if .Values.app.rust_log }}
+            - name: RUST_LOG
+              value: {{ .Values.app.rust_log | quote }}
+            {{- end }}
             # TODO: do we need to do anything to make this more optional for non-consensus nodes?
             - name: CONSENSUS_KEY_SECRET
               valueFrom:

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -12,6 +12,7 @@ app:
   p2p_key: ${fuel_core_p2p_key}
   allow_private_addresses: ${fuel_core_allow_private_addresses}
   human_logging: ${fuel_core_human_logging}
+  rust_log: ${fuel_core_rust_log}
   utxo_validation: ${fuel_core_utxo_validation}
   vm_backtrace: ${fuel_core_vm_backtrace}
   min_gas_price: ${fuel_core_min_gas_price}

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -11,6 +11,7 @@ pvc_storage_class="gp2"
 pvc_storage_requests="3Gi"
 chain_spec_file="../test_chainspec.json"
 fuel_core_human_logging=false
+fuel_core_rust_log="info"
 fuel_core_utxo_validation=true
 fuel_core_vm_backtrace=false
 fuel_core_min_gas_price=0


### PR DESCRIPTION
- add rust_log option to deployment charts
- increase default max_transmit_size to match our load balancer limit