### PR TITLE
Rust 1.68.1 & Sparse Registry

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[registries.crates-io]
+protocol = "sparse"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.67.1
+  RUST_VERSION: 1.68.1
   NIGHTLY_RUST_VERSION: nightly-2022-12-14
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -1631,7 +1631,6 @@ mod tests {
 
     pub(crate) fn test_block(num_txs: usize) -> Block {
         let transactions = (1..num_txs + 1)
-            .into_iter()
             .map(|i| {
                 TxBuilder::new(2322u64)
                     .gas_limit(10)

--- a/crates/fuel-core/src/query/block.rs
+++ b/crates/fuel-core/src/query/block.rs
@@ -79,7 +79,6 @@ impl<D: DatabasePort + ?Sized> BlockQueryData for D {
         direction: IterDirection,
     ) -> BoxedIter<StorageResult<CompressedBlock>> {
         self.blocks_ids(start.map(Into::into), direction)
-            .into_iter()
             .map(|result| {
                 result.and_then(|(_, id)| {
                     let block = self.block(&id)?;

--- a/crates/fuel-core/src/schema/coins.rs
+++ b/crates/fuel-core/src/schema/coins.rs
@@ -174,7 +174,6 @@ impl CoinQuery {
             let owner: fuel_tx::Address = filter.owner.into();
             let coins = query
                 .owned_coins(&owner, (*start).map(Into::into), direction)
-                .into_iter()
                 .filter_map(|result| {
                     if let (Ok(coin), Some(filter_asset_id)) = (&result, &filter.asset_id)
                     {

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -199,7 +199,7 @@ where
                         }
                     }
                     Some(TaskRequest::GetPeerIds(channel)) => {
-                        let peer_ids = self.p2p_service.get_peers_ids().into_iter().copied().collect();
+                        let peer_ids = self.p2p_service.get_peers_ids().copied().collect();
                         let _ = channel.send(peer_ids);
                     }
                     Some(TaskRequest::GetBlock { height, channel }) => {

--- a/tests/tests/sync.rs
+++ b/tests/tests/sync.rs
@@ -149,7 +149,7 @@ async fn test_partitions_larger_groups(
                 .with_txs(num_txs)
                 .with_name(format!("{pub_key}:producer")),
         )],
-        (0..num_validators).into_iter().map(|i| {
+        (0..num_validators).map(|i| {
             Some(ValidatorSetup::new(pub_key).with_name(format!("{pub_key}:{i}")))
         }),
     )

--- a/tests/tests/tx/utxo_validation.rs
+++ b/tests/tests/tx/utxo_validation.rs
@@ -30,7 +30,6 @@ async fn submit_utxo_verified_tx_with_min_gas_price() {
     let (_, contract_id) = test_builder.setup_contract(vec![], None, None, None);
     // initialize 10 random transactions that transfer coins and call a contract
     let transactions = (1..=10)
-        .into_iter()
         .map(|i| {
             TransactionBuilder::script(
                 op::ret(RegId::ONE).to_bytes().into_iter().collect(),
@@ -227,7 +226,6 @@ async fn concurrent_tx_submission_produces_expected_blocks() {
     // generate random txs
     let secret = SecretKey::random(&mut rng);
     let txs = (0..TEST_TXS)
-        .into_iter()
         .map(|i| {
             TransactionBuilder::script(
                 op::ret(RegId::ONE).to_bytes().into_iter().collect(),


### PR DESCRIPTION
Upgrade to rust 1.68.1 and utilize the new sparse registry feature to speedup clean builds.