### PR TITLE
sync port with network info

### DIFF
--- a/bin/e2e-test-client/tests/integration_tests.rs
+++ b/bin/e2e-test-client/tests/integration_tests.rs
@@ -2,13 +2,10 @@ use fuel_core::service::{
     Config,
     FuelService,
 };
-use fuel_core_chain_config::ConsensusConfig;
+
 // Add methods on commands
 use fuel_core_e2e_client::config::SuiteConfig;
-use std::{
-    fs,
-    time::Duration,
-};
+use std::fs;
 use tempfile::TempDir; // Used for writing assertions // Run programs
 
 // Use Jemalloc

--- a/bin/e2e-test-client/tests/integration_tests.rs
+++ b/bin/e2e-test-client/tests/integration_tests.rs
@@ -2,9 +2,13 @@ use fuel_core::service::{
     Config,
     FuelService,
 };
+use fuel_core_chain_config::ConsensusConfig;
 // Add methods on commands
 use fuel_core_e2e_client::config::SuiteConfig;
-use std::fs;
+use std::{
+    fs,
+    time::Duration,
+};
 use tempfile::TempDir; // Used for writing assertions // Run programs
 
 // Use Jemalloc
@@ -87,6 +91,20 @@ async fn setup_local_node() -> FuelService {
     let mut config = Config::local_node();
     // The `run_contract_large_state` test creates a contract with a huge state
     config.chain_conf.transaction_parameters.max_storage_slots = 1 << 17; // 131072
+    match config.chain_conf.consensus {
+        ConsensusConfig::PoA {
+            signing_key,
+            timeout_between_checking_peers,
+            ..
+        } => {
+            config.chain_conf.consensus = ConsensusConfig::PoA {
+                signing_key,
+                time_until_synced: Duration::from_secs(0),
+                min_connected_resereved_peers: 0,
+                timeout_between_checking_peers,
+            }
+        }
+    }
     FuelService::new_node(config).await.unwrap()
 }
 

--- a/bin/e2e-test-client/tests/integration_tests.rs
+++ b/bin/e2e-test-client/tests/integration_tests.rs
@@ -91,20 +91,6 @@ async fn setup_local_node() -> FuelService {
     let mut config = Config::local_node();
     // The `run_contract_large_state` test creates a contract with a huge state
     config.chain_conf.transaction_parameters.max_storage_slots = 1 << 17; // 131072
-    match config.chain_conf.consensus {
-        ConsensusConfig::PoA {
-            signing_key,
-            timeout_between_checking_peers,
-            ..
-        } => {
-            config.chain_conf.consensus = ConsensusConfig::PoA {
-                signing_key,
-                time_until_synced: Duration::from_secs(0),
-                min_connected_resereved_peers: 0,
-                timeout_between_checking_peers,
-            }
-        }
-    }
     FuelService::new_node(config).await.unwrap()
 }
 

--- a/crates/chain-config/src/config/chain.rs
+++ b/crates/chain-config/src/config/chain.rs
@@ -7,7 +7,6 @@ use fuel_core_types::{
     fuel_crypto::Hasher,
     fuel_tx::{
         ConsensusParameters,
-        Input,
         UtxoId,
     },
     fuel_types::{
@@ -46,7 +45,6 @@ use crate::{
         coin::CoinConfig,
         state::StateConfig,
     },
-    default_consensus_dev_key,
     genesis::GenesisCommitment,
     ConsensusConfig,
 };
@@ -81,9 +79,7 @@ impl Default for ChainConfig {
             transaction_parameters: ConsensusParameters::DEFAULT,
             initial_state: None,
             gas_costs: GasCosts::default(),
-            consensus: ConsensusConfig::PoA {
-                signing_key: Input::owner(&default_consensus_dev_key().public_key()),
-            },
+            consensus: ConsensusConfig::default_poa(),
         }
     }
 }

--- a/crates/chain-config/src/config/consensus.rs
+++ b/crates/chain-config/src/config/consensus.rs
@@ -27,8 +27,8 @@ impl ConsensusConfig {
     pub fn default_poa() -> Self {
         ConsensusConfig::PoA {
             signing_key: Input::owner(&default_consensus_dev_key().public_key()),
-            min_connected_resereved_peers: 4,
-            time_until_synced: Duration::from_secs(60),
+            min_connected_resereved_peers: 0,
+            time_until_synced: Duration::from_secs(6),
             timeout_between_checking_peers: Duration::from_millis(500),
         }
     }

--- a/crates/chain-config/src/config/consensus.rs
+++ b/crates/chain-config/src/config/consensus.rs
@@ -19,6 +19,7 @@ pub enum ConsensusConfig {
         time_until_synced: Duration,
         /// Minimum number of connected reserved peers to start block production
         min_connected_resereved_peers: usize,
+        timeout_between_checking_peers: Duration,
     },
 }
 
@@ -28,6 +29,7 @@ impl ConsensusConfig {
             signing_key: Input::owner(&default_consensus_dev_key().public_key()),
             min_connected_resereved_peers: 4,
             time_until_synced: Duration::from_secs(60),
+            timeout_between_checking_peers: Duration::from_millis(500),
         }
     }
 }

--- a/crates/chain-config/src/config/consensus.rs
+++ b/crates/chain-config/src/config/consensus.rs
@@ -1,10 +1,33 @@
-use fuel_core_types::fuel_types::Address;
+use std::time::Duration;
+
+use fuel_core_types::{
+    fuel_tx::Input,
+    fuel_types::Address,
+};
 use serde::{
     Deserialize,
     Serialize,
 };
 
+use crate::default_consensus_dev_key;
+
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub enum ConsensusConfig {
-    PoA { signing_key: Address },
+    PoA {
+        signing_key: Address,
+        /// If this time expires before receving new block - we consider to be synced with the chain
+        time_until_synced: Duration,
+        /// Minimum number of connected reserved peers to start block production
+        min_connected_resereved_peers: usize,
+    },
+}
+
+impl ConsensusConfig {
+    pub fn default_poa() -> Self {
+        ConsensusConfig::PoA {
+            signing_key: Input::owner(&default_consensus_dev_key().public_key()),
+            min_connected_resereved_peers: 4,
+            time_until_synced: Duration::from_secs(60),
+        }
+    }
 }

--- a/crates/chain-config/src/config/consensus.rs
+++ b/crates/chain-config/src/config/consensus.rs
@@ -18,8 +18,7 @@ pub enum ConsensusConfig {
         /// If this time expires before receving new block - we consider to be synced with the chain
         time_until_synced: Duration,
         /// Minimum number of connected reserved peers to start block production
-        min_connected_resereved_peers: usize,
-        timeout_between_checking_peers: Duration,
+        min_connected_reserved_peers: usize,
     },
 }
 
@@ -27,9 +26,8 @@ impl ConsensusConfig {
     pub fn default_poa() -> Self {
         ConsensusConfig::PoA {
             signing_key: Input::owner(&default_consensus_dev_key().public_key()),
-            min_connected_resereved_peers: 0,
-            time_until_synced: Duration::from_secs(6),
-            timeout_between_checking_peers: Duration::from_millis(500),
+            min_connected_reserved_peers: 0,
+            time_until_synced: Duration::ZERO,
         }
     }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
@@ -151,14 +151,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
@@ -151,10 +151,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
@@ -149,7 +149,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
@@ -162,14 +162,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
@@ -162,10 +162,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
@@ -160,7 +160,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
@@ -162,14 +162,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
@@ -162,10 +162,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
@@ -160,7 +160,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
@@ -158,10 +158,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
@@ -158,14 +158,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
@@ -156,7 +156,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
@@ -158,10 +158,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
@@ -158,14 +158,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
@@ -156,7 +156,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
@@ -175,7 +175,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
@@ -177,10 +177,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
@@ -177,14 +177,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
@@ -162,14 +162,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
@@ -162,10 +162,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
@@ -160,7 +160,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
@@ -156,10 +156,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
@@ -154,7 +154,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
@@ -156,14 +156,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
@@ -160,10 +160,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 60,
+        "secs": 6,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 4,
+      "min_connected_resereved_peers": 0,
       "timeout_between_checking_peers": {
         "secs": 0,
         "nanos": 500000000

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
@@ -158,7 +158,16 @@ expression: json
   },
   "consensus": {
     "PoA": {
-      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"
+      "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
+      "time_until_synced": {
+        "secs": 60,
+        "nanos": 0
+      },
+      "min_connected_resereved_peers": 4,
+      "timeout_between_checking_peers": {
+        "secs": 0,
+        "nanos": 500000000
+      }
     }
   }
 }

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
@@ -160,14 +160,10 @@ expression: json
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",
       "time_until_synced": {
-        "secs": 6,
+        "secs": 0,
         "nanos": 0
       },
-      "min_connected_resereved_peers": 0,
-      "timeout_between_checking_peers": {
-        "secs": 0,
-        "nanos": 500000000
-      }
+      "min_connected_reserved_peers": 0
     }
   }
 }

