### PR TITLE
use sticky sessions for GQL requests to sentries

### DIFF
--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -49,6 +49,7 @@ metadata:
   name: {{ template "fuel-core.name" . }}-lb-service
 spec:
   type: LoadBalancer
+  sessionAffinity: ClientIP
   selector:
     app: {{ .Values.app.selector_name }}
   ports:


### PR DESCRIPTION
since sentries might not be in perfect sync at any given moment, use sticky sessions when routing api requests