### PR TITLE
Revert "use sticky sessions for GQL requests to sentries"

### DIFF
--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -49,7 +49,6 @@ metadata:
   name: {{ template "fuel-core.name" . }}-lb-service
 spec:
   type: LoadBalancer
-  sessionAffinity: ClientIP
   selector:
     app: {{ .Values.app.selector_name }}
   ports:


### PR DESCRIPTION
Reverts FuelLabs/fuel-core#1042

session affinity doesn't seem to be supported by eks