--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -237,7 +237,10 @@ pub async fn make_nodes(
                     );
                     if let Some(BootstrapSetup { pub_key, .. }) = boot {
                         match &mut node_config.chain_conf.consensus {
-                            crate::chain_config::ConsensusConfig::PoA { signing_key } => {
+                            crate::chain_config::ConsensusConfig::PoA {
+                                signing_key,
+                                ..
+                            } => {
                                 *signing_key = pub_key;
                             }
                         }
@@ -268,7 +271,7 @@ pub async fn make_nodes(
         if let Some((ProducerSetup { secret, .. }, txs)) = s {
             let pub_key = secret.public_key();
             match &mut node_config.chain_conf.consensus {
-                crate::chain_config::ConsensusConfig::PoA { signing_key } => {
+                crate::chain_config::ConsensusConfig::PoA { signing_key, .. } => {
                     *signing_key = Input::owner(&pub_key);
                 }
             }
@@ -297,7 +300,7 @@ pub async fn make_nodes(
 
         if let Some(ValidatorSetup { pub_key, .. }) = s {
             match &mut node_config.chain_conf.consensus {
-                crate::chain_config::ConsensusConfig::PoA { signing_key } => {
+                crate::chain_config::ConsensusConfig::PoA { signing_key, .. } => {
                     *signing_key = pub_key;
                 }
             }

--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -11,7 +11,6 @@ use crate::{
         ServiceTrait,
     },
 };
-use fuel_core_chain_config::ConsensusConfig;
 use fuel_core_p2p::{
     codecs::postcard::PostcardCodec,
     network_service::FuelP2PService,
@@ -199,21 +198,6 @@ pub async fn make_nodes(
     let mut producers_with_txs = Vec::with_capacity(producers.len());
     let mut chain_config = ChainConfig::local_testnet();
     chain_config.transaction_parameters.max_storage_slots = 1 << 17; // 131072
-
-    match chain_config.consensus {
-        ConsensusConfig::PoA {
-            signing_key,
-            timeout_between_checking_peers,
-            ..
-        } => {
-            chain_config.consensus = ConsensusConfig::PoA {
-                signing_key,
-                time_until_synced: Duration::from_secs(0),
-                min_connected_resereved_peers: 0,
-                timeout_between_checking_peers,
-            }
-        }
-    }
 
     for (all, producer) in txs_coins.into_iter().zip(producers.into_iter()) {
         match all {

--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -11,6 +11,7 @@ use crate::{
         ServiceTrait,
     },
 };
+use fuel_core_chain_config::ConsensusConfig;
 use fuel_core_p2p::{
     codecs::postcard::PostcardCodec,
     network_service::FuelP2PService,
@@ -198,6 +199,21 @@ pub async fn make_nodes(
     let mut producers_with_txs = Vec::with_capacity(producers.len());
     let mut chain_config = ChainConfig::local_testnet();
     chain_config.transaction_parameters.max_storage_slots = 1 << 17; // 131072
+
+    match chain_config.consensus {
+        ConsensusConfig::PoA {
+            signing_key,
+            timeout_between_checking_peers,
+            ..
+        } => {
+            chain_config.consensus = ConsensusConfig::PoA {
+                signing_key,
+                time_until_synced: Duration::from_secs(0),
+                min_connected_resereved_peers: 0,
+                timeout_between_checking_peers,
+            }
+        }
+    }
 
     for (all, producer) in txs_coins.into_iter().zip(producers.into_iter()) {
         match all {

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -308,6 +308,7 @@ mod tests {
             i += 1;
         }
 
+        // current services: graphql, txpool, PoA
         #[allow(unused_mut)]
         let mut expected_services = 3;
 
@@ -318,8 +319,8 @@ mod tests {
         // }
         #[cfg(feature = "p2p")]
         {
-            // p2p
-            expected_services += 1;
+            // p2p & sync
+            expected_services += 2;
         }
 
         // # Dev-note: Update the `expected_services` when we add/remove a new/old service.

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -5,7 +5,10 @@ use crate::{
 use fuel_core_consensus_module::block_verifier::Verifier;
 use fuel_core_txpool::service::SharedState as TxPoolSharedState;
 use fuel_core_types::services::block_importer::ImportResult;
-use std::sync::Arc;
+use std::{
+    sync::Arc,
+    time::Duration,
+};
 use tokio::sync::broadcast::Receiver;
 
 pub mod block_importer;
@@ -118,6 +121,7 @@ pub trait NetworkInfo {
 pub struct SyncAdapter<T: NetworkInfo> {
     block_rx: Receiver<Arc<ImportResult>>,
     min_connected_reserved_peers: usize,
+    time_until_synced: Duration,
     network_info: T,
 }
 
@@ -125,11 +129,13 @@ impl<T: NetworkInfo> SyncAdapter<T> {
     pub fn new(
         block_rx: Receiver<Arc<ImportResult>>,
         min_connected_reserved_peers: usize,
+        time_until_synced: Duration,
         network_info: T,
     ) -> Self {
         Self {
             block_rx,
             min_connected_reserved_peers,
+            time_until_synced,
             network_info,
         }
     }

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -106,7 +106,8 @@ impl P2PAdapter {
 #[async_trait::async_trait]
 impl NetworkInfo for P2PAdapter {
     async fn connected_reserved_peers(&self) -> usize {
-        0
+        /// returns fake number of connected peers - since p2p is not enabled at all
+        usize::MAX
     }
 }
 

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -2,15 +2,10 @@ use crate::{
     database::Database,
     service::Config,
 };
-use anyhow::Result;
+
 use fuel_core_consensus_module::block_verifier::Verifier;
 use fuel_core_txpool::service::SharedState as TxPoolSharedState;
-use fuel_core_types::services::block_importer::ImportResult;
-use std::{
-    sync::Arc,
-    time::Duration,
-};
-use tokio::sync::broadcast::Receiver;
+use std::sync::Arc;
 
 pub mod block_importer;
 pub mod consensus_module;
@@ -87,59 +82,9 @@ impl P2PAdapter {
     }
 }
 
-#[cfg(feature = "p2p")]
-#[async_trait::async_trait]
-impl NetworkInfo for P2PAdapter {
-    async fn connected_reserved_peers(&self) -> anyhow::Result<usize> {
-        if let Some(service) = self.service.as_ref() {
-            service.connected_reserved_peers_count().await
-        } else {
-            anyhow::bail!("P2P is not enabled")
-        }
-    }
-}
-
 #[cfg(not(feature = "p2p"))]
 impl P2PAdapter {
     pub fn new() -> Self {
         Default::default()
-    }
-}
-
-#[cfg(not(feature = "p2p"))]
-#[async_trait::async_trait]
-impl NetworkInfo for P2PAdapter {
-    async fn connected_reserved_peers(&self) -> Result<usize> {
-        Ok(0)
-    }
-}
-
-#[async_trait::async_trait]
-pub trait NetworkInfo {
-    async fn connected_reserved_peers(&self) -> Result<usize>;
-}
-pub struct SyncAdapter<T: NetworkInfo> {
-    block_rx: Receiver<Arc<ImportResult>>,
-    min_connected_reserved_peers: usize,
-    time_until_synced: Duration,
-    timeout_between_checking_peers: Duration,
-    network_info: T,
-}
-
-impl<T: NetworkInfo> SyncAdapter<T> {
-    pub fn new(
-        block_rx: Receiver<Arc<ImportResult>>,
-        min_connected_reserved_peers: usize,
-        time_until_synced: Duration,
-        timeout_between_checking_peers: Duration,
-        network_info: T,
-    ) -> Self {
-        Self {
-            block_rx,
-            min_connected_reserved_peers,
-            time_until_synced,
-            timeout_between_checking_peers,
-            network_info,
-        }
     }
 }

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -106,7 +106,7 @@ impl P2PAdapter {
 #[async_trait::async_trait]
 impl NetworkInfo for P2PAdapter {
     async fn connected_reserved_peers(&self) -> usize {
-        /// returns fake number of connected peers - since p2p is not enabled at all
+        // returns fake number of connected peers - since p2p is not enabled at all
         usize::MAX
     }
 }

--- a/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
@@ -118,16 +118,11 @@ impl SyncPort for crate::service::adapters::SyncAdapter {
     async fn sync_with_peers(&mut self) -> anyhow::Result<()> {
         // todo: connect to N amount of peers first!
 
-        'outer: loop {
-            tokio::select! {
-                _ = self.block_rx.recv() => {
-                    // keep receiving them blocks
-                }
-                _ = tokio::time::sleep(TIME_UNTIL_SYNCED) => {
-                    // time expired we are synced!
-                    break 'outer;
-                }
-            }
+        while tokio::time::timeout(TIME_UNTIL_SYNCED, self.block_rx.recv())
+            .await
+            .is_ok()
+        {
+            // keep receiving them blocks
         }
 
         Ok(())

--- a/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
@@ -138,13 +138,3 @@ impl P2pPort for P2PAdapter {
         Box::pin(tokio_stream::pending())
     }
 }
-
-// `ImportResult` add new field to identify is the block produce by ourself or from the network
-// P2P provides subscription to the "current number of connected reserved peers".
-//
-// With next statements all unit test should continue to work as before:
-// If `min_connected_reserved_peers` is zero, then the initial `State` is `SufficientPeers`.
-// If `time_until_synced` and `min_connected_reserved_peers` are, then the initial `State` is `Synced`.
-// For the `Config::local_testnet` `min_connected_reserved_peers` and `time_until_synced` are zero.
-//
-// Not to forget to add a new integration test where we start teh second block producer.

--- a/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
@@ -113,8 +113,6 @@ impl BlockImporter for BlockImporterAdapter {
     }
 }
 
-const TIME_UNTIL_SYNCED: Duration = Duration::from_secs(60);
-
 #[async_trait::async_trait]
 impl SyncPort for crate::service::adapters::SyncAdapter<P2PAdapter> {
     async fn sync_with_peers(&mut self) -> anyhow::Result<()> {
@@ -132,7 +130,7 @@ impl SyncPort for crate::service::adapters::SyncAdapter<P2PAdapter> {
         }
 
         // 2. receive all the blocks
-        while tokio::time::timeout(TIME_UNTIL_SYNCED, self.block_rx.recv())
+        while tokio::time::timeout(self.time_until_synced, self.block_rx.recv())
             .await
             .is_ok()
         {

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 use fuel_core_chain_config::{
     default_consensus_dev_key,
     ChainConfig,
+    ConsensusConfig,
 };
 use fuel_core_types::{
     blockchain::primitives::SecretKeyWrapper,
@@ -112,12 +113,23 @@ impl TryFrom<&Config> for fuel_core_poa::Config {
             "Cannot use manual block production unless trigger mode is never, instant or interval."
         );
 
+        let (min_connected_reserved_peers, time_until_synced) =
+            match config.chain_conf.consensus {
+                ConsensusConfig::PoA {
+                    min_connected_reserved_peers,
+                    time_until_synced,
+                    ..
+                } => (min_connected_reserved_peers, time_until_synced),
+            };
+
         Ok(fuel_core_poa::Config {
             trigger: config.block_production,
             block_gas_limit: config.chain_conf.block_gas_limit,
             signing_key: config.consensus_key.clone(),
             metrics: false,
             consensus_params: config.chain_conf.transaction_parameters,
+            min_connected_reserved_peers,
+            time_until_synced,
         })
     }
 }

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -132,11 +132,13 @@ pub fn init_sub_services(
             fuel_core_chain_config::ConsensusConfig::PoA {
                 time_until_synced,
                 min_connected_resereved_peers,
+                timeout_between_checking_peers,
                 ..
             } => SyncAdapter::new(
                 importer_adapter.block_importer.subscribe(),
                 min_connected_resereved_peers,
                 time_until_synced,
+                timeout_between_checking_peers,
                 p2p_adapter.clone(),
             ),
         };

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -1,8 +1,5 @@
 #![allow(clippy::let_unit_value)]
-use super::adapters::{
-    P2PAdapter,
-    SyncAdapter,
-};
+use super::adapters::P2PAdapter;
 
 use crate::{
     database::Database,
@@ -27,12 +24,8 @@ use fuel_core_poa::Trigger;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-pub type PoAService = fuel_core_poa::Service<
-    TxPoolAdapter,
-    BlockProducerAdapter,
-    BlockImporterAdapter,
-    SyncAdapter<P2PAdapter>,
->;
+pub type PoAService =
+    fuel_core_poa::Service<TxPoolAdapter, BlockProducerAdapter, BlockImporterAdapter>;
 #[cfg(feature = "relayer")]
 pub type RelayerService = fuel_core_relayer::Service<Database>;
 #[cfg(feature = "p2p")]
@@ -128,20 +121,20 @@ pub fn init_sub_services(
         !matches!(poa_config.trigger, Trigger::Never) || config.manual_blocks_enabled;
 
     let poa = (production_enabled).then(|| {
-        let syncer = match config.chain_conf.consensus {
-            fuel_core_chain_config::ConsensusConfig::PoA {
-                time_until_synced,
-                min_connected_resereved_peers,
-                timeout_between_checking_peers,
-                ..
-            } => SyncAdapter::new(
-                importer_adapter.block_importer.subscribe(),
-                min_connected_resereved_peers,
-                time_until_synced,
-                timeout_between_checking_peers,
-                p2p_adapter.clone(),
-            ),
-        };
+        // let syncer = match config.chain_conf.consensus {
+        //     fuel_core_chain_config::ConsensusConfig::PoA {
+        //         time_until_synced,
+        //         min_connected_resereved_peers,
+        //         timeout_between_checking_peers,
+        //         ..
+        //     } => SyncAdapter::new(
+        //         importer_adapter.block_importer.subscribe(),
+        //         min_connected_resereved_peers,
+        //         time_until_synced,
+        //         timeout_between_checking_peers,
+        //         p2p_adapter.clone(),
+        //     ),
+        // };
 
         fuel_core_poa::new_service(
             last_block.header(),
@@ -149,7 +142,6 @@ pub fn init_sub_services(
             tx_pool_adapter.clone(),
             producer_adapter.clone(),
             importer_adapter.clone(),
-            syncer,
         )
     });
     let poa_adapter = PoAAdapter::new(poa.as_ref().map(|service| service.shared.clone()));

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -121,27 +121,13 @@ pub fn init_sub_services(
         !matches!(poa_config.trigger, Trigger::Never) || config.manual_blocks_enabled;
 
     let poa = (production_enabled).then(|| {
-        // let syncer = match config.chain_conf.consensus {
-        //     fuel_core_chain_config::ConsensusConfig::PoA {
-        //         time_until_synced,
-        //         min_connected_resereved_peers,
-        //         timeout_between_checking_peers,
-        //         ..
-        //     } => SyncAdapter::new(
-        //         importer_adapter.block_importer.subscribe(),
-        //         min_connected_resereved_peers,
-        //         time_until_synced,
-        //         timeout_between_checking_peers,
-        //         p2p_adapter.clone(),
-        //     ),
-        // };
-
         fuel_core_poa::new_service(
             last_block.header(),
             poa_config,
             tx_pool_adapter.clone(),
             producer_adapter.clone(),
             importer_adapter.clone(),
+            p2p_adapter.clone(),
         )
     });
     let poa_adapter = PoAAdapter::new(poa.as_ref().map(|service| service.shared.clone()));

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -31,7 +31,7 @@ pub type PoAService = fuel_core_poa::Service<
     TxPoolAdapter,
     BlockProducerAdapter,
     BlockImporterAdapter,
-    SyncAdapter,
+    SyncAdapter<P2PAdapter>,
 >;
 #[cfg(feature = "relayer")]
 pub type RelayerService = fuel_core_relayer::Service<Database>;
@@ -128,7 +128,11 @@ pub fn init_sub_services(
         !matches!(poa_config.trigger, Trigger::Never) || config.manual_blocks_enabled;
 
     let poa = (production_enabled).then(|| {
-        let syncer = SyncAdapter::new(importer_adapter.block_importer.subscribe());
+        let syncer = SyncAdapter::new(
+            importer_adapter.block_importer.subscribe(),
+            4,
+            p2p_adapter.clone(),
+        );
 
         fuel_core_poa::new_service(
             last_block.header(),

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -128,11 +128,18 @@ pub fn init_sub_services(
         !matches!(poa_config.trigger, Trigger::Never) || config.manual_blocks_enabled;
 
     let poa = (production_enabled).then(|| {
-        let syncer = SyncAdapter::new(
-            importer_adapter.block_importer.subscribe(),
-            4,
-            p2p_adapter.clone(),
-        );
+        let syncer = match config.chain_conf.consensus {
+            fuel_core_chain_config::ConsensusConfig::PoA {
+                time_until_synced,
+                min_connected_resereved_peers,
+                ..
+            } => SyncAdapter::new(
+                importer_adapter.block_importer.subscribe(),
+                min_connected_resereved_peers,
+                time_until_synced,
+                p2p_adapter.clone(),
+            ),
+        };
 
         fuel_core_poa::new_service(
             last_block.header(),

--- a/crates/services/consensus_module/poa/src/config.rs
+++ b/crates/services/consensus_module/poa/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub signing_key: Option<Secret<SecretKeyWrapper>>,
     pub metrics: bool,
     pub consensus_params: ConsensusParameters,
+    pub min_connected_reserved_peers: usize,
+    pub time_until_synced: Duration,
 }
 
 /// Block production trigger for PoA operation

--- a/crates/services/consensus_module/poa/src/lib.rs
+++ b/crates/services/consensus_module/poa/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(unused_must_use)]
 
 mod deadline_clock;
+mod sync;
 
 #[cfg(test)]
 mod service_test;

--- a/crates/services/consensus_module/poa/src/ports.rs
+++ b/crates/services/consensus_module/poa/src/ports.rs
@@ -88,6 +88,7 @@ pub trait RelayerPort {
 }
 
 #[async_trait::async_trait]
+#[cfg_attr(test, mockall::automock)]
 pub trait SyncPort: Send + Sync {
     /// await synchronization with the peers
     async fn sync_with_peers(&mut self) -> anyhow::Result<()>;

--- a/crates/services/consensus_module/poa/src/ports.rs
+++ b/crates/services/consensus_module/poa/src/ports.rs
@@ -39,7 +39,6 @@ pub trait TransactionPool: Send + Sync {
 
 #[cfg(test)]
 use fuel_core_storage::test_helpers::EmptyStorage;
-use tokio::sync::broadcast::Receiver;
 
 #[cfg_attr(test, mockall::automock(type Database=EmptyStorage;))]
 #[async_trait::async_trait]
@@ -62,6 +61,8 @@ pub trait BlockImporter: Send + Sync {
         &self,
         result: UncommittedImportResult<StorageTransaction<Self::Database>>,
     ) -> anyhow::Result<()>;
+
+    fn block_stream(&self) -> BoxStream<BlockHeight>;
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -88,9 +89,10 @@ pub trait RelayerPort {
     ) -> anyhow::Result<()>;
 }
 
+#[cfg_attr(test, mockall::automock)]
 pub trait P2pPort: Send + Sync + 'static {
     /// Subscribe to reserved peers connection updates.
-    fn reserved_peers_count(&self) -> Receiver<usize>;
+    fn reserved_peers_count(&self) -> BoxStream<usize>;
 }
 
 #[async_trait::async_trait]

--- a/crates/services/consensus_module/poa/src/ports.rs
+++ b/crates/services/consensus_module/poa/src/ports.rs
@@ -39,6 +39,7 @@ pub trait TransactionPool: Send + Sync {
 
 #[cfg(test)]
 use fuel_core_storage::test_helpers::EmptyStorage;
+use tokio::sync::broadcast::Receiver;
 
 #[cfg_attr(test, mockall::automock(type Database=EmptyStorage;))]
 #[async_trait::async_trait]
@@ -85,6 +86,11 @@ pub trait RelayerPort {
         da_height: &DaBlockHeight,
         max_da_lag: &DaBlockHeight,
     ) -> anyhow::Result<()>;
+}
+
+pub trait P2pPort: Send + Sync + 'static {
+    /// Subscribe to reserved peers connection updates.
+    fn reserved_peers_count(&self) -> Receiver<usize>;
 }
 
 #[async_trait::async_trait]

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -470,6 +470,9 @@ where
     S: SyncPort,
 {
     async fn run(&mut self, watcher: &mut StateWatcher) -> anyhow::Result<bool> {
+        // make sure we're synced first
+        self.sync_port.sync_with_peers().await?;
+
         let should_continue;
         tokio::select! {
             _ = watcher.while_started() => {
@@ -479,7 +482,6 @@ where
                 if let Some(request) = request {
                     match request {
                         Request::ManualBlocks((block, response)) => {
-                            let _ = self.sync_port.sync_with_peers().await;
                             let result = self.produce_manual_blocks(block).await;
                             let _ = response.send(result);
                         }

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -471,7 +471,12 @@ where
 {
     async fn run(&mut self, watcher: &mut StateWatcher) -> anyhow::Result<bool> {
         // make sure we're synced first
-        self.sync_port.sync_with_peers().await?;
+        tokio::select! {
+            _ = self.sync_port.sync_with_peers() => {},
+            _ = watcher.while_started() => {
+                return Ok(false);
+            }
+        }
 
         let should_continue;
         tokio::select! {

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -132,7 +132,6 @@ pub struct MainTask<T, B, I> {
     block_producer: B,
     block_importer: I,
     txpool: T,
-    sync_state: tokio::sync::watch::Receiver<SyncState>,
     tx_status_update_stream: BoxStream<TxStatus>,
     request_receiver: mpsc::Receiver<Request>,
     shared_state: SharedState,
@@ -143,6 +142,7 @@ pub struct MainTask<T, B, I> {
     /// Deadline clock, used by the triggers
     timer: DeadlineClock,
     consensus_params: ConsensusParameters,
+    sync_state: tokio::sync::watch::Receiver<SyncState>,
     sync_task_handle: ServiceRunner<SyncTask>,
 }
 
@@ -166,9 +166,8 @@ where
             Duration::from_secs(Tai64::now().0.saturating_sub(last_timestamp.0));
         let last_block_created = Instant::now() - duration;
 
-        // todo get from config
-        let min_connected_reserved_peers = 0;
-        let time_until_synced = Duration::ZERO;
+        let min_connected_reserved_peers = config.min_connected_reserved_peers;
+        let time_until_synced = config.time_until_synced;
 
         let initial_sync_state =
             SyncState::from_config(min_connected_reserved_peers, time_until_synced);

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -442,7 +442,7 @@ where
     async fn into_task(
         self,
         _: &StateWatcher,
-        params: Self::TaskParams,
+        _: Self::TaskParams,
     ) -> anyhow::Result<Self::Task> {
         match self.trigger {
             Trigger::Never | Trigger::Instant => {}
@@ -476,10 +476,10 @@ where
                 should_continue = false;
             }
             request = self.request_receiver.recv() => {
-                // todo read sync before producing a block
                 if let Some(request) = request {
                     match request {
                         Request::ManualBlocks((block, response)) => {
+                            let _ = self.sync_port.sync_with_peers().await;
                             let result = self.produce_manual_blocks(block).await;
                             let _ = response.send(result);
                         }

--- a/crates/services/consensus_module/poa/src/service_test.rs
+++ b/crates/services/consensus_module/poa/src/service_test.rs
@@ -142,6 +142,9 @@ impl TestContextBuilder {
             let mut importer = MockBlockImporter::default();
             importer.expect_commit_result().returning(|_| Ok(()));
             importer
+                .expect_block_stream()
+                .returning(|| Box::pin(tokio_stream::pending()));
+            importer
         });
 
         let txpool = self
@@ -319,7 +322,7 @@ async fn remove_skipped_transactions() {
         block_gas_limit: 1000000,
         signing_key: Some(Secret::new(secret_key.into())),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     };
 
     let p2p_port = generate_p2p_port();
@@ -364,7 +367,7 @@ async fn does_not_produce_when_txpool_empty_in_instant_mode() {
         block_gas_limit: 1000000,
         signing_key: Some(Secret::new(secret_key.into())),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     };
 
     let p2p_port = generate_p2p_port();
@@ -424,7 +427,7 @@ async fn hybrid_production_doesnt_produce_empty_blocks_when_txpool_is_empty() {
         block_gas_limit: 1000000,
         signing_key: Some(Secret::new(secret_key.into())),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     };
 
     let p2p_port = generate_p2p_port();

--- a/crates/services/consensus_module/poa/src/service_test.rs
+++ b/crates/services/consensus_module/poa/src/service_test.rs
@@ -84,7 +84,7 @@ fn generate_sync_port() -> MockSyncPort {
 
     syncer
         .expect_sync_with_peers()
-        .return_once(move || Box::pin(async { Ok(()) }));
+        .returning(move || Box::pin(async { Ok(()) }));
 
     syncer
 }

--- a/crates/services/consensus_module/poa/src/service_test.rs
+++ b/crates/services/consensus_module/poa/src/service_test.rs
@@ -296,6 +296,10 @@ async fn remove_skipped_transactions() {
         .times(1)
         .returning(|_| Ok(()));
 
+    block_importer
+        .expect_block_stream()
+        .returning(|| Box::pin(tokio_stream::pending()));
+
     let mut txpool = MockTransactionPool::no_tx_updates();
     // Test created for only for this check.
     txpool.expect_remove_txs().returning(move |skipped_ids| {
@@ -357,6 +361,9 @@ async fn does_not_produce_when_txpool_empty_in_instant_mode() {
     block_importer
         .expect_commit_result()
         .returning(|_| panic!("Block importer should not be called"));
+    block_importer
+        .expect_block_stream()
+        .returning(|| Box::pin(tokio_stream::pending()));
 
     let mut txpool = MockTransactionPool::no_tx_updates();
     txpool.expect_total_consumable_gas().returning(|| 0);
@@ -413,6 +420,10 @@ async fn hybrid_production_doesnt_produce_empty_blocks_when_txpool_is_empty() {
     block_importer
         .expect_commit_result()
         .returning(|_| panic!("Block importer should not be called"));
+
+    block_importer
+        .expect_block_stream()
+        .returning(|| Box::pin(tokio_stream::pending()));
 
     let mut txpool = MockTransactionPool::no_tx_updates();
     txpool.expect_total_consumable_gas().returning(|| 0);

--- a/crates/services/consensus_module/poa/src/service_test.rs
+++ b/crates/services/consensus_module/poa/src/service_test.rs
@@ -6,7 +6,7 @@ use crate::{
         MockSyncPort,
         MockTransactionPool,
     },
-    service::Task,
+    service::MainTask,
     Config,
     Service,
     Trigger,
@@ -325,7 +325,7 @@ async fn remove_skipped_transactions() {
 
     let syncer = generate_sync_port();
 
-    let mut task = Task::new(
+    let mut task = MainTask::new(
         &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
         config,
         txpool,
@@ -370,7 +370,7 @@ async fn does_not_produce_when_txpool_empty_in_instant_mode() {
 
     let syncer = generate_sync_port();
 
-    let mut task = Task::new(
+    let mut task = MainTask::new(
         &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
         config,
         txpool,
@@ -430,7 +430,7 @@ async fn hybrid_production_doesnt_produce_empty_blocks_when_txpool_is_empty() {
 
     let syncer = generate_sync_port();
 
-    let task = Task::new(
+    let task = MainTask::new(
         &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
         config,
         txpool,

--- a/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
@@ -65,6 +65,10 @@ async fn can_manually_produce_block(
             .unwrap();
         Ok(())
     });
+    importer
+        .expect_block_stream()
+        .returning(|| Box::pin(tokio_stream::pending()));
+
     let mut producer = MockBlockProducer::default();
     producer
         .expect_produce_and_execute_block()

--- a/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
@@ -45,7 +45,7 @@ async fn can_manually_produce_block(
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
 
     // initialize txpool with some txs

--- a/crates/services/consensus_module/poa/src/service_test/trigger_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/trigger_tests.rs
@@ -20,7 +20,7 @@ async fn clean_startup_shutdown_each_trigger() -> anyhow::Result<()> {
             block_gas_limit: 100_000,
             signing_key: Some(test_signing_key()),
             metrics: false,
-            consensus_params: Default::default(),
+            ..Default::default()
         });
         let ctx = ctx_builder.build();
 
@@ -40,7 +40,7 @@ async fn never_trigger_never_produces_blocks() {
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
 
     // initialize txpool with some txs
@@ -57,6 +57,9 @@ async fn never_trigger_never_produces_blocks() {
     importer
         .expect_commit_result()
         .returning(|_| panic!("Should not commit result"));
+    importer
+        .expect_block_stream()
+        .returning(|| Box::pin(tokio_stream::pending()));
     ctx_builder.with_importer(importer);
     let ctx = ctx_builder.build();
     for _ in 0..TX_COUNT {
@@ -100,6 +103,9 @@ impl DefaultContext {
             block_import_sender.send(sealed_block)?;
             Ok(())
         });
+        importer
+            .expect_block_stream()
+            .returning(|| Box::pin(tokio_stream::pending()));
         ctx_builder.with_importer(importer);
 
         let test_ctx = ctx_builder.build();
@@ -121,7 +127,7 @@ async fn instant_trigger_produces_block_instantly() {
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
     ctx.status_sender.send_replace(Some(TxStatus::Submitted));
 
@@ -141,7 +147,7 @@ async fn interval_trigger_produces_blocks_periodically() -> anyhow::Result<()> {
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
     ctx.status_sender.send_replace(Some(TxStatus::Submitted));
 
@@ -207,7 +213,7 @@ async fn interval_trigger_doesnt_react_to_full_txpool() -> anyhow::Result<()> {
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
 
     // Brackets to release the lock.
@@ -254,7 +260,7 @@ async fn hybrid_trigger_produces_blocks_correctly_max_block_time() -> anyhow::Re
         block_gas_limit: 100_000,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
 
     // Make sure no blocks are produced yet
@@ -301,7 +307,7 @@ async fn hybrid_trigger_produces_blocks_correctly_max_block_time_not_overrides_m
         block_gas_limit: Word::MAX,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
 
     // Make sure no blocks are produced when txpool is empty and `MAX_BLOCK_TIME` is not exceeded
@@ -344,7 +350,7 @@ async fn hybrid_trigger_produces_blocks_correctly_max_tx_idle_time() -> anyhow::
         block_gas_limit: Word::MAX,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
 
     assert!(matches!(
@@ -396,7 +402,7 @@ async fn hybrid_trigger_produces_blocks_correctly_min_block_time_min_block_gas_l
         block_gas_limit: Word::MIN,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
 
     // Emulate tx status update to trigger the execution.
@@ -454,7 +460,7 @@ async fn hybrid_trigger_produces_blocks_correctly_min_block_time_max_block_gas_l
         block_gas_limit: Word::MAX,
         signing_key: Some(test_signing_key()),
         metrics: false,
-        consensus_params: Default::default(),
+        ..Default::default()
     });
 
     // Emulate tx status update to trigger the execution.

--- a/crates/services/consensus_module/poa/src/sync.rs
+++ b/crates/services/consensus_module/poa/src/sync.rs
@@ -208,7 +208,7 @@ impl InnerSyncState {
         match self {
             InnerSyncState::InsufficientPeers(block_height)
             | InnerSyncState::SufficientPeers(block_height)
-            | InnerSyncState::Synced(block_height) => &block_height,
+            | InnerSyncState::Synced(block_height) => block_height,
         }
     }
 

--- a/crates/services/consensus_module/poa/src/sync.rs
+++ b/crates/services/consensus_module/poa/src/sync.rs
@@ -1,0 +1,245 @@
+use std::{
+    sync::Arc,
+    time::Duration,
+};
+
+use fuel_core_types::{
+    fuel_types::BlockHeight,
+    services::block_importer::ImportResult,
+};
+use tokio::{
+    sync::{
+        broadcast,
+        watch,
+    },
+    time::Instant,
+};
+
+use crate::ports::P2pPort;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SyncState {
+    NotSynced,
+    Synced,
+}
+
+pub struct SyncTask<T> {
+    min_connected_reserved_peers: usize,
+    time_until_synced: Duration,
+    time_left_until_synced: Duration,
+    p2p_port: T,
+    block_rx: broadcast::Receiver<Arc<ImportResult>>,
+    state_sender: watch::Sender<SyncState>,
+    inner_state: InnerSyncState,
+    notify: Arc<tokio::sync::Notify>,
+}
+
+impl<T> SyncTask<T> {
+    pub fn new(
+        p2p_port: T,
+        min_connected_reserved_peers: usize,
+        time_until_synced: Duration,
+        block_rx: broadcast::Receiver<Arc<ImportResult>>,
+        notify: Arc<tokio::sync::Notify>,
+        state_sender: watch::Sender<SyncState>,
+        block_height: BlockHeight,
+    ) -> Self {
+        let inner_state = {
+            match (min_connected_reserved_peers, time_until_synced) {
+                (0, Duration::ZERO) => InnerSyncState::Synced(block_height),
+                (0, _) => InnerSyncState::SufficientPeers(block_height),
+                _ => InnerSyncState::InsufficientPeers(block_height),
+            }
+        };
+
+        Self {
+            min_connected_reserved_peers,
+            time_until_synced,
+            time_left_until_synced: time_until_synced,
+            p2p_port,
+            block_rx,
+            state_sender,
+            inner_state,
+            notify,
+        }
+    }
+}
+
+impl<T> SyncTask<T>
+where
+    T: P2pPort,
+{
+    pub async fn run(&mut self) -> anyhow::Result<()> {
+        if self.inner_state.is_sufficient() {
+            self.sync_when_sufficient().await?;
+        } else {
+            self.sync().await?;
+        }
+
+        Ok(())
+    }
+
+    async fn sync(&mut self) -> anyhow::Result<()> {
+        let mut reserved_peers_count = self.p2p_port.reserved_peers_count();
+
+        tokio::select! {
+            latest_count = reserved_peers_count.recv() => {
+                if let Ok(latest_count) = latest_count {
+                    if self.inner_state.change_state_on_peers_update(latest_count >= self.min_connected_reserved_peers) {
+                        self.state_sender.send(self.inner_state.sync_state())?;
+                    }
+                }
+            }
+            block = self.block_rx.recv() => {
+                if let Ok(block) = block {
+                    if self.inner_state.change_state_on_block(block) {
+                        self.state_sender.send(self.inner_state.sync_state())?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn sync_when_sufficient(&mut self) -> anyhow::Result<()> {
+        let mut reserved_peers_count = self.p2p_port.reserved_peers_count();
+        let now = Instant::now();
+
+        tokio::select! {
+            latest_count = reserved_peers_count.recv() => {
+                if let Ok(latest_count) = latest_count {
+                    if self.inner_state.change_state_on_peers_update(latest_count >= self.min_connected_reserved_peers) {
+                        self.time_left_until_synced = self.time_until_synced;
+                        self.state_sender.send(self.inner_state.sync_state())?;
+                    } else {
+                        self.time_left_until_synced = self.time_left_until_synced - now.elapsed();
+                    }
+                }
+
+            }
+            block = self.block_rx.recv() => {
+                if let Ok(block) = block {
+                    if self.inner_state.change_state_on_block(block) {
+                        self.time_left_until_synced = self.time_until_synced;
+                        self.state_sender.send(self.inner_state.sync_state())?;
+                    } else {
+                        self.time_left_until_synced = self.time_left_until_synced - now.elapsed();
+                    }
+                }
+            }
+            _ = tokio::time::sleep(self.time_left_until_synced) => {
+                if self.inner_state.change_on_sync_timeout() {
+                    self.time_left_until_synced = self.time_until_synced;
+                    self.notify.notify_one();
+                    self.state_sender.send(self.inner_state.sync_state())?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InnerSyncState {
+    /// We are not connected to at least `min_connected_reserved_peers` peers.
+    ///
+    /// InsufficientPeers -> SufficientPeers
+    InsufficientPeers(BlockHeight),
+    /// We are connected to at least `min_connected_reserved_peers` peers.
+    ///
+    /// SufficientPeers -> Synced(...)
+    SufficientPeers(BlockHeight),
+    /// We can go into this state if we didn't receive any notification
+    /// about new block height from the network for `time_until_synced` timeout.
+    ///
+    /// We can leave this state only in the case, if we received a valid block
+    /// from the network with higher block height.
+    ///
+    /// Synced -> either InsufficientPeers(...) or SufficientPeers(...)
+    Synced(BlockHeight),
+}
+
+impl InnerSyncState {
+    fn change_state_on_block(&mut self, block: Arc<ImportResult>) -> bool {
+        let mut state_changed = false;
+
+        let latest_block_height = block.sealed_block.entity.header().height();
+        let current_block_height = self.block_height();
+
+        if latest_block_height > current_block_height {
+            match self {
+                InnerSyncState::InsufficientPeers(_) => {
+                    *self = InnerSyncState::InsufficientPeers(*latest_block_height);
+                }
+                InnerSyncState::SufficientPeers(_) => {
+                    *self = InnerSyncState::SufficientPeers(*latest_block_height);
+                }
+                InnerSyncState::Synced(_) => {
+                    // we considered to be synced but we're obiously not!
+                    *self = InnerSyncState::SufficientPeers(*latest_block_height);
+                    state_changed = true;
+                }
+            }
+        }
+
+        state_changed
+    }
+
+    fn change_state_on_peers_update(&mut self, sufficient_peers: bool) -> bool {
+        let mut state_changed = false;
+
+        match self {
+            InnerSyncState::InsufficientPeers(block_height) => {
+                if sufficient_peers {
+                    *self = InnerSyncState::SufficientPeers(*block_height);
+                    state_changed = true;
+                }
+            }
+            InnerSyncState::SufficientPeers(block_height)
+            | InnerSyncState::Synced(block_height) => {
+                if !sufficient_peers {
+                    *self = InnerSyncState::InsufficientPeers(*block_height);
+                    state_changed = true;
+                }
+            }
+        }
+
+        state_changed
+    }
+
+    fn change_on_sync_timeout(&mut self) -> bool {
+        match self {
+            InnerSyncState::SufficientPeers(block_height) => {
+                *self = InnerSyncState::Synced(*block_height);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn sync_state(&self) -> SyncState {
+        match self {
+            InnerSyncState::InsufficientPeers(_) | InnerSyncState::SufficientPeers(_) => {
+                SyncState::NotSynced
+            }
+            InnerSyncState::Synced(_) => SyncState::Synced,
+        }
+    }
+
+    fn block_height(&self) -> &BlockHeight {
+        match self {
+            InnerSyncState::InsufficientPeers(block_height)
+            | InnerSyncState::SufficientPeers(block_height)
+            | InnerSyncState::Synced(block_height) => &block_height,
+        }
+    }
+
+    fn is_sufficient(&self) -> bool {
+        match self {
+            InnerSyncState::InsufficientPeers(_) | InnerSyncState::Synced(_) => false,
+            InnerSyncState::SufficientPeers(_) => true,
+        }
+    }
+}

--- a/crates/services/consensus_module/poa/src/sync.rs
+++ b/crates/services/consensus_module/poa/src/sync.rs
@@ -1,21 +1,9 @@
-use std::{
-    sync::Arc,
-    time::Duration,
-};
+use std::time::Duration;
 
-use fuel_core_types::{
-    fuel_types::BlockHeight,
-    services::block_importer::ImportResult,
-};
-use tokio::{
-    sync::{
-        broadcast,
-        watch,
-    },
-    time::Instant,
-};
-
-use crate::ports::P2pPort;
+use fuel_core_services::stream::BoxStream;
+use fuel_core_types::fuel_types::BlockHeight;
+use tokio::sync::watch;
+use tokio_stream::StreamExt;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SyncState {
@@ -23,52 +11,55 @@ pub enum SyncState {
     Synced,
 }
 
-pub struct SyncTask<T> {
-    min_connected_reserved_peers: usize,
-    time_until_synced: Duration,
-    time_left_until_synced: Duration,
-    p2p_port: T,
-    block_rx: broadcast::Receiver<Arc<ImportResult>>,
-    state_sender: watch::Sender<SyncState>,
-    inner_state: InnerSyncState,
-    notify: Arc<tokio::sync::Notify>,
-}
-
-impl<T> SyncTask<T> {
-    pub fn new(
-        p2p_port: T,
+impl SyncState {
+    pub fn from_config(
         min_connected_reserved_peers: usize,
         time_until_synced: Duration,
-        block_rx: broadcast::Receiver<Arc<ImportResult>>,
-        notify: Arc<tokio::sync::Notify>,
-        state_sender: watch::Sender<SyncState>,
-        block_height: BlockHeight,
-    ) -> Self {
-        let inner_state = {
-            match (min_connected_reserved_peers, time_until_synced) {
-                (0, Duration::ZERO) => InnerSyncState::Synced(block_height),
-                (0, _) => InnerSyncState::SufficientPeers(block_height),
-                _ => InnerSyncState::InsufficientPeers(block_height),
-            }
-        };
-
-        Self {
-            min_connected_reserved_peers,
-            time_until_synced,
-            time_left_until_synced: time_until_synced,
-            p2p_port,
-            block_rx,
-            state_sender,
-            inner_state,
-            notify,
+    ) -> SyncState {
+        if min_connected_reserved_peers == 0 && time_until_synced == Duration::ZERO {
+            SyncState::Synced
+        } else {
+            SyncState::NotSynced
         }
     }
 }
 
-impl<T> SyncTask<T>
-where
-    T: P2pPort,
-{
+pub struct SyncTask {
+    min_connected_reserved_peers: usize,
+    time_until_synced: Duration,
+    time_left_until_synced: tokio::time::Interval,
+    peer_connections_stream: BoxStream<usize>,
+    block_stream: BoxStream<BlockHeight>,
+    state_sender: watch::Sender<SyncState>,
+    inner_state: InnerSyncState,
+}
+
+impl SyncTask {
+    pub fn new(
+        peer_connections_stream: BoxStream<usize>,
+        min_connected_reserved_peers: usize,
+        time_until_synced: Duration,
+        block_stream: BoxStream<BlockHeight>,
+        state_sender: watch::Sender<SyncState>,
+        block_height: BlockHeight,
+    ) -> Self {
+        let inner_state = InnerSyncState::from_config(
+            min_connected_reserved_peers,
+            time_until_synced,
+            block_height,
+        );
+
+        Self {
+            peer_connections_stream,
+            min_connected_reserved_peers,
+            time_until_synced,
+            time_left_until_synced: tokio::time::interval(time_until_synced),
+            block_stream,
+            state_sender,
+            inner_state,
+        }
+    }
+
     pub async fn run(&mut self) -> anyhow::Result<()> {
         if self.inner_state.is_sufficient() {
             self.sync_when_sufficient().await?;
@@ -80,19 +71,17 @@ where
     }
 
     async fn sync(&mut self) -> anyhow::Result<()> {
-        let mut reserved_peers_count = self.p2p_port.reserved_peers_count();
-
         tokio::select! {
-            latest_count = reserved_peers_count.recv() => {
-                if let Ok(latest_count) = latest_count {
-                    if self.inner_state.change_state_on_peers_update(latest_count >= self.min_connected_reserved_peers) {
+            latest_count = self.peer_connections_stream.next() => {
+                if let Some(latest_count) = latest_count {
+                    if self.inner_state.change_state_on_peers_update(latest_count, self.min_connected_reserved_peers) {
                         self.state_sender.send(self.inner_state.sync_state())?;
                     }
                 }
             }
-            block = self.block_rx.recv() => {
-                if let Ok(block) = block {
-                    if self.inner_state.change_state_on_block(block) {
+            block = self.block_stream.next() => {
+                if let Some(new_block_height) = block {
+                    if self.inner_state.change_state_on_block(new_block_height) {
                         self.state_sender.send(self.inner_state.sync_state())?;
                     }
                 }
@@ -103,35 +92,27 @@ where
     }
 
     async fn sync_when_sufficient(&mut self) -> anyhow::Result<()> {
-        let mut reserved_peers_count = self.p2p_port.reserved_peers_count();
-        let now = Instant::now();
-
         tokio::select! {
-            latest_count = reserved_peers_count.recv() => {
-                if let Ok(latest_count) = latest_count {
-                    if self.inner_state.change_state_on_peers_update(latest_count >= self.min_connected_reserved_peers) {
-                        self.time_left_until_synced = self.time_until_synced;
+            latest_count = self.peer_connections_stream.next() => {
+                if let Some(latest_count) = latest_count {
+                    if self.inner_state.change_state_on_peers_update(latest_count, self.min_connected_reserved_peers) {
+                        self.time_left_until_synced.reset();
                         self.state_sender.send(self.inner_state.sync_state())?;
-                    } else {
-                        self.time_left_until_synced = self.time_left_until_synced - now.elapsed();
                     }
                 }
 
             }
-            block = self.block_rx.recv() => {
-                if let Ok(block) = block {
-                    if self.inner_state.change_state_on_block(block) {
-                        self.time_left_until_synced = self.time_until_synced;
+            block = self.block_stream.next() => {
+                if let Some(new_block_height) = block {
+                    if self.inner_state.change_state_on_block(new_block_height) {
+                        self.time_left_until_synced.reset();
                         self.state_sender.send(self.inner_state.sync_state())?;
-                    } else {
-                        self.time_left_until_synced = self.time_left_until_synced - now.elapsed();
                     }
                 }
             }
-            _ = tokio::time::sleep(self.time_left_until_synced) => {
+            _ = self.time_left_until_synced.tick() => {
                 if self.inner_state.change_on_sync_timeout() {
-                    self.time_left_until_synced = self.time_until_synced;
-                    self.notify.notify_one();
+                    self.time_left_until_synced.reset();
                     self.state_sender.send(self.inner_state.sync_state())?;
                 }
             }
@@ -162,23 +143,33 @@ enum InnerSyncState {
 }
 
 impl InnerSyncState {
-    fn change_state_on_block(&mut self, block: Arc<ImportResult>) -> bool {
-        let mut state_changed = false;
+    fn from_config(
+        min_connected_reserved_peers: usize,
+        time_until_synced: Duration,
+        block_height: BlockHeight,
+    ) -> Self {
+        match (min_connected_reserved_peers, time_until_synced) {
+            (0, Duration::ZERO) => InnerSyncState::Synced(block_height),
+            (0, _) => InnerSyncState::SufficientPeers(block_height),
+            _ => InnerSyncState::InsufficientPeers(block_height),
+        }
+    }
 
-        let latest_block_height = block.sealed_block.entity.header().height();
+    fn change_state_on_block(&mut self, new_block_height: BlockHeight) -> bool {
+        let mut state_changed = false;
         let current_block_height = self.block_height();
 
-        if latest_block_height > current_block_height {
+        if &new_block_height > current_block_height {
             match self {
                 InnerSyncState::InsufficientPeers(_) => {
-                    *self = InnerSyncState::InsufficientPeers(*latest_block_height);
+                    *self = InnerSyncState::InsufficientPeers(new_block_height);
                 }
                 InnerSyncState::SufficientPeers(_) => {
-                    *self = InnerSyncState::SufficientPeers(*latest_block_height);
+                    *self = InnerSyncState::SufficientPeers(new_block_height);
                 }
                 InnerSyncState::Synced(_) => {
                     // we considered to be synced but we're obiously not!
-                    *self = InnerSyncState::SufficientPeers(*latest_block_height);
+                    *self = InnerSyncState::SufficientPeers(new_block_height);
                     state_changed = true;
                 }
             }
@@ -187,26 +178,27 @@ impl InnerSyncState {
         state_changed
     }
 
-    fn change_state_on_peers_update(&mut self, sufficient_peers: bool) -> bool {
-        let mut state_changed = false;
+    fn change_state_on_peers_update(
+        &mut self,
+        currently_connected_peers: usize,
+        min_connected_reserved_peers: usize,
+    ) -> bool {
+        let sufficient_peers = currently_connected_peers >= min_connected_reserved_peers;
 
         match self {
-            InnerSyncState::InsufficientPeers(block_height) => {
-                if sufficient_peers {
-                    *self = InnerSyncState::SufficientPeers(*block_height);
-                    state_changed = true;
-                }
+            InnerSyncState::InsufficientPeers(block_height) if sufficient_peers => {
+                *self = InnerSyncState::SufficientPeers(*block_height);
+                true
             }
             InnerSyncState::SufficientPeers(block_height)
-            | InnerSyncState::Synced(block_height) => {
-                if !sufficient_peers {
-                    *self = InnerSyncState::InsufficientPeers(*block_height);
-                    state_changed = true;
-                }
+            | InnerSyncState::Synced(block_height)
+                if !sufficient_peers =>
+            {
+                *self = InnerSyncState::InsufficientPeers(*block_height);
+                true
             }
+            _ => false,
         }
-
-        state_changed
     }
 
     fn change_on_sync_timeout(&mut self) -> bool {
@@ -241,5 +233,299 @@ impl InnerSyncState {
             InnerSyncState::InsufficientPeers(_) | InnerSyncState::Synced(_) => false,
             InnerSyncState::SufficientPeers(_) => true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        collections::VecDeque,
+        pin::Pin,
+        task::{
+            Context,
+            Poll,
+        },
+        time::Duration,
+    };
+
+    #[test]
+    fn test_inner_sync_state() {
+        // given that we set `min_connected_reserved_peers` to be 0
+        // and `time_until_synced` to finish immediately
+        let min_connected_reserved_peers = 0;
+        let time_until_synced = Duration::ZERO;
+        let block_height = BlockHeight::default();
+
+        let inner_sync_state = InnerSyncState::from_config(
+            min_connected_reserved_peers,
+            time_until_synced,
+            block_height,
+        );
+
+        // inner state should be synced
+        assert!(matches!(inner_sync_state, InnerSyncState::Synced(_)));
+        assert_eq!(*inner_sync_state.block_height(), block_height);
+        assert_eq!(inner_sync_state.sync_state(), SyncState::Synced);
+
+        // given that `time_until_synced` has been increased
+        // yet `min_connected_reserved_peers` is still 0
+        let time_until_synced = Duration::from_secs(10);
+
+        let inner_sync_state = InnerSyncState::from_config(
+            min_connected_reserved_peers,
+            time_until_synced,
+            block_height,
+        );
+
+        // we should have sufficient number of peers but not synced yet,
+        // ie `time_until_synced` has not completed yet
+        assert!(inner_sync_state.is_sufficient());
+        assert_eq!(inner_sync_state.sync_state(), SyncState::NotSynced);
+
+        // given that we now increased `min_connected_reserved_peers`
+        // `time_until_synced` is still 10 seconds
+        let min_connected_reserved_peers = 10;
+        let inner_sync_state = InnerSyncState::from_config(
+            min_connected_reserved_peers,
+            time_until_synced,
+            block_height,
+        );
+
+        // we should be in InsufficientPeers state
+        // since we neither have enough peers nor `time_until_synced` has completed
+        assert!(matches!(
+            inner_sync_state,
+            InnerSyncState::InsufficientPeers(_)
+        ));
+        assert_eq!(inner_sync_state.sync_state(), SyncState::NotSynced);
+    }
+
+    #[test]
+    fn test_inner_sync_state_change_state_on_peers_update() {
+        // given that we start from InssuficientPeers state
+        let block_height = BlockHeight::default();
+        let mut inner_sync_state = InnerSyncState::InsufficientPeers(block_height);
+
+        let min_connected_reserved_peers = 10;
+        let connected_peers = 0;
+
+        // and that we still don't have enough peers connected
+        assert!(!inner_sync_state
+            .change_state_on_peers_update(connected_peers, min_connected_reserved_peers));
+
+        // we should be still at insufficient peers
+        assert!(matches!(
+            inner_sync_state,
+            InnerSyncState::InsufficientPeers(_)
+        ));
+
+        // given that now our peer count has increased
+        let connected_peers = 10;
+        assert!(inner_sync_state
+            .change_state_on_peers_update(connected_peers, min_connected_reserved_peers));
+
+        // we should move to SufficientPeers state
+        assert!(matches!(
+            inner_sync_state,
+            InnerSyncState::SufficientPeers(_)
+        ));
+
+        // given that our peer count has decreased
+        let connected_peers = 9;
+        assert!(inner_sync_state
+            .change_state_on_peers_update(connected_peers, min_connected_reserved_peers));
+
+        // we should move back to InsufficientPeers state
+        assert!(matches!(
+            inner_sync_state,
+            InnerSyncState::InsufficientPeers(_)
+        ));
+    }
+
+    #[test]
+    fn test_inner_sync_state_change_state_on_block() {
+        // given that we start from InssuficientPeers state
+        let block_height = BlockHeight::default();
+        let mut inner_sync_state = InnerSyncState::InsufficientPeers(block_height);
+
+        // and that we receive a new, bigger block height
+        let new_block_height = BlockHeight::from(10);
+
+        // the state should remain the same
+        assert!(!inner_sync_state.change_state_on_block(new_block_height));
+        assert!(matches!(
+            inner_sync_state,
+            InnerSyncState::InsufficientPeers(_)
+        ));
+        // but the block height should be updated
+        assert_eq!(&new_block_height, inner_sync_state.block_height());
+
+        // given that we moved to SufficientPeers state
+        let mut inner_sync_state = InnerSyncState::SufficientPeers(new_block_height);
+
+        // and that we receive a new, bigger block height
+        let new_block_height = BlockHeight::from(11);
+
+        // the state should remain the same
+        assert!(!inner_sync_state.change_state_on_block(new_block_height));
+        assert!(matches!(
+            inner_sync_state,
+            InnerSyncState::SufficientPeers(_)
+        ));
+        // but the block height should be updated
+        assert_eq!(&new_block_height, inner_sync_state.block_height());
+
+        // given that we moved to Synced state
+        let mut inner_sync_state = InnerSyncState::Synced(new_block_height);
+
+        // and that we receive a new, bigger block height
+        let new_block_height = BlockHeight::from(12);
+
+        // the state should change
+        // since this would mean we're not synced with other peers
+        assert!(inner_sync_state.change_state_on_block(new_block_height));
+        assert!(matches!(
+            inner_sync_state,
+            InnerSyncState::SufficientPeers(_)
+        ));
+        // the block height should be updated
+        assert_eq!(&new_block_height, inner_sync_state.block_height());
+    }
+
+    #[test]
+    fn test_inner_sync_state_change_on_timeout() {
+        // given that we start from InssuficientPeers state
+        let block_height = BlockHeight::default();
+        let mut inner_sync_state = InnerSyncState::InsufficientPeers(block_height);
+
+        // the state should remain the same if sync_timeout happened
+        assert!(!inner_sync_state.change_on_sync_timeout());
+        assert!(matches!(
+            inner_sync_state,
+            InnerSyncState::InsufficientPeers(_)
+        ));
+
+        // given that we moved to SufficientPeers state
+        let mut inner_sync_state = InnerSyncState::SufficientPeers(block_height);
+
+        // the state should move to Synced
+        // since the timeout is used to go from Syncing -> Synced
+        assert!(inner_sync_state.change_on_sync_timeout());
+        assert!(matches!(inner_sync_state, InnerSyncState::Synced(_)));
+
+        // given that we're now in Synced state
+        // the state should remain the same if sync_timeout happened
+        assert!(!inner_sync_state.change_on_sync_timeout());
+        assert!(matches!(inner_sync_state, InnerSyncState::Synced(_)));
+    }
+
+    use fuel_core_services::stream::IntoBoxStream;
+
+    struct MockStream<T> {
+        items: VecDeque<T>,
+    }
+
+    impl<T> MockStream<T> {
+        fn new(range: impl IntoIterator<Item = T>) -> Self {
+            Self {
+                items: range.into_iter().collect(),
+            }
+        }
+    }
+
+    impl<T> tokio_stream::Stream for MockStream<T>
+    where
+        T: Unpin,
+    {
+        type Item = T;
+
+        fn poll_next(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+            if this.items.is_empty() {
+                Poll::Pending
+            } else {
+                let next_item = this.items.pop_front();
+                Poll::Ready(next_item)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sync_task() {
+        // given the following config
+        let connected_peers_report = 5;
+        let amount_of_updates_from_stream = 1;
+        let min_connected_reserved_peers = 5;
+        let biggest_block = 5;
+        let time_until_synced = Duration::from_secs(10);
+
+        let sync_state =
+            SyncState::from_config(min_connected_reserved_peers, time_until_synced);
+
+        let (state_sender, state_receiver) = watch::channel(sync_state);
+        let connections_stream =
+            MockStream::new(vec![connected_peers_report; amount_of_updates_from_stream])
+                .into_boxed();
+        let block_stream =
+            MockStream::new((1..biggest_block + 1).map(BlockHeight::from)).into_boxed();
+
+        // and the SyncTask
+        let mut sync_task = SyncTask::new(
+            connections_stream,
+            min_connected_reserved_peers,
+            time_until_synced,
+            block_stream,
+            state_sender,
+            BlockHeight::default(),
+        );
+
+        // sync state should be NotSynced at the beginning
+        assert_eq!(SyncState::NotSynced, *state_receiver.borrow());
+        // we should have insufficient peers
+        assert!(matches!(
+            sync_task.inner_state,
+            InnerSyncState::InsufficientPeers(_)
+        ));
+
+        // given that we've performed a `run()` `amount_of_updates_from_stream + biggest_block` times
+        let run_times = amount_of_updates_from_stream + biggest_block as usize;
+        for _ in 0..run_times {
+            let _ = sync_task.run().await;
+        }
+
+        // the state should still be NotSynced
+        assert_eq!(SyncState::NotSynced, *state_receiver.borrow());
+
+        // but we should have sufficient peers
+        assert!(matches!(
+            sync_task.inner_state,
+            InnerSyncState::SufficientPeers(_)
+        ));
+
+        // and the block should be the latest one
+        assert_eq!(
+            sync_task.inner_state.block_height(),
+            &BlockHeight::from(biggest_block)
+        );
+
+        // given that we now run the task again
+        // both block stream and p2p connected peers updates stream would be empty
+        let _ = sync_task.run().await;
+
+        // we should be in Synced state
+        assert_eq!(SyncState::Synced, *state_receiver.borrow());
+
+        // synced should reflect here as well
+        assert!(matches!(sync_task.inner_state, InnerSyncState::Synced(_)));
+
+        // and the block should be still the latest one
+        assert_eq!(
+            sync_task.inner_state.block_height(),
+            &BlockHeight::from(biggest_block)
+        );
     }
 }

--- a/crates/services/consensus_module/poa/src/verifier.rs
+++ b/crates/services/consensus_module/poa/src/verifier.rs
@@ -26,7 +26,7 @@ pub fn verify_consensus(
     consensus: &PoAConsensus,
 ) -> bool {
     match consensus_config {
-        ConsensusConfig::PoA { signing_key } => {
+        ConsensusConfig::PoA { signing_key, .. } => {
             let id = header.id();
             let m = id.as_message();
             consensus

--- a/crates/services/p2p/src/peer_manager.rs
+++ b/crates/services/p2p/src/peer_manager.rs
@@ -83,6 +83,10 @@ impl PeerManager {
         }
     }
 
+    pub fn connected_reserved_peers(&self) -> usize {
+        self.reserved_connected_peers.len()
+    }
+
     pub fn handle_gossip_score_update<T: Punisher>(
         &self,
         peer_id: PeerId,

--- a/crates/services/p2p/src/peer_manager.rs
+++ b/crates/services/p2p/src/peer_manager.rs
@@ -83,8 +83,13 @@ impl PeerManager {
         }
     }
 
-    pub fn connected_reserved_peers(&self) -> usize {
-        self.reserved_connected_peers.len()
+    /// Returns `count` if the peer was just added or removed from the reserved connected peers.
+    pub fn connected_reserved_peers(&self, peer_id: &PeerId) -> Option<usize> {
+        if self.reserved_peers.contains(peer_id) {
+            Some(self.reserved_connected_peers.len())
+        } else {
+            None
+        }
     }
 
     pub fn handle_gossip_score_update<T: Punisher>(

--- a/tests/tests/blocks.rs
+++ b/tests/tests/blocks.rs
@@ -1,4 +1,5 @@
 use fuel_core::{
+    chain_config::ConsensusConfig,
     database::Database,
     schema::scalars::BlockId,
     service::{
@@ -238,6 +239,16 @@ async fn produce_block_bad_start_time() {
     let mut config = Config::local_node();
 
     config.manual_blocks_enabled = true;
+
+    match config.chain_conf.consensus {
+        ConsensusConfig::PoA { signing_key, .. } => {
+            config.chain_conf.consensus = ConsensusConfig::PoA {
+                signing_key,
+                time_until_synced: Duration::from_secs(1),
+                min_connected_resereved_peers: 0,
+            }
+        }
+    }
 
     let srv = FuelService::from_database(db.clone(), config)
         .await

--- a/tests/tests/blocks.rs
+++ b/tests/tests/blocks.rs
@@ -212,6 +212,16 @@ async fn produce_block_custom_time() {
         block_time: Duration::from_secs(10),
     };
 
+    match config.chain_conf.consensus {
+        ConsensusConfig::PoA { signing_key, .. } => {
+            config.chain_conf.consensus = ConsensusConfig::PoA {
+                signing_key,
+                time_until_synced: Duration::from_secs(0),
+                min_connected_resereved_peers: 0,
+            }
+        }
+    }
+
     let srv = FuelService::from_database(db.clone(), config)
         .await
         .unwrap();
@@ -239,16 +249,6 @@ async fn produce_block_bad_start_time() {
     let mut config = Config::local_node();
 
     config.manual_blocks_enabled = true;
-
-    match config.chain_conf.consensus {
-        ConsensusConfig::PoA { signing_key, .. } => {
-            config.chain_conf.consensus = ConsensusConfig::PoA {
-                signing_key,
-                time_until_synced: Duration::from_secs(1),
-                min_connected_resereved_peers: 0,
-            }
-        }
-    }
 
     let srv = FuelService::from_database(db.clone(), config)
         .await

--- a/tests/tests/blocks.rs
+++ b/tests/tests/blocks.rs
@@ -213,11 +213,16 @@ async fn produce_block_custom_time() {
     };
 
     match config.chain_conf.consensus {
-        ConsensusConfig::PoA { signing_key, .. } => {
+        ConsensusConfig::PoA {
+            signing_key,
+            timeout_between_checking_peers,
+            ..
+        } => {
             config.chain_conf.consensus = ConsensusConfig::PoA {
                 signing_key,
                 time_until_synced: Duration::from_secs(0),
                 min_connected_resereved_peers: 0,
+                timeout_between_checking_peers,
             }
         }
     }

--- a/tests/tests/blocks.rs
+++ b/tests/tests/blocks.rs
@@ -1,5 +1,4 @@
 use fuel_core::{
-    chain_config::ConsensusConfig,
     database::Database,
     schema::scalars::BlockId,
     service::{
@@ -211,21 +210,6 @@ async fn produce_block_custom_time() {
     config.block_production = Trigger::Interval {
         block_time: Duration::from_secs(10),
     };
-
-    match config.chain_conf.consensus {
-        ConsensusConfig::PoA {
-            signing_key,
-            timeout_between_checking_peers,
-            ..
-        } => {
-            config.chain_conf.consensus = ConsensusConfig::PoA {
-                signing_key,
-                time_until_synced: Duration::from_secs(0),
-                min_connected_resereved_peers: 0,
-                timeout_between_checking_peers,
-            }
-        }
-    }
 
     let srv = FuelService::from_database(db.clone(), config)
         .await

--- a/tests/tests/trigger_integration/hybrid.rs
+++ b/tests/tests/trigger_integration/hybrid.rs
@@ -162,7 +162,7 @@ async fn poa_hybrid_produces_nonempty_blocks_at_correct_rate() {
     assert!(
         round_time_seconds <= secs_per_round
             && secs_per_round
-                <= round_time_seconds + 3 * (rounds as u64) / round_time_seconds,
+                <= round_time_seconds + 2 * (rounds as u64) / round_time_seconds,
         "Round time not within treshold"
     );
 }

--- a/tests/tests/trigger_integration/hybrid.rs
+++ b/tests/tests/trigger_integration/hybrid.rs
@@ -162,7 +162,7 @@ async fn poa_hybrid_produces_nonempty_blocks_at_correct_rate() {
     assert!(
         round_time_seconds <= secs_per_round
             && secs_per_round
-                <= round_time_seconds + 2 * (rounds as u64) / round_time_seconds,
+                <= round_time_seconds + 3 * (rounds as u64) / round_time_seconds,
         "Round time not within treshold"
     );
 }

--- a/tests/tests/trigger_integration/interval.rs
+++ b/tests/tests/trigger_integration/interval.rs
@@ -159,7 +159,7 @@ async fn poa_interval_produces_nonempty_blocks_at_correct_rate() {
     assert!(
         round_time_seconds <= secs_per_round
             && secs_per_round
-                <= round_time_seconds + 2 * (rounds as u64) / round_time_seconds,
+                <= round_time_seconds + 3 * (rounds as u64) / round_time_seconds,
         "Round time not within treshold"
     );
 

--- a/tests/tests/trigger_integration/interval.rs
+++ b/tests/tests/trigger_integration/interval.rs
@@ -159,7 +159,7 @@ async fn poa_interval_produces_nonempty_blocks_at_correct_rate() {
     assert!(
         round_time_seconds <= secs_per_round
             && secs_per_round
-                <= round_time_seconds + 3 * (rounds as u64) / round_time_seconds,
+                <= round_time_seconds + 2 * (rounds as u64) / round_time_seconds,
         "Round time not within treshold"
     );
 


### PR DESCRIPTION
In this approach I have added NetworkInfo trait to SyncAdapter implementation,

it returns number of reserved peers that are currently connected, so when we are syncing with the network we first check the min amount of reserved peers are already connected.

