### PR TITLE
use trait to convert network behaviour actions

### DIFF
--- a/crates/services/p2p/src/peer_report.rs
+++ b/crates/services/p2p/src/peer_report.rs
@@ -401,7 +401,7 @@ impl FromAction<Identify> for PeerReportBehaviour {
                         addresses: listen_addrs,
                     };
 
-                    return Some(NetworkBehaviourAction::GenerateEvent(event))
+                    Some(NetworkBehaviourAction::GenerateEvent(event))
                 }
                 IdentifyEvent::Error { peer_id, error } => {
                     debug!(target: "fuel-p2p", "Identification with peer {:?} failed => {}", peer_id, error);
@@ -412,7 +412,7 @@ impl FromAction<Identify> for PeerReportBehaviour {
             NetworkBehaviourAction::Dial { handler, opts } => {
                 let handler =
                     IntoConnectionHandler::select(self.heartbeat.new_handler(), handler);
-                return Some(NetworkBehaviourAction::Dial { handler, opts })
+                Some(NetworkBehaviourAction::Dial { handler, opts })
             }
             NetworkBehaviourAction::NotifyHandler {
                 peer_id,


### PR DESCRIPTION
Attempt to partially address @freesig's comment about using a helper function: https://github.com/FuelLabs/fuel-core/pull/1028#discussion_r1159275452

This extracts the conversion of network behaviour events out of the poll function and into separate functions.