### PR TITLE
Make `FuelClient::query` public and up version nto `0.17.12`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "parking_lot 0.12.1",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "clap 4.2.4",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "clap 4.2.4",
  "fuel-core-client",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "clap 4.2.4",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "axum",
  "lazy_static",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "ctor",
  "tracing",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,32 +45,32 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.17.11"
+version = "0.17.12"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.17.11", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.17.11", path = "./bin/client" }
-fuel-core-bin = { version = "0.17.11", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.17.11", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.17.11", path = "./crates/chain-config" }
-fuel-core-client = { version = "0.17.11", path = "./crates/client" }
-fuel-core-database = { version = "0.17.11", path = "./crates/database" }
-fuel-core-metrics = { version = "0.17.11", path = "./crates/metrics" }
-fuel-core-services = { version = "0.17.11", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.17.11", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.17.11", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.17.11", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.17.11", path = "./crates/services/executor" }
-fuel-core-importer = { version = "0.17.11", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.17.11", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.17.11", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.17.11", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.17.11", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.17.11", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.17.11", path = "./crates/storage" }
-fuel-core-trace = { version = "0.17.11", path = "./crates/trace" }
-fuel-core-types = { version = "0.17.11", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.17.12", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.17.12", path = "./bin/client" }
+fuel-core-bin = { version = "0.17.12", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.17.12", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.17.12", path = "./crates/chain-config" }
+fuel-core-client = { version = "0.17.12", path = "./crates/client" }
+fuel-core-database = { version = "0.17.12", path = "./crates/database" }
+fuel-core-metrics = { version = "0.17.12", path = "./crates/metrics" }
+fuel-core-services = { version = "0.17.12", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.17.12", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.17.12", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.17.12", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.17.12", path = "./crates/services/executor" }
+fuel-core-importer = { version = "0.17.12", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.17.12", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.17.12", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.17.12", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.17.12", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.17.12", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.17.12", path = "./crates/storage" }
+fuel-core-trace = { version = "0.17.12", path = "./crates/trace" }
+fuel-core-types = { version = "0.17.12", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -164,7 +164,8 @@ impl FuelClient {
         Self::from_str(url.as_ref())
     }
 
-    async fn query<ResponseData, Vars>(
+    /// Send the GraphQL query ot the client.
+    pub async fn query<ResponseData, Vars>(
         &self,
         q: Operation<ResponseData, Vars>,
     ) -> io::Result<ResponseData>

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.17.11"
+appVersion: "0.17.12"
 version: 0.1.0


### PR DESCRIPTION
The indexer team needs a public version of the `FuelClient::query` method to write custom queries. We don't need to deploy it to testnet, only a new version as a lirbary