### PR TITLE
chore: Update balance and state Merkleization

### DIFF
--- a/crates/fuel-core/src/database/state.rs
+++ b/crates/fuel-core/src/database/state.rs
@@ -19,9 +19,12 @@ use fuel_core_storage::{
     StorageMutate,
 };
 use fuel_core_types::{
-    fuel_merkle::sparse::{
-        in_memory,
-        MerkleTree,
+    fuel_merkle::{
+        sparse,
+        sparse::{
+            in_memory,
+            MerkleTree,
+        },
     },
     fuel_types::ContractId,
 };
@@ -70,16 +73,9 @@ impl StorageMutate<ContractsState> for Database {
 
         let root = prev_metadata.root;
         let storage = self.borrow_mut();
-        let mut tree: MerkleTree<ContractsStateMerkleData, _> = {
-            if root == [0; 32] {
-                // The tree is empty
-                MerkleTree::new(storage)
-            } else {
-                // Load the tree saved in metadata
-                MerkleTree::load(storage, &root)
-                    .map_err(|err| StorageError::Other(err.into()))?
-            }
-        };
+        let mut tree: MerkleTree<ContractsStateMerkleData, _> =
+            MerkleTree::load(storage, &root)
+                .map_err(|err| StorageError::Other(err.into()))?;
 
         // Update the contract's key-value dataset. The key is the state key and
         // the value is the 32 bytes
@@ -122,7 +118,7 @@ impl StorageMutate<ContractsState> for Database {
                 .map_err(|err| StorageError::Other(err.into()))?;
 
             let root = tree.root();
-            if root == in_memory::MerkleTree::new().root() {
+            if root == *sparse::empty_sum() {
                 // The tree is now empty; remove the metadata
                 self.storage::<ContractsStateMerkleMetadata>()
                     .remove(key.contract_id())?;

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -1518,6 +1518,7 @@ mod tests {
         entities::message::Message,
         fuel_asm::op,
         fuel_crypto::SecretKey,
+        fuel_merkle::sparse,
         fuel_tx,
         fuel_tx::{
             field::{
@@ -2646,7 +2647,7 @@ mod tests {
             .unwrap();
 
         // Assert the balance and state roots should be the same before and after execution.
-        let empty_state = [0; 32].into();
+        let empty_state = (*sparse::empty_sum()).into();
         let executed_tx = block.transactions()[2].as_script().unwrap();
         assert!(matches!(
             tx_status[2].result,
@@ -2712,7 +2713,7 @@ mod tests {
             .unwrap();
 
         // Assert the balance and state roots should be the same before and after execution.
-        let empty_state = [0; 32].into();
+        let empty_state = (*sparse::empty_sum()).into();
         let executed_tx = block.transactions()[2].as_script().unwrap();
         assert!(matches!(
             tx_status[2].result,
@@ -2823,7 +2824,7 @@ mod tests {
             .execute_and_commit(ExecutionBlock::Production(block))
             .unwrap();
 
-        let empty_state = [0; 32].into();
+        let empty_state = (*sparse::empty_sum()).into();
         let executed_tx = block.transactions()[2].as_script().unwrap();
         assert!(matches!(
             tx_status[2].result,
@@ -2906,7 +2907,7 @@ mod tests {
             .unwrap();
 
         // Assert the balance root should not be affected.
-        let empty_state = [0; 32].into();
+        let empty_state = (*sparse::empty_sum()).into();
         assert_eq!(
             ContractRef::new(db, contract_id).balance_root().unwrap(),
             empty_state


### PR DESCRIPTION
Follow up on https://github.com/FuelLabs/fuel-core/pull/1008

Now that loading a Sparse Merkle tree checks for empty sum roots, we can simplify the usage at the client code level. 