### PR TITLE
Release 0.17.6: Revert `receipts` signature back to be aligned with sem ver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   rustfmt:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       - name: Install latest nightly
@@ -35,7 +35,7 @@ jobs:
         run: cargo +${{ env.NIGHTLY_RUST_VERSION }} fmt --all -- --check
 
   lint-toml-files:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       - uses: FuelLabs/.github/.github/actions/lint-toml-template@master
@@ -46,7 +46,7 @@ jobs:
           slack_webhook: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
 
   prevent-openssl:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       # ensure openssl hasn't crept into the dep tree
@@ -63,7 +63,7 @@ jobs:
       - lint-toml-files
       - prevent-openssl
       - rustfmt
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       matrix:
         include:
@@ -112,7 +112,7 @@ jobs:
           RUSTFLAGS: -D warnings
 
   publish-crates-check:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -132,14 +132,14 @@ jobs:
     needs:
       - cargo-verifications
       - publish-crates-check
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - run: echo "pass"
 
   verify-tag-version:
     # Only do this job if publishing a release
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
 
     steps:
       - name: Checkout repository
@@ -162,7 +162,7 @@ jobs:
       - verify-tag-version
       - verifications-complete
     if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
 
     steps:
       - name: Checkout repository
@@ -193,7 +193,7 @@ jobs:
   publish-docker-image:
     needs:
       - verifications-complete
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     permissions:
       contents: read
       packages: write
@@ -245,7 +245,7 @@ jobs:
   publish-e2e-client-docker-image:
     needs:
       - verifications-complete
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     permissions:
       contents: read
       packages: write
@@ -307,11 +307,11 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - os: ubuntu-latest
+          - os: buildjet-4vcpu-ubuntu-2204
             platform: linux
             target: x86_64-unknown-linux-gnu
             cross_image: x86_64-linux-gnu
-          - os: ubuntu-latest
+          - os: buildjet-4vcpu-ubuntu-2204
             platform: linux-arm
             target: aarch64-unknown-linux-gnu
             cross_image: aarch64-linux-gnu
@@ -434,7 +434,7 @@ jobs:
     if:  startsWith(github.head_ref, 'preview/')
     needs:
       - publish-docker-image
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Set Environment Variables
         run: |
@@ -462,7 +462,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     needs:
       - publish-docker-image
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Set Environment Variables
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "parking_lot 0.12.1",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "clap 4.1.14",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "clap 4.1.14",
  "fuel-core-client",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "clap 4.1.14",
@@ -2576,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "axum",
  "lazy_static",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "ctor",
  "tracing",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,32 +45,32 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.17.5"
+version = "0.17.6"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.17.5", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.17.5", path = "./bin/client" }
-fuel-core-bin = { version = "0.17.5", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.17.5", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.17.5", path = "./crates/chain-config" }
-fuel-core-client = { version = "0.17.5", path = "./crates/client" }
-fuel-core-database = { version = "0.17.5", path = "./crates/database" }
-fuel-core-metrics = { version = "0.17.5", path = "./crates/metrics" }
-fuel-core-services = { version = "0.17.5", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.17.5", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.17.5", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.17.5", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.17.5", path = "./crates/services/executor" }
-fuel-core-importer = { version = "0.17.5", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.17.5", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.17.5", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.17.5", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.17.5", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.17.5", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.17.5", path = "./crates/storage" }
-fuel-core-trace = { version = "0.17.5", path = "./crates/trace" }
-fuel-core-types = { version = "0.17.5", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.17.6", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.17.6", path = "./bin/client" }
+fuel-core-bin = { version = "0.17.6", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.17.6", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.17.6", path = "./crates/chain-config" }
+fuel-core-client = { version = "0.17.6", path = "./crates/client" }
+fuel-core-database = { version = "0.17.6", path = "./crates/database" }
+fuel-core-metrics = { version = "0.17.6", path = "./crates/metrics" }
+fuel-core-services = { version = "0.17.6", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.17.6", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.17.6", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.17.6", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.17.6", path = "./crates/services/executor" }
+fuel-core-importer = { version = "0.17.6", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.17.6", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.17.6", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.17.6", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.17.6", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.17.6", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.17.6", path = "./crates/storage" }
+fuel-core-trace = { version = "0.17.6", path = "./crates/trace" }
+fuel-core-types = { version = "0.17.6", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 

--- a/bin/e2e-test-client/src/tests/script.rs
+++ b/bin/e2e-test-client/src/tests/script.rs
@@ -28,7 +28,7 @@ pub async fn receipts(ctx: &TestContext) -> Result<(), Failed> {
     for query in queries {
         let (query, query_number) = query;
         let receipts = query?;
-        if receipts.is_none() {
+        if receipts.is_empty() {
             return Err(
                 format!("Receipts are empty for query_number {query_number}").into(),
             )

--- a/bin/fuel-core-client/src/main.rs
+++ b/bin/fuel-core-client/src/main.rs
@@ -57,7 +57,7 @@ impl CliArgs {
                     println!("{:?}", json!(tx).to_string())
                 }
                 TransactionCommands::Receipts { id } => {
-                    let receipts = client.receipts(id.as_str()).await.unwrap().unwrap();
+                    let receipts = client.receipts(id.as_str()).await.unwrap();
                     println!("{:?}", json!(receipts).to_string())
                 }
             },

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.17.5"
+appVersion: "0.17.6"
 version: 0.1.0

--- a/tests/tests/contract.rs
+++ b/tests/tests/contract.rs
@@ -292,7 +292,6 @@ async fn can_get_message_proof() {
     let receipts = client
         .receipts(transaction_id.to_string().as_str())
         .await
-        .unwrap()
         .unwrap();
     let logd = receipts
         .iter()

--- a/tests/tests/messages.rs
+++ b/tests/tests/messages.rs
@@ -347,7 +347,6 @@ async fn can_get_message_proof() {
         let receipts = client
             .receipts(transaction_id.to_string().as_str())
             .await
-            .unwrap()
             .unwrap();
 
         // Get the message id from the receipts.

--- a/tests/tests/tx.rs
+++ b/tests/tests/tx.rs
@@ -217,7 +217,7 @@ async fn receipts() {
         .expect("transaction should insert");
     // run test
     let receipts = client.receipts(&format!("{id:#x}")).await.unwrap();
-    assert!(receipts.is_some());
+    assert!(!receipts.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
The previous release introduced a breaking change. Revert that part back