### PR TITLE
sync with peers before producing blocks

### DIFF
--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -4,7 +4,9 @@ use crate::{
 };
 use fuel_core_consensus_module::block_verifier::Verifier;
 use fuel_core_txpool::service::SharedState as TxPoolSharedState;
+use fuel_core_types::services::block_importer::ImportResult;
 use std::sync::Arc;
+use tokio::sync::broadcast::Receiver;
 
 pub mod block_importer;
 pub mod consensus_module;
@@ -85,5 +87,15 @@ impl P2PAdapter {
 impl P2PAdapter {
     pub fn new() -> Self {
         Default::default()
+    }
+}
+
+pub struct SyncAdapter {
+    block_rx: Receiver<Arc<ImportResult>>,
+}
+
+impl SyncAdapter {
+    pub fn new(block_rx: Receiver<Arc<ImportResult>>) -> Self {
+        Self { block_rx }
     }
 }

--- a/crates/services/consensus_module/poa/src/ports.rs
+++ b/crates/services/consensus_module/poa/src/ports.rs
@@ -86,3 +86,9 @@ pub trait RelayerPort {
         max_da_lag: &DaBlockHeight,
     ) -> anyhow::Result<()>;
 }
+
+#[async_trait::async_trait]
+pub trait SyncPort: Send + Sync {
+    /// await synchronization with the peers
+    async fn sync_with_peers(&mut self) -> anyhow::Result<()>;
+}


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/1120

After refactoring and enabling `TaskParams` for `Services` in order for them to be turned into `Task` with a `TaskParam`,
I created SyncPort, and added it as a `TaskParam` for `poa`'s Service.

The current implementation is that the `SyncAdapter` only checks for 60 seconds if a new block was imported, if not, it considers the PoA node to be synced.

Improvement on top of this would be - waiting first to connect with N amount of Reserved Peers.