### PR TITLE
fix the dry-run e2e test to actually perform dry runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "libtest-mimic",
  "serde",
  "tempfile",
+ "tikv-jemallocator",
  "tokio 1.27.0",
  "toml",
 ]

--- a/bin/e2e-test-client/Cargo.toml
+++ b/bin/e2e-test-client/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3"
 humantime-serde = "1.1"
 libtest-mimic = "0.6.0"
 serde = { workspace = true }
+tikv-jemallocator = "0.5"
 tokio = { workspace = true }
 toml = { version = "0.5" }
 

--- a/bin/e2e-test-client/src/lib.rs
+++ b/bin/e2e-test-client/src/lib.rs
@@ -14,10 +14,6 @@ use std::{
     time::Duration,
 };
 
-// Use Jemalloc
-#[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
 pub const CONFIG_FILE_KEY: &str = "FUEL_CORE_E2E_CONFIG";
 pub const SYNC_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/bin/e2e-test-client/src/lib.rs
+++ b/bin/e2e-test-client/src/lib.rs
@@ -14,6 +14,10 @@ use std::{
     time::Duration,
 };
 
+// Use Jemalloc
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 pub const CONFIG_FILE_KEY: &str = "FUEL_CORE_E2E_CONFIG";
 pub const SYNC_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -66,7 +70,7 @@ pub fn main_body(config: SuiteConfig, mut args: Arguments) {
             with_cloned(&config, |config| {
                 async_execute(async {
                     let ctx = TestContext::new(config).await;
-                    tests::transfers::transfer_back(&ctx).await
+                    tests::script::dry_run(&ctx).await
                 })?;
                 Ok(())
             }),

--- a/bin/e2e-test-client/tests/integration_tests.rs
+++ b/bin/e2e-test-client/tests/integration_tests.rs
@@ -7,6 +7,10 @@ use fuel_core_e2e_client::config::SuiteConfig;
 use std::fs;
 use tempfile::TempDir; // Used for writing assertions // Run programs
 
+// Use Jemalloc
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[tokio::test(flavor = "multi_thread")]
 async fn works_in_local_env() {
     // setup a local node


### PR DESCRIPTION
For some reason the e2e test for dry-run's was actually running `transfer_back`, this corrects that to use the actual dry run test impl.

Also includes jemalloc in the e2e integration tests to more closely represent production.