### PR TITLE
WIP: multi-arch build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,20 +215,24 @@ jobs:
           flavor: |
             latest=${{ github.ref == 'refs/heads/master' }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Log in to the ghcr.io registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push the image to ghcr.io
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: deployment/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I was able to build an arm64 image using docker buildx with the following steps locally while in the root of the fuel-core project

https://cloud.google.com/kubernetes-engine/docs/how-to/build-multi-arch-for-arm

docker buildx create --name mybuilder --use --bootstrap

docker buildx build --platform linux/arm64 -t fuel-core:buildx-latest . -f deployment/Dockerfile --load

```
docker images
REPOSITORY                                TAG               IMAGE ID       CREATED          SIZE
fuel-core                                 buildx-latest     61af27bfabe2   27 minutes ago   99.6MB
```

I still have some testing to do to make sure this works.