### PR TITLE
Release 0.17.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
             args: test --no-default-features
           - command: test
             args: --manifest-path version-compatibility/Cargo.toml --workspace
+          - command: build
+            args: -p fuel-core-bin --no-default-features --features production
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45
     continue-on-error: ${{ matrix.skip-error || false }}
@@ -378,7 +380,7 @@ jobs:
 
       - name: Build fuel-core and fuel-core-keygen
         run: |
-          cross build --profile=release --target ${{ matrix.job.target }} --features "production" -p fuel-core-bin
+          cross build --profile=release --target ${{ matrix.job.target }} --no-default-features --features "production" -p fuel-core-bin
           cross build --profile=release --target ${{ matrix.job.target }} -p fuel-core-keygen
 
       - name: Strip release binary linux x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,6 +2572,7 @@ dependencies = [
  "libhoney-rust",
  "serde_json",
  "test-case",
+ "tikv-jemallocator",
  "tokio 1.27.0",
  "tracing",
  "tracing-honeycomb",
@@ -7121,6 +7122,16 @@ checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "aead"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
  "generic-array 0.14.7",
@@ -101,7 +101,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
 dependencies = [
- "aead 0.5.1",
+ "aead 0.5.2",
  "aes 0.8.2",
  "cipher 0.4.4",
  "ctr 0.9.2",
@@ -471,7 +471,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -1091,7 +1091,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core2"
@@ -1578,7 +1578,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1595,7 +1595,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fixed-hash"
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "parking_lot 0.12.1",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "clap 4.2.1",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "clap 4.2.1",
  "fuel-core-client",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "clap 4.2.1",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "axum",
  "lazy_static",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2828,7 +2828,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "ctor",
  "tracing",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.17.7"
+version = "0.17.8"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3117,7 +3117,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -3357,7 +3357,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.7",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -3647,16 +3647,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows 0.46.0",
+ "windows 0.48.0",
 ]
 
 [[package]]
@@ -3983,9 +3983,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libhoney-rust"
@@ -4803,9 +4803,9 @@ dependencies = [
 
 [[package]]
 name = "multer"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed4198ce7a4cbd2a57af78d28c6fbb57d81ac5f1d6ad79ac6c5587419cbdf22"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
  "bytes 1.4.0",
  "encoding_rs",
@@ -4815,7 +4815,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin 0.9.7",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -5644,9 +5644,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -6259,9 +6259,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.5"
+version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e78cc525325c06b4a7ff02db283472f3c042b7ff0c391f96c6d5ac6f4f91b75"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
  "bitflags",
  "errno",
@@ -6577,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "serde-aux"
-version = "4.1.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c599b3fd89a75e0c18d6d2be693ddb12cccaf771db4ff9e39097104808a014c0"
+checksum = "c3dfe1b7eb6f9dcf011bd6fad169cdeaae75eda0d61b1a99a3f015b41b0cae39"
 dependencies = [
  "serde",
  "serde_json",
@@ -6593,7 +6593,7 @@ checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -6852,9 +6852,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0959fd6f767df20b231736396e4f602171e00d95205676286e79d4a4eb67bef"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
@@ -6956,9 +6956,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.12"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7092,7 +7092,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -7261,7 +7261,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -8315,11 +8315,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -8328,12 +8328,12 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.2",
  "windows_aarch64_msvc 0.42.2",
  "windows_i686_gnu 0.42.2",
  "windows_i686_msvc 0.42.2",
  "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
 ]
 
@@ -8343,7 +8343,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -8352,13 +8352,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.2",
  "windows_aarch64_msvc 0.42.2",
  "windows_i686_gnu 0.42.2",
  "windows_i686_msvc 0.42.2",
  "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -8366,6 +8381,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8380,6 +8401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8390,6 +8417,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8404,6 +8437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8416,10 +8455,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8432,6 +8483,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
@@ -8605,5 +8662,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.13",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,32 +45,32 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.17.7"
+version = "0.17.8"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.17.7", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.17.7", path = "./bin/client" }
-fuel-core-bin = { version = "0.17.7", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.17.7", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.17.7", path = "./crates/chain-config" }
-fuel-core-client = { version = "0.17.7", path = "./crates/client" }
-fuel-core-database = { version = "0.17.7", path = "./crates/database" }
-fuel-core-metrics = { version = "0.17.7", path = "./crates/metrics" }
-fuel-core-services = { version = "0.17.7", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.17.7", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.17.7", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.17.7", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.17.7", path = "./crates/services/executor" }
-fuel-core-importer = { version = "0.17.7", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.17.7", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.17.7", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.17.7", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.17.7", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.17.7", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.17.7", path = "./crates/storage" }
-fuel-core-trace = { version = "0.17.7", path = "./crates/trace" }
-fuel-core-types = { version = "0.17.7", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.17.8", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.17.8", path = "./bin/client" }
+fuel-core-bin = { version = "0.17.8", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.17.8", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.17.8", path = "./crates/chain-config" }
+fuel-core-client = { version = "0.17.8", path = "./crates/client" }
+fuel-core-database = { version = "0.17.8", path = "./crates/database" }
+fuel-core-metrics = { version = "0.17.8", path = "./crates/metrics" }
+fuel-core-services = { version = "0.17.8", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.17.8", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.17.8", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.17.8", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.17.8", path = "./crates/services/executor" }
+fuel-core-importer = { version = "0.17.8", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.17.8", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.17.8", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.17.8", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.17.8", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.17.8", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.17.8", path = "./crates/storage" }
+fuel-core-trace = { version = "0.17.8", path = "./crates/trace" }
+fuel-core-types = { version = "0.17.8", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 

--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -24,6 +24,7 @@ humantime = "2.1"
 lazy_static = { workspace = true }
 libhoney-rust = { version = "0.1.6" }
 serde_json = { workspace = true, features = ["raw_value"], optional = true }
+tikv-jemallocator = "0.5"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-honeycomb = { version = "0.4", features = ["use_parking_lot"] }

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -289,8 +289,11 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
     let network_name = {
         #[cfg(feature = "p2p")]
         {
-            let config = config.p2p.as_ref().unwrap();
-            config.network_name.clone()
+            config
+                .p2p
+                .as_ref()
+                .map(|config| config.network_name.clone())
+                .unwrap_or_else(|| "default_network".to_string())
         }
         #[cfg(not(feature = "p2p"))]
         "default_network".to_string()

--- a/bin/fuel-core/src/cli/snapshot.rs
+++ b/bin/fuel-core/src/cli/snapshot.rs
@@ -21,7 +21,7 @@ pub struct Command {
     pub chain_config: String,
 }
 
-#[cfg(not(feature = "rocksdb"))]
+#[cfg(not(any(feature = "rocksdb", feature = "rocksdb-production")))]
 pub async fn exec(command: Command) -> anyhow::Result<()> {
     Err(anyhow::anyhow!(
         "Rocksdb must be enabled to use the database at {}",
@@ -29,7 +29,7 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
     ))
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(any(feature = "rocksdb", feature = "rocksdb-production"))]
 pub async fn exec(command: Command) -> anyhow::Result<()> {
     use anyhow::Context;
     use fuel_core::{

--- a/bin/fuel-core/src/main.rs
+++ b/bin/fuel-core/src/main.rs
@@ -1,5 +1,9 @@
 #![deny(unused_crate_dependencies)]
 
+// Use Jemalloc for main binary
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use fuel_core::service::FuelService;
 
 mod cli;

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -81,4 +81,4 @@ relayer = ["dep:fuel-core-relayer"]
 rocksdb = ["dep:rocksdb", "dep:tempfile"]
 test-helpers = ["fuel-core-p2p?/test-helpers"]
 # features to enable in production, but increase build times
-rocksdb-production = ["rocksdb", "rocksdb?/jemalloc"]
+rocksdb-production = ["rocksdb", "rocksdb/jemalloc"]

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -60,7 +60,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tower-http = { version = "0.3", features = ["set-header", "trace"] }
 tracing = { workspace = true }
 tracing-honeycomb = { version = "0.4", features = ["use_parking_lot"] }
-uuid = { version = "1.1", features = ["v4"] }
+uuid = { version = "1.1", features = ["v4"], optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -72,7 +72,8 @@ mockall = { workspace = true }
 test-case = { workspace = true }
 
 [features]
-debug = ["fuel-core-types/debug"]
+dap = ["dep:uuid"]
+debug = ["fuel-core-types/debug", "dap"]
 default = ["debug", "metrics", "rocksdb"]
 metrics = ["dep:fuel-core-metrics"]
 p2p = ["dep:fuel-core-p2p", "dep:fuel-core-sync"]
@@ -80,4 +81,4 @@ relayer = ["dep:fuel-core-relayer"]
 rocksdb = ["dep:rocksdb", "dep:tempfile"]
 test-helpers = ["fuel-core-p2p?/test-helpers"]
 # features to enable in production, but increase build times
-rocksdb-production = ["rocksdb?/jemalloc"]
+rocksdb-production = ["rocksdb", "rocksdb?/jemalloc"]

--- a/crates/fuel-core/src/schema.rs
+++ b/crates/fuel-core/src/schema.rs
@@ -22,6 +22,7 @@ pub mod block;
 pub mod chain;
 pub mod coin;
 pub mod contract;
+#[cfg(feature = "dap")]
 pub mod dap;
 pub mod health;
 pub mod message;
@@ -30,6 +31,7 @@ pub mod resource;
 pub mod scalars;
 pub mod tx;
 
+#[cfg(feature = "dap")]
 #[derive(MergedObject, Default)]
 pub struct Query(
     dap::DapQuery,
@@ -46,8 +48,29 @@ pub struct Query(
     resource::ResourceQuery,
 );
 
+#[cfg(not(feature = "dap"))]
+#[derive(MergedObject, Default)]
+pub struct Query(
+    balance::BalanceQuery,
+    block::BlockQuery,
+    chain::ChainQuery,
+    tx::TxQuery,
+    health::HealthQuery,
+    coin::CoinQuery,
+    contract::ContractQuery,
+    contract::ContractBalanceQuery,
+    node_info::NodeQuery,
+    message::MessageQuery,
+    resource::ResourceQuery,
+);
+
+#[cfg(feature = "dap")]
 #[derive(MergedObject, Default)]
 pub struct Mutation(dap::DapMutation, tx::TxMutation, block::BlockMutation);
+
+#[cfg(not(feature = "dap"))]
+#[derive(MergedObject, Default)]
+pub struct Mutation(tx::TxMutation, block::BlockMutation);
 
 #[derive(MergedSubscription, Default)]
 pub struct Subscription(tx::TxStatusSubscription);

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -213,6 +213,7 @@ impl TxMutation {
         let txpool = ctx.data_unchecked::<TxPool>();
         let mut tx = FuelTx::from_bytes(&tx.0)?;
         tx.precompute();
+        // TODO: use spawn_blocking here
         let _: Vec<_> = txpool
             .insert(vec![Arc::new(tx.clone())])
             .into_iter()

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -4,10 +4,7 @@ use super::adapters::P2PAdapter;
 use crate::{
     database::Database,
     fuel_core_graphql_api::Config as GraphQLConfig,
-    schema::{
-        build_schema,
-        dap,
-    },
+    schema::build_schema,
     service::{
         adapters::{
             BlockImporterAdapter,
@@ -152,12 +149,22 @@ pub fn init_sub_services(
         .transpose()?;
 
     // TODO: Figure out on how to move it into `fuel-core-graphql-api`.
-    let schema = dap::init(
-        build_schema(),
-        config.chain_conf.transaction_parameters,
-        config.chain_conf.gas_costs.clone(),
-    )
-    .data(database.clone());
+    let schema = {
+        #[cfg(feature = "dap")]
+        {
+            crate::schema::dap::init(
+                build_schema(),
+                config.chain_conf.transaction_parameters,
+                config.chain_conf.gas_costs.clone(),
+            )
+            .data(database.clone())
+        }
+        #[cfg(not(feature = "dap"))]
+        {
+            build_schema()
+        }
+    };
+
     let gql_database = Box::new(database.clone());
 
     let graph_ql = crate::fuel_core_graphql_api::service::new_service(

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -21,11 +21,11 @@ FROM chef as builder
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY --from=planner /build/recipe.json recipe.json
 # Build our project dependecies, not our application!
-RUN cargo chef cook --release --features "production" -p fuel-core-bin --recipe-path recipe.json
+RUN cargo chef cook --release --no-default-features --features "production" -p fuel-core-bin --recipe-path recipe.json
 # Up to this point, if our dependency tree stays the same,
 # all layers should be cached.
 COPY . .
-RUN cargo build --release --features "production" -p fuel-core-bin
+RUN cargo build --release --no-default-features --features "production" -p fuel-core-bin
 
 # Stage 2: Run
 FROM ubuntu:22.04 as run

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.17.7"
+appVersion: "0.17.8"
 version: 0.1.0

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ["metrics"]
 
 [dependencies]
 ethers = "1.0.2"
-fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["test-helpers"] }
+fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["dap", "test-helpers"] }
 fuel-core-client = { path = "../crates/client", features = ["test-helpers"] }
 fuel-core-p2p = { path = "../crates/services/p2p", features = ["test-helpers"], optional = true }
 fuel-core-poa = { path = "../crates/services/consensus_module/poa" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { workspace = true, features = ["env", "derive"] }
-fuel-core = { path = "../crates/fuel-core", default-features = false }
+fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["dap"] }
 
 [features]
 default = ["fuel-core/default"]


### PR DESCRIPTION
Yet another hotfix.. In my local testing it seems like jemalloc has less overhead when initializing vm instances (which we do frequently). It should also do a better job of reclaiming memory.

The release also disables `dap` endpoints for the `production`.