### PR TITLE
v0.17.11 pyroscope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,9 @@ jobs:
         with:
           context: .
           file: deployment/Dockerfile
-          build-args: "FEATURES=production,profiling DEBUG_SYMBOLS=true"
+          build-args: |
+            "FEATURES=production,profiling"
+            "DEBUG_SYMBOLS=true"
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,9 +294,7 @@ jobs:
         with:
           context: .
           file: deployment/Dockerfile
-          build-args:
-            FEATURES: "production,profiling"
-            DEBUG_SYMBOLS: true
+          build-args: "FEATURES=production,profiling DEBUG_SYMBOLS=true"
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,9 @@ jobs:
         with:
           context: .
           file: deployment/Dockerfile
-          build-args: "production,profiling"
+          build-args:
+            FEATURES: "production,profiling"
+            DEBUG_SYMBOLS: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,55 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # duplicate of publish-docker-image, but with profiling features enabled
+  # this is split into a separate action since it takes longer to build
+  publish-docker-image-profiling:
+    needs:
+      - verifications-complete
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/fuellabs/fuel-core-profiling
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{raw}}
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/master' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to the ghcr.io registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the image to ghcr.io
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: deployment/Dockerfile
+          build-args: "production,profiling"
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - uses: FuelLabs/.github/.github/actions/slack-notify-template@master
         if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
         with:

--- a/.github/workflows/scripts/verify_openssl.sh
+++ b/.github/workflows/scripts/verify_openssl.sh
@@ -9,8 +9,8 @@ status() {
     printf "\e[32m\e[1m%${WIDTH}s\e[0m %s\n" "$1" "$2"
 }
 
-grep "openssl-sys" Cargo.lock &> /dev/null
-test $? -ne 0
+cargo tree -p fuel-core-bin --invert openssl-sys 2>&1 | grep -i "did not match any packages" &> /dev/null
+test $? -ne 1
 openssl=$?
 
 if [ $openssl != 0 ]; then

--- a/.github/workflows/scripts/verify_openssl.sh
+++ b/.github/workflows/scripts/verify_openssl.sh
@@ -9,8 +9,8 @@ status() {
     printf "\e[32m\e[1m%${WIDTH}s\e[0m %s\n" "$1" "$2"
 }
 
-cargo tree -p fuel-core-bin --invert openssl-sys 2>&1 | grep -i "did not match any packages" &> /dev/null
-test $? -ne 1
+grep "openssl-sys" Cargo.lock &> /dev/null
+test $? -ne 0
 openssl=$?
 
 if [ $openssl != 0 ]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,7 +1797,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "uuid 1.3.0",
+ "uuid 1.3.1",
 ]
 
 [[package]]
