### PR TITLE
use chainid for transactions and predicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,8 +2493,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "fuel-asm"
-version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f205fd626a7b1a35fbdb3272da9f3e9f798607d9670f86d6e1b4addffff468"
 dependencies = [
  "bitflags",
  "fuel-types",
@@ -2964,8 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1aa066c847ace24b8f5e1210503638dcce3d0e9ac5171397ca60328290507bf"
 dependencies = [
  "borrown",
  "coins-bip32",
@@ -2981,8 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e393fb1e10364aefe5176ee5329d08393eb470e9869fc584bdbc3c62363c939"
 dependencies = [
  "digest 0.10.6",
  "fuel-storage",
@@ -2994,13 +2997,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173212ca99bac6274446c79338d09cacd496c5e67a16e58a242d5e0e49b506c2"
 
 [[package]]
 name = "fuel-tx"
-version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5441c510e8ae98f44a39419988589b30f95d92b9a3d6db6805e0fa56fa8137ca"
 dependencies = [
  "derivative",
  "fuel-asm",
@@ -3018,8 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0642fdfeb9f4b21454f2c4b322085c290b97e4ba81ef0bbca030cabda42a847d"
 dependencies = [
  "hex",
  "rand 0.8.5",
@@ -3028,8 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941751b43c918b332f43ee7084e787f758a134cbac870dcf82b0b1cd94f03590"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,8 +2494,7 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 [[package]]
 name = "fuel-asm"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b223c29a05426eaf6184b601198d8687bec822f4671ecfaae59e2a98370457d"
+source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
 dependencies = [
  "bitflags",
  "fuel-types",
@@ -2965,8 +2964,7 @@ dependencies = [
 [[package]]
 name = "fuel-crypto"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9246309f17e7275d1bc427b4079e2991e35e35a2cea1520d642da2fbb52435"
+source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
 dependencies = [
  "borrown",
  "coins-bip32",
@@ -2983,8 +2981,7 @@ dependencies = [
 [[package]]
 name = "fuel-merkle"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25c7ee5c47099f7ef6f09a60b969b1b4f825a66f29940329474a5e593b49017"
+source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
 dependencies = [
  "digest 0.10.6",
  "fuel-storage",
@@ -2997,14 +2994,12 @@ dependencies = [
 [[package]]
 name = "fuel-storage"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528d5c6f23e77e13767987c90158ac713afaf1485a891122dceaa0adde016dea"
+source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
 
 [[package]]
 name = "fuel-tx"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e44caded39f85b4f136075d0d1f00f59629b57473ee87f03841528db0ecf81c"
+source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
 dependencies = [
  "derivative",
  "fuel-asm",
@@ -3023,9 +3018,9 @@ dependencies = [
 [[package]]
 name = "fuel-types"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd68fdf8caddf68c2b0eee8b03727abac65dadc4b13af924fa03fe4858bd966"
+source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
 dependencies = [
+ "hex",
  "rand 0.8.5",
  "serde",
 ]
@@ -3033,11 +3028,11 @@ dependencies = [
 [[package]]
 name = "fuel-vm"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6dd6db654b889b4b9d59e72ced740e0f99358d27dafe0a3bba7af471257db28"
+source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
 dependencies = [
  "anyhow",
  "bitflags",
+ "derivative",
  "fuel-asm",
  "fuel-crypto",
  "fuel-merkle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,7 +2494,7 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 [[package]]
 name = "fuel-asm"
 version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
+source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
 dependencies = [
  "bitflags",
  "fuel-types",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "fuel-crypto"
 version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
+source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
 dependencies = [
  "borrown",
  "coins-bip32",
@@ -2982,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "fuel-merkle"
 version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
+source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
 dependencies = [
  "digest 0.10.6",
  "fuel-storage",
@@ -2995,12 +2995,12 @@ dependencies = [
 [[package]]
 name = "fuel-storage"
 version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
+source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
 
 [[package]]
 name = "fuel-tx"
 version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
+source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
 dependencies = [
  "derivative",
  "fuel-asm",
@@ -3019,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "fuel-types"
 version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
+source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
 dependencies = [
  "hex",
  "rand 0.8.5",
@@ -3029,7 +3029,7 @@ dependencies = [
 [[package]]
 name = "fuel-vm"
 version = "0.29.0"
-source = "git+https://github.com/FuelLabs/fuel-vm.git#582c61d1da67ee35972e6a68a277249e92d1520e"
+source = "git+https://github.com/FuelLabs/fuel-vm.git?branch=Voxelot/cached-id#c30800a29fb192b5769364ac3ffb6f2b64162281"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.29", package = "fuel-vm" }
+fuel-vm-private = { version = "0.30", package = "fuel-vm" }
 
 # Common dependencies
 anyhow = "1.0"
@@ -104,11 +104,3 @@ prometheus-client = "0.18"
 itertools = "0.10"
 insta = "1.8"
 tempfile = "3.4"
-
-[patch.crates-io]
-fuel-types = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
-fuel-asm = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
-fuel-tx = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
-fuel-crypto = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
-fuel-merkle = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
-fuel-vm = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,3 +104,11 @@ prometheus-client = "0.18"
 itertools = "0.10"
 insta = "1.8"
 tempfile = "3.4"
+
+[patch.crates-io]
+fuel-types = { git = "https://github.com/FuelLabs/fuel-vm.git" }
+fuel-asm = { git = "https://github.com/FuelLabs/fuel-vm.git" }
+fuel-tx = { git = "https://github.com/FuelLabs/fuel-vm.git" }
+fuel-crypto = { git = "https://github.com/FuelLabs/fuel-vm.git" }
+fuel-merkle = { git = "https://github.com/FuelLabs/fuel-vm.git" }
+fuel-vm = { git = "https://github.com/FuelLabs/fuel-vm.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,9 +106,9 @@ insta = "1.8"
 tempfile = "3.4"
 
 [patch.crates-io]
-fuel-types = { git = "https://github.com/FuelLabs/fuel-vm.git" }
-fuel-asm = { git = "https://github.com/FuelLabs/fuel-vm.git" }
-fuel-tx = { git = "https://github.com/FuelLabs/fuel-vm.git" }
-fuel-crypto = { git = "https://github.com/FuelLabs/fuel-vm.git" }
-fuel-merkle = { git = "https://github.com/FuelLabs/fuel-vm.git" }
-fuel-vm = { git = "https://github.com/FuelLabs/fuel-vm.git" }
+fuel-types = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
+fuel-asm = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
+fuel-tx = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
+fuel-crypto = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
+fuel-merkle = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }
+fuel-vm = { git = "https://github.com/FuelLabs/fuel-vm.git", branch = "Voxelot/cached-id" }

--- a/benches/benches/set/blockchain.rs
+++ b/benches/benches/set/blockchain.rs
@@ -11,6 +11,7 @@ use fuel_core_storage::ContractsAssetsStorage;
 use fuel_core_types::{
     fuel_asm::*,
     fuel_tx::{
+        ConsensusParameters,
         Input,
         Output,
     },
@@ -368,7 +369,7 @@ pub fn run(c: &mut Criterion) {
         let coin_output = Output::variable(Address::zeroed(), 100, AssetId::zeroed());
         input.outputs.push(coin_output);
         let predicate = op::ret(RegId::ONE).to_bytes().to_vec();
-        let owner = Input::predicate_owner(&predicate);
+        let owner = Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT);
         let coin_input = Input::coin_predicate(
             Default::default(),
             owner,
@@ -441,7 +442,7 @@ pub fn run(c: &mut Criterion) {
                 .chain(vec![2u8; i as usize]),
         );
         let predicate = op::ret(RegId::ONE).to_bytes().to_vec();
-        let owner = Input::predicate_owner(&predicate);
+        let owner = Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT);
         let coin_input = Input::coin_predicate(
             Default::default(),
             owner,

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -381,7 +381,8 @@ impl TryFrom<VmBench> for VmBenchPrepared {
             .gas_price(gas_price)
             .gas_limit(gas_limit)
             .maturity(maturity)
-            .finalize_checked(height, &p, &Default::default());
+            .with_params(p)
+            .finalize_checked(height, &Default::default());
 
         let mut txtor = Transactor::new(db, params, GasCosts::free());
 

--- a/bin/e2e-test-client/src/lib.rs
+++ b/bin/e2e-test-client/src/lib.rs
@@ -37,37 +37,47 @@ pub fn main_body(config: SuiteConfig, mut args: Arguments) {
         Trial::test(
             "can transfer from alice to bob",
             with_cloned(&config, |config| {
-                let ctx = TestContext::new(config);
-                async_execute(tests::transfers::basic_transfer(&ctx))
+                async_execute(async {
+                    let ctx = TestContext::new(config).await;
+                    tests::transfers::basic_transfer(&ctx).await
+                })
             }),
         ),
         Trial::test(
             "can transfer from alice to bob and back",
             with_cloned(&config, |config| {
-                let ctx = TestContext::new(config);
-                async_execute(tests::transfers::transfer_back(&ctx))
+                async_execute(async {
+                    let ctx = TestContext::new(config).await;
+                    tests::transfers::transfer_back(&ctx).await
+                })
             }),
         ),
         Trial::test(
             "can execute script and get receipts",
             with_cloned(&config, |config| {
-                let ctx = TestContext::new(config);
-                async_execute(tests::script::receipts(&ctx))
+                async_execute(async {
+                    let ctx = TestContext::new(config).await;
+                    tests::transfers::transfer_back(&ctx).await
+                })
             }),
         ),
         Trial::test(
             "can dry run transfer script and get receipts",
             with_cloned(&config, |config| {
-                let ctx = TestContext::new(config);
-                async_execute(tests::script::dry_run(&ctx))?;
+                async_execute(async {
+                    let ctx = TestContext::new(config).await;
+                    tests::transfers::transfer_back(&ctx).await
+                })?;
                 Ok(())
             }),
         ),
         Trial::test(
             "can deploy a large contract",
             with_cloned(&config, |config| {
-                let ctx = TestContext::new(config);
-                async_execute(tests::contracts::deploy_large_contract(&ctx))
+                async_execute(async {
+                    let ctx = TestContext::new(config).await;
+                    tests::transfers::transfer_back(&ctx).await
+                })
             }),
         ),
     ];

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
@@ -21,7 +21,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
@@ -32,7 +32,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
@@ -32,7 +32,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
@@ -28,7 +28,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
@@ -28,7 +28,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
@@ -47,7 +47,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
@@ -32,7 +32,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
@@ -26,7 +26,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
@@ -30,7 +30,8 @@ expression: json
     "max_predicate_data_length": 1048576,
     "gas_price_factor": 1000000000,
     "gas_per_byte": 4,
-    "max_message_data_length": 1048576
+    "max_message_data_length": 1048576,
+    "chain_id": 0
   },
   "gas_costs": {
     "add": 1,

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -187,6 +187,7 @@ type ConsensusParameters {
 	gasPriceFactor: U64!
 	gasPerByte: U64!
 	maxMessageDataLength: U64!
+	chainId: U64!
 }
 
 type Contract {

--- a/crates/client/src/client/schema/chain.rs
+++ b/crates/client/src/client/schema/chain.rs
@@ -22,6 +22,7 @@ pub struct ConsensusParameters {
     pub gas_price_factor: U64,
     pub gas_per_byte: U64,
     pub max_message_data_length: U64,
+    pub chain_id: U64,
 }
 
 impl From<ConsensusParameters> for TxConsensusParameters {
@@ -40,6 +41,7 @@ impl From<ConsensusParameters> for TxConsensusParameters {
             gas_price_factor: params.gas_price_factor.into(),
             gas_per_byte: params.gas_per_byte.into(),
             max_message_data_length: params.max_message_data_length.into(),
+            chain_id: params.chain_id.into(),
         }
     }
 }

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -51,6 +51,7 @@ query {
       gasPriceFactor
       gasPerByte
       maxMessageDataLength
+      chainId
     }
   }
 }

--- a/crates/fuel-core/src/database/block.rs
+++ b/crates/fuel-core/src/database/block.rs
@@ -300,6 +300,7 @@ mod tests {
             },
             primitives::Empty,
         },
+        fuel_tx::ConsensusParameters,
         fuel_vm::crypto::ephemeral_merkle_root,
     };
     use test_case::test_case;
@@ -334,7 +335,7 @@ mod tests {
             StorageMutate::<FuelBlocks>::insert(
                 &mut database,
                 &block.id(),
-                &block.compress(),
+                &block.compress(&ConsensusParameters::DEFAULT),
             )
             .unwrap();
         }
@@ -395,8 +396,12 @@ mod tests {
 
         // Insert the blocks
         for block in &blocks {
-            StorageMutate::<FuelBlocks>::insert(database, &block.id(), &block.compress())
-                .unwrap();
+            StorageMutate::<FuelBlocks>::insert(
+                database,
+                &block.id(),
+                &block.compress(&ConsensusParameters::DEFAULT),
+            )
+            .unwrap();
         }
     }
 

--- a/crates/fuel-core/src/database/vm_database.rs
+++ b/crates/fuel-core/src/database/vm_database.rs
@@ -174,9 +174,7 @@ impl InterpreterStorage for VmDatabase {
         Ok(timestamp.0)
     }
 
-    fn block_hash(&self, block_height: u32) -> Result<Bytes32, Self::DataError> {
-        // TODO: https://github.com/FuelLabs/fuel-vm/pull/412
-        let block_height: BlockHeight = block_height.into();
+    fn block_hash(&self, block_height: BlockHeight) -> Result<Bytes32, Self::DataError> {
         // Block header hashes for blocks with height greater than or equal to current block height are zero (0x00**32).
         // https://github.com/FuelLabs/fuel-specs/blob/master/specs/vm/instruction_set.md#bhsh-block-hash
         if block_height >= self.current_block_height || block_height == Default::default()

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -225,7 +225,7 @@ where
             .transactions()
             .iter()
             .map(|tx| {
-                let id = tx.id();
+                let id = tx.id(&self.config.chain_conf.transaction_parameters);
                 StorageInspect::<Receipts>::get(temporary_db.as_ref(), &id)
                     .transpose()
                     .unwrap_or_else(|| Ok(Default::default()))
@@ -309,7 +309,12 @@ where
         block_db_transaction
             .deref_mut()
             .storage::<FuelBlocks>()
-            .insert(&finalized_block_id, &result.block.compress())?;
+            .insert(
+                &finalized_block_id,
+                &result
+                    .block
+                    .compress(&self.config.chain_conf.transaction_parameters),
+            )?;
 
         // Get the complete fuel block.
         Ok(UncommittedResult::new(
@@ -443,7 +448,7 @@ where
         execution_kind: ExecutionKind,
         tx_db_transaction: &mut DatabaseTransaction,
     ) -> ExecutorResult<()> {
-        let tx_id = tx.id();
+        let tx_id = tx.id(&self.config.chain_conf.transaction_parameters);
         // Throw a clear error if the transaction id is a duplicate
         if tx_db_transaction
             .deref_mut()
@@ -492,7 +497,7 @@ where
         block_db_transaction: &mut DatabaseTransaction,
     ) -> ExecutorResult<()> {
         let block_height = *block.header.height();
-        let coinbase_id = coinbase_tx.id();
+        let coinbase_id = coinbase_tx.id(&self.config.chain_conf.transaction_parameters);
         self.persist_output_utxos(
             block_height,
             0,
@@ -588,7 +593,9 @@ where
             &self.config.chain_conf.transaction_parameters,
         )?;
 
-        let tx_id = checked_tx.transaction().id();
+        let tx_id = checked_tx
+            .transaction()
+            .id(&self.config.chain_conf.transaction_parameters);
         let min_fee = checked_tx.metadata().min_fee();
         let max_fee = checked_tx.metadata().max_fee();
 
@@ -607,7 +614,7 @@ where
             // validate transaction signature
             checked_tx
                 .transaction()
-                .check_signatures()
+                .check_signatures(&self.config.chain_conf.transaction_parameters)
                 .map_err(TransactionValidityError::from)?;
         }
 
@@ -867,7 +874,9 @@ where
         Tx: ExecutableTransaction,
         <Tx as IntoChecked>::Metadata: CheckedMetadata,
     {
-        let id = tx.transaction().id();
+        let id = tx
+            .transaction()
+            .id(&self.config.chain_conf.transaction_parameters);
         if Interpreter::<PredicateStorage>::check_predicates(
             tx,
             self.config.chain_conf.transaction_parameters,
@@ -898,7 +907,10 @@ where
         {
             Ok(())
         } else {
-            Err(TransactionValidityError::NoCoinOrMessageInput(tx.id()).into())
+            Err(TransactionValidityError::NoCoinOrMessageInput(
+                tx.id(&self.config.chain_conf.transaction_parameters),
+            )
+            .into())
         }
     }
 
@@ -1053,7 +1065,10 @@ where
                             )?;
                             if tx_pointer != &coin.tx_pointer {
                                 return Err(ExecutorError::InvalidTransactionOutcome {
-                                    transaction_id: tx.id(),
+                                    transaction_id: tx.id(&self
+                                        .config
+                                        .chain_conf
+                                        .transaction_parameters),
                                 })
                             }
                         }
@@ -1074,17 +1089,26 @@ where
                                 != contract.validated_utxo(self.config.utxo_validation)?
                             {
                                 return Err(ExecutorError::InvalidTransactionOutcome {
-                                    transaction_id: tx.id(),
+                                    transaction_id: tx.id(&self
+                                        .config
+                                        .chain_conf
+                                        .transaction_parameters),
                                 })
                             }
                             if balance_root != &contract.balance_root()? {
                                 return Err(ExecutorError::InvalidTransactionOutcome {
-                                    transaction_id: tx.id(),
+                                    transaction_id: tx.id(&self
+                                        .config
+                                        .chain_conf
+                                        .transaction_parameters),
                                 })
                             }
                             if state_root != &contract.state_root()? {
                                 return Err(ExecutorError::InvalidTransactionOutcome {
-                                    transaction_id: tx.id(),
+                                    transaction_id: tx.id(&self
+                                        .config
+                                        .chain_conf
+                                        .transaction_parameters),
                                 })
                             }
                         }
@@ -1128,7 +1152,8 @@ where
                             contract_id
                         } else {
                             return Err(ExecutorError::InvalidTransactionOutcome {
-                                transaction_id: tx.id(),
+                                transaction_id: tx
+                                    .id(&self.config.chain_conf.transaction_parameters),
                             })
                         };
 
@@ -1155,19 +1180,22 @@ where
                             contract_id
                         } else {
                             return Err(ExecutorError::InvalidTransactionOutcome {
-                                transaction_id: tx.id(),
+                                transaction_id: tx
+                                    .id(&self.config.chain_conf.transaction_parameters),
                             })
                         };
 
                         let mut contract = ContractRef::new(&mut *db, *contract_id);
                         if balance_root != &contract.balance_root()? {
                             return Err(ExecutorError::InvalidTransactionOutcome {
-                                transaction_id: tx.id(),
+                                transaction_id: tx
+                                    .id(&self.config.chain_conf.transaction_parameters),
                             })
                         }
                         if state_root != &contract.state_root()? {
                             return Err(ExecutorError::InvalidTransactionOutcome {
-                                transaction_id: tx.id(),
+                                transaction_id: tx
+                                    .id(&self.config.chain_conf.transaction_parameters),
                             })
                         }
                     }
@@ -1362,7 +1390,7 @@ where
             let block_height = *block.header().height();
             let mut inputs = &[][..];
             let outputs;
-            let tx_id = tx.id();
+            let tx_id = tx.id(&self.config.chain_conf.transaction_parameters);
             match tx {
                 Transaction::Script(tx) => {
                     inputs = tx.inputs().as_slice();
@@ -1821,6 +1849,8 @@ mod tests {
                 .transaction_parameters
                 .gas_price_factor = gas_price_factor;
 
+            let params = producer.config.chain_conf.transaction_parameters;
+
             let mut block = Block::default();
             *block.transactions_mut() = vec![script.into()];
 
@@ -1853,7 +1883,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             // Should own `Mint` transaction
-            assert_eq!(owned_transactions_td_id, produced_txs[0].id());
+            assert_eq!(owned_transactions_td_id, produced_txs[0].id(&params));
         }
 
         #[test]
@@ -1909,7 +1939,7 @@ mod tests {
                 let receipts = producer
                     .database
                     .storage::<Receipts>()
-                    .get(&script.id())
+                    .get(&script.id(&producer.config.chain_conf.transaction_parameters))
                     .unwrap()
                     .unwrap();
 
@@ -2304,7 +2334,7 @@ mod tests {
             .clone()
             .into();
 
-        let tx_id = tx.id();
+        let tx_id = tx.id(&ConsensusParameters::DEFAULT);
 
         let producer = Executor::test(Default::default(), Config::local_node());
 
@@ -2372,7 +2402,7 @@ mod tests {
     fn executor_invalidates_missing_coin_input() {
         let tx: Transaction =
             TxBuilder::new(2322u64).build().transaction().clone().into();
-        let tx_id = tx.id();
+        let tx_id = tx.id(&ConsensusParameters::DEFAULT);
 
         let executor = Executor::test(
             Database::default(),
@@ -2489,8 +2519,12 @@ mod tests {
         assert_eq!(block.transactions().len(), 2 /* coinbase and `tx1` */);
         assert_eq!(skipped_transactions.len(), 1);
         assert_eq!(
-            skipped_transactions[0].0.as_script().unwrap().id(),
-            tx2.id()
+            skipped_transactions[0]
+                .0
+                .as_script()
+                .unwrap()
+                .id(&ConsensusParameters::DEFAULT),
+            tx2.id(&ConsensusParameters::DEFAULT)
         );
 
         // The first input should be spent by `tx1` after execution.
@@ -2543,8 +2577,14 @@ mod tests {
             block.transactions().len(),
             3 // coinbase, `tx2` and `tx3`
         );
-        assert_eq!(block.transactions()[1].id(), tx2.id());
-        assert_eq!(block.transactions()[2].id(), tx3.id());
+        assert_eq!(
+            block.transactions()[1].id(&ConsensusParameters::DEFAULT),
+            tx2.id(&ConsensusParameters::DEFAULT)
+        );
+        assert_eq!(
+            block.transactions()[2].id(&ConsensusParameters::DEFAULT),
+            tx3.id(&ConsensusParameters::DEFAULT)
+        );
         // `tx1` should be skipped.
         assert_eq!(skipped_transactions.len(), 1);
         assert_eq!(skipped_transactions[0].0.as_script(), Some(&tx1));
@@ -2653,7 +2693,7 @@ mod tests {
         let storage_tx = executor
             .database
             .storage::<Transactions>()
-            .get(&executed_tx.id())
+            .get(&executed_tx.id(&ConsensusParameters::DEFAULT))
             .unwrap()
             .unwrap()
             .into_owned();
@@ -2725,7 +2765,7 @@ mod tests {
         let storage_tx = executor
             .database
             .storage::<Transactions>()
-            .get(&expected_tx.id())
+            .get(&expected_tx.id(&ConsensusParameters::DEFAULT))
             .unwrap()
             .unwrap()
             .into_owned();
@@ -2837,7 +2877,7 @@ mod tests {
         let storage_tx = executor
             .database
             .storage::<Transactions>()
-            .get(&expected_tx.id())
+            .get(&expected_tx.id(&ConsensusParameters::DEFAULT))
             .unwrap()
             .unwrap()
             .into_owned();
@@ -3074,7 +3114,7 @@ mod tests {
             .transaction()
             .clone()
             .into();
-        let tx_id = tx3.id();
+        let tx_id = tx3.id(&ConsensusParameters::DEFAULT);
 
         let second_block = PartialFuelBlock {
             header: PartialBlockHeader {
@@ -3128,7 +3168,7 @@ mod tests {
     #[test]
     fn outputs_with_amount_are_included_utxo_set() {
         let (deploy, script) = setup_executable_script();
-        let script_id = script.id();
+        let script_id = script.id(&ConsensusParameters::DEFAULT);
 
         let database = &Database::default();
         let executor = Executor::test(database.clone(), Config::local_node());
@@ -3179,7 +3219,7 @@ mod tests {
             .transaction()
             .clone()
             .into();
-        let tx_id = tx.id();
+        let tx_id = tx.id(&ConsensusParameters::DEFAULT);
 
         let database = &Database::default();
         let executor = Executor::test(database.clone(), Config::local_node());
@@ -3278,7 +3318,7 @@ mod tests {
             .add_unsigned_message_input(rng.gen(), rng.gen(), rng.gen(), amount, vec![0xff; 10])
             .add_output(Output::change(to, amount + amount, AssetId::BASE))
             .finalize();
-        let tx_id = tx.id();
+        let tx_id = tx.id(&ConsensusParameters::DEFAULT);
 
         let message_coin = message_from_input(&tx.inputs()[0], 0);
         let message_data = message_from_input(&tx.inputs()[1], 0);
@@ -3336,7 +3376,7 @@ mod tests {
             .add_unsigned_message_input(rng.gen(), rng.gen(), rng.gen(), amount, vec![0xff; 10])
             .add_output(Output::change(to, amount + amount, AssetId::BASE))
             .finalize();
-        let tx_id = tx.id();
+        let tx_id = tx.id(&ConsensusParameters::DEFAULT);
 
         let message_coin = message_from_input(&tx.inputs()[0], 0);
         let message_data = message_from_input(&tx.inputs()[1], 0);
@@ -3587,7 +3627,7 @@ mod tests {
 
         let receipts = database
             .storage::<Receipts>()
-            .get(&tx.id())
+            .get(&tx.id(&ConsensusParameters::DEFAULT))
             .unwrap()
             .unwrap();
         assert_eq!(block_height as u64, receipts[0].val().unwrap());
@@ -3659,7 +3699,7 @@ mod tests {
 
         let receipts = database
             .storage::<Receipts>()
-            .get(&tx.id())
+            .get(&tx.id(&ConsensusParameters::DEFAULT))
             .unwrap()
             .unwrap();
 

--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -28,6 +28,7 @@ use fuel_core_types::{
     },
     fuel_crypto::SecretKey,
     fuel_tx::{
+        ConsensusParameters,
         Input,
         Transaction,
         TransactionBuilder,
@@ -398,7 +399,7 @@ impl Node {
                 .unwrap();
 
             let tx = Transaction::from(tx_result.inserted.as_ref());
-            expected.insert(tx.id(), tx);
+            expected.insert(tx.id(&ConsensusParameters::DEFAULT), tx);
 
             assert!(tx_result.removed.is_empty());
         }
@@ -426,7 +427,7 @@ fn not_found_txs<'iter>(
 ) -> Vec<TxId> {
     let mut not_found = vec![];
     txs.iter().for_each(|(id, tx)| {
-        assert_eq!(id, &tx.id());
+        assert_eq!(id, &tx.id(&ConsensusParameters::DEFAULT));
         if !db.storage::<Transactions>().contains_key(id).unwrap() {
             not_found.push(*id);
         }

--- a/crates/fuel-core/src/schema/block.rs
+++ b/crates/fuel-core/src/schema/block.rs
@@ -113,7 +113,7 @@ impl Block {
             .iter()
             .map(|tx_id| {
                 let tx = query.transaction(tx_id)?;
-                Ok(tx.into())
+                Ok((tx, *tx_id).into())
             })
             .collect()
     }

--- a/crates/fuel-core/src/schema/block.rs
+++ b/crates/fuel-core/src/schema/block.rs
@@ -113,7 +113,7 @@ impl Block {
             .iter()
             .map(|tx_id| {
                 let tx = query.transaction(tx_id)?;
-                Ok((tx, *tx_id).into())
+                Ok(Transaction::from_tx(*tx_id, tx))
             })
             .collect()
     }

--- a/crates/fuel-core/src/schema/chain.rs
+++ b/crates/fuel-core/src/schema/chain.rs
@@ -78,6 +78,10 @@ impl ConsensusParameters {
     async fn max_message_data_length(&self) -> U64 {
         self.0.max_message_data_length.into()
     }
+
+    async fn chain_id(&self) -> U64 {
+        self.0.chain_id.into()
+    }
 }
 
 #[Object]

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -81,7 +81,10 @@ impl TxQuery {
         if let Some(transaction) = txpool.transaction(id) {
             Ok(Some(Transaction(transaction, id)))
         } else {
-            query.transaction(&id).map(|tx| (tx, id)).into_api_result()
+            query
+                .transaction(&id)
+                .map(|tx| Transaction::from_tx(id, tx))
+                .into_api_result()
         }
     }
 
@@ -137,7 +140,7 @@ impl TxQuery {
                     result.and_then(|sorted| {
                         let tx = tx_query.transaction(&sorted.tx_id.0)?;
 
-                        Ok((sorted, (tx, sorted.tx_id.0).into()))
+                        Ok((sorted, Transaction::from_tx(sorted.tx_id.0, tx)))
                     })
                 });
 
@@ -181,7 +184,7 @@ impl TxQuery {
                         .map(|result| {
                             result.map(|(cursor, tx)| {
                                 let tx_id = tx.id(&config.transaction_parameters);
-                                (cursor.into(), (tx, tx_id).into())
+                                (cursor.into(), Transaction::from_tx(tx_id, tx))
                             })
                         });
                 Ok(txs)

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -116,6 +116,7 @@ impl TryFrom<&Config> for fuel_core_poa::Config {
             block_gas_limit: config.chain_conf.block_gas_limit,
             signing_key: config.consensus_key.clone(),
             metrics: false,
+            consensus_params: config.chain_conf.transaction_parameters,
         })
     }
 }

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -128,9 +128,10 @@ fn import_genesis_block(
     );
 
     let block_id = block.id();
-    database
-        .storage::<FuelBlocks>()
-        .insert(&block_id, &block.compress())?;
+    database.storage::<FuelBlocks>().insert(
+        &block_id,
+        &block.compress(&config.chain_conf.transaction_parameters),
+    )?;
     let consensus = Consensus::Genesis(genesis);
     let block = SealedBlock {
         entity: block,

--- a/crates/services/consensus_module/poa/src/config.rs
+++ b/crates/services/consensus_module/poa/src/config.rs
@@ -1,6 +1,7 @@
 use fuel_core_types::{
     blockchain::primitives::SecretKeyWrapper,
     fuel_asm::Word,
+    fuel_tx::ConsensusParameters,
     secrecy::Secret,
 };
 use tokio::time::Duration;
@@ -11,6 +12,7 @@ pub struct Config {
     pub block_gas_limit: Word,
     pub signing_key: Option<Secret<SecretKeyWrapper>>,
     pub metrics: bool,
+    pub consensus_params: ConsensusParameters,
 }
 
 /// Block production trigger for PoA operation

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -36,7 +36,10 @@ use fuel_core_types::{
     },
     fuel_asm::Word,
     fuel_crypto::Signature,
-    fuel_tx::UniqueIdentifier,
+    fuel_tx::{
+        ConsensusParameters,
+        UniqueIdentifier,
+    },
     fuel_types::BlockHeight,
     secrecy::{
         ExposeSecret,
@@ -136,6 +139,7 @@ pub struct Task<T, B, I> {
     //  https://github.com/FuelLabs/fuel-core/issues/918
     /// Deadline clock, used by the triggers
     timer: DeadlineClock,
+    consensus_params: ConsensusParameters,
 }
 
 impl<T, B, I> Task<T, B, I>
@@ -169,6 +173,7 @@ where
             last_block_created,
             trigger: config.trigger,
             timer: DeadlineClock::new(),
+            consensus_params: config.consensus_params,
         }
     }
 
@@ -275,7 +280,7 @@ where
                 "During block production got invalid transaction {:?} with error {:?}",
                 tx, err
             );
-            tx_ids_to_remove.push(tx.id());
+            tx_ids_to_remove.push(tx.id(&self.consensus_params));
         }
         self.txpool.remove_txs(tx_ids_to_remove);
 

--- a/crates/services/consensus_module/poa/src/service_test.rs
+++ b/crates/services/consensus_module/poa/src/service_test.rs
@@ -221,7 +221,7 @@ impl MockTransactionPool {
             .returning(move |tx_ids: Vec<TxId>| {
                 let mut guard = removed.lock().unwrap();
                 for id in tx_ids {
-                    guard.retain(|tx| tx.id() == id);
+                    guard.retain(|tx| tx.id(&ConsensusParameters::DEFAULT) == id);
                 }
                 vec![]
             });
@@ -283,8 +283,10 @@ async fn remove_skipped_transactions() {
     // Test created for only for this check.
     txpool.expect_remove_txs().returning(move |skipped_ids| {
         // Transform transactions into ids.
-        let skipped_transactions: Vec<_> =
-            skipped_transactions.iter().map(|tx| tx.id()).collect();
+        let skipped_transactions: Vec<_> = skipped_transactions
+            .iter()
+            .map(|tx| tx.id(&ConsensusParameters::DEFAULT))
+            .collect();
 
         // Check that all transactions are unique.
         let expected_skipped_ids_set: HashSet<_> =
@@ -303,6 +305,7 @@ async fn remove_skipped_transactions() {
         block_gas_limit: 1000000,
         signing_key: Some(Secret::new(secret_key.into())),
         metrics: false,
+        consensus_params: Default::default(),
     };
     let mut task = Task::new(
         &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
@@ -343,6 +346,7 @@ async fn does_not_produce_when_txpool_empty_in_instant_mode() {
         block_gas_limit: 1000000,
         signing_key: Some(Secret::new(secret_key.into())),
         metrics: false,
+        consensus_params: Default::default(),
     };
     let mut task = Task::new(
         &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
@@ -398,6 +402,7 @@ async fn hybrid_production_doesnt_produce_empty_blocks_when_txpool_is_empty() {
         block_gas_limit: 1000000,
         signing_key: Some(Secret::new(secret_key.into())),
         metrics: false,
+        consensus_params: Default::default(),
     };
     let task = Task::new(
         &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),

--- a/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
@@ -45,6 +45,7 @@ async fn can_manually_produce_block(
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
 
     // initialize txpool with some txs

--- a/crates/services/consensus_module/poa/src/service_test/trigger_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/trigger_tests.rs
@@ -20,6 +20,7 @@ async fn clean_startup_shutdown_each_trigger() -> anyhow::Result<()> {
             block_gas_limit: 100_000,
             signing_key: Some(test_signing_key()),
             metrics: false,
+            consensus_params: Default::default(),
         });
         let ctx = ctx_builder.build();
 
@@ -39,6 +40,7 @@ async fn never_trigger_never_produces_blocks() {
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
 
     // initialize txpool with some txs
@@ -119,6 +121,7 @@ async fn instant_trigger_produces_block_instantly() {
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
     ctx.status_sender.send_replace(Some(TxStatus::Submitted));
 
@@ -138,6 +141,7 @@ async fn interval_trigger_produces_blocks_periodically() -> anyhow::Result<()> {
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
     ctx.status_sender.send_replace(Some(TxStatus::Submitted));
 
@@ -203,6 +207,7 @@ async fn interval_trigger_doesnt_react_to_full_txpool() -> anyhow::Result<()> {
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
 
     // Brackets to release the lock.
@@ -249,6 +254,7 @@ async fn hybrid_trigger_produces_blocks_correctly_max_block_time() -> anyhow::Re
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
 
     // Make sure no blocks are produced yet
@@ -295,6 +301,7 @@ async fn hybrid_trigger_produces_blocks_correctly_max_block_time_not_overrides_m
         block_gas_limit: Word::MAX,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
 
     // Make sure no blocks are produced when txpool is empty and `MAX_BLOCK_TIME` is not exceeded
@@ -337,6 +344,7 @@ async fn hybrid_trigger_produces_blocks_correctly_max_tx_idle_time() -> anyhow::
         block_gas_limit: Word::MAX,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
 
     assert!(matches!(
@@ -388,6 +396,7 @@ async fn hybrid_trigger_produces_blocks_correctly_min_block_time_min_block_gas_l
         block_gas_limit: Word::MIN,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
 
     // Emulate tx status update to trigger the execution.
@@ -445,6 +454,7 @@ async fn hybrid_trigger_produces_blocks_correctly_min_block_time_max_block_gas_l
         block_gas_limit: Word::MAX,
         signing_key: Some(test_signing_key()),
         metrics: false,
+        consensus_params: Default::default(),
     });
 
     // Emulate tx status update to trigger the execution.

--- a/crates/services/producer/src/block_producer/tests.rs
+++ b/crates/services/producer/src/block_producer/tests.rs
@@ -24,6 +24,7 @@ use fuel_core_types::{
             PartialBlockHeader,
         },
     },
+    fuel_tx::ConsensusParameters,
     services::executor::Error as ExecutorError,
     tai64::Tai64,
 };
@@ -84,7 +85,7 @@ async fn can_produce_next_block() {
         transactions: vec![],
     }
     .generate(&[])
-    .compress();
+    .compress(&ConsensusParameters::DEFAULT);
 
     let db = MockDb {
         blocks: Arc::new(Mutex::new(
@@ -134,7 +135,7 @@ async fn cant_produce_if_previous_block_da_height_too_high() {
         transactions: vec![],
     }
     .generate(&[])
-    .compress();
+    .compress(&ConsensusParameters::DEFAULT);
 
     let db = MockDb {
         blocks: Arc::new(Mutex::new(

--- a/crates/services/producer/src/mocks.rs
+++ b/crates/services/producer/src/mocks.rs
@@ -17,7 +17,10 @@ use fuel_core_types::{
         block::CompressedBlock,
         primitives::DaBlockHeight,
     },
-    fuel_tx::Receipt,
+    fuel_tx::{
+        ConsensusParameters,
+        Receipt,
+    },
     fuel_types::{
         Address,
         BlockHeight,
@@ -131,7 +134,10 @@ impl Executor<MockDb> for MockExecutor {
         };
         // simulate executor inserting a block
         let mut block_db = self.0.blocks.lock().unwrap();
-        block_db.insert(*block.header().height(), block.compress());
+        block_db.insert(
+            *block.header().height(),
+            block.compress(&ConsensusParameters::DEFAULT),
+        );
         Ok(UncommittedResult::new(
             ExecutionResult {
                 block,

--- a/crates/services/txpool/src/containers/dependency.rs
+++ b/crates/services/txpool/src/containers/dependency.rs
@@ -24,7 +24,6 @@ use fuel_core_types::{
                 MessageDataSigned,
             },
         },
-        ConsensusParameters,
         Input,
         Output,
         UtxoId,
@@ -52,8 +51,6 @@ pub struct Dependency {
     max_depth: usize,
     /// utxo-validation feature flag
     utxo_validation: bool,
-    /// consensus parameters
-    consensus_params: ConsensusParameters,
 }
 
 #[derive(Debug, Clone)]
@@ -99,18 +96,13 @@ pub struct MessageState {
 }
 
 impl Dependency {
-    pub fn new(
-        max_depth: usize,
-        utxo_validation: bool,
-        params: ConsensusParameters,
-    ) -> Self {
+    pub fn new(max_depth: usize, utxo_validation: bool) -> Self {
         Self {
             coins: HashMap::new(),
             contracts: HashMap::new(),
             messages: HashMap::new(),
             max_depth,
             utxo_validation,
-            consensus_params: params,
         }
     }
 
@@ -123,7 +115,7 @@ impl Dependency {
         txs: &HashMap<TxId, TxInfo>,
     ) {
         // for every input aggregate UtxoId and check if it is inside
-        let mut check = vec![tx.id(&self.consensus_params)];
+        let mut check = vec![tx.id()];
         while let Some(parent_txhash) = check.pop() {
             let mut is_new = false;
             let mut parent_tx = None;
@@ -431,7 +423,7 @@ impl Dependency {
                     db_coins.insert(
                         *utxo_id,
                         CoinState {
-                            is_spend_by: Some(tx.id(&self.consensus_params) as TxId),
+                            is_spend_by: Some(tx.id() as TxId),
                             depth: max_depth - 1,
                         },
                     );
@@ -477,7 +469,7 @@ impl Dependency {
                     db_messages.insert(
                         *nonce,
                         MessageState {
-                            spent_by: tx.id(&self.consensus_params),
+                            spent_by: tx.id(),
                             gas_price: tx.price(),
                         },
                     );
@@ -516,7 +508,7 @@ impl Dependency {
                                 gas_price: GasPrice::MAX,
                             })
                             .used_by
-                            .insert(tx.id(&self.consensus_params));
+                            .insert(tx.id());
                     }
 
                     // yey we got our contract
@@ -586,7 +578,7 @@ impl Dependency {
                 | Input::CoinPredicate(CoinPredicate { utxo_id, .. }) => {
                     // spend coin
                     if let Some(state) = self.coins.get_mut(utxo_id) {
-                        state.is_spend_by = Some(tx.id(&self.consensus_params));
+                        state.is_spend_by = Some(tx.id());
                     }
                 }
                 Input::Contract(Contract { contract_id, .. }) => {
@@ -594,7 +586,7 @@ impl Dependency {
                     // or it will be added when db_contracts extends self.contracts (and it
                     // already contains changed used_by)
                     if let Some(state) = self.contracts.get_mut(contract_id) {
-                        state.used_by.insert(tx.id(&self.consensus_params));
+                        state.used_by.insert(tx.id());
                     }
                 }
                 Input::MessageCoinSigned(_)
@@ -614,7 +606,7 @@ impl Dependency {
 
         // iterate over all outputs and insert them, marking them as available.
         for (index, output) in tx.outputs().iter().enumerate() {
-            let utxo_id = UtxoId::new(tx.id(&self.consensus_params), index as u8);
+            let utxo_id = UtxoId::new(tx.id(), index as u8);
             match output {
                 Output::Coin { .. } | Output::Change { .. } | Output::Variable { .. } => {
                     // insert output coin inside by_coin
@@ -664,7 +656,7 @@ impl Dependency {
                 }
                 Output::Coin { .. } | Output::Change { .. } | Output::Variable { .. } => {
                     // remove transactions that depend on this coin output
-                    let utxo = UtxoId::new(tx.id(&self.consensus_params), index as u8);
+                    let utxo = UtxoId::new(tx.id(), index as u8);
                     if let Some(state) = self.coins.remove(&utxo).map(|c| c.is_spend_by) {
                         // there may or may not be any dependents for this coin output
                         if let Some(spend_by) = state {
@@ -728,7 +720,7 @@ impl Dependency {
                     // 2.a. contract state can be removed if it's from the database and this is the
                     //      last tx to use it, since no other txs are involved.
                     if let Some(state) = self.contracts.get_mut(contract_id) {
-                        state.used_by.remove(&tx.id(&self.consensus_params));
+                        state.used_by.remove(&tx.id());
                         // if contract list is empty and is in db, flag contract state for removal.
                         if state.used_by.is_empty() && state.is_in_database() {
                             self.contracts.remove(contract_id);

--- a/crates/services/txpool/src/containers/price_sort.rs
+++ b/crates/services/txpool/src/containers/price_sort.rs
@@ -6,7 +6,6 @@ use crate::{
     types::*,
     TxInfo,
 };
-use fuel_core_types::fuel_tx::ConsensusParameters;
 use std::cmp;
 
 /// all transactions sorted by min/max price
@@ -21,10 +20,10 @@ pub struct PriceSortKey {
 impl SortableKey for PriceSortKey {
     type Value = GasPrice;
 
-    fn new(info: &TxInfo, params: &ConsensusParameters) -> Self {
+    fn new(info: &TxInfo) -> Self {
         Self {
             price: info.tx().price(),
-            tx_id: info.tx().id(params),
+            tx_id: info.tx().id(),
         }
     }
 

--- a/crates/services/txpool/src/containers/price_sort.rs
+++ b/crates/services/txpool/src/containers/price_sort.rs
@@ -6,6 +6,7 @@ use crate::{
     types::*,
     TxInfo,
 };
+use fuel_core_types::fuel_tx::ConsensusParameters;
 use std::cmp;
 
 /// all transactions sorted by min/max price
@@ -20,10 +21,10 @@ pub struct PriceSortKey {
 impl SortableKey for PriceSortKey {
     type Value = GasPrice;
 
-    fn new(info: &TxInfo) -> Self {
+    fn new(info: &TxInfo, params: &ConsensusParameters) -> Self {
         Self {
             price: info.tx().price(),
-            tx_id: info.tx().id(),
+            tx_id: info.tx().id(params),
         }
     }
 

--- a/crates/services/txpool/src/containers/sort.rs
+++ b/crates/services/txpool/src/containers/sort.rs
@@ -2,7 +2,10 @@ use crate::{
     types::*,
     TxInfo,
 };
-use fuel_core_types::services::txpool::ArcPoolTx;
+use fuel_core_types::{
+    fuel_tx::ConsensusParameters,
+    services::txpool::ArcPoolTx,
+};
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
@@ -23,8 +26,8 @@ impl<Key> Sort<Key>
 where
     Key: SortableKey,
 {
-    pub fn remove(&mut self, info: &TxInfo) {
-        self.sort.remove(&Key::new(info));
+    pub fn remove(&mut self, info: &TxInfo, params: &ConsensusParameters) {
+        self.sort.remove(&Key::new(info, params));
     }
 
     pub fn lowest_tx(&self) -> Option<ArcPoolTx> {
@@ -39,16 +42,16 @@ where
         self.sort.iter().next()
     }
 
-    pub fn insert(&mut self, info: &TxInfo) {
+    pub fn insert(&mut self, info: &TxInfo, params: &ConsensusParameters) {
         let tx = info.tx().clone();
-        self.sort.insert(Key::new(info), tx);
+        self.sort.insert(Key::new(info, params), tx);
     }
 }
 
 pub trait SortableKey: Ord {
     type Value: Clone;
 
-    fn new(info: &TxInfo) -> Self;
+    fn new(info: &TxInfo, params: &ConsensusParameters) -> Self;
 
     fn value(&self) -> &Self::Value;
 

--- a/crates/services/txpool/src/containers/sort.rs
+++ b/crates/services/txpool/src/containers/sort.rs
@@ -2,10 +2,7 @@ use crate::{
     types::*,
     TxInfo,
 };
-use fuel_core_types::{
-    fuel_tx::ConsensusParameters,
-    services::txpool::ArcPoolTx,
-};
+use fuel_core_types::services::txpool::ArcPoolTx;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
@@ -26,8 +23,8 @@ impl<Key> Sort<Key>
 where
     Key: SortableKey,
 {
-    pub fn remove(&mut self, info: &TxInfo, params: &ConsensusParameters) {
-        self.sort.remove(&Key::new(info, params));
+    pub fn remove(&mut self, info: &TxInfo) {
+        self.sort.remove(&Key::new(info));
     }
 
     pub fn lowest_tx(&self) -> Option<ArcPoolTx> {
@@ -42,16 +39,16 @@ where
         self.sort.iter().next()
     }
 
-    pub fn insert(&mut self, info: &TxInfo, params: &ConsensusParameters) {
+    pub fn insert(&mut self, info: &TxInfo) {
         let tx = info.tx().clone();
-        self.sort.insert(Key::new(info, params), tx);
+        self.sort.insert(Key::new(info), tx);
     }
 }
 
 pub trait SortableKey: Ord {
     type Value: Clone;
 
-    fn new(info: &TxInfo, params: &ConsensusParameters) -> Self;
+    fn new(info: &TxInfo) -> Self;
 
     fn value(&self) -> &Self::Value;
 

--- a/crates/services/txpool/src/containers/time_sort.rs
+++ b/crates/services/txpool/src/containers/time_sort.rs
@@ -10,7 +10,6 @@ use core::{
     cmp,
     time::Duration,
 };
-use fuel_core_types::fuel_tx::ConsensusParameters;
 
 /// all transactions sorted by min/max time
 pub type TimeSort = Sort<TimeSortKey>;
@@ -31,11 +30,11 @@ impl TimeSortKey {
 impl SortableKey for TimeSortKey {
     type Value = Duration;
 
-    fn new(info: &TxInfo, params: &ConsensusParameters) -> Self {
+    fn new(info: &TxInfo) -> Self {
         Self {
             time: info.submitted_time(),
             created: info.created(),
-            tx_id: info.tx().id(params),
+            tx_id: info.tx().id(),
         }
     }
 

--- a/crates/services/txpool/src/containers/time_sort.rs
+++ b/crates/services/txpool/src/containers/time_sort.rs
@@ -10,6 +10,7 @@ use core::{
     cmp,
     time::Duration,
 };
+use fuel_core_types::fuel_tx::ConsensusParameters;
 
 /// all transactions sorted by min/max time
 pub type TimeSort = Sort<TimeSortKey>;
@@ -30,11 +31,11 @@ impl TimeSortKey {
 impl SortableKey for TimeSortKey {
     type Value = Duration;
 
-    fn new(info: &TxInfo) -> Self {
+    fn new(info: &TxInfo, params: &ConsensusParameters) -> Self {
         Self {
             time: info.submitted_time(),
             created: info.created(),
-            tx_id: info.tx().id(),
+            tx_id: info.tx().id(params),
         }
     }
 

--- a/crates/services/txpool/src/service.rs
+++ b/crates/services/txpool/src/service.rs
@@ -19,6 +19,7 @@ use fuel_core_services::{
 };
 use fuel_core_types::{
     fuel_tx::{
+        ConsensusParameters,
         Transaction,
         TxId,
         UniqueIdentifier,
@@ -98,6 +99,7 @@ pub struct SharedState<P2P, DB> {
     tx_status_sender: TxStatusChange,
     txpool: Arc<ParkingMutex<TxPool<DB>>>,
     p2p: Arc<P2P>,
+    consensus_params: ConsensusParameters,
 }
 
 impl<P2P, DB> Clone for SharedState<P2P, DB> {
@@ -106,6 +108,7 @@ impl<P2P, DB> Clone for SharedState<P2P, DB> {
             tx_status_sender: self.tx_status_sender.clone(),
             txpool: self.txpool.clone(),
             p2p: self.p2p.clone(),
+            consensus_params: self.consensus_params,
         }
     }
 }
@@ -157,7 +160,7 @@ where
             _ = self.ttl_timer.tick() => {
                 let removed = self.shared.txpool.lock().prune_old_txs();
                 for tx in removed {
-                    self.shared.tx_status_sender.send_squeezed_out(tx.id(), Error::TTLReason);
+                    self.shared.tx_status_sender.send_squeezed_out(tx.id(&self.shared.consensus_params), Error::TTLReason);
                 }
 
                 should_continue = true
@@ -174,7 +177,7 @@ where
 
             new_transaction = self.gossiped_tx_stream.next() => {
                 if let Some(GossipData { data: Some(tx), message_id, peer_id }) = new_transaction {
-                    let id = tx.id();
+                    let id = tx.id(&self.shared.consensus_params);
                     let txs = vec!(Arc::new(tx));
                     let mut result = tracing::info_span!("Received tx via gossip", %id)
                         .in_scope(|| {
@@ -256,7 +259,7 @@ where
         let sorted_txs = select_transactions(txs, max_gas);
 
         for tx in sorted_txs.iter() {
-            guard.remove_committed_tx(&tx.id());
+            guard.remove_committed_tx(&tx.id(&self.consensus_params));
         }
         sorted_txs
     }
@@ -355,6 +358,7 @@ where
     let committed_block_stream = importer.block_events();
     let mut ttl_timer = tokio::time::interval(config.transaction_ttl);
     ttl_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let consensus_params = config.chain_config.transaction_parameters;
     let txpool = Arc::new(ParkingMutex::new(TxPool::new(config, db)));
     let task = Task {
         gossiped_tx_stream,
@@ -363,6 +367,7 @@ where
             tx_status_sender: TxStatusChange::new(100),
             txpool,
             p2p,
+            consensus_params,
         },
         ttl_timer,
     };

--- a/crates/services/txpool/src/service.rs
+++ b/crates/services/txpool/src/service.rs
@@ -160,7 +160,7 @@ where
             _ = self.ttl_timer.tick() => {
                 let removed = self.shared.txpool.lock().prune_old_txs();
                 for tx in removed {
-                    self.shared.tx_status_sender.send_squeezed_out(tx.id(&self.shared.consensus_params), Error::TTLReason);
+                    self.shared.tx_status_sender.send_squeezed_out(tx.id(), Error::TTLReason);
                 }
 
                 should_continue = true
@@ -259,7 +259,7 @@ where
         let sorted_txs = select_transactions(txs, max_gas);
 
         for tx in sorted_txs.iter() {
-            guard.remove_committed_tx(&tx.id(&self.consensus_params));
+            guard.remove_committed_tx(&tx.id());
         }
         sorted_txs
     }

--- a/crates/services/txpool/src/service/tests.rs
+++ b/crates/services/txpool/src/service/tests.rs
@@ -44,7 +44,7 @@ async fn test_find() {
     ]);
     assert_eq!(out.len(), 2, "Should be len 2:{out:?}");
     assert!(out[0].is_some(), "Tx1 should be some:{out:?}");
-    let id = out[0].as_ref().unwrap().id(&ConsensusParameters::DEFAULT);
+    let id = out[0].as_ref().unwrap().id();
     assert_eq!(
         id,
         tx1.id(&ConsensusParameters::DEFAULT),
@@ -192,7 +192,7 @@ async fn simple_insert_removal_subscription() {
         let update = subscribe_update.try_recv().unwrap();
         assert_eq!(
             *update.tx_id(),
-            tx.inserted.id(&ConsensusParameters::DEFAULT),
+            tx.inserted.id(),
             "First added should be tx1"
         );
     } else {
@@ -208,7 +208,7 @@ async fn simple_insert_removal_subscription() {
         let update = subscribe_update.try_recv().unwrap();
         assert_eq!(
             *update.tx_id(),
-            tx.inserted.id(&ConsensusParameters::DEFAULT),
+            tx.inserted.id(),
             "Second added should be tx2"
         );
     } else {
@@ -234,11 +234,7 @@ async fn simple_insert_removal_subscription() {
             .await
             .unwrap()
             .unwrap();
-    assert_eq!(
-        *update.tx_id(),
-        rem[0].id(&ConsensusParameters::DEFAULT),
-        "First removed should be tx1"
-    );
+    assert_eq!(*update.tx_id(), rem[0].id(), "First removed should be tx1");
 
     assert_eq!(
         tokio::time::timeout(std::time::Duration::from_secs(2), subscribe_status.recv())
@@ -253,11 +249,7 @@ async fn simple_insert_removal_subscription() {
             .await
             .unwrap()
             .unwrap();
-    assert_eq!(
-        *update.tx_id(),
-        rem[1].id(&ConsensusParameters::DEFAULT),
-        "Second removed should be tx2"
-    );
+    assert_eq!(*update.tx_id(), rem[1].id(), "Second removed should be tx2");
 
     service.stop_and_await().await.unwrap();
 }

--- a/crates/services/txpool/src/service/tests.rs
+++ b/crates/services/txpool/src/service/tests.rs
@@ -38,11 +38,18 @@ async fn test_find() {
     assert_eq!(out.len(), 2, "Should be len 2:{out:?}");
     assert!(out[0].is_ok(), "Tx1 should be OK, got err:{out:?}");
     assert!(out[1].is_ok(), "Tx2 should be OK, got err:{out:?}");
-    let out = service.shared.find(vec![tx1.id(), tx3.id()]);
+    let out = service.shared.find(vec![
+        tx1.id(&ConsensusParameters::DEFAULT),
+        tx3.id(&ConsensusParameters::DEFAULT),
+    ]);
     assert_eq!(out.len(), 2, "Should be len 2:{out:?}");
     assert!(out[0].is_some(), "Tx1 should be some:{out:?}");
-    let id = out[0].as_ref().unwrap().id();
-    assert_eq!(id, tx1.id(), "Found tx id match{out:?}");
+    let id = out[0].as_ref().unwrap().id(&ConsensusParameters::DEFAULT);
+    assert_eq!(
+        id,
+        tx1.id(&ConsensusParameters::DEFAULT),
+        "Found tx id match{out:?}"
+    );
     assert!(out[1].is_none(), "Tx3 should not be found:{out:?}");
     service.stop_and_await().await.unwrap();
 }
@@ -77,14 +84,22 @@ async fn test_prune_transactions() {
     assert!(out[2].is_ok(), "Tx3 should be OK, got err:{out:?}");
 
     tokio::time::sleep(Duration::from_secs(TIMEOUT / 2)).await;
-    let out = service.shared.find(vec![tx1.id(), tx2.id(), tx3.id()]);
+    let out = service.shared.find(vec![
+        tx1.id(&ConsensusParameters::DEFAULT),
+        tx2.id(&ConsensusParameters::DEFAULT),
+        tx3.id(&ConsensusParameters::DEFAULT),
+    ]);
     assert_eq!(out.len(), 3, "Should be len 3:{out:?}");
     assert!(out[0].is_some(), "Tx1 should exist");
     assert!(out[1].is_some(), "Tx2 should exist");
     assert!(out[2].is_some(), "Tx3 should exist");
 
     tokio::time::sleep(Duration::from_secs(TIMEOUT / 2 + 1)).await;
-    let out = service.shared.find(vec![tx1.id(), tx2.id(), tx3.id()]);
+    let out = service.shared.find(vec![
+        tx1.id(&ConsensusParameters::DEFAULT),
+        tx2.id(&ConsensusParameters::DEFAULT),
+        tx3.id(&ConsensusParameters::DEFAULT),
+    ]);
     assert_eq!(out.len(), 3, "Should be len 3:{out:?}");
     assert!(out[0].is_none(), "Tx1 should be pruned");
     assert!(out[1].is_none(), "Tx2 should be pruned");
@@ -120,7 +135,11 @@ async fn test_prune_transactions_the_oldest() {
     let out = service.shared.insert(vec![tx2.clone()]);
     assert!(out[0].is_ok(), "Tx2 should be OK, got err:{out:?}");
 
-    let out = service.shared.find(vec![tx1.id(), tx2.id(), tx3.id()]);
+    let out = service.shared.find(vec![
+        tx1.id(&ConsensusParameters::DEFAULT),
+        tx2.id(&ConsensusParameters::DEFAULT),
+        tx3.id(&ConsensusParameters::DEFAULT),
+    ]);
     assert!(out[0].is_some(), "Tx1 should exist");
     assert!(out[1].is_some(), "Tx2 should exist");
 
@@ -128,14 +147,22 @@ async fn test_prune_transactions_the_oldest() {
     let out = service.shared.insert(vec![tx3.clone()]);
     assert!(out[0].is_ok(), "Tx3 should be OK, got err:{out:?}");
 
-    let out = service.shared.find(vec![tx1.id(), tx2.id(), tx3.id()]);
+    let out = service.shared.find(vec![
+        tx1.id(&ConsensusParameters::DEFAULT),
+        tx2.id(&ConsensusParameters::DEFAULT),
+        tx3.id(&ConsensusParameters::DEFAULT),
+    ]);
     assert!(out[0].is_none(), "Tx1 should pruned");
     assert!(out[1].is_some(), "Tx2 should exist");
     assert!(out[2].is_some(), "Tx3 should exist");
 
     tokio::time::sleep(Duration::from_secs(TIMEOUT)).await;
 
-    let out = service.shared.find(vec![tx1.id(), tx2.id(), tx3.id()]);
+    let out = service.shared.find(vec![
+        tx1.id(&ConsensusParameters::DEFAULT),
+        tx2.id(&ConsensusParameters::DEFAULT),
+        tx3.id(&ConsensusParameters::DEFAULT),
+    ]);
     assert!(out[0].is_none(), "Tx1 should pruned");
     assert!(out[1].is_none(), "Tx2 should pruned");
     assert!(out[2].is_some(), "Tx3 should exist");
@@ -165,7 +192,7 @@ async fn simple_insert_removal_subscription() {
         let update = subscribe_update.try_recv().unwrap();
         assert_eq!(
             *update.tx_id(),
-            tx.inserted.id(),
+            tx.inserted.id(&ConsensusParameters::DEFAULT),
             "First added should be tx1"
         );
     } else {
@@ -181,7 +208,7 @@ async fn simple_insert_removal_subscription() {
         let update = subscribe_update.try_recv().unwrap();
         assert_eq!(
             *update.tx_id(),
-            tx.inserted.id(),
+            tx.inserted.id(&ConsensusParameters::DEFAULT),
             "Second added should be tx2"
         );
     } else {
@@ -189,7 +216,10 @@ async fn simple_insert_removal_subscription() {
     }
 
     // remove them
-    let rem = service.shared.remove(vec![tx1.id(), tx2.id()]);
+    let rem = service.shared.remove(vec![
+        tx1.id(&ConsensusParameters::DEFAULT),
+        tx2.id(&ConsensusParameters::DEFAULT),
+    ]);
 
     assert_eq!(
         tokio::time::timeout(std::time::Duration::from_secs(2), subscribe_status.recv())
@@ -204,7 +234,11 @@ async fn simple_insert_removal_subscription() {
             .await
             .unwrap()
             .unwrap();
-    assert_eq!(*update.tx_id(), rem[0].id(), "First removed should be tx1");
+    assert_eq!(
+        *update.tx_id(),
+        rem[0].id(&ConsensusParameters::DEFAULT),
+        "First removed should be tx1"
+    );
 
     assert_eq!(
         tokio::time::timeout(std::time::Duration::from_secs(2), subscribe_status.recv())
@@ -219,7 +253,11 @@ async fn simple_insert_removal_subscription() {
             .await
             .unwrap()
             .unwrap();
-    assert_eq!(*update.tx_id(), rem[1].id(), "Second removed should be tx2");
+    assert_eq!(
+        *update.tx_id(),
+        rem[1].id(&ConsensusParameters::DEFAULT),
+        "Second removed should be tx2"
+    );
 
     service.stop_and_await().await.unwrap();
 }

--- a/crates/services/txpool/src/service/tests_p2p.rs
+++ b/crates/services/txpool/src/service/tests_p2p.rs
@@ -75,7 +75,7 @@ async fn insert_from_local_broadcasts_to_p2p() {
         let update = subscribe_update.try_recv().unwrap();
         assert_eq!(
             *update.tx_id(),
-            result.inserted.id(&ConsensusParameters::DEFAULT),
+            result.inserted.id(),
             "First added should be tx1"
         );
     } else {

--- a/crates/services/txpool/src/service/tests_p2p.rs
+++ b/crates/services/txpool/src/service/tests_p2p.rs
@@ -31,7 +31,9 @@ async fn can_insert_from_p2p() {
     assert!(res.is_ok());
 
     // fetch tx from pool
-    let out = service.shared.find(vec![tx1.id()]);
+    let out = service
+        .shared
+        .find(vec![tx1.id(&ConsensusParameters::DEFAULT)]);
 
     let got_tx: Transaction = out[0].as_ref().unwrap().tx().clone().deref().into();
     assert_eq!(tx1, got_tx);
@@ -73,7 +75,7 @@ async fn insert_from_local_broadcasts_to_p2p() {
         let update = subscribe_update.try_recv().unwrap();
         assert_eq!(
             *update.tx_id(),
-            result.inserted.id(),
+            result.inserted.id(&ConsensusParameters::DEFAULT),
             "First added should be tx1"
         );
     } else {

--- a/crates/services/txpool/src/test_helpers.rs
+++ b/crates/services/txpool/src/test_helpers.rs
@@ -20,6 +20,7 @@ use fuel_core_types::{
             },
             contract::Contract,
         },
+        ConsensusParameters,
         Input,
         Output,
         UtxoId,
@@ -95,7 +96,7 @@ pub(crate) fn random_predicate(
     let mut predicate_code: Vec<u8> = vec![op::ret(1)].into_iter().collect();
     // append some randomizing bytes after the predicate has already returned.
     predicate_code.push(rng.gen());
-    let owner = Input::predicate_owner(&predicate_code);
+    let owner = Input::predicate_owner(&predicate_code, &ConsensusParameters::DEFAULT);
     Input::coin_predicate(
         utxo_id.unwrap_or_else(|| rng.gen()),
         owner,
@@ -115,7 +116,7 @@ pub(crate) fn custom_predicate(
     code: Vec<u8>,
     utxo_id: Option<UtxoId>,
 ) -> Input {
-    let owner = Input::predicate_owner(&code);
+    let owner = Input::predicate_owner(&code, &ConsensusParameters::DEFAULT);
     Input::coin_predicate(
         utxo_id.unwrap_or_else(|| rng.gen()),
         owner,

--- a/crates/services/txpool/src/transaction_selector.rs
+++ b/crates/services/txpool/src/transaction_selector.rs
@@ -96,15 +96,13 @@ mod tests {
                     amount: 0,
                     asset_id: Default::default(),
                 })
+                .with_params(ConsensusParameters {
+                    gas_price_factor: 1,
+                    ..ConsensusParameters::default()
+                })
                 // The block producer assumes transactions are already checked
                 // so it doesn't need to compute valid sigs for tests
-                .finalize_checked_basic(
-                    Default::default(),
-                    &ConsensusParameters {
-                        gas_price_factor: 1,
-                        ..ConsensusParameters::default()
-                    },
-                ).into()
+                .finalize_checked_basic(Default::default()).into()
             })
             .map(Arc::new)
             .collect();

--- a/crates/services/txpool/src/txpool/test_helpers.rs
+++ b/crates/services/txpool/src/txpool/test_helpers.rs
@@ -2,6 +2,7 @@ use fuel_core_types::{
     entities::message::Message,
     fuel_asm::op,
     fuel_tx::{
+        ConsensusParameters,
         Contract,
         ContractId,
         Input,
@@ -19,7 +20,7 @@ pub(crate) fn create_message_predicate_from_message(
     let predicate = vec![op::ret(1)].into_iter().collect::<Vec<u8>>();
     let message = Message {
         sender: Default::default(),
-        recipient: Input::predicate_owner(&predicate),
+        recipient: Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT),
         nonce: nonce.into(),
         amount,
         data: vec![],
@@ -30,7 +31,7 @@ pub(crate) fn create_message_predicate_from_message(
         message.clone(),
         Input::message_coin_predicate(
             message.sender,
-            Input::predicate_owner(&predicate),
+            Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT),
             message.amount,
             message.nonce,
             predicate,

--- a/crates/services/txpool/src/txpool/tests.rs
+++ b/crates/services/txpool/src/txpool/tests.rs
@@ -29,6 +29,7 @@ use fuel_core_types::{
         rngs::StdRng,
         SeedableRng,
     },
+    fuel_tx,
     fuel_tx::{
         input::coin::CoinPredicate,
         Address,
@@ -87,7 +88,10 @@ fn insert_simple_tx_dependency_chain_succeeds() {
     );
 
     let (_, gas_coin) = setup_coin(&mut rng, Some(&txpool.database));
-    let input = unset_input.into_input(UtxoId::new(tx1.id(), 0));
+    let input = unset_input.into_input(UtxoId::new(
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        0,
+    ));
     let tx2 = Arc::new(
         TransactionBuilder::script(vec![], vec![])
             .gas_price(1)
@@ -132,7 +136,10 @@ fn faulty_t2_collided_on_contract_id_from_tx1() {
     );
 
     let (_, gas_coin) = setup_coin(&mut rng, Some(&txpool.database));
-    let input = unset_input.into_input(UtxoId::new(tx.id(), 1));
+    let input = unset_input.into_input(UtxoId::new(
+        tx.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        1,
+    ));
 
     // attempt to insert a different creation tx with a valid dependency on the first tx,
     // but with a conflicting output contract id
@@ -195,7 +202,10 @@ fn fail_to_insert_tx_with_dependency_on_invalid_utxo_type() {
                 &mut rng,
                 AssetId::BASE,
                 TEST_COIN_AMOUNT,
-                Some(UtxoId::new(tx_faulty.id(), 0)),
+                Some(UtxoId::new(
+                    tx_faulty.id(&fuel_tx::ConsensusParameters::DEFAULT),
+                    0,
+                )),
             ))
             .finalize_as_transaction(),
     );
@@ -209,7 +219,7 @@ fn fail_to_insert_tx_with_dependency_on_invalid_utxo_type() {
         .expect_err("Tx2 should be Err, got Ok");
     assert!(matches!(
         err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedInputUtxoIdNotExisting(id)) if id == &UtxoId::new(tx_faulty.id(), 0)
+        Some(Error::NotInsertedInputUtxoIdNotExisting(id)) if id == &UtxoId::new(tx_faulty.id(&fuel_tx::ConsensusParameters::DEFAULT), 0)
     ));
 }
 
@@ -284,7 +294,11 @@ fn higher_priced_tx_removes_lower_priced_tx() {
         .expect("Tx1 should be Ok, got Err");
 
     let vec = txpool.insert_inner(tx2).expect("Tx2 should be Ok, got Err");
-    assert_eq!(vec.removed[0].id(), tx1.id(), "Tx1 id should be removed");
+    assert_eq!(
+        vec.removed[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "Tx1 id should be removed"
+    );
 }
 
 #[test]
@@ -303,7 +317,10 @@ fn underpriced_tx1_not_included_coin_collision() {
             .add_output(output)
             .finalize_as_transaction(),
     );
-    let input = unset_input.into_input(UtxoId::new(tx1.id(), 0));
+    let input = unset_input.into_input(UtxoId::new(
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        0,
+    ));
 
     let tx2 = Arc::new(
         TransactionBuilder::script(vec![], vec![])
@@ -332,7 +349,7 @@ fn underpriced_tx1_not_included_coin_collision() {
         .expect_err("Tx3 should be Err, got Ok");
     assert!(matches!(
         err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedCollision(id, utxo_id)) if id == &tx2.id() && utxo_id == &UtxoId::new(tx1.id(), 0)
+        Some(Error::NotInsertedCollision(id, utxo_id)) if id == &tx2.id(&fuel_tx::ConsensusParameters::DEFAULT) && utxo_id == &UtxoId::new(tx1.id(&fuel_tx::ConsensusParameters::DEFAULT), 0)
     ));
 }
 
@@ -441,7 +458,10 @@ fn more_priced_tx3_removes_tx1_and_dependent_tx2() {
             .add_output(output)
             .finalize_as_transaction(),
     );
-    let input = unset_input.into_input(UtxoId::new(tx1.id(), 0));
+    let input = unset_input.into_input(UtxoId::new(
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        0,
+    ));
 
     let tx2 = Arc::new(
         TransactionBuilder::script(vec![], vec![])
@@ -470,8 +490,16 @@ fn more_priced_tx3_removes_tx1_and_dependent_tx2() {
         2,
         "Tx1 and Tx2 should be removed:{vec:?}",
     );
-    assert_eq!(vec.removed[0].id(), tx1.id(), "Tx1 id should be removed");
-    assert_eq!(vec.removed[1].id(), tx2.id(), "Tx2 id should be removed");
+    assert_eq!(
+        vec.removed[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "Tx1 id should be removed"
+    );
+    assert_eq!(
+        vec.removed[1].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx2.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "Tx2 id should be removed"
+    );
 }
 
 #[test]
@@ -576,7 +604,10 @@ fn tx_depth_hit() {
             .finalize_as_transaction(),
     );
 
-    let input = unset_input.into_input(UtxoId::new(tx1.id(), 0));
+    let input = unset_input.into_input(UtxoId::new(
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        0,
+    ));
     let (output, unset_input) = create_output_and_input(&mut rng, 5_000);
     let tx2 = Arc::new(
         TransactionBuilder::script(vec![], vec![])
@@ -586,7 +617,10 @@ fn tx_depth_hit() {
             .finalize_as_transaction(),
     );
 
-    let input = unset_input.into_input(UtxoId::new(tx2.id(), 0));
+    let input = unset_input.into_input(UtxoId::new(
+        tx2.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        0,
+    ));
     let tx3 = Arc::new(
         TransactionBuilder::script(vec![], vec![])
             .gas_limit(GAS_LIMIT)
@@ -652,9 +686,21 @@ async fn sorted_out_tx1_2_4() {
     let txs = txpool.sorted_includable();
 
     assert_eq!(txs.len(), 3, "Should have 3 txs");
-    assert_eq!(txs[0].id(), tx3.id(), "First should be tx3");
-    assert_eq!(txs[1].id(), tx1.id(), "Second should be tx1");
-    assert_eq!(txs[2].id(), tx2.id(), "Third should be tx2");
+    assert_eq!(
+        txs[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx3.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "First should be tx3"
+    );
+    assert_eq!(
+        txs[1].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "Second should be tx1"
+    );
+    assert_eq!(
+        txs[2].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx2.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "Third should be tx2"
+    );
 }
 
 #[tokio::test]
@@ -674,7 +720,10 @@ async fn find_dependent_tx1_tx2() {
             .finalize_as_transaction(),
     );
 
-    let input = unset_input.into_input(UtxoId::new(tx1.id(), 0));
+    let input = unset_input.into_input(UtxoId::new(
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        0,
+    ));
     let (output, unset_input) = create_output_and_input(&mut rng, 7_500);
     let tx2 = Arc::new(
         TransactionBuilder::script(vec![], vec![])
@@ -685,7 +734,10 @@ async fn find_dependent_tx1_tx2() {
             .finalize_as_transaction(),
     );
 
-    let input = unset_input.into_input(UtxoId::new(tx2.id(), 0));
+    let input = unset_input.into_input(UtxoId::new(
+        tx2.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        0,
+    ));
     let tx3 = Arc::new(
         TransactionBuilder::script(vec![], vec![])
             .gas_price(9)
@@ -713,9 +765,21 @@ async fn find_dependent_tx1_tx2() {
     // sort from high to low price
     list.sort_by_key(|tx| Reverse(tx.price()));
     assert_eq!(list.len(), 3, "We should have three items");
-    assert_eq!(list[0].id(), tx1.id(), "Tx1 should be first.");
-    assert_eq!(list[1].id(), tx2.id(), "Tx2 should be second.");
-    assert_eq!(list[2].id(), tx3.id(), "Tx3 should be third.");
+    assert_eq!(
+        list[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "Tx1 should be first."
+    );
+    assert_eq!(
+        list[1].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx2.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "Tx2 should be second."
+    );
+    assert_eq!(
+        list[2].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx3.id(&fuel_tx::ConsensusParameters::DEFAULT),
+        "Tx3 should be third."
+    );
 }
 
 #[tokio::test]
@@ -789,8 +853,13 @@ async fn tx_inserted_into_pool_when_input_message_id_exists_in_db() {
 
     txpool.insert_inner(tx.clone()).expect("should succeed");
 
-    let tx_info = txpool.find_one(&tx.id()).unwrap();
-    assert_eq!(tx_info.tx().id(), tx.id());
+    let tx_info = txpool
+        .find_one(&tx.id(&fuel_tx::ConsensusParameters::DEFAULT))
+        .unwrap();
+    assert_eq!(
+        tx_info.tx().id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx.id(&fuel_tx::ConsensusParameters::DEFAULT)
+    );
 }
 
 #[tokio::test]
@@ -886,7 +955,7 @@ async fn tx_rejected_from_pool_when_gas_price_is_lower_than_another_tx_with_same
     // check error
     assert!(matches!(
         err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedCollisionMessageId(tx_id, msg_id)) if tx_id == &tx_high.id() && msg_id == message.id()
+        Some(Error::NotInsertedCollisionMessageId(tx_id, msg_id)) if tx_id == &tx_high.id(&fuel_tx::ConsensusParameters::DEFAULT) && msg_id == message.id()
     ));
 }
 
@@ -929,7 +998,10 @@ async fn higher_priced_tx_squeezes_out_lower_priced_tx_with_same_message_id() {
     let squeezed_out_txs = txpool.insert_inner(tx_high).expect("should succeed");
 
     assert_eq!(squeezed_out_txs.removed.len(), 1);
-    assert_eq!(squeezed_out_txs.removed[0].id(), tx_low.id());
+    assert_eq!(
+        squeezed_out_txs.removed[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx_low.id(&fuel_tx::ConsensusParameters::DEFAULT)
+    );
 }
 
 #[tokio::test]

--- a/crates/services/txpool/src/txpool/tests.rs
+++ b/crates/services/txpool/src/txpool/tests.rs
@@ -295,7 +295,7 @@ fn higher_priced_tx_removes_lower_priced_tx() {
 
     let vec = txpool.insert_inner(tx2).expect("Tx2 should be Ok, got Err");
     assert_eq!(
-        vec.removed[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        vec.removed[0].id(),
         tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "Tx1 id should be removed"
     );
@@ -491,12 +491,12 @@ fn more_priced_tx3_removes_tx1_and_dependent_tx2() {
         "Tx1 and Tx2 should be removed:{vec:?}",
     );
     assert_eq!(
-        vec.removed[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        vec.removed[0].id(),
         tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "Tx1 id should be removed"
     );
     assert_eq!(
-        vec.removed[1].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        vec.removed[1].id(),
         tx2.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "Tx2 id should be removed"
     );
@@ -687,17 +687,17 @@ async fn sorted_out_tx1_2_4() {
 
     assert_eq!(txs.len(), 3, "Should have 3 txs");
     assert_eq!(
-        txs[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        txs[0].id(),
         tx3.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "First should be tx3"
     );
     assert_eq!(
-        txs[1].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        txs[1].id(),
         tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "Second should be tx1"
     );
     assert_eq!(
-        txs[2].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        txs[2].id(),
         tx2.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "Third should be tx2"
     );
@@ -766,17 +766,17 @@ async fn find_dependent_tx1_tx2() {
     list.sort_by_key(|tx| Reverse(tx.price()));
     assert_eq!(list.len(), 3, "We should have three items");
     assert_eq!(
-        list[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        list[0].id(),
         tx1.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "Tx1 should be first."
     );
     assert_eq!(
-        list[1].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        list[1].id(),
         tx2.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "Tx2 should be second."
     );
     assert_eq!(
-        list[2].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        list[2].id(),
         tx3.id(&fuel_tx::ConsensusParameters::DEFAULT),
         "Tx3 should be third."
     );
@@ -857,7 +857,7 @@ async fn tx_inserted_into_pool_when_input_message_id_exists_in_db() {
         .find_one(&tx.id(&fuel_tx::ConsensusParameters::DEFAULT))
         .unwrap();
     assert_eq!(
-        tx_info.tx().id(&fuel_tx::ConsensusParameters::DEFAULT),
+        tx_info.tx().id(),
         tx.id(&fuel_tx::ConsensusParameters::DEFAULT)
     );
 }
@@ -999,7 +999,7 @@ async fn higher_priced_tx_squeezes_out_lower_priced_tx_with_same_message_id() {
 
     assert_eq!(squeezed_out_txs.removed.len(), 1);
     assert_eq!(
-        squeezed_out_txs.removed[0].id(&fuel_tx::ConsensusParameters::DEFAULT),
+        squeezed_out_txs.removed[0].id(),
         tx_low.id(&fuel_tx::ConsensusParameters::DEFAULT)
     );
 }

--- a/crates/types/src/blockchain/block.rs
+++ b/crates/types/src/blockchain/block.rs
@@ -15,6 +15,7 @@ use super::{
 };
 use crate::{
     fuel_tx::{
+        ConsensusParameters,
         Transaction,
         TxId,
         UniqueIdentifier,
@@ -87,10 +88,10 @@ impl Block<Transaction> {
     }
 
     /// Compresses the fuel block and replaces transactions with hashes.
-    pub fn compress(&self) -> CompressedBlock {
+    pub fn compress(&self, params: &ConsensusParameters) -> CompressedBlock {
         Block {
             header: self.header.clone(),
-            transactions: self.transactions.iter().map(|tx| tx.id()).collect(),
+            transactions: self.transactions.iter().map(|tx| tx.id(params)).collect(),
         }
     }
 }

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -10,18 +10,15 @@ use crate::{
         },
         Cacheable,
         Chargeable,
-        ConsensusParameters,
         Create,
         Input,
         Output,
         Script,
         Transaction,
         TxId,
-        UniqueIdentifier,
         UtxoId,
     },
     fuel_types::{
-        Bytes32,
         ContractId,
         Nonce,
     },
@@ -72,14 +69,12 @@ impl PoolTransaction {
             PoolTransaction::Create(create) => create.transaction().metered_bytes_size(),
         }
     }
-}
 
-impl PoolTransaction {
-    /// Return the unique identifier of the transaction.
-    pub fn id(&self, params: &ConsensusParameters) -> Bytes32 {
+    /// Returns the transaction ID
+    pub fn id(&self) -> TxId {
         match self {
-            PoolTransaction::Script(script) => script.transaction().id(params),
-            PoolTransaction::Create(create) => create.transaction().id(params),
+            PoolTransaction::Script(script) => script.id(),
+            PoolTransaction::Create(create) => create.id(),
         }
     }
 }

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -10,6 +10,7 @@ use crate::{
         },
         Cacheable,
         Chargeable,
+        ConsensusParameters,
         Create,
         Input,
         Output,
@@ -75,10 +76,10 @@ impl PoolTransaction {
 
 impl PoolTransaction {
     /// Return the unique identifier of the transaction.
-    pub fn id(&self) -> Bytes32 {
+    pub fn id(&self, params: &ConsensusParameters) -> Bytes32 {
         match self {
-            PoolTransaction::Script(script) => script.transaction().id(),
-            PoolTransaction::Create(create) => create.transaction().id(),
+            PoolTransaction::Script(script) => script.transaction().id(params),
+            PoolTransaction::Create(create) => create.transaction().id(params),
         }
     }
 }

--- a/tests/tests/blocks.rs
+++ b/tests/tests/blocks.rs
@@ -99,7 +99,7 @@ async fn produce_block() {
     client.submit_and_await_commit(&tx).await.unwrap();
 
     let transaction_response = client
-        .transaction(&format!("{:#x}", tx.id()))
+        .transaction(&format!("{:#x}", tx.id(&ConsensusParameters::DEFAULT)))
         .await
         .unwrap();
 
@@ -177,7 +177,7 @@ async fn produce_block_negative() {
     client.submit_and_await_commit(&tx).await.unwrap();
 
     let transaction_response = client
-        .transaction(&format!("{:#x}", tx.id()))
+        .transaction(&format!("{:#x}", tx.id(&ConsensusParameters::DEFAULT)))
         .await
         .unwrap();
 

--- a/tests/tests/contract.rs
+++ b/tests/tests/contract.rs
@@ -233,7 +233,7 @@ async fn can_get_message_proof() {
         .collect();
 
     let predicate = op::ret(RegId::ONE).to_bytes().to_vec();
-    let owner = Input::predicate_owner(&predicate);
+    let owner = Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT);
     let coin_input = Input::coin_predicate(
         Default::default(),
         owner,
@@ -276,7 +276,7 @@ async fn can_get_message_proof() {
         vec![],
     );
 
-    let transaction_id = script.id();
+    let transaction_id = script.id(&ConsensusParameters::DEFAULT);
 
     // setup server & client
     let srv = FuelService::new_node(config).await.unwrap();

--- a/tests/tests/messages.rs
+++ b/tests/tests/messages.rs
@@ -293,7 +293,7 @@ async fn can_get_message_proof() {
             .collect();
 
         let predicate = op::ret(RegId::ONE).to_bytes().to_vec();
-        let owner = Input::predicate_owner(&predicate);
+        let owner = Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT);
         let coin_input = Input::coin_predicate(
             Default::default(),
             owner,
@@ -336,7 +336,7 @@ async fn can_get_message_proof() {
             vec![],
         );
 
-        let transaction_id = script.id();
+        let transaction_id = script.id(&ConsensusParameters::DEFAULT);
 
         // setup server & client
         let srv = FuelService::new_node(config).await.unwrap();

--- a/tests/tests/tx/predicates.rs
+++ b/tests/tests/tx/predicates.rs
@@ -24,7 +24,7 @@ async fn transaction_with_valid_predicate_is_executed() {
     let asset_id = rng.gen();
     // make predicate return 1 which mean valid
     let predicate = op::ret(RegId::ONE).to_bytes().to_vec();
-    let owner = Input::predicate_owner(&predicate);
+    let owner = Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT);
     let predicate_tx = TransactionBuilder::script(Default::default(), Default::default())
         .add_input(Input::coin_predicate(
             rng.gen(),
@@ -56,7 +56,7 @@ async fn transaction_with_valid_predicate_is_executed() {
     // check transaction change amount to see if predicate was spent
     let transaction = context
         .client
-        .transaction(&predicate_tx.id().to_string())
+        .transaction(&predicate_tx.id(&ConsensusParameters::DEFAULT).to_string())
         .await
         .unwrap()
         .unwrap()
@@ -76,7 +76,7 @@ async fn transaction_with_invalid_predicate_is_rejected() {
     let asset_id = rng.gen();
     // make predicate return 0 which means invalid
     let predicate = op::ret(RegId::ZERO).to_bytes().to_vec();
-    let owner = Input::predicate_owner(&predicate);
+    let owner = Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT);
     let predicate_tx = TransactionBuilder::script(Default::default(), Default::default())
         .add_input(Input::coin_predicate(
             rng.gen(),
@@ -111,7 +111,7 @@ async fn transaction_with_predicates_that_exhaust_gas_limit_are_rejected() {
     let asset_id = rng.gen();
     // make predicate jump in infinite loop
     let predicate = op::jmp(RegId::ZERO).to_bytes().to_vec();
-    let owner = Input::predicate_owner(&predicate);
+    let owner = Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT);
     let predicate_tx = TransactionBuilder::script(Default::default(), Default::default())
         .add_input(Input::coin_predicate(
             rng.gen(),

--- a/tests/tests/tx/tx_pointer.rs
+++ b/tests/tests/tx/tx_pointer.rs
@@ -5,6 +5,7 @@ use crate::helpers::{
 use fuel_core::chain_config::CoinConfig;
 use fuel_core_types::{
     fuel_crypto::SecretKey,
+    fuel_tx,
     fuel_tx::{
         field::{
             Inputs,
@@ -82,7 +83,7 @@ async fn tx_pointer_set_from_genesis_for_coin_and_contract_inputs() {
 
     // verify that the tx returned from the api has tx pointers set matching the genesis config
     let ret_tx = client
-        .transaction(&tx.id().to_string())
+        .transaction(&tx.id(&fuel_tx::ConsensusParameters::DEFAULT).to_string())
         .await
         .unwrap()
         .unwrap()
@@ -136,7 +137,7 @@ async fn tx_pointer_set_from_previous_block() {
     let tx1 = tx1.into();
     client.submit_and_await_commit(&tx1).await.unwrap();
     let ret_tx1 = client
-        .transaction(&tx1.id().to_string())
+        .transaction(&tx1.id(&fuel_tx::ConsensusParameters::DEFAULT).to_string())
         .await
         .unwrap()
         .unwrap()
@@ -147,7 +148,7 @@ async fn tx_pointer_set_from_previous_block() {
     let tx2 = script_tx(
         secret_key,
         ret_tx1.outputs()[0].amount().unwrap(),
-        UtxoId::new(tx1.id(), 0),
+        UtxoId::new(tx1.id(&fuel_tx::ConsensusParameters::DEFAULT), 0),
         contract_id,
         rng.gen(),
     );
@@ -155,7 +156,7 @@ async fn tx_pointer_set_from_previous_block() {
     client.submit_and_await_commit(&tx2).await.unwrap();
 
     let ret_tx2 = client
-        .transaction(&tx2.id().to_string())
+        .transaction(&tx2.id(&fuel_tx::ConsensusParameters::DEFAULT).to_string())
         .await
         .unwrap()
         .unwrap()
@@ -204,7 +205,7 @@ async fn tx_pointer_unset_when_utxo_validation_disabled() {
     client.submit_and_await_commit(&tx).await.unwrap();
 
     let ret_tx = client
-        .transaction(&tx.id().to_string())
+        .transaction(&tx.id(&fuel_tx::ConsensusParameters::DEFAULT).to_string())
         .await
         .unwrap()
         .unwrap()

--- a/tests/tests/tx/txn_status_subscription.rs
+++ b/tests/tests/tx/txn_status_subscription.rs
@@ -33,7 +33,7 @@ async fn subscribe_txn_status() {
             .collect();
 
         let predicate = op::ret(RegId::ONE).to_bytes().to_vec();
-        let owner = Input::predicate_owner(&predicate);
+        let owner = Input::predicate_owner(&predicate, &ConsensusParameters::DEFAULT);
         // The third transaction needs to have a different input.
         let utxo_id = if i == 2 { 2 } else { 1 };
         let utxo_id = UtxoId::new(Bytes32::from([utxo_id; 32]), 1);
@@ -63,7 +63,11 @@ async fn subscribe_txn_status() {
     let txns: Vec<_> = (0..3).map(create_script).collect();
     let mut jhs = vec![];
 
-    for (txn_idx, id) in txns.iter().map(|t| t.id().to_string()).enumerate() {
+    for (txn_idx, id) in txns
+        .iter()
+        .map(|t| t.id(&ConsensusParameters::DEFAULT).to_string())
+        .enumerate()
+    {
         let jh = tokio::spawn({
             let client = client.clone();
             async move {

--- a/tests/tests/tx/utxo_validation.rs
+++ b/tests/tests/tx/utxo_validation.rs
@@ -74,14 +74,14 @@ async fn submit_utxo_verified_tx_with_min_gas_price() {
         client.submit_and_await_commit(&tx).await.unwrap();
         // verify that the tx returned from the api matches the submitted tx
         let ret_tx = client
-            .transaction(&tx.id().to_string())
+            .transaction(&tx.id(&ConsensusParameters::DEFAULT).to_string())
             .await
             .unwrap()
             .unwrap()
             .transaction;
 
         let transaction_result = client
-            .transaction_status(&ret_tx.id().to_string())
+            .transaction_status(&ret_tx.id(&ConsensusParameters::DEFAULT).to_string())
             .await
             .ok()
             .unwrap();
@@ -246,7 +246,10 @@ async fn concurrent_tx_submission_produces_expected_blocks() {
         .collect_vec();
 
     // collect all tx ids
-    let tx_ids: BTreeSet<_> = txs.iter().map(|tx| tx.id()).collect();
+    let tx_ids: BTreeSet<_> = txs
+        .iter()
+        .map(|tx| tx.id(&ConsensusParameters::DEFAULT))
+        .collect();
 
     // setup the genesis coins for spending
     test_builder.config_coin_inputs_from_transactions(&txs.iter().collect_vec());

--- a/tests/tests/tx_gossip.rs
+++ b/tests/tests/tx_gossip.rs
@@ -92,6 +92,7 @@ async fn test_tx_gossiping() {
         .finalize();
 
     let node_config = create_node_config_from_inputs(tx.inputs());
+    let params = node_config.chain_conf.transaction_parameters;
     let node_one = FuelService::new_node(node_config).await.unwrap();
     let client_one = FuelClient::from(node_one.bound_address);
 
@@ -106,11 +107,17 @@ async fn test_tx_gossiping() {
     let tx = tx.into();
     client_one.submit_and_await_commit(&tx).await.unwrap();
 
-    let response = client_one.transaction(&tx.id().to_string()).await.unwrap();
+    let response = client_one
+        .transaction(&tx.id(&params).to_string())
+        .await
+        .unwrap();
     assert!(response.is_some());
 
     tokio::time::sleep(wait_time).await;
 
-    let response = client_two.transaction(&tx.id().to_string()).await.unwrap();
+    let response = client_two
+        .transaction(&tx.id(&params).to_string())
+        .await
+        .unwrap();
     assert!(response.is_some());
 }


### PR DESCRIPTION
Adapts fuel-core to changes in https://github.com/FuelLabs/fuel-vm/pull/406

Routing the consensus parameters everywhere is a little painful, since we need to fetch the transaction ID so often. I've cleaned this up a little bit by introducing a new infallible api in [fuel-vm](https://github.com/FuelLabs/fuel-vm/pull/419) to fetch the transaction id when it's known to be computed already. 

This could be cleaned up even further by using Checked\<Tx\> in more places, such as using `pub type CheckedBlock = Block<CheckedTransaction>` in the executor and consensus modules. But this would involve larger structural changes and optimizations to avoid rechecking transactions that have already been checked in the tx pool during sync, and should be done in a separate PR.