### PR TITLE
Added example with custom query around the `fuel-core-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,8 @@ dependencies = [
 name = "fuel-core-tests"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
+ "cynic",
  "ethers",
  "fuel-core",
  "fuel-core-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ fuel-vm-private = { version = "0.31.1", package = "fuel-vm" }
 # Common dependencies
 anyhow = "1.0"
 async-trait = "0.1"
+cynic = { version = "2.2.1", features = ["http-reqwest"] }
 clap = "4.1"
 hyper = { version = "0.14.26" }
 rand = "0.8"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -12,7 +12,7 @@ description = "Tx client and schema specification."
 
 [dependencies]
 anyhow = { workspace = true }
-cynic = { version = "2.2.1", features = ["http-reqwest"] }
+cynic = { workspace = true }
 derive_more = { version = "0.99" }
 eventsource-client = { version = "0.10.2", optional = true }
 fuel-core-types = { workspace = true, path = "../types", features = ["serde"] }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -167,7 +167,7 @@ impl FuelClient {
         Self::from_str(url.as_ref())
     }
 
-    async fn query<ResponseData, Vars>(
+    pub async fn query<ResponseData, Vars>(
         &self,
         q: Operation<ResponseData, Vars>,
     ) -> io::Result<ResponseData>

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -25,6 +25,8 @@ path = "tests/metrics.rs"
 required-features = ["metrics"]
 
 [dependencies]
+async-trait = { workspace = true }
+cynic = { workspace = true }
 ethers = "1.0.2"
 fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["dap", "test-helpers"] }
 fuel-core-client = { path = "../crates/client", features = ["test-helpers"] }


### PR DESCRIPTION
Makes the `FuelClient::query` public to allow custom queries. Added an example of how to write custom queries for https://github.com/FuelLabs/fuel-core/issues/1174 but it requires access to the `schema.sdl`
