### PR TITLE
Disable `dap` for the production `fuel-core-bin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
 
       - name: Build fuel-core and fuel-core-keygen
         run: |
-          cross build --profile=release --target ${{ matrix.job.target }} --features "production" -p fuel-core-bin
+          cross build --profile=release --target ${{ matrix.job.target }} --no-default-features --features "production" -p fuel-core-bin
           cross build --profile=release --target ${{ matrix.job.target }} -p fuel-core-keygen
 
       - name: Strip release binary linux x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
             args: test --no-default-features
           - command: test
             args: --manifest-path version-compatibility/Cargo.toml --workspace
+          - command: build
+            args: -p fuel-core-bin --no-default-features --features production
     # disallow any job that takes longer than 45 minutes
     timeout-minutes: 45
     continue-on-error: ${{ matrix.skip-error || false }}

--- a/bin/fuel-core/src/cli/snapshot.rs
+++ b/bin/fuel-core/src/cli/snapshot.rs
@@ -21,7 +21,7 @@ pub struct Command {
     pub chain_config: String,
 }
 
-#[cfg(not(feature = "rocksdb"))]
+#[cfg(not(any(feature = "rocksdb", feature = "rocksdb-production")))]
 pub async fn exec(command: Command) -> anyhow::Result<()> {
     Err(anyhow::anyhow!(
         "Rocksdb must be enabled to use the database at {}",
@@ -29,7 +29,7 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
     ))
 }
 
-#[cfg(feature = "rocksdb")]
+#[cfg(any(feature = "rocksdb", feature = "rocksdb-production"))]
 pub async fn exec(command: Command) -> anyhow::Result<()> {
     use anyhow::Context;
     use fuel_core::{

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -72,7 +72,8 @@ mockall = { workspace = true }
 test-case = { workspace = true }
 
 [features]
-debug = ["fuel-core-types/debug"]
+dap = []
+debug = ["fuel-core-types/debug", "dap"]
 default = ["debug", "metrics", "rocksdb"]
 metrics = ["dep:fuel-core-metrics"]
 p2p = ["dep:fuel-core-p2p", "dep:fuel-core-sync"]

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -81,4 +81,4 @@ relayer = ["dep:fuel-core-relayer"]
 rocksdb = ["dep:rocksdb", "dep:tempfile"]
 test-helpers = ["fuel-core-p2p?/test-helpers"]
 # features to enable in production, but increase build times
-rocksdb-production = ["rocksdb?/jemalloc"]
+rocksdb-production = ["rocksdb", "rocksdb?/jemalloc"]

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -60,7 +60,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tower-http = { version = "0.3", features = ["set-header", "trace"] }
 tracing = { workspace = true }
 tracing-honeycomb = { version = "0.4", features = ["use_parking_lot"] }
-uuid = { version = "1.1", features = ["v4"] }
+uuid = { version = "1.1", features = ["v4"], optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
@@ -72,7 +72,7 @@ mockall = { workspace = true }
 test-case = { workspace = true }
 
 [features]
-dap = []
+dap = ["dep:uuid"]
 debug = ["fuel-core-types/debug", "dap"]
 default = ["debug", "metrics", "rocksdb"]
 metrics = ["dep:fuel-core-metrics"]

--- a/crates/fuel-core/src/schema.rs
+++ b/crates/fuel-core/src/schema.rs
@@ -22,6 +22,7 @@ pub mod block;
 pub mod chain;
 pub mod coin;
 pub mod contract;
+#[cfg(feature = "dap")]
 pub mod dap;
 pub mod health;
 pub mod message;
@@ -30,6 +31,7 @@ pub mod resource;
 pub mod scalars;
 pub mod tx;
 
+#[cfg(feature = "dap")]
 #[derive(MergedObject, Default)]
 pub struct Query(
     dap::DapQuery,
@@ -46,8 +48,30 @@ pub struct Query(
     resource::ResourceQuery,
 );
 
+#[cfg(not(feature = "dap"))]
+#[cfg(feature = "dap")]
+#[derive(MergedObject, Default)]
+pub struct Query(
+    balance::BalanceQuery,
+    block::BlockQuery,
+    chain::ChainQuery,
+    tx::TxQuery,
+    health::HealthQuery,
+    coin::CoinQuery,
+    contract::ContractQuery,
+    contract::ContractBalanceQuery,
+    node_info::NodeQuery,
+    message::MessageQuery,
+    resource::ResourceQuery,
+);
+
+#[cfg(feature = "dap")]
 #[derive(MergedObject, Default)]
 pub struct Mutation(dap::DapMutation, tx::TxMutation, block::BlockMutation);
+
+#[cfg(not(feature = "dap"))]
+#[derive(MergedObject, Default)]
+pub struct Mutation(tx::TxMutation, block::BlockMutation);
 
 #[derive(MergedSubscription, Default)]
 pub struct Subscription(tx::TxStatusSubscription);

--- a/crates/fuel-core/src/schema.rs
+++ b/crates/fuel-core/src/schema.rs
@@ -49,7 +49,6 @@ pub struct Query(
 );
 
 #[cfg(not(feature = "dap"))]
-#[cfg(feature = "dap")]
 #[derive(MergedObject, Default)]
 pub struct Query(
     balance::BalanceQuery,

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -4,10 +4,7 @@ use super::adapters::P2PAdapter;
 use crate::{
     database::Database,
     fuel_core_graphql_api::Config as GraphQLConfig,
-    schema::{
-        build_schema,
-        dap,
-    },
+    schema::build_schema,
     service::{
         adapters::{
             BlockImporterAdapter,
@@ -155,7 +152,7 @@ pub fn init_sub_services(
     let schema = {
         #[cfg(feature = "dap")]
         {
-            dap::init(
+            crate::schema::dap::init(
                 build_schema(),
                 config.chain_conf.transaction_parameters,
                 config.chain_conf.gas_costs.clone(),

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -152,12 +152,22 @@ pub fn init_sub_services(
         .transpose()?;
 
     // TODO: Figure out on how to move it into `fuel-core-graphql-api`.
-    let schema = dap::init(
-        build_schema(),
-        config.chain_conf.transaction_parameters,
-        config.chain_conf.gas_costs.clone(),
-    )
-    .data(database.clone());
+    let schema = {
+        #[cfg(feature = "dap")]
+        {
+            dap::init(
+                build_schema(),
+                config.chain_conf.transaction_parameters,
+                config.chain_conf.gas_costs.clone(),
+            )
+            .data(database.clone())
+        }
+        #[cfg(not(feature = "dap"))]
+        {
+            build_schema()
+        }
+    };
+
     let gql_database = Box::new(database.clone());
 
     let graph_ql = crate::fuel_core_graphql_api::service::new_service(

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -21,11 +21,11 @@ FROM chef as builder
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY --from=planner /build/recipe.json recipe.json
 # Build our project dependecies, not our application!
-RUN cargo chef cook --release --features "production" -p fuel-core-bin --recipe-path recipe.json
+RUN cargo chef cook --release --no-default-features --features "production" -p fuel-core-bin --recipe-path recipe.json
 # Up to this point, if our dependency tree stays the same,
 # all layers should be cached.
 COPY . .
-RUN cargo build --release --features "production" -p fuel-core-bin
+RUN cargo build --release --no-default-features --features "production" -p fuel-core-bin
 
 # Stage 2: Run
 FROM ubuntu:22.04 as run

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ["metrics"]
 
 [dependencies]
 ethers = "1.0.2"
-fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["test-helpers"] }
+fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["dap", "test-helpers"] }
 fuel-core-client = { path = "../crates/client", features = ["test-helpers"] }
 fuel-core-p2p = { path = "../crates/services/p2p", features = ["test-helpers"], optional = true }
 fuel-core-poa = { path = "../crates/services/consensus_module/poa" }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { workspace = true, features = ["env", "derive"] }
-fuel-core = { path = "../crates/fuel-core", default-features = false }
+fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["dap"] }
 
 [features]
 default = ["fuel-core/default"]


### PR DESCRIPTION
It is a separate change from https://github.com/FuelLabs/fuel-core/pull/1096 to create an image without `jemallocator` not to mix fixes. 

Do not merge it. Maybe we will combine it with `jemallocator` for the release.