### PR TITLE
add prometheus extension for graphql tracing

### DIFF
--- a/crates/fuel-core/src/graphql_api.rs
+++ b/crates/fuel-core/src/graphql_api.rs
@@ -10,6 +10,7 @@ use fuel_core_types::{
 use std::net::SocketAddr;
 
 pub mod ports;
+#[cfg(feature = "metrics")]
 pub(crate) mod prometheus;
 pub mod service;
 

--- a/crates/fuel-core/src/graphql_api.rs
+++ b/crates/fuel-core/src/graphql_api.rs
@@ -10,6 +10,7 @@ use fuel_core_types::{
 use std::net::SocketAddr;
 
 pub mod ports;
+pub(crate) mod prometheus;
 pub mod service;
 
 #[derive(Clone, Debug)]

--- a/crates/fuel-core/src/graphql_api/prometheus.rs
+++ b/crates/fuel-core/src/graphql_api/prometheus.rs
@@ -1,0 +1,51 @@
+use std::{
+    sync::Arc,
+    time::Instant,
+};
+
+use async_graphql::extensions::{
+    Extension,
+    ExtensionContext,
+    ExtensionFactory,
+    NextExecute,
+    NextRequest,
+};
+use fuel_core_metrics::graphql_metrics::GRAPHQL_METRICS;
+
+pub(crate) struct PrometheusExtension;
+
+impl ExtensionFactory for PrometheusExtension {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(PrometheusExtension)
+    }
+}
+
+#[async_trait::async_trait]
+impl Extension for PrometheusExtension {
+    async fn request(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        next: NextRequest<'_>,
+    ) -> async_graphql::Response {
+        GRAPHQL_METRICS.num_of_requests.inc();
+
+        next.run(ctx).await
+    }
+
+    async fn execute(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        operation_name: Option<&str>,
+        next: NextExecute<'_>,
+    ) -> async_graphql::Response {
+        let start_time = Instant::now();
+
+        let result = next.run(ctx, operation_name).await;
+
+        GRAPHQL_METRICS
+            .response_times
+            .observe(start_time.elapsed().as_secs_f64());
+
+        result
+    }
+}

--- a/crates/fuel-core/src/graphql_api/service.rs
+++ b/crates/fuel-core/src/graphql_api/service.rs
@@ -5,7 +5,10 @@ use crate::{
         DatabasePort,
         TxPoolPort,
     },
-    graphql_api::Config,
+    graphql_api::{
+        prometheus::PrometheusExtension,
+        Config,
+    },
     schema::{
         CoreSchema,
         CoreSchemaBuilder,
@@ -160,6 +163,7 @@ pub fn new_service(
         .data(producer)
         .data(consensus_module)
         .extension(Tracing)
+        .extension(PrometheusExtension {})
         .finish();
 
     let router = Router::new()

--- a/crates/metrics/src/graphql_metrics.rs
+++ b/crates/metrics/src/graphql_metrics.rs
@@ -1,0 +1,49 @@
+use lazy_static::lazy_static;
+use prometheus_client::{
+    metrics::{
+        counter::Counter,
+        histogram::Histogram,
+    },
+    registry::Registry,
+};
+
+pub struct GraphqlMetrics {
+    pub registry: Registry,
+    pub num_of_requests: Counter,
+    pub response_times: Histogram,
+}
+
+impl GraphqlMetrics {
+    fn new() -> Self {
+        let registry = Registry::default();
+
+        let response_bytes = Vec::new();
+        let response_times = Histogram::new(response_bytes.into_iter());
+
+        let num_of_requests = Counter::default();
+
+        let mut metrics = Self {
+            registry,
+            response_times,
+            num_of_requests,
+        };
+
+        metrics.registry.register(
+            "Number_of_Requests",
+            "Count of number of requests per second",
+            Box::new(metrics.num_of_requests.clone()),
+        );
+
+        metrics.registry.register(
+            "Response_Times",
+            "Histogram containing values of response times of graphql queries",
+            Box::new(metrics.response_times.clone()),
+        );
+
+        metrics
+    }
+}
+
+lazy_static! {
+    pub static ref GRAPHQL_METRICS: GraphqlMetrics = GraphqlMetrics::new();
+}

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unused_crate_dependencies)]
 
 pub mod core_metrics;
+pub mod graphql_metrics;
 pub mod p2p_metrics;
 pub mod service;
 pub mod txpool_metrics;

--- a/crates/metrics/src/service.rs
+++ b/crates/metrics/src/service.rs
@@ -1,4 +1,5 @@
 use crate::{
+    graphql_metrics::GRAPHQL_METRICS,
     p2p_metrics::P2P_METRICS,
     txpool_metrics::TXPOOL_METRICS,
 };
@@ -17,27 +18,29 @@ pub fn encode_metrics_response() -> impl IntoResponse {
 
     if let Option::Some(value) = P2P_METRICS.gossip_sub_registry.get() {
         if encode(&mut encoded, value).is_err() {
-            return Response::builder()
-                .status(503)
-                .body(Body::from(""))
-                .unwrap()
+            return error_body()
         }
     }
     if encode(&mut encoded, &P2P_METRICS.peer_metrics).is_err() {
-        return Response::builder()
-            .status(503)
-            .body(Body::from(""))
-            .unwrap()
+        return error_body()
     }
     if encode(&mut encoded, &TXPOOL_METRICS.registry).is_err() {
-        return Response::builder()
-            .status(503)
-            .body(Body::from(""))
-            .unwrap()
+        return error_body()
+    }
+
+    if encode(&mut encoded, &GRAPHQL_METRICS.registry).is_err() {
+        return error_body()
     }
 
     Response::builder()
         .status(200)
         .body(Body::from(encoded))
+        .unwrap()
+}
+
+fn error_body() -> Response<Body> {
+    Response::builder()
+        .status(503)
+        .body(Body::from(""))
         .unwrap()
 }


### PR DESCRIPTION
closes #1036 

on metrics side I created GrapqhlMetrics with a Counter (requests per second) and Histogram (response times),
and on Grapqhl side I created a PrometheusExtension implementing `Extension` trait from async-grapqhl.