### PR TITLE
Fix multi-platform images

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -59,7 +59,7 @@ WORKDIR /root/
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends ca-certificates \
     && xx-apt-get update -y  \
-    && xx-apt-get install -y libc6-dev \
+    && xx-apt-get install -y libc6-dev g++ binutils \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -43,6 +43,8 @@ RUN xx-cargo build --release --no-default-features --features "production" -p fu
 # Stage 2: Run
 FROM --platform=$BUILDPLATFORM ubuntu:22.04 as run
 
+ARG TARGETPLATFORM
+
 COPY --from=xx / /
 
 ARG IP=0.0.0.0
@@ -59,7 +61,7 @@ WORKDIR /root/
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends ca-certificates \
     && xx-apt-get update -y  \
-    && xx-apt-get install -y libc6-dev g++ binutils \
+    && xx-apt-get install -y libc6 \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -41,11 +41,7 @@ RUN xx-cargo build --release --no-default-features --features "production" -p fu
     && mv ./target/$(xx-cargo --print-target-triple)/release/fuel-core.d ./target/release/fuel-core.d
 
 # Stage 2: Run
-FROM --platform=$BUILDPLATFORM ubuntu:22.04 as run
-
-ARG TARGETPLATFORM
-
-COPY --from=xx / /
+FROM ubuntu:22.04 as run
 
 ARG IP=0.0.0.0
 ARG PORT=4000
@@ -60,8 +56,6 @@ WORKDIR /root/
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends ca-certificates \
-    && xx-apt-get update -y  \
-    && xx-apt-get install -y libc6 \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -43,6 +43,8 @@ RUN xx-cargo build --release --no-default-features --features "production" -p fu
 # Stage 2: Run
 FROM --platform=$BUILDPLATFORM ubuntu:22.04 as run
 
+COPY --from=xx / /
+
 ARG IP=0.0.0.0
 ARG PORT=4000
 ARG P2P_PORT=30333
@@ -56,6 +58,8 @@ WORKDIR /root/
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends ca-certificates \
+    && xx-apt-get update -y  \
+    && xx-apt-get install -y libc6-dev \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \


### PR DESCRIPTION
Removed erroneous build-platform on the runnable image, as it was forcing builds on all platforms to always use the native platform of the build env.