### PR TITLE
Take into account the previous block timestamp during block production

### DIFF
--- a/bin/e2e-test-client/src/test_context.rs
+++ b/bin/e2e-test-client/src/test_context.rs
@@ -256,10 +256,7 @@ impl Wallet {
         if let TransactionStatus::Failure { .. } | TransactionStatus::SqueezedOut { .. } =
             &status
         {
-            return Err(anyhow!(format!(
-                "unexpected transaction status {:?}",
-                status
-            )))
+            return Err(anyhow!(format!("unexpected transaction status {status:?}")))
         }
 
         Ok(())

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -455,7 +455,7 @@ type Mutation {
 	Submits transaction to the txpool
 	"""
 	submit(tx: HexString!): Transaction!
-	produceBlocks(blocksToProduce: U64!, time: TimeParameters): U64!
+	produceBlocks(startTimestamp: U64, blocksToProduce: U64!): U64!
 }
 
 type NodeInfo {
@@ -677,17 +677,6 @@ type SuccessStatus {
 }
 
 scalar Tai64Timestamp
-
-input TimeParameters {
-	"""
-	The time to set on the first block
-	"""
-	startTime: U64!
-	"""
-	The time interval between subsequent blocks
-	"""
-	blockTimeInterval: U64!
-}
 
 type Transaction {
 	id: TransactionId!

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -455,6 +455,12 @@ type Mutation {
 	Submits transaction to the txpool
 	"""
 	submit(tx: HexString!): Transaction!
+	"""
+	Sequentially produces `blocks_to_produce` blocks. The first block starts with
+	`start_timestamp`. If the block production in the [`crate::service::Config`] is
+	`Trigger::Interval { block_time }`, produces blocks with `block_time ` intervals between
+	them. The `start_timestamp` is the timestamp in seconds.
+	"""
 	produceBlocks(startTimestamp: U64, blocksToProduce: U64!): U64!
 }
 

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -461,7 +461,7 @@ type Mutation {
 	`Trigger::Interval { block_time }`, produces blocks with `block_time ` intervals between
 	them. The `start_timestamp` is the timestamp in seconds.
 	"""
-	produceBlocks(startTimestamp: U64, blocksToProduce: U64!): U64!
+	produceBlocks(startTimestamp: Tai64Timestamp, blocksToProduce: U64!): U64!
 }
 
 type NodeInfo {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -92,10 +92,7 @@ pub use schema::{
 };
 
 use self::schema::{
-    block::{
-        ProduceBlockArgs,
-        TimeParameters,
-    },
+    block::ProduceBlockArgs,
     message::MessageProofArgs,
 };
 
@@ -561,11 +558,11 @@ impl FuelClient {
     pub async fn produce_blocks(
         &self,
         blocks_to_produce: u64,
-        time: Option<TimeParameters>,
+        start_timestamp: Option<u64>,
     ) -> io::Result<u64> {
         let query = schema::block::BlockMutation::build(ProduceBlockArgs {
             blocks_to_produce: blocks_to_produce.into(),
-            time,
+            start_timestamp: start_timestamp.map(|timestamp| timestamp.into()),
         });
 
         let new_height = self.query(query).await?.produce_blocks;

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -3,6 +3,7 @@ use crate::client::schema::{
     contract::ContractBalanceQueryArgs,
     resource::ExcludeInput,
     tx::DryRunArg,
+    Tai64Timestamp,
 };
 use anyhow::Context;
 #[cfg(feature = "subscriptions")]
@@ -562,7 +563,8 @@ impl FuelClient {
     ) -> io::Result<u64> {
         let query = schema::block::BlockMutation::build(ProduceBlockArgs {
             blocks_to_produce: blocks_to_produce.into(),
-            start_timestamp: start_timestamp.map(|timestamp| timestamp.into()),
+            start_timestamp: start_timestamp
+                .map(|timestamp| Tai64Timestamp::from_unix(timestamp as i64)),
         });
 
         let new_height = self.query(query).await?.produce_blocks;

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -80,6 +80,7 @@ use std::{
         FromStr,
     },
 };
+use tai64::Tai64;
 use tracing as _;
 use types::{
     TransactionResponse,
@@ -564,7 +565,7 @@ impl FuelClient {
         let query = schema::block::BlockMutation::build(ProduceBlockArgs {
             blocks_to_produce: blocks_to_produce.into(),
             start_timestamp: start_timestamp
-                .map(|timestamp| Tai64Timestamp::from_unix(timestamp as i64)),
+                .map(|timestamp| Tai64Timestamp::from(Tai64(timestamp))),
         });
 
         let new_height = self.query(query).await?.produce_blocks;

--- a/crates/client/src/client/schema/block.rs
+++ b/crates/client/src/client/schema/block.rs
@@ -100,17 +100,10 @@ pub struct BlockIdFragment {
     pub id: BlockId,
 }
 
-#[derive(cynic::InputObject, Clone, Debug)]
-#[cynic(schema_path = "./assets/schema.sdl")]
-pub struct TimeParameters {
-    pub start_time: U64,
-    pub block_time_interval: U64,
-}
-
 #[derive(cynic::QueryVariables, Debug)]
 pub struct ProduceBlockArgs {
+    pub start_timestamp: Option<U64>,
     pub blocks_to_produce: U64,
-    pub time: Option<TimeParameters>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -120,7 +113,7 @@ pub struct ProduceBlockArgs {
     graphql_type = "Mutation"
 )]
 pub struct BlockMutation {
-    #[arguments(blocksToProduce: $blocks_to_produce, time: $time)]
+    #[arguments(blocksToProduce: $blocks_to_produce, startTimestamp: $start_timestamp)]
     pub produce_blocks: U64,
 }
 
@@ -206,7 +199,7 @@ mod tests {
         use cynic::MutationBuilder;
         let operation = BlockMutation::build(ProduceBlockArgs {
             blocks_to_produce: U64(0),
-            time: None,
+            start_timestamp: None,
         });
         insta::assert_snapshot!(operation.query)
     }

--- a/crates/client/src/client/schema/block.rs
+++ b/crates/client/src/client/schema/block.rs
@@ -102,7 +102,7 @@ pub struct BlockIdFragment {
 
 #[derive(cynic::QueryVariables, Debug)]
 pub struct ProduceBlockArgs {
-    pub start_timestamp: Option<U64>,
+    pub start_timestamp: Option<Tai64Timestamp>,
     pub blocks_to_produce: U64,
 }
 

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__block__tests__block_mutation_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__block__tests__block_mutation_query_gql_output.snap
@@ -2,8 +2,8 @@
 source: crates/client/src/client/schema/block.rs
 expression: operation.query
 ---
-mutation($blocksToProduce: U64!, $time: TimeParameters) {
-  produceBlocks(blocksToProduce: $blocksToProduce, time: $time)
+mutation($startTimestamp: U64, $blocksToProduce: U64!) {
+  produceBlocks(blocksToProduce: $blocksToProduce, startTimestamp: $startTimestamp)
 }
 
 

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__block__tests__block_mutation_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__block__tests__block_mutation_query_gql_output.snap
@@ -2,7 +2,7 @@
 source: crates/client/src/client/schema/block.rs
 expression: operation.query
 ---
-mutation($startTimestamp: U64, $blocksToProduce: U64!) {
+mutation($startTimestamp: Tai64Timestamp, $blocksToProduce: U64!) {
   produceBlocks(blocksToProduce: $blocksToProduce, startTimestamp: $startTimestamp)
 }
 

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -174,6 +174,7 @@ pub trait BlockProducerPort: Send + Sync + DryRunExecution {}
 pub trait ConsensusModulePort: Send + Sync {
     async fn manual_produce_block(
         &self,
-        block_times: Vec<Option<Tai64>>,
+        block_time: Tai64,
+        number_of_blocks: u32,
     ) -> anyhow::Result<()>;
 }

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use async_trait::async_trait;
 use fuel_core_services::stream::BoxStream;
 use fuel_core_storage::{
@@ -158,7 +157,7 @@ pub trait TxPoolPort: Send + Sync {
 
     fn tx_update_subscribe(
         &self,
-    ) -> BoxStream<Result<TxUpdate, BroadcastStreamRecvError>>;
+    ) -> BoxStream<anyhow::Result<TxUpdate, BroadcastStreamRecvError>>;
 }
 
 #[async_trait]
@@ -177,7 +176,7 @@ pub trait BlockProducerPort: Send + Sync + DryRunExecution {}
 pub trait ConsensusModulePort: Send + Sync {
     async fn manually_produce_blocks(
         &self,
-        start_time: Tai64,
+        start_time: Option<Tai64>,
         number_of_blocks: u32,
     ) -> anyhow::Result<()>;
 }

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -175,9 +175,9 @@ pub trait BlockProducerPort: Send + Sync + DryRunExecution {}
 
 #[async_trait::async_trait]
 pub trait ConsensusModulePort: Send + Sync {
-    async fn manual_produce_block(
+    async fn manually_produce_blocks(
         &self,
-        block_time: Tai64,
+        start_time: Tai64,
         number_of_blocks: u32,
     ) -> anyhow::Result<()>;
 }

--- a/crates/fuel-core/src/schema/block.rs
+++ b/crates/fuel-core/src/schema/block.rs
@@ -278,6 +278,10 @@ pub struct BlockMutation;
 
 #[Object]
 impl BlockMutation {
+    /// Sequentially produces `blocks_to_produce` blocks. The first block starts with
+    /// `start_timestamp`. If the block production in the [`crate::service::Config`] is
+    /// `Trigger::Interval { block_time }`, produces blocks with `block_time ` intervals between
+    /// them. The `start_timestamp` is the timestamp in seconds.
     async fn produce_blocks(
         &self,
         ctx: &Context<'_>,

--- a/crates/fuel-core/src/schema/block.rs
+++ b/crates/fuel-core/src/schema/block.rs
@@ -291,7 +291,7 @@ impl BlockMutation {
     async fn produce_blocks(
         &self,
         ctx: &Context<'_>,
-        start_timestamp: Option<U64>,
+        start_timestamp: Option<Tai64Timestamp>,
         blocks_to_produce: U64,
     ) -> async_graphql::Result<U64> {
         let query: &Database = ctx.data_unchecked();
@@ -305,11 +305,11 @@ impl BlockMutation {
         }
 
         let start_time = start_timestamp
-            .map(|timestamp| Tai64(timestamp.into()))
+            .map(|timestamp| timestamp.0)
             .unwrap_or(Tai64::now());
         let blocks_to_produce: u64 = blocks_to_produce.into();
         consensus_module
-            .manual_produce_block(start_time, blocks_to_produce as u32)
+            .manually_produce_blocks(start_time, blocks_to_produce as u32)
             .await?;
 
         query

--- a/crates/fuel-core/src/schema/block.rs
+++ b/crates/fuel-core/src/schema/block.rs
@@ -50,7 +50,6 @@ use fuel_core_types::{
         header::BlockHeader,
     },
     fuel_types,
-    tai64::Tai64,
 };
 
 pub struct Block(pub(crate) CompressedBlock);
@@ -304,9 +303,7 @@ impl BlockMutation {
             )
         }
 
-        let start_time = start_timestamp
-            .map(|timestamp| timestamp.0)
-            .unwrap_or(Tai64::now());
+        let start_time = start_timestamp.map(|timestamp| timestamp.0);
         let blocks_to_produce: u64 = blocks_to_produce.into();
         consensus_module
             .manually_produce_blocks(start_time, blocks_to_produce as u32)

--- a/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
@@ -47,12 +47,13 @@ impl PoAAdapter {
 impl ConsensusModulePort for PoAAdapter {
     async fn manual_produce_block(
         &self,
-        block_times: Vec<Option<Tai64>>,
+        block_time: Tai64,
+        number_of_blocks: u32,
     ) -> anyhow::Result<()> {
         self.shared_state
             .as_ref()
             .ok_or(anyhow!("The block production is disabled"))?
-            .manually_produce_block(block_times)
+            .manually_produce_block(block_time, number_of_blocks)
             .await
     }
 }
@@ -89,7 +90,7 @@ impl fuel_core_poa::ports::BlockProducer for BlockProducerAdapter {
     async fn produce_and_execute_block(
         &self,
         height: BlockHeight,
-        block_time: Option<Tai64>,
+        block_time: Tai64,
         max_gas: Word,
     ) -> anyhow::Result<UncommittedResult<StorageTransaction<Database>>> {
         self.block_producer

--- a/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
@@ -47,7 +47,7 @@ impl PoAAdapter {
 impl ConsensusModulePort for PoAAdapter {
     async fn manually_produce_blocks(
         &self,
-        start_time: Tai64,
+        start_time: Option<Tai64>,
         number_of_blocks: u32,
     ) -> anyhow::Result<()> {
         self.shared_state

--- a/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
@@ -45,15 +45,15 @@ impl PoAAdapter {
 
 #[async_trait::async_trait]
 impl ConsensusModulePort for PoAAdapter {
-    async fn manual_produce_block(
+    async fn manually_produce_blocks(
         &self,
-        block_time: Tai64,
+        start_time: Tai64,
         number_of_blocks: u32,
     ) -> anyhow::Result<()> {
         self.shared_state
             .as_ref()
             .ok_or(anyhow!("The block production is disabled"))?
-            .manually_produce_block(block_time, number_of_blocks)
+            .manually_produce_block(start_time, number_of_blocks)
             .await
     }
 }

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -102,8 +102,11 @@ impl TryFrom<&Config> for fuel_core_poa::Config {
         // If manual block production then require trigger never or instant.
         anyhow::ensure!(
             !config.manual_blocks_enabled
-                || matches!(config.block_production, Trigger::Never | Trigger::Instant),
-            "Cannot use manual block production unless trigger mode is never or instant."
+                || matches!(
+                    config.block_production,
+                    Trigger::Never | Trigger::Instant | Trigger::Interval { .. }
+                ),
+            "Cannot use manual block production unless trigger mode is never, instant or interval."
         );
 
         Ok(fuel_core_poa::Config {

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -43,7 +43,9 @@ pub fn init_sub_services(
     config: &Config,
     database: &Database,
 ) -> anyhow::Result<(SubServices, SharedState)> {
-    let last_height = database.latest_height()?;
+    let last_block = database.get_current_block()?.ok_or(anyhow::anyhow!(
+        "The blockchain is not initialized with any block"
+    ))?;
     #[cfg(feature = "relayer")]
     let relayer_service = if config.relayer.eth_client.is_some() {
         Some(fuel_core_relayer::new_service(
@@ -129,7 +131,7 @@ pub fn init_sub_services(
         !matches!(poa_config.trigger, Trigger::Never) || config.manual_blocks_enabled;
     let poa = (production_enabled).then(|| {
         fuel_core_poa::new_service(
-            last_height,
+            last_block.header(),
             poa_config,
             tx_pool_adapter.clone(),
             producer_adapter.clone(),
@@ -142,7 +144,7 @@ pub fn init_sub_services(
     let sync = (!production_enabled)
         .then(|| {
             fuel_core_sync::service::new_service(
-                last_height,
+                *last_block.header().height(),
                 p2p_adapter,
                 importer_adapter.clone(),
                 verifier,

--- a/crates/services/consensus_module/poa/src/ports.rs
+++ b/crates/services/consensus_module/poa/src/ports.rs
@@ -52,7 +52,7 @@ pub trait BlockProducer: Send + Sync {
     async fn produce_and_execute_block(
         &self,
         height: BlockHeight,
-        block_time: Option<Tai64>,
+        block_time: Tai64,
         max_gas: Word,
     ) -> anyhow::Result<UncommittedExecutionResult<StorageTransaction<Self::Database>>>;
 

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -193,7 +193,7 @@ where
                 if now > self.last_timestamp {
                     Ok(now)
                 } else {
-                    let duration = Instant::now().duration_since(self.last_block_created);
+                    let duration = self.last_block_created.elapsed();
                     increase_time(self.last_timestamp, duration)
                 }
             }

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -30,6 +30,7 @@ use fuel_core_types::{
             poa::PoAConsensus,
             Consensus,
         },
+        header::BlockHeader,
         primitives::{
             BlockHeight,
             SecretKeyWrapper,
@@ -54,7 +55,10 @@ use fuel_core_types::{
     },
     tai64::Tai64,
 };
-use std::ops::Deref;
+use std::{
+    ops::Deref,
+    time::Duration,
+};
 use tokio::{
     sync::{
         mpsc,
@@ -75,22 +79,34 @@ pub struct SharedState {
 impl SharedState {
     pub async fn manually_produce_block(
         &self,
-        block_times: Vec<Option<Tai64>>,
+        block_time: Tai64,
+        number_of_blocks: u32,
     ) -> anyhow::Result<()> {
         let (sender, receiver) = oneshot::channel();
 
         self.request_sender
-            .send(Request::ManualBlocks((block_times, sender)))
+            .send(Request::ManualBlocks((
+                ManualProduction {
+                    block_time,
+                    number_of_blocks,
+                },
+                sender,
+            )))
             .await?;
         receiver.await?
     }
+}
+
+struct ManualProduction {
+    pub block_time: Tai64,
+    pub number_of_blocks: u32,
 }
 
 /// Requests accepted by the task.
 enum Request {
     /// Manually produces the next blocks with `Tai64` block timestamp.
     /// The block timestamp should be higher than previous one.
-    ManualBlocks((Vec<Option<Tai64>>, oneshot::Sender<anyhow::Result<()>>)),
+    ManualBlocks((ManualProduction, oneshot::Sender<anyhow::Result<()>>)),
 }
 
 impl core::fmt::Debug for Request {
@@ -114,9 +130,7 @@ pub struct Task<T, B, I> {
     request_receiver: mpsc::Receiver<Request>,
     shared_state: SharedState,
     last_height: BlockHeight,
-    /// Last block creation time. When starting up, this is initialized
-    /// to `Instant::now()`, which delays the first block on startup for
-    /// a bit, but doesn't cause any other issues.
+    last_timestamp: Tai64,
     last_block_created: Instant,
     trigger: Trigger,
     // TODO: Consider that the creation of the block takes some time, and maybe we need to
@@ -131,7 +145,7 @@ where
     T: TransactionPool,
 {
     pub fn new(
-        last_height: BlockHeight,
+        last_block: &BlockHeader,
         config: Config,
         txpool: T,
         block_producer: B,
@@ -139,6 +153,9 @@ where
     ) -> Self {
         let tx_status_update_stream = txpool.transaction_status_events();
         let (request_sender, request_receiver) = mpsc::channel(100);
+        let last_timestamp = last_block.time();
+        let duration = Duration::from_secs(Tai64::now().0 - last_timestamp.0);
+        let last_block_created = Instant::now() - duration;
         Self {
             block_gas_limit: config.block_gas_limit,
             signing_key: config.signing_key,
@@ -148,8 +165,9 @@ where
             tx_status_update_stream,
             request_receiver,
             shared_state: SharedState { request_sender },
-            last_height,
-            last_block_created: Instant::now(),
+            last_height: *last_block.height(),
+            last_timestamp,
+            last_block_created,
             trigger: config.trigger,
             timer: DeadlineClock::new(),
         }
@@ -157,6 +175,29 @@ where
 
     fn next_height(&self) -> BlockHeight {
         self.last_height + 1u32.into()
+    }
+
+    fn next_time(&self, request_type: RequestType) -> anyhow::Result<Tai64> {
+        let now = Tai64::now();
+        match request_type {
+            RequestType::Manual => match self.trigger {
+                Trigger::Never | Trigger::Instant => self.next_time(RequestType::Trigger),
+                Trigger::Interval { block_time } => {
+                    increase_time(self.last_timestamp, block_time)
+                }
+                Trigger::Hybrid { min_block_time, .. } => {
+                    increase_time(self.last_timestamp, min_block_time)
+                }
+            },
+            RequestType::Trigger => {
+                if now > self.last_timestamp {
+                    Ok(now)
+                } else {
+                    let duration = Instant::now().duration_since(self.last_block_created);
+                    increase_time(self.last_timestamp, duration)
+                }
+            }
+        }
     }
 }
 
@@ -170,7 +211,7 @@ where
     async fn signal_produce_block(
         &self,
         height: BlockHeight,
-        block_time: Option<Tai64>,
+        block_time: Tai64,
     ) -> anyhow::Result<UncommittedExecutionResult<StorageTransaction<D>>> {
         self.block_producer
             .produce_and_execute_block(height, block_time, self.block_gas_limit)
@@ -178,30 +219,41 @@ where
     }
 
     pub(crate) async fn produce_next_block(&mut self) -> anyhow::Result<()> {
-        self.produce_block(self.next_height(), None, RequestType::Trigger)
-            .await
+        self.produce_block(
+            self.next_height(),
+            self.next_time(RequestType::Trigger)?,
+            RequestType::Trigger,
+        )
+        .await
     }
 
-    pub(crate) async fn produce_manual_blocks(
+    async fn produce_manual_blocks(
         &mut self,
-        block_times: Vec<Option<Tai64>>,
+        block_production: ManualProduction,
     ) -> anyhow::Result<()> {
-        for block_time in block_times {
+        let mut block_time = block_production.block_time;
+        for _ in 0..block_production.number_of_blocks {
             self.produce_block(self.next_height(), block_time, RequestType::Manual)
                 .await?;
+            block_time = self.next_time(RequestType::Manual)?;
         }
         Ok(())
     }
 
-    pub(crate) async fn produce_block(
+    async fn produce_block(
         &mut self,
         height: BlockHeight,
-        block_time: Option<Tai64>,
+        block_time: Tai64,
         request_type: RequestType,
     ) -> anyhow::Result<()> {
+        let produce_block_start = Instant::now();
         // verify signing key is set
         if self.signing_key.is_none() {
             return Err(anyhow!("unable to produce blocks without a consensus key"))
+        }
+
+        if self.last_timestamp > block_time {
+            return Err(anyhow!("The block timestamp should monotonically increase"))
         }
 
         // Ask the block producer to create the block
@@ -241,6 +293,7 @@ where
 
         // Update last block time
         self.last_height = height;
+        self.last_timestamp = block_time;
         self.last_block_created = Instant::now();
 
         // Set timer for the next block
@@ -251,8 +304,14 @@ where
             }
             (Trigger::Instant, _) => {}
             (Trigger::Interval { block_time }, RequestType::Trigger) => {
-                // TODO: instead of sleeping for `block_time`, subtract the time we used for processing
-                self.timer.set_timeout(block_time, OnConflict::Min).await;
+                self.timer
+                    .set_deadline(produce_block_start + block_time, OnConflict::Min)
+                    .await;
+            }
+            (Trigger::Interval { block_time }, RequestType::Manual) => {
+                self.timer
+                    .set_deadline(produce_block_start + block_time, OnConflict::Overwrite)
+                    .await;
             }
             (
                 Trigger::Hybrid {
@@ -281,9 +340,8 @@ where
                         .await;
                 }
             }
-            (Trigger::Interval { .. }, RequestType::Manual)
-            | (Trigger::Hybrid { .. }, RequestType::Manual) => {
-                unreachable!("Trigger types interval and hybrid cannot be used with manual. This is enforced during config validation")
+            (Trigger::Hybrid { .. }, RequestType::Manual) => {
+                unreachable!("Trigger types hybrid cannot be used with manual. This is enforced during config validation")
             }
         }
 
@@ -404,8 +462,8 @@ where
             request = self.request_receiver.recv() => {
                 if let Some(request) = request {
                     match request {
-                        Request::ManualBlocks((block_times, response)) => {
-                            let result = self.produce_manual_blocks(block_times).await;
+                        Request::ManualBlocks((block, response)) => {
+                            let result = self.produce_manual_blocks(block).await;
                             let _ = response.send(result);
                         }
                     }
@@ -444,7 +502,7 @@ where
 }
 
 pub fn new_service<D, T, B, I>(
-    last_height: BlockHeight,
+    last_block: &BlockHeader,
     config: Config,
     txpool: T,
     block_producer: B,
@@ -456,7 +514,7 @@ where
     I: BlockImporter<Database = D> + 'static,
 {
     Service::new(Task::new(
-        last_height,
+        last_block,
         config,
         txpool,
         block_producer,
@@ -481,4 +539,14 @@ fn seal_block(
     } else {
         Err(anyhow!("no PoA signing key configured"))
     }
+}
+
+fn increase_time(time: Tai64, duration: Duration) -> anyhow::Result<Tai64> {
+    let timestamp = time.0;
+    let timestamp = timestamp
+        .checked_add(duration.as_secs())
+        .ok_or(anyhow::anyhow!(
+            "The provided time parameters lead to an overflow"
+        ))?;
+    Ok(Tai64(timestamp))
 }

--- a/crates/services/consensus_module/poa/src/service_test.rs
+++ b/crates/services/consensus_module/poa/src/service_test.rs
@@ -21,6 +21,7 @@ use fuel_core_storage::{
 };
 use fuel_core_types::{
     blockchain::{
+        header::BlockHeader,
         primitives::{
             BlockHeight,
             SecretKeyWrapper,
@@ -45,6 +46,7 @@ use fuel_core_types::{
             TxStatus,
         },
     },
+    tai64::Tai64,
 };
 use rand::{
     prelude::StdRng,
@@ -137,8 +139,13 @@ impl TestContextBuilder {
             .txpool
             .unwrap_or_else(MockTransactionPool::no_tx_updates);
 
-        let service =
-            new_service(BlockHeight::from(1u64), config, txpool, producer, importer);
+        let service = new_service(
+            &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
+            config,
+            txpool,
+            producer,
+            importer,
+        );
         service.start().unwrap();
         TestContext { service }
     }
@@ -300,7 +307,7 @@ async fn remove_skipped_transactions() {
         metrics: false,
     };
     let mut task = Task::new(
-        BlockHeight::from(1u32),
+        &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
         config,
         txpool,
         block_producer,
@@ -340,7 +347,7 @@ async fn does_not_produce_when_txpool_empty_in_instant_mode() {
         metrics: false,
     };
     let mut task = Task::new(
-        BlockHeight::from(1u32),
+        &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
         config,
         txpool,
         block_producer,
@@ -395,7 +402,7 @@ async fn hybrid_production_doesnt_produce_empty_blocks_when_txpool_is_empty() {
         metrics: false,
     };
     let task = Task::new(
-        BlockHeight::from(1u32),
+        &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
         config,
         txpool,
         block_producer,

--- a/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
@@ -6,19 +6,35 @@ use test_case::test_case;
 
 use super::*;
 
-#[test_case(vec![None; 10], Trigger::Never, 0)]
-#[test_case(vec![None; 10], Trigger::Instant, 0)]
-#[test_case(vec![Some(Tai64(20))], Trigger::Never, 0)]
-#[test_case(vec![Some(Tai64(20)), None, Some(Tai64(30))], Trigger::Never, 0)]
-#[test_case(vec![Some(Tai64(20)), None, Some(Tai64(30))], Trigger::Instant, 0)]
-#[test_case(vec![None; 10], Trigger::Never, 10)]
-#[test_case(vec![None; 10], Trigger::Instant, 10)]
-#[test_case(vec![Some(Tai64(20))], Trigger::Never, 10)]
-#[test_case(vec![Some(Tai64(20)), None, Some(Tai64(30))], Trigger::Never, 10)]
-#[test_case(vec![Some(Tai64(20)), None, Some(Tai64(30))], Trigger::Instant, 10)]
+#[test_case(Tai64::now(), 10, vec![Tai64::now(); 10], Trigger::Never, 0)]
+#[test_case(Tai64::now(), 10, vec![Tai64::now(); 10], Trigger::Instant, 0)]
+#[test_case(
+    Tai64::now(), 3, vec![Tai64::now(), Tai64::now() + 10, Tai64::now() + 20],
+    Trigger::Interval { block_time: Duration::from_secs(10) }, 0
+)]
+#[test_case(Tai64::now() + 100, 10, vec![Tai64::now() + 100; 10], Trigger::Never, 0)]
+#[test_case(Tai64::now() + 100, 10, vec![Tai64::now() + 100; 10], Trigger::Instant, 0)]
+#[test_case(
+    Tai64::now() + 100, 3, vec![Tai64::now() + 100, Tai64::now() + 110, Tai64::now() + 120],
+    Trigger::Interval { block_time: Duration::from_secs(10) }, 0
+)]
+#[test_case(Tai64::now(), 10, vec![Tai64::now(); 10], Trigger::Never, 10)]
+#[test_case(Tai64::now(), 10, vec![Tai64::now(); 10], Trigger::Instant, 10)]
+#[test_case(
+    Tai64::now(), 3, vec![Tai64::now(), Tai64::now() + 10, Tai64::now() + 20],
+    Trigger::Interval { block_time: Duration::from_secs(10) }, 10
+)]
+#[test_case(Tai64::now() + 100, 10, vec![Tai64::now() + 100; 10], Trigger::Never, 10)]
+#[test_case(Tai64::now() + 100, 10, vec![Tai64::now() + 100; 10], Trigger::Instant, 10)]
+#[test_case(
+    Tai64::now() + 100, 3, vec![Tai64::now() + 100, Tai64::now() + 110, Tai64::now() + 120],
+    Trigger::Interval { block_time: Duration::from_secs(10) }, 10
+)]
 #[tokio::test]
 async fn can_manually_produce_block(
-    times: Vec<Option<Tai64>>,
+    start_time: Tai64,
+    number_of_blocks: u32,
+    times: Vec<Tai64>,
     trigger: Trigger,
     num_txns: usize,
 ) {
@@ -42,7 +58,7 @@ async fn can_manually_produce_block(
     ctx_builder.with_txpool(txpool);
 
     let mut importer = MockBlockImporter::default();
-    let (tx, mut rx) = tokio::sync::mpsc::channel(times.len() + 1);
+    let (tx, mut rx) = tokio::sync::mpsc::channel(times.len());
     importer.expect_commit_result().returning(move |r| {
         tx.try_send(r.into_result().sealed_block.entity.header().time())
             .unwrap();
@@ -53,10 +69,8 @@ async fn can_manually_produce_block(
         .expect_produce_and_execute_block()
         .returning(|_, time, _| {
             let mut block = Block::default();
-            if let Some(time) = time {
-                block.header_mut().consensus.time = time;
-                block.header_mut().recalculate_metadata();
-            }
+            block.header_mut().consensus.time = time;
+            block.header_mut().recalculate_metadata();
             Ok(UncommittedResult::new(
                 ExecutionResult {
                     block,
@@ -72,21 +86,16 @@ async fn can_manually_produce_block(
 
     ctx.service
         .shared
-        .manually_produce_block(times.clone())
+        .manually_produce_block(start_time, number_of_blocks)
         .await
         .unwrap();
     for _ in 0..num_txns {
         status_sender.send_replace(Some(TxStatus::Submitted));
     }
 
-    for t in times.into_iter().chain(
-        std::iter::once(None)
-            .take_while(|_| num_txns > 0 && matches!(trigger, Trigger::Instant)),
-    ) {
+    for t in times.into_iter() {
         let block_time = rx.recv().await.unwrap();
-        if let Some(t) = t {
-            assert_eq!(t, block_time);
-        }
+        assert_eq!(t, block_time);
     }
 
     // Stop

--- a/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
@@ -86,7 +86,7 @@ async fn can_manually_produce_block(
 
     ctx.service
         .shared
-        .manually_produce_block(start_time, number_of_blocks)
+        .manually_produce_block(Some(start_time), number_of_blocks)
         .await
         .unwrap();
     for _ in 0..num_txns {

--- a/crates/services/producer/src/block_producer.rs
+++ b/crates/services/producer/src/block_producer.rs
@@ -82,7 +82,7 @@ where
     pub async fn produce_and_execute_block(
         &self,
         height: BlockHeight,
-        block_time: Option<Tai64>,
+        block_time: Tai64,
         max_gas: Word,
     ) -> anyhow::Result<UncommittedResult<StorageTransaction<Database>>> {
         //  - get previous block info (hash, root, etc)
@@ -140,7 +140,7 @@ where
         } + 1u64.into();
 
         let is_script = transaction.is_script();
-        let header = self.new_header(height, None).await?;
+        let header = self.new_header(height, Tai64::now()).await?;
         let block =
             PartialFuelBlock::new(header, vec![transaction].into_iter().collect());
 
@@ -169,7 +169,7 @@ where
     async fn new_header(
         &self,
         height: BlockHeight,
-        block_time: Option<Tai64>,
+        block_time: Tai64,
     ) -> anyhow::Result<PartialBlockHeader> {
         let previous_block_info = self.previous_block_info(height)?;
         let new_da_height = self
@@ -184,7 +184,7 @@ where
             consensus: ConsensusHeader {
                 prev_root: previous_block_info.prev_root,
                 height,
-                time: block_time.unwrap_or_else(Tai64::now),
+                time: block_time,
                 generated: Default::default(),
             },
         })

--- a/crates/services/producer/src/block_producer/tests.rs
+++ b/crates/services/producer/src/block_producer/tests.rs
@@ -25,6 +25,7 @@ use fuel_core_types::{
         },
     },
     services::executor::Error as ExecutorError,
+    tai64::Tai64,
 };
 use rand::{
     rngs::StdRng,
@@ -43,7 +44,7 @@ async fn cant_produce_at_genesis_height() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_and_execute_block(0u32.into(), None, 1_000_000_000)
+        .produce_and_execute_block(0u32.into(), Tai64::now(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 
@@ -59,7 +60,7 @@ async fn can_produce_initial_block() {
     let producer = ctx.producer();
 
     let result = producer
-        .produce_and_execute_block(1u32.into(), None, 1_000_000_000)
+        .produce_and_execute_block(1u32.into(), Tai64::now(), 1_000_000_000)
         .await;
 
     assert!(result.is_ok());
@@ -94,7 +95,7 @@ async fn can_produce_next_block() {
     let ctx = TestContext::default_from_db(db);
     let producer = ctx.producer();
     let result = producer
-        .produce_and_execute_block(prev_height + 1u32.into(), None, 1_000_000_000)
+        .produce_and_execute_block(prev_height + 1u32.into(), Tai64::now(), 1_000_000_000)
         .await;
 
     assert!(result.is_ok());
@@ -107,7 +108,7 @@ async fn cant_produce_if_no_previous_block() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_and_execute_block(100u32.into(), None, 1_000_000_000)
+        .produce_and_execute_block(100u32.into(), Tai64::now(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 
@@ -151,7 +152,7 @@ async fn cant_produce_if_previous_block_da_height_too_high() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_and_execute_block(prev_height + 1u32.into(), None, 1_000_000_000)
+        .produce_and_execute_block(prev_height + 1u32.into(), Tai64::now(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 
@@ -179,7 +180,7 @@ async fn production_fails_on_execution_error() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_and_execute_block(1u32.into(), None, 1_000_000_000)
+        .produce_and_execute_block(1u32.into(), Tai64::now(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 

--- a/crates/services/txpool/src/service.rs
+++ b/crates/services/txpool/src/service.rs
@@ -18,6 +18,7 @@ use fuel_core_services::{
     StateWatcher,
 };
 use fuel_core_types::{
+    blockchain::primitives::BlockHeight,
     fuel_tx::{
         Transaction,
         TxId,
@@ -66,8 +67,10 @@ impl TxStatusChange {
         }
     }
 
-    pub fn send_complete(&self, id: Bytes32) {
-        tracing::info!("Transaction {id} successfully included in a block");
+    pub fn send_complete(&self, id: Bytes32, block_height: &BlockHeight) {
+        tracing::info!(
+            "Transaction {id} successfully included in a block {block_height}"
+        );
         let _ = self.status_sender.send(TxStatus::Completed);
         self.updated(id);
     }

--- a/crates/services/txpool/src/service.rs
+++ b/crates/services/txpool/src/service.rs
@@ -68,9 +68,7 @@ impl TxStatusChange {
     }
 
     pub fn send_complete(&self, id: Bytes32, block_height: &BlockHeight) {
-        tracing::info!(
-            "Transaction {id} successfully included in block {block_height}"
-        );
+        tracing::info!("Transaction {id} successfully included in block {block_height}");
         let _ = self.status_sender.send(TxStatus::Completed);
         self.updated(id);
     }

--- a/crates/services/txpool/src/service.rs
+++ b/crates/services/txpool/src/service.rs
@@ -69,7 +69,7 @@ impl TxStatusChange {
 
     pub fn send_complete(&self, id: Bytes32, block_height: &BlockHeight) {
         tracing::info!(
-            "Transaction {id} successfully included in a block {block_height}"
+            "Transaction {id} successfully included in block {block_height}"
         );
         let _ = self.status_sender.send(TxStatus::Completed);
         self.updated(id);

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -337,7 +337,7 @@ where
         // spend_outputs: [Input], added_outputs: [AddedOutputs]
     ) {
         for tx in block.entity.transactions() {
-            tx_status_sender.send_complete(tx.id());
+            tx_status_sender.send_complete(tx.id(), block.entity.header().height());
             self.remove_committed_tx(&tx.id());
         }
     }

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -126,6 +126,19 @@ impl Default for BlockHeader {
     }
 }
 
+#[cfg(any(test, feature = "test-helpers"))]
+impl BlockHeader {
+    /// Creates the block header around the `height` and `time`.
+    /// The method should be used only for tests.
+    pub fn new_block(height: BlockHeight, time: Tai64) -> Self {
+        let mut default = Self::default();
+        default.consensus.height = height;
+        default.consensus.time = time;
+        default.recalculate_metadata();
+        default
+    }
+}
+
 // Accessors for the consensus header.
 impl BlockHeader {
     /// Merkle root of all previous block header hashes.


### PR DESCRIPTION
Updated the logic of the `PoA` to take into account the `last_timestamp` during block production. If the user manually specified the block with the future timestamp, the block production will use a new timestamp as a base to produce blocks.

Changed the API of the `produce_blocks` endpoint to accept only the start time and the number of blocks(The user can't specify the interval between blocks, it is defined by the `Trigger::Interval` mode).

Allowed enabling of the `manual_blocks_enabled` for the `Trigger::Interval` production mode.