### PR TITLE
fix yaml and add linting job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,6 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: v3.10.0
-      - name: Substitue values
-        run: |
-          source deployment/scripts/.env
-          envsubst deployment/charts/values.yaml
-          envsubst deployment/charts/Chart.yaml
       - name: helm lint
         run: |
           cd deployment/charts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
+  lint-helm-chart:
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.10.0
+      - name: Substitue values
+        run: |
+          source deployment/scripts/.env
+          envsubst deployment/charts/values.yaml
+          envsubst deployment/charts/Chart.yaml
+      - name: helm lint
+        run: |
+          cd deployment/charts
+          helm lint
+
   prevent-openssl:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
     needs:
       - cargo-verifications
       - publish-crates-check
+      - lint-helm-chart
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - run: echo "pass"

--- a/bin/e2e-test-client/README.md
+++ b/bin/e2e-test-client/README.md
@@ -9,6 +9,7 @@ When `FUEL_CORE_E2E_CONFIG` is unset a default configuration is used which is su
 ```toml
 endpoint = "http://localhost:4000"
 wallet_sync_timeout = "10s"
+full_test = false
 
 [wallet_a]
 secret = "de97d8624a438121b86a1956544bd72ed68cd69f2c99555b08b1e8c51ffd511c"

--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -180,30 +180,30 @@ spec:
             - "{{ .Values.app.relayer_eth_sync_log_freq_s }}"
           {{- end }}
           {{- if .Values.app.network_name }}
-          - "--network"
-          - "{{ .Values.app.network_name }}"
+            - "--network"
+            - "{{ .Values.app.network_name }}"
           {{- end }}
           {{- if .Values.app.p2p_key }}
-          - "--keypair"
-          - "{{ .Values.app.p2p_key }}"
+            - "--keypair"
+            - "{{ .Values.app.p2p_key }}"
           {{- end }}
           {{- if .Values.app.peering_port }}
-          - "--peering_port"
-          - "{{ .Values.app.peering_port }}"
+            - "--peering_port"
+            - "{{ .Values.app.peering_port }}"
           {{- end }}
           {{- if .Values.app.max_block_size }}
-          - "--max_block_size"
-          - "{{ .Values.app.max_block_size }}"
+            - "--max_block_size"
+            - "{{ .Values.app.max_block_size }}"
           {{- end }}
           {{- if .Values.app.max_transmit_size }}
-          - "--max_transmit_size"
-          - "{{ .Values.app.max_transmit_size }}"
+            - "--max_transmit_size"
+            - "{{ .Values.app.max_transmit_size }}"
           {{- end }}
           {{- if .Values.app.reserved_nodes_only_mode }}
-          - "--reserved_nodes_only_mode"
+            - "--reserved_nodes_only_mode"
           {{- end}}
           {{- if .Values.app.allow_private_addresses }}
-          - "--allow_private_addresses"
+            - "--allow_private_addresses"
           {{- end }}
           resources:
             limits:

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -13,15 +13,15 @@ app:
   rust_log: ${fuel_core_rust_log}
   utxo_validation: ${fuel_core_utxo_validation}
   vm_backtrace: ${fuel_core_vm_backtrace}
-  min_gas_price: ${fuel_core_min_gas_price}
+  min_gas_price: "${fuel_core_min_gas_price}"
   network_name: ${fuel_core_network_name}
   poa_instant: "${fuel_core_poa_instant}"
-  poa_interval_period: ${fuel_core_poa_interval_period}
-  poa_hybrid_min_time: ${fuel_core_poa_hybrid_min_time}
-  poa_hybrid_idle_time: ${fuel_core_poa_hybrid_idle_time}
-  poa_hybrid_max_time: ${fuel_core_poa_hybrid_max_time}
-  max_block_size: ${fuel_core_max_buffer_size}
-  max_transmit_size: ${fuel_core_max_buffer_size}
+  poa_interval_period: "${fuel_core_poa_interval_period}"
+  poa_hybrid_min_time: "${fuel_core_poa_hybrid_min_time}"
+  poa_hybrid_idle_time: "${fuel_core_poa_hybrid_idle_time}"
+  poa_hybrid_max_time: "${fuel_core_poa_hybrid_max_time}"
+  max_block_size: "${fuel_core_max_buffer_size}"
+  max_transmit_size: "${fuel_core_max_buffer_size}"
   p2p_key: ${fuel_core_p2p_key}
   allow_private_addresses: ${fuel_core_allow_private_addresses}
   reserved_nodes_only_mode: ${fuel_core_reserved_only}


### PR DESCRIPTION
A recent PR broke the yaml indentation for the helm chart. This fixes that issue and adds a linting job to prevent further breakages from slipping past CI.