### PR TITLE
Nginx tuneup

### DIFF
--- a/deployment/ingress/eks/fuel-core-ingress.yaml
+++ b/deployment/ingress/eks/fuel-core-ingress.yaml
@@ -12,9 +12,12 @@ metadata:
     nginx.ingress.kubernetes.io/affinity-mode: persistent
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
-    nginx.org/proxy-connect-timeout: "3600s"
-    nginx.org/proxy-read-timeout: "3600s"
-    nginx.org/proxy-send-timeout: "3600s"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600s"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600s"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600s"
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "1m"
+    nginx.ingress.kubernetes.io/client-body-buffer-size: "1m"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: cookie

--- a/deployment/ingress/eks/fuel-core-ingress.yaml
+++ b/deployment/ingress/eks/fuel-core-ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     nginx.ingress.kubernetes.io/affinity-mode: persistent
     nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+    nginx.org/proxy-connect-timeout: "3600s"
+    nginx.org/proxy-read-timeout: "3600s"
+    nginx.org/proxy-send-timeout: "3600s"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/affinity: cookie


### PR DESCRIPTION
- enables buffering of proxy responses
- increases client and response buffer sizes to 1mb to avoid frequent tmp file access / disk IO
- increase timeout from a default of 1m to 1h to avoid 504 timeouts