@@ -2511,21 +2517,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3716,7 +3707,7 @@ dependencies = [
  "hyper 0.14.26",
  "log",
  "rustls 0.19.1",
- "rustls-native-certs 0.5.0",
+ "rustls-native-certs",
  "tokio 1.27.0",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
@@ -3746,19 +3737,6 @@ dependencies = [
  "pin-project-lite 0.2.9",
  "tokio 1.27.0",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes 1.4.0",
- "hyper 0.14.25",
- "native-tls",
- "tokio 1.27.0",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -4054,6 +4032,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4102,6 +4086,26 @@ name = "libc"
 version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+
+[[package]]
+name = "libflate"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97822bf791bd4d5b403713886a5fbe8bf49520fe78e323b0dc480ca1a03e50b0"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
+dependencies = [
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libhoney-rust"
@@ -4191,7 +4195,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "rand 0.8.5",
  "rw-stream-sink",
@@ -4264,7 +4268,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "prometheus-client 0.18.1",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "prost-codec",
  "rand 0.8.5",
@@ -4289,7 +4293,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "lru",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "prost-codec",
  "smallvec",
@@ -4308,7 +4312,7 @@ dependencies = [
  "log",
  "multiaddr 0.17.1",
  "multihash 0.17.0",
- "prost",
+ "prost 0.11.9",
  "quick-protobuf",
  "rand 0.8.5",
  "thiserror",
@@ -4332,7 +4336,7 @@ dependencies = [
  "libp2p-core 0.38.0",
  "libp2p-swarm",
  "log",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "rand 0.8.5",
  "sha2 0.10.6",
@@ -4407,7 +4411,7 @@ dependencies = [
  "libp2p-core 0.38.0",
  "log",
  "once_cell",
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "rand 0.8.5",
  "sha2 0.10.6",
@@ -5074,24 +5078,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5341,48 +5327,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.13",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -5930,12 +5878,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+dependencies = [
+ "bytes 1.4.0",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes 1.4.0",
- "prost-derive",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -5952,7 +5910,7 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.11.9",
  "prost-types",
  "regex",
  "syn 1.0.109",
@@ -5968,9 +5926,22 @@ checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.4.0",
- "prost",
+ "prost 0.11.9",
  "thiserror",
  "unsigned-varint",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5992,7 +5963,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -6013,23 +5984,29 @@ dependencies = [
 
 [[package]]
 name = "pyroscope"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f94e4ab21b0a044f9e6a78d8dad5f73d08c34e4102a0420586ce2e28ed4f409"
+checksum = "6636d352280fb587c8716f10e1d61fe88cb002660e0a8b0d3e47de17f3b5aaed"
 dependencies = [
+ "json",
  "libc",
+ "libflate",
  "log",
  "names",
+ "prost 0.10.4",
  "reqwest 0.11.16",
  "thiserror",
+ "url",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "pyroscope_pprofrs"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e9d063a1d882eb2459967e70839c84d107267a3f7a2cbe2bb8277820782e05"
+checksum = "14e699bf3e7da41b3a7573d5944d77b1bd96a187aa72f5fa96afb4ed5609cc45"
 dependencies = [
+ "log",
  "pprof",
  "pyroscope",
  "thiserror",
@@ -6347,23 +6324,19 @@ dependencies = [
  "http-body 0.4.5",
  "hyper 0.14.26",
  "hyper-rustls 0.23.2",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite 0.2.9",
  "rustls 0.20.8",
- "rustls-native-certs 0.6.2",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.27.0",
- "tokio-native-tls",
  "tokio-rustls 0.23.4",
  "tower-service",
  "url",
@@ -6418,6 +6391,12 @@ checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.6",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rlp"
@@ -6611,18 +6590,6 @@ checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
  "rustls 0.19.1",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -7267,7 +7234,7 @@ dependencies = [
  "debugid",
  "memmap2",
  "stable_deref_trait",
- "uuid 1.3.0",
+ "uuid 1.3.1",
 ]
 
 [[package]]
@@ -7609,16 +7576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf33a76e0b1dd03b778f83244137bd59887abf25c0e87bc3e7071105f457693"
 dependencies = [
  "rayon",
- "tokio 1.27.0",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
  "tokio 1.27.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +620,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,9 +1085,14 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
+ "atty",
  "bitflags",
+ "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
  "textwrap",
 ]
 
@@ -1074,7 +1103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
 dependencies = [
  "clap_builder",
- "clap_derive",
+ "clap_derive 4.2.0",
  "once_cell",
 ]
 
@@ -1089,6 +1118,19 @@ dependencies = [
  "bitflags",
  "clap_lex 0.4.1",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1311,6 +1353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d458e66999348f56fd3ffcfbb7f7951542075ca8359687c703de6500c1ddccd"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "cpp_demangle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1732,6 +1783,15 @@ checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2397,6 +2457,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2511,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2570,6 +2657,8 @@ dependencies = [
  "humantime",
  "lazy_static",
  "libhoney-rust",
+ "pyroscope",
+ "pyroscope_pprofrs",
  "serde_json",
  "test-case",
  "tikv-jemallocator",
@@ -3248,6 +3337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,7 +3716,7 @@ dependencies = [
  "hyper 0.14.26",
  "log",
  "rustls 0.19.1",
- "rustls-native-certs",
+ "rustls-native-certs 0.5.0",
  "tokio 1.27.0",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
@@ -3651,6 +3746,19 @@ dependencies = [
  "pin-project-lite 0.2.9",
  "tokio 1.27.0",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.4.0",
+ "hyper 0.14.25",
+ "native-tls",
+ "tokio 1.27.0",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4702,6 +4810,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4947,6 +5064,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "names"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d66043b25d4a6cccb23619d10c19c25304b355a7dccd4a8e11423dd2382146"
+dependencies = [
+ "clap 3.2.23",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,6 +5265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5187,10 +5341,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -5556,6 +5748,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pprof"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6472bfed9475542ac46c518734a8d06d71b0f6cb2c17f904aa301711a57786f"
+dependencies = [
+ "backtrace",
+ "cfg-if 1.0.0",
+ "findshlibs",
+ "libc",
+ "log",
+ "nix 0.24.3",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5797,6 +6009,30 @@ checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
 dependencies = [
  "idna 0.3.0",
  "psl-types",
+]
+
+[[package]]
+name = "pyroscope"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f94e4ab21b0a044f9e6a78d8dad5f73d08c34e4102a0420586ce2e28ed4f409"
+dependencies = [
+ "libc",
+ "log",
+ "names",
+ "reqwest 0.11.16",
+ "thiserror",
+]
+
+[[package]]
+name = "pyroscope_pprofrs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e9d063a1d882eb2459967e70839c84d107267a3f7a2cbe2bb8277820782e05"
+dependencies = [
+ "pprof",
+ "pyroscope",
+ "thiserror",
 ]
 
 [[package]]
@@ -6111,19 +6347,23 @@ dependencies = [
  "http-body 0.4.5",
  "hyper 0.14.26",
  "hyper-rustls 0.23.2",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite 0.2.9",
  "rustls 0.20.8",
+ "rustls-native-certs 0.6.2",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.27.0",
+ "tokio-native-tls",
  "tokio-rustls 0.23.4",
  "tower-service",
  "url",
@@ -6276,6 +6516,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6365,6 +6611,18 @@ checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
  "rustls 0.19.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -7001,6 +7259,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
+name = "symbolic-common"
+version = "9.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "800963ba330b09a2ae4a4f7c6392b81fbc2784099a98c1eac68c3437aa9382b2"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid 1.3.0",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "9.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b940a1fdbc72bb3369e38714efe6cd332dbbe46d093cf03d668b9ac390d1ad0"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7328,6 +7609,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf33a76e0b1dd03b778f83244137bd59887abf25c0e87bc3e7071105f457693"
 dependencies = [
  "rayon",
+ "tokio 1.27.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
  "tokio 1.27.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,4 @@ prometheus-client = "0.20"
 itertools = "0.10"
 insta = "1.8"
 tempfile = "3.3"
+

--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -23,6 +23,8 @@ fuel-core = { workspace = true }
 humantime = "2.1"
 lazy_static = { workspace = true }
 libhoney-rust = { version = "0.1.6" }
+pyroscope = { version = "0.5.3", optional = true }
+pyroscope_pprofrs = { version = "0.2.3", optional = true }
 serde_json = { workspace = true, features = ["raw_value"], optional = true }
 tikv-jemallocator = "0.5"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
@@ -46,5 +48,6 @@ p2p = ["fuel-core/p2p"]
 relayer = ["fuel-core/relayer", "dep:url", "dep:serde_json"]
 rocksdb = ["fuel-core/rocksdb"]
 rocksdb-production = ["fuel-core/rocksdb-production"]
+profiling = ["dep:pyroscope", "dep:pyroscope_pprofrs"]
 # features to enable in production, but increase build times
-production = ["metrics", "relayer", "rocksdb-production", "p2p"]
+production = ["metrics", "relayer", "rocksdb-production", "p2p", "profiling"]

--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -23,8 +23,8 @@ fuel-core = { workspace = true }
 humantime = "2.1"
 lazy_static = { workspace = true }
 libhoney-rust = { version = "0.1.6" }
-pyroscope = { version = "0.5.3", optional = true }
-pyroscope_pprofrs = { version = "0.2.3", optional = true }
+pyroscope = { version = "0.5", optional = true }
+pyroscope_pprofrs = { version = "0.2", optional = true }
 serde_json = { workspace = true, features = ["raw_value"], optional = true }
 tikv-jemallocator = "0.5"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
@@ -50,4 +50,4 @@ rocksdb = ["fuel-core/rocksdb"]
 rocksdb-production = ["fuel-core/rocksdb-production"]
 profiling = ["dep:pyroscope", "dep:pyroscope_pprofrs"]
 # features to enable in production, but increase build times
-production = ["metrics", "relayer", "rocksdb-production", "p2p", "profiling"]
+production = ["metrics", "relayer", "rocksdb-production", "p2p"]

--- a/bin/fuel-core/src/cli/run/profiling.rs
+++ b/bin/fuel-core/src/cli/run/profiling.rs
@@ -1,0 +1,10 @@
+use clap::Args;
+
+#[derive(Debug, Clone, Args)]
+pub struct ProfilingArgs {
+    #[clap(long = "pyroscope-url", env)]
+    pub pyroscope_url: Option<String>,
+
+    #[clap(long = "pprof-sample-rate", default_value = "100", env)]
+    pub pprof_sample_rate: u32,
+}

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -9,8 +9,6 @@ RUN apt-get update && \
     clang \
     libclang-dev \
     protobuf-compiler \
-    pkg-config \
-    libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -19,12 +17,13 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
+ARG FEATURES="production"
 FROM chef as builder
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 ENV CARGO_PROFILE_RELEASE_DEBUG=true
 COPY --from=planner /build/recipe.json recipe.json
 # Build our project dependecies, not our application!
-RUN cargo chef cook --release --no-default-features --features "production" -p fuel-core-bin --recipe-path recipe.json
+RUN cargo chef cook --release --no-default-features --features "${FEATURES}" -p fuel-core-bin --recipe-path recipe.json
 # Up to this point, if our dependency tree stays the same,
 # all layers should be cached.
 COPY . .
@@ -45,7 +44,7 @@ ENV DB_PATH="${DB_PATH}"
 WORKDIR /root/
 
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends ca-certificates pkg-config libssl-dev \
+    && apt-get install -y --no-install-recommends ca-certificates \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && \
     clang \
     libclang-dev \
     protobuf-compiler \
+    pkg-config \
+    libssl-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -19,6 +21,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef as builder
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV CARGO_PROFILE_RELEASE_DEBUG=true
 COPY --from=planner /build/recipe.json recipe.json
 # Build our project dependecies, not our application!
 RUN cargo chef cook --release --no-default-features --features "production" -p fuel-core-bin --recipe-path recipe.json
@@ -42,7 +45,7 @@ ENV DB_PATH="${DB_PATH}"
 WORKDIR /root/
 
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends ca-certificates \
+    && apt-get install -y --no-install-recommends ca-certificates pkg-config libssl-dev \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -17,17 +17,22 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-ARG FEATURES="production"
+
 FROM chef as builder
+ARG FEATURES="production"
+ARG DEBUG_SYMBOLS=false
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-ENV CARGO_PROFILE_RELEASE_DEBUG=true
+ENV CARGO_PROFILE_RELEASE_DEBUG=$DEBUG_SYMBOLS
+ENV BUILD_FEATURES=$FEATURES
 COPY --from=planner /build/recipe.json recipe.json
+RUN echo $CARGO_PROFILE_RELEASE_DEBUG
+RUN echo $BUILD_FEATURES
 # Build our project dependecies, not our application!
 RUN cargo chef cook --release --no-default-features --features "${FEATURES}" -p fuel-core-bin --recipe-path recipe.json
 # Up to this point, if our dependency tree stays the same,
 # all layers should be cached.
 COPY . .
-RUN cargo build --release --no-default-features --features "${FEATURES}" -p fuel-core-bin
+RUN cargo build --release --no-default-features --features "$BUILD_FEATURES" -p fuel-core-bin
 
 # Stage 2: Run
 FROM ubuntu:22.04 as run

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -27,7 +27,7 @@ RUN cargo chef cook --release --no-default-features --features "${FEATURES}" -p 
 # Up to this point, if our dependency tree stays the same,
 # all layers should be cached.
 COPY . .
-RUN cargo build --release --no-default-features --features "production" -p fuel-core-bin
+RUN cargo build --release --no-default-features --features "${FEATURES}" -p fuel-core-bin
 
 # Stage 2: Run
 FROM ubuntu:22.04 as run

--- a/deployment/charts/templates/fuel-core-deploy.yaml
+++ b/deployment/charts/templates/fuel-core-deploy.yaml
@@ -213,6 +213,14 @@ spec:
           {{- if .Values.app.allow_private_addresses }}
             - "--allow_private_addresses"
           {{- end }}
+          {{- if .Values.app.pyroscope_url }}
+            - "--pyroscope-url"
+            - "{{ .Values.app.pyroscope_url }}"
+          {{- end }}
+          {{- if .Values.app.pprof_sample_rate }}
+            - "--pprof-sample-rate"
+            - "{{ .Values.app.pprof_sample_rate }}"
+          {{- end }}
           resources:
             limits:
               cpu: {{ .Values.app.resources.cpu_limits }}

--- a/deployment/charts/values.yaml
+++ b/deployment/charts/values.yaml
@@ -38,6 +38,8 @@ app:
   relayer_eth_sync_call_freq_s: "${fuel_core_relayer_eth_sync_call_freq_s}"
   relayer_eth_sync_log_freq_s: "${fuel_core_relayer_eth_sync_log_freq_s}"
   sentry_enabled: ${fuel_core_sentry_enabled}
+  pyroscope_url: "${fuel_core_pyroscope_url}"
+  pprof_sample_rate: "${fuel_core_pprof_sample_rate}"
   image:
     repository: ${fuel_core_image_repository}
     tag: ${fuel_core_image_tag}

--- a/deployment/scripts/.env
+++ b/deployment/scripts/.env
@@ -24,6 +24,10 @@ fuel_core_memory_requests="50Mi"
 fuel_core_cpu_limits="2m"
 fuel_core_memory_limits="100Mi"
 
+# profiling agent settings
+fuel_core_pyroscope_url="http://pyroscope:4040"
+fuel_core_pprof_sample_rate="100"
+
 # consensus key secret 
 fuel_core_consensus_key_secret="dGVzdA=="
 


### PR DESCRIPTION
This PR adds pyroscope to fuel-core-bin. Pyroscope is a platform that allows for continuous profiling, enabling real-time flamegraphs in deployed environments.

It also builds a separate docker image with debug symbols and profiling enabled, leaving the original docker image the same as before.

This is still in draft, and requires additional testing in the dev environment.

![image](https://user-images.githubusercontent.com/794823/232946832-3ddff966-31be-4b19-bb6c-80d476ed8028.png)

reopening of #1140, with a newer version of pyroscope which solves the openssl dependency issue