### PR TITLE
version compatibility cleanup

### DIFF
--- a/version-compatibility/Cargo.toml
+++ b/version-compatibility/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "2"
 members = [
+    # Add new versions here when testing backwards compatibility between fuel-core-client and fuel-core
+    "placeholder"
+]
+
+# exclude previous versions no longer maintained
+exclude = [
     "0.14.1-0.15.0/fuel-core:0.14.1-client:0.15.0",
-    "0.14.1-0.15.0/fuel-core:0.15.0-client:0.14.1",
+    "0.14.1-0.15.0/fuel-core:0.15.0-client:0.14.1"
 ]

--- a/version-compatibility/placeholder/Cargo.toml
+++ b/version-compatibility/placeholder/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "placeholder"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "BUSL-1.1"
+description = "placeholder for version compatibility tests"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/version-compatibility/placeholder/src/main.rs
+++ b/version-compatibility/placeholder/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
The versions being tested for backwards compatibility are no longer supported, so I've excluded them from the workspace to avoid spending ci hours on these.