### PR TITLE
Pruning of the transaction by TTL

### DIFF
--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -153,9 +153,6 @@ pub struct Command {
 
     #[clap(long = "tx-pool-ttl", default_value = "5m", env)]
     pub tx_pool_ttl: humantime::Duration,
-
-    #[clap(long = "tx-pool-rebroadcast-interval", default_value = "30s", env)]
-    pub tx_pool_rebroadcast_interval: humantime::Duration,
 }
 
 impl Command {
@@ -184,7 +181,6 @@ impl Command {
             max_da_lag,
             max_wait_time,
             tx_pool_ttl,
-            tx_pool_rebroadcast_interval,
         } = self;
 
         let addr = net::SocketAddr::new(ip, port);
@@ -256,7 +252,6 @@ impl Command {
                 utxo_validation,
                 metrics,
                 tx_pool_ttl.into(),
-                tx_pool_rebroadcast_interval.into(),
             ),
             block_producer: ProducerConfig {
                 utxo_validation,

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -150,6 +150,12 @@ pub struct Command {
     pub max_da_lag: u64,
     #[clap(long = "verify_max_relayer_wait", default_value = "30s", env)]
     pub max_wait_time: humantime::Duration,
+
+    #[clap(long = "tx-pool-ttl", default_value = "5m", env)]
+    pub tx_pool_ttl: humantime::Duration,
+
+    #[clap(long = "tx-pool-rebroadcast-interval", default_value = "30s", env)]
+    pub tx_pool_rebroadcast_interval: humantime::Duration,
 }
 
 impl Command {
@@ -177,6 +183,8 @@ impl Command {
             metrics,
             max_da_lag,
             max_wait_time,
+            tx_pool_ttl,
+            tx_pool_rebroadcast_interval,
         } = self;
 
         let addr = net::SocketAddr::new(ip, port);
@@ -242,7 +250,14 @@ impl Command {
             vm: VMConfig {
                 backtrace: vm_backtrace,
             },
-            txpool: TxPoolConfig::new(chain_conf, min_gas_price, utxo_validation),
+            txpool: TxPoolConfig::new(
+                chain_conf,
+                min_gas_price,
+                utxo_validation,
+                metrics,
+                tx_pool_ttl.into(),
+                tx_pool_rebroadcast_interval.into(),
+            ),
             block_producer: ProducerConfig {
                 utxo_validation,
                 coinbase_recipient,

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -45,7 +45,6 @@ use fuel_core_types::{
         txpool::{
             InsertionResult,
             TransactionStatus,
-            TxInfo,
         },
     },
     tai64::Tai64,
@@ -148,7 +147,9 @@ pub trait DatabaseChain {
 }
 
 pub trait TxPoolPort: Send + Sync {
-    fn find_one(&self, id: TxId) -> Option<TxInfo>;
+    fn transaction(&self, id: TxId) -> Option<Transaction>;
+
+    fn submission_time(&self, id: TxId) -> Option<Tai64>;
 
     fn insert(&self, txs: Vec<Arc<Transaction>>) -> Vec<anyhow::Result<InsertionResult>>;
 

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -48,7 +48,6 @@ use futures::{
 use itertools::Itertools;
 use std::{
     iter,
-    ops::Deref,
     sync::Arc,
 };
 use types::Transaction;
@@ -74,8 +73,8 @@ impl TxQuery {
         let id = id.0;
         let txpool = ctx.data_unchecked::<TxPool>();
 
-        if let Some(transaction) = txpool.find_one(id) {
-            Ok(Some(Transaction(transaction.tx().clone().deref().into())))
+        if let Some(transaction) = txpool.transaction(id) {
+            Ok(Some(Transaction(transaction)))
         } else {
             query.transaction(&id).into_api_result()
         }

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -500,11 +500,10 @@ pub(super) async fn get_tx_status(
         .into_api_result::<txpool::TransactionStatus, StorageError>()?
     {
         Some(status) => Ok(Some(status.into())),
-        None => match txpool.find_one(id) {
-            Some(transaction_in_pool) => {
-                let time = transaction_in_pool.submitted_time();
-                Ok(Some(TransactionStatus::Submitted(SubmittedStatus(time))))
-            }
+        None => match txpool.submission_time(id) {
+            Some(submitted_time) => Ok(Some(TransactionStatus::Submitted(
+                SubmittedStatus(submitted_time),
+            ))),
             _ => Ok(None),
         },
     }

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -72,7 +72,7 @@ impl Config {
             vm: Default::default(),
             utxo_validation,
             txpool: fuel_core_txpool::Config {
-                chain_config: chain_conf.clone(),
+                chain_config: chain_conf,
                 min_gas_price,
                 utxo_validation,
                 ..fuel_core_txpool::Config::default()

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -71,11 +71,12 @@ impl Config {
             block_production: Trigger::Instant,
             vm: Default::default(),
             utxo_validation,
-            txpool: fuel_core_txpool::Config::new(
-                chain_conf,
+            txpool: fuel_core_txpool::Config {
+                chain_config: chain_conf.clone(),
                 min_gas_price,
                 utxo_validation,
-            ),
+                ..fuel_core_txpool::Config::default()
+            },
             block_producer: Default::default(),
             block_executor: Default::default(),
             block_importer: Default::default(),

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -13,6 +13,7 @@ use std::{
         SocketAddr,
     },
     path::PathBuf,
+    time::Duration,
 };
 use strum_macros::{
     Display,
@@ -75,6 +76,7 @@ impl Config {
                 chain_config: chain_conf,
                 min_gas_price,
                 utxo_validation,
+                transaction_ttl: Duration::from_secs(60 * 100000000),
                 ..fuel_core_txpool::Config::default()
             },
             block_producer: Default::default(),

--- a/crates/services/txpool/Cargo.toml
+++ b/crates/services/txpool/Cargo.toml
@@ -29,6 +29,10 @@ fuel-core-txpool = { path = "", features = ["test-helpers"] }
 itertools = { workspace = true }
 mockall = { workspace = true }
 rstest = "0.15"
+tokio = { workspace = true, features = [
+    "sync",
+    "test-util",
+] }
 
 [features]
 test-helpers = [

--- a/crates/services/txpool/src/config.rs
+++ b/crates/services/txpool/src/config.rs
@@ -17,8 +17,6 @@ pub struct Config {
     pub metrics: bool,
     /// Transaction TTL
     pub transaction_ttl: Duration,
-    /// Rebroadcast interval for txs
-    pub transaction_rebroadcast_interval: Duration,
 }
 
 impl Default for Config {
@@ -28,16 +26,12 @@ impl Default for Config {
         let metrics = false;
         // 5 minute TTL
         let transaction_ttl = Duration::from_secs(60 * 5);
-        // 30 second rebroadcast interval
-        // TODO: ensure no punishment occurs for rebroadcasting
-        let transaction_rebroadcast_interval = Duration::from_secs(30);
         Self::new(
             ChainConfig::default(),
             min_gas_price,
             utxo_validation,
             metrics,
             transaction_ttl,
-            transaction_rebroadcast_interval,
         )
     }
 }
@@ -49,7 +43,6 @@ impl Config {
         utxo_validation: bool,
         metrics: bool,
         transaction_ttl: Duration,
-        transaction_rebroadcast_interval: Duration,
     ) -> Self {
         // # Dev-note: If you add a new field, be sure that this field is propagated correctly
         //  in all places where `new` is used.
@@ -61,7 +54,6 @@ impl Config {
             chain_config,
             metrics,
             transaction_ttl,
-            transaction_rebroadcast_interval,
         }
     }
 }

--- a/crates/services/txpool/src/config.rs
+++ b/crates/services/txpool/src/config.rs
@@ -1,4 +1,5 @@
 use fuel_core_chain_config::ChainConfig;
+use std::time::Duration;
 
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -14,13 +15,30 @@ pub struct Config {
     pub chain_config: ChainConfig,
     /// Enables prometheus metrics for this fuel-service
     pub metrics: bool,
+    /// Transaction TTL
+    pub transaction_ttl: Duration,
+    /// Rebroadcast interval for txs
+    pub transaction_rebroadcast_interval: Duration,
 }
 
 impl Default for Config {
     fn default() -> Self {
         let min_gas_price = 0;
         let utxo_validation = true;
-        Self::new(ChainConfig::default(), min_gas_price, utxo_validation)
+        let metrics = false;
+        // 5 minute TTL
+        let transaction_ttl = Duration::from_secs(60 * 5);
+        // 30 second rebroadcast interval
+        // TODO: ensure no punishment occurs for rebroadcasting
+        let transaction_rebroadcast_interval = Duration::from_secs(30);
+        Self::new(
+            ChainConfig::default(),
+            min_gas_price,
+            utxo_validation,
+            metrics,
+            transaction_ttl,
+            transaction_rebroadcast_interval,
+        )
     }
 }
 
@@ -29,6 +47,9 @@ impl Config {
         chain_config: ChainConfig,
         min_gas_price: u64,
         utxo_validation: bool,
+        metrics: bool,
+        transaction_ttl: Duration,
+        transaction_rebroadcast_interval: Duration,
     ) -> Self {
         // # Dev-note: If you add a new field, be sure that this field is propagated correctly
         //  in all places where `new` is used.
@@ -38,7 +59,9 @@ impl Config {
             min_gas_price,
             utxo_validation,
             chain_config,
-            metrics: false,
+            metrics,
+            transaction_ttl,
+            transaction_rebroadcast_interval,
         }
     }
 }

--- a/crates/services/txpool/src/containers.rs
+++ b/crates/services/txpool/src/containers.rs
@@ -1,2 +1,4 @@
 pub mod dependency;
 pub mod price_sort;
+pub mod sort;
+pub mod time_sort;

--- a/crates/services/txpool/src/containers/dependency.rs
+++ b/crates/services/txpool/src/containers/dependency.rs
@@ -2,6 +2,7 @@ use crate::{
     ports::TxPoolDb,
     types::*,
     Error,
+    TxInfo,
 };
 use anyhow::anyhow;
 use fuel_core_types::{
@@ -15,10 +16,7 @@ use fuel_core_types::{
         UtxoId,
     },
     fuel_types::MessageId,
-    services::txpool::{
-        ArcPoolTx,
-        TxInfo,
-    },
+    services::txpool::ArcPoolTx,
 };
 use std::collections::{
     HashMap,

--- a/crates/services/txpool/src/containers/price_sort.rs
+++ b/crates/services/txpool/src/containers/price_sort.rs
@@ -4,8 +4,8 @@ use crate::{
         SortableKey,
     },
     types::*,
+    TxInfo,
 };
-use fuel_core_types::services::txpool::TxInfo;
 use std::cmp;
 
 /// all transactions sorted by min/max price

--- a/crates/services/txpool/src/containers/sort.rs
+++ b/crates/services/txpool/src/containers/sort.rs
@@ -1,0 +1,56 @@
+use crate::types::*;
+use fuel_core_types::services::txpool::{
+    ArcPoolTx,
+    TxInfo,
+};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone)]
+pub struct Sort<Key> {
+    /// all transactions sorted by min/max value
+    pub sort: BTreeMap<Key, ArcPoolTx>,
+}
+
+impl<Key> Default for Sort<Key> {
+    fn default() -> Self {
+        Self {
+            sort: Default::default(),
+        }
+    }
+}
+
+impl<Key> Sort<Key>
+where
+    Key: SortableKey,
+{
+    pub fn remove(&mut self, info: &TxInfo) {
+        self.sort.remove(&Key::new(info));
+    }
+
+    pub fn lowest_tx(&self) -> Option<ArcPoolTx> {
+        self.sort.iter().next().map(|(_, tx)| tx.clone())
+    }
+
+    pub fn lowest_value(&self) -> Option<Key::Value> {
+        self.sort.iter().next().map(|(key, _)| key.value().clone())
+    }
+
+    pub fn lowest(&self) -> Option<(&Key, &ArcPoolTx)> {
+        self.sort.iter().next()
+    }
+
+    pub fn insert(&mut self, info: &TxInfo) {
+        let tx = info.tx().clone();
+        self.sort.insert(Key::new(info), tx);
+    }
+}
+
+pub trait SortableKey: Ord {
+    type Value: Clone;
+
+    fn new(info: &TxInfo) -> Self;
+
+    fn value(&self) -> &Self::Value;
+
+    fn tx_id(&self) -> &TxId;
+}

--- a/crates/services/txpool/src/containers/sort.rs
+++ b/crates/services/txpool/src/containers/sort.rs
@@ -1,8 +1,8 @@
-use crate::types::*;
-use fuel_core_types::services::txpool::{
-    ArcPoolTx,
+use crate::{
+    types::*,
     TxInfo,
 };
+use fuel_core_types::services::txpool::ArcPoolTx;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]

--- a/crates/services/txpool/src/containers/time_sort.rs
+++ b/crates/services/txpool/src/containers/time_sort.rs
@@ -5,30 +5,33 @@ use crate::{
     },
     types::*,
 };
-use fuel_core_types::services::txpool::TxInfo;
+use fuel_core_types::{
+    services::txpool::TxInfo,
+    tai64::Tai64,
+};
 use std::cmp;
 
-/// all transactions sorted by min/max price
-pub type PriceSort = Sort<PriceSortKey>;
+/// all transactions sorted by min/max time
+pub type TimeSort = Sort<TimeSortKey>;
 
 #[derive(Clone, Debug)]
-pub struct PriceSortKey {
-    price: GasPrice,
+pub struct TimeSortKey {
+    time: Tai64,
     tx_id: TxId,
 }
 
-impl SortableKey for PriceSortKey {
-    type Value = GasPrice;
+impl SortableKey for TimeSortKey {
+    type Value = Tai64;
 
     fn new(info: &TxInfo) -> Self {
         Self {
-            price: info.tx().price(),
+            time: info.submitted_time(),
             tx_id: info.tx().id(),
         }
     }
 
     fn value(&self) -> &Self::Value {
-        &self.price
+        &self.time
     }
 
     fn tx_id(&self) -> &TxId {
@@ -36,17 +39,17 @@ impl SortableKey for PriceSortKey {
     }
 }
 
-impl PartialEq for PriceSortKey {
+impl PartialEq for TimeSortKey {
     fn eq(&self, other: &Self) -> bool {
         self.tx_id == other.tx_id
     }
 }
 
-impl Eq for PriceSortKey {}
+impl Eq for TimeSortKey {}
 
-impl PartialOrd for PriceSortKey {
+impl PartialOrd for TimeSortKey {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        match self.price.partial_cmp(&other.price) {
+        match self.time.partial_cmp(&other.time) {
             Some(core::cmp::Ordering::Equal) => {}
             ord => return ord,
         }
@@ -54,9 +57,9 @@ impl PartialOrd for PriceSortKey {
     }
 }
 
-impl Ord for PriceSortKey {
+impl Ord for TimeSortKey {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        let cmp = self.price.cmp(&other.price);
+        let cmp = self.time.cmp(&other.time);
         if cmp == cmp::Ordering::Equal {
             return self.tx_id.cmp(&other.tx_id)
         }

--- a/crates/services/txpool/src/containers/time_sort.rs
+++ b/crates/services/txpool/src/containers/time_sort.rs
@@ -4,28 +4,36 @@ use crate::{
         SortableKey,
     },
     types::*,
+    TxInfo,
 };
-use fuel_core_types::{
-    services::txpool::TxInfo,
-    tai64::Tai64,
+use core::{
+    cmp,
+    time::Duration,
 };
-use std::cmp;
 
 /// all transactions sorted by min/max time
 pub type TimeSort = Sort<TimeSortKey>;
 
 #[derive(Clone, Debug)]
 pub struct TimeSortKey {
-    time: Tai64,
+    time: Duration,
+    created: tokio::time::Instant,
     tx_id: TxId,
 }
 
+impl TimeSortKey {
+    pub fn created(&self) -> &tokio::time::Instant {
+        &self.created
+    }
+}
+
 impl SortableKey for TimeSortKey {
-    type Value = Tai64;
+    type Value = Duration;
 
     fn new(info: &TxInfo) -> Self {
         Self {
             time: info.submitted_time(),
+            created: info.created(),
             tx_id: info.tx().id(),
         }
     }

--- a/crates/services/txpool/src/lib.rs
+++ b/crates/services/txpool/src/lib.rs
@@ -1,5 +1,11 @@
 #![deny(unused_crate_dependencies)]
 
+use fuel_core_types::services::txpool::ArcPoolTx;
+use std::{
+    ops::Deref,
+    time::Duration,
+};
+
 pub mod config;
 mod containers;
 pub mod ports;
@@ -26,3 +32,45 @@ pub(crate) mod test_helpers;
 
 #[cfg(test)]
 fuel_core_trace::enable_tracing!();
+
+/// Information of a transaction fetched from the txpool.
+#[derive(Debug, Clone)]
+pub struct TxInfo {
+    tx: ArcPoolTx,
+    submitted_time: Duration,
+    creation_instant: tokio::time::Instant,
+}
+
+#[allow(missing_docs)]
+impl TxInfo {
+    pub fn new(tx: ArcPoolTx) -> Self {
+        let since_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Now is bellow of the `UNIX_EPOCH`");
+
+        Self {
+            tx,
+            submitted_time: since_epoch,
+            creation_instant: tokio::time::Instant::now(),
+        }
+    }
+
+    pub fn tx(&self) -> &ArcPoolTx {
+        &self.tx
+    }
+
+    pub fn submitted_time(&self) -> Duration {
+        self.submitted_time
+    }
+
+    pub fn created(&self) -> tokio::time::Instant {
+        self.creation_instant
+    }
+}
+
+impl Deref for TxInfo {
+    type Target = ArcPoolTx;
+    fn deref(&self) -> &Self::Target {
+        &self.tx
+    }
+}

--- a/crates/services/txpool/src/service/test_helpers.rs
+++ b/crates/services/txpool/src/service/test_helpers.rs
@@ -127,6 +127,7 @@ impl MockImporter {
 }
 
 pub struct TestContextBuilder {
+    config: Option<Config>,
     mock_db: MockDb,
     rng: StdRng,
     p2p: Option<MockP2P>,
@@ -142,11 +143,17 @@ impl Default for TestContextBuilder {
 impl TestContextBuilder {
     pub fn new() -> Self {
         Self {
+            config: None,
             mock_db: MockDb::default(),
             rng: StdRng::seed_from_u64(10),
             p2p: None,
             importer: None,
         }
+    }
+
+    pub fn with_config(mut self, config: Config) -> Self {
+        self.config = Some(config);
+        self
     }
 
     pub fn with_importer(&mut self, importer: MockImporter) {
@@ -169,9 +176,10 @@ impl TestContextBuilder {
     pub fn setup_coin(&mut self) -> (Coin, Input) {
         crate::test_helpers::setup_coin(&mut self.rng, Some(&self.mock_db))
     }
+
     pub fn build(self) -> TestContext {
         let rng = RefCell::new(self.rng);
-        let config = Config::default();
+        let config = self.config.unwrap_or_default();
         let mock_db = self.mock_db;
 
         let p2p = self.p2p.unwrap_or_else(|| MockP2P::new_with_txs(vec![]));

--- a/crates/services/txpool/src/service/tests.rs
+++ b/crates/services/txpool/src/service/tests.rs
@@ -8,6 +8,7 @@ use fuel_core_types::{
     fuel_tx::UniqueIdentifier,
     services::txpool::Error as TxpoolError,
 };
+use std::time::Duration;
 
 #[tokio::test]
 async fn test_start_stop() {
@@ -43,6 +44,52 @@ async fn test_find() {
     let id = out[0].as_ref().unwrap().id();
     assert_eq!(id, tx1.id(), "Found tx id match{out:?}");
     assert!(out[1].is_none(), "Tx3 should not be found:{out:?}");
+    service.stop_and_await().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_prune_transactions() {
+    const TIMEOUT: u64 = 1;
+
+    let config = Config {
+        transaction_ttl: Duration::from_secs(TIMEOUT),
+        ..Default::default()
+    };
+    let ctx = TestContextBuilder::new()
+        .with_config(config)
+        .build_and_start()
+        .await;
+
+    let tx1 = Arc::new(ctx.setup_script_tx(10));
+    let tx2 = Arc::new(ctx.setup_script_tx(20));
+    let tx3 = Arc::new(ctx.setup_script_tx(30));
+
+    let service = ctx.service();
+
+    let out = service
+        .shared
+        .insert(vec![tx1.clone(), tx2.clone(), tx3.clone()]);
+
+    // Check that we have all transactions after insertion.
+    assert_eq!(out.len(), 3, "Should be len 3:{out:?}");
+    assert!(out[0].is_ok(), "Tx1 should be OK, got err:{out:?}");
+    assert!(out[1].is_ok(), "Tx2 should be OK, got err:{out:?}");
+    assert!(out[2].is_ok(), "Tx3 should be OK, got err:{out:?}");
+
+    tokio::time::sleep(Duration::from_secs(TIMEOUT)).await;
+    let out = service.shared.find(vec![tx1.id(), tx2.id(), tx3.id()]);
+    assert_eq!(out.len(), 3, "Should be len 3:{out:?}");
+    assert!(out[0].is_some(), "Tx1 should exist");
+    assert!(out[1].is_some(), "Tx2 should exist");
+    assert!(out[2].is_some(), "Tx3 should exist");
+
+    tokio::time::sleep(Duration::from_secs(2 * TIMEOUT)).await;
+    let out = service.shared.find(vec![tx1.id(), tx2.id(), tx3.id()]);
+    assert_eq!(out.len(), 3, "Should be len 3:{out:?}");
+    assert!(out[0].is_none(), "Tx1 should be pruned");
+    assert!(out[1].is_none(), "Tx2 should be pruned");
+    assert!(out[2].is_none(), "Tx3 should be pruned");
+
     service.stop_and_await().await.unwrap();
 }
 

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -361,17 +361,19 @@ where
 
     /// Remove all old transactions from the pool.
     pub fn prune_old_txs(&mut self) -> Vec<ArcPoolTx> {
-        let now = Tai64N::now() + self.config.transaction_ttl;
-        let now = now.0;
+        let now = Tai64N::now() - self.config.transaction_ttl;
+        let deadline = now.0;
 
         let mut result = vec![];
 
         while let Some((oldest_time, oldest_tx)) = self.by_time.lowest() {
             let oldest_time = *oldest_time.value();
             let oldest_tx = oldest_tx.clone();
-            if oldest_time < now {
+            if oldest_time < deadline {
                 let removed = self.remove_inner(&oldest_tx);
                 result.extend(removed.into_iter());
+            } else {
+                break
             }
         }
 

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -267,7 +267,7 @@ pub enum Error {
     // small todo for now it can pass but in future we should include better messages
     #[error("Transaction removed.")]
     Removed,
-    #[error("Transaction removed because of the TTL.")]
+    #[error("Transaction expired because it exceeded the configured time to live `tx-pool-ttl`.")]
     TTLReason,
     #[error("Transaction squeezed out because {0}")]
     SqueezedOut(String),

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -29,10 +29,7 @@ use crate::{
         ProgramState,
     },
 };
-use std::{
-    ops::Deref,
-    sync::Arc,
-};
+use std::sync::Arc;
 use tai64::Tai64;
 
 /// The alias for transaction pool result.
@@ -150,39 +147,6 @@ pub struct InsertionResult {
     pub inserted: ArcPoolTx,
     /// These were removed during the insertion
     pub removed: Vec<ArcPoolTx>,
-}
-
-/// Information of a transaction fetched from the txpool
-// TODO: Move me to `fuel-core-txpool` crate
-#[derive(Debug, Clone)]
-pub struct TxInfo {
-    tx: ArcPoolTx,
-    submitted_time: Tai64,
-}
-
-#[allow(missing_docs)]
-impl TxInfo {
-    pub fn new(tx: ArcPoolTx) -> Self {
-        Self {
-            tx,
-            submitted_time: Tai64::now(),
-        }
-    }
-
-    pub fn tx(&self) -> &ArcPoolTx {
-        &self.tx
-    }
-
-    pub fn submitted_time(&self) -> Tai64 {
-        self.submitted_time
-    }
-}
-
-impl Deref for TxInfo {
-    type Target = ArcPoolTx;
-    fn deref(&self) -> &Self::Target {
-        &self.tx
-    }
 }
 
 /// The status of the transaction during its life from the tx pool until the block.

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -36,6 +36,7 @@ use fuel_vm_private::prelude::GasCosts;
 use std::{
     ops::Deref,
     sync::Arc,
+    time::Instant,
 };
 use tai64::Tai64;
 

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -36,7 +36,6 @@ use fuel_vm_private::prelude::GasCosts;
 use std::{
     ops::Deref,
     sync::Arc,
-    time::Instant,
 };
 use tai64::Tai64;
 
@@ -183,6 +182,7 @@ pub struct InsertionResult {
 }
 
 /// Information of a transaction fetched from the txpool
+// TODO: Move me to `fuel-core-txpool` crate
 #[derive(Debug, Clone)]
 pub struct TxInfo {
     tx: ArcPoolTx,
@@ -332,6 +332,8 @@ pub enum Error {
     // small todo for now it can pass but in future we should include better messages
     #[error("Transaction removed.")]
     Removed,
+    #[error("Transaction removed because of the TTL.")]
+    TTLReason,
     #[error("Transaction squeezed out because {0}")]
     SqueezedOut(String),
     // TODO: We need it for now until channels are removed from TxPool.

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -137,11 +137,12 @@ impl TestSetupBuilder {
         let utxo_validation = true;
         let config = Config {
             utxo_validation,
-            txpool: fuel_core_txpool::Config::new(
-                chain_config.clone(),
-                self.min_gas_price,
+            txpool: fuel_core_txpool::Config {
+                chain_config: chain_config.clone(),
+                min_gas_price: self.min_gas_price,
                 utxo_validation,
-            ),
+                ..fuel_core_txpool::Config::default()
+            },
             chain_conf: chain_config,
             ..Config::local_node()
         };


### PR DESCRIPTION
Added basic pruning of the transaction by the TTL.

It is done periodically for constant period of time. We can do it often(based on the remaining time to the next timeout), but I tried to avoid to often locking.
