### PR TITLE
Adding specific app selector 

### DIFF
--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "fuel-core.name" . }}
+      app: {{ .Values.app.selector_name }}
   endpoints:
   - path: /metrics 
     port: http
@@ -42,7 +42,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: {{ template "fuel-core.name" . }}
+    app: {{ .Values.app.selector_name }}
     chart: {{ template "fuel-core.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -50,7 +50,7 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    app: {{ template "fuel-core.name" . }}
+    app: {{ .Values.app.selector_name }}
   ports:
     - name: http
       port: {{ .Values.app.http_port }}
@@ -62,7 +62,7 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    app: {{ template "fuel-core.name" . }}
+    app: {{ .Values.app.selector_name }}
     chart: {{ template "fuel-core.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -70,7 +70,7 @@ metadata:
 spec:
   type: NodePort
   selector:
-    app: {{ template "fuel-core.name" . }}
+    app: {{ .Values.app.selector_name }}
   ports:
     - name: http
       port: {{ .Values.app.http_port }}
@@ -86,14 +86,14 @@ kind: Deployment
 metadata:
   name: {{ template "fuel-core.name" . }}-k8s
   labels:
-    app: {{ template "fuel-core.name" . }}
+    app: {{ .Values.app.selector_name }}
     chart: {{ template "fuel-core.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "fuel-core.name" . }}
+      app: {{ .Values.app.selector_name }}
       release: {{ .Release.Name }}
   replicas: {{ .Values.app.replicas }}
   strategy:
@@ -101,7 +101,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fuel-core.name" . }}
+        app: {{ .Values.app.selector_name }}
         release: {{ .Release.Name }}
     spec:
       containers:

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -4,6 +4,7 @@
 
 app:
   name: ${fuel_core_service_name}
+  selector_name: ${fuel_core_selector_name}
   replicas: ${fuel_core_pod_replicas}
   http_port: 80
   target_port: 4000

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -45,6 +45,7 @@ fuel_core_consensus_key_secret="dGVzdA=="
 
 # allow multiple fuel-core nodes in the same namespace, also used for setting up reserved nodes
 fuel_core_service_name="fuel-core"
+fuel_core_selector_name="fuel-core"
 
 fuel_core_p2p_key="0x123123123123"
 # disables discovery using internal ip addresses


### PR DESCRIPTION
Given we are now doing multiple sentries, we need to add a specific app selector that is common to fuel-core or sentry deployments, this is just an addition for it