### PR TITLE
Fixed wrong encoding of the `Mint` and `Burn` receipts.

### DIFF
--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -650,6 +650,10 @@ type Query {
 	"""
 	estimatePredicates(tx: HexString!): Transaction!
 	"""
+	Returns all possible receipts for test purposes.
+	"""
+	allReceipts: [Receipt!]!
+	"""
 	Returns true when the GraphQL API is serving requests.
 	"""
 	health: Boolean!

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -648,6 +648,19 @@ impl FuelClient {
         Ok(receipts)
     }
 
+    #[cfg(feature = "test-helpers")]
+    pub async fn all_receipts(&self) -> io::Result<Vec<Receipt>> {
+        let query = schema::tx::AllReceipts::build(());
+        let receipts = self.query(query).await?.all_receipts;
+
+        let vec: Result<Vec<Receipt>, ConversionError> = receipts
+            .into_iter()
+            .map(TryInto::<Receipt>::try_into)
+            .collect();
+
+        Ok(vec?)
+    }
+
     pub async fn produce_blocks(
         &self,
         blocks_to_produce: u64,

--- a/crates/client/src/client/schema/tx.rs
+++ b/crates/client/src/client/schema/tx.rs
@@ -284,7 +284,7 @@ pub struct DryRunArg {
 )]
 pub struct DryRun {
     #[arguments(tx: $tx, utxoValidation: $utxo_validation)]
-    pub dry_run: Vec<transparent_receipt::Receipt>,
+    pub dry_run: Vec<Receipt>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -307,6 +307,12 @@ pub struct Submit {
 pub struct SubmitAndAwaitSubscription {
     #[arguments(tx: $tx)]
     pub submit_and_await: TransactionStatus,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Query")]
+pub struct AllReceipts {
+    pub all_receipts: Vec<Receipt>,
 }
 
 #[cfg(test)]

--- a/crates/client/src/client/schema/tx/transparent_receipt.rs
+++ b/crates/client/src/client/schema/tx/transparent_receipt.rs
@@ -343,10 +343,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .sub_id
                     .ok_or_else(|| MissingField("sub_id".to_string()))?
                     .into(),
-                contract_id: schema
-                    .contract_id
-                    .ok_or_else(|| MissingField("contract_id".to_string()))?
-                    .into(),
+                contract_id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
                 val: schema
                     .val
                     .ok_or_else(|| MissingField("val".to_string()))?
@@ -365,10 +362,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .sub_id
                     .ok_or_else(|| MissingField("sub_id".to_string()))?
                     .into(),
-                contract_id: schema
-                    .contract_id
-                    .ok_or_else(|| MissingField("contract_id".to_string()))?
-                    .into(),
+                contract_id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
                 val: schema
                     .val
                     .ok_or_else(|| MissingField("val".to_string()))?

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -214,6 +214,15 @@ impl TxQuery {
             tx,
         ))
     }
+
+    #[cfg(feature = "test-helpers")]
+    /// Returns all possible receipts for test purposes.
+    async fn all_receipts(&self) -> Vec<receipt::Receipt> {
+        receipt::all_receipts()
+            .into_iter()
+            .map(Into::into)
+            .collect()
+    }
 }
 
 #[derive(Default)]

--- a/crates/fuel-core/src/schema/tx/receipt.rs
+++ b/crates/fuel-core/src/schema/tx/receipt.rs
@@ -20,7 +20,7 @@ use fuel_core_types::{
     fuel_tx,
 };
 
-#[derive(Copy, Clone, Debug, Display, Enum, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Display, Enum, Eq, PartialEq, strum_macros::EnumIter)]
 pub enum ReceiptType {
     Call,
     Return,
@@ -157,4 +157,110 @@ impl From<fuel_tx::Receipt> for Receipt {
     fn from(receipt: fuel_tx::Receipt) -> Self {
         Receipt(receipt)
     }
+}
+
+#[cfg(feature = "test-helpers")]
+pub fn all_receipts() -> Vec<fuel_tx::Receipt> {
+    use strum::IntoEnumIterator;
+
+    let mut receipts = vec![];
+    for variant in ReceiptType::iter() {
+        let receipt = match variant {
+            ReceiptType::Call => fuel_tx::Receipt::call(
+                fuel_tx::ContractId::from([1u8; 32]),
+                fuel_tx::ContractId::from([2u8; 32]),
+                3,
+                fuel_tx::AssetId::from([3u8; 32]),
+                5,
+                6,
+                7,
+                8,
+                9,
+            ),
+            ReceiptType::Return => {
+                fuel_tx::Receipt::ret(fuel_tx::ContractId::from([1u8; 32]), 2, 3, 4)
+            }
+            ReceiptType::ReturnData => fuel_tx::Receipt::return_data(
+                fuel_tx::ContractId::from([1u8; 32]),
+                2,
+                3,
+                4,
+                vec![5; 30],
+            ),
+            ReceiptType::Panic => fuel_tx::Receipt::panic(
+                fuel_tx::ContractId::from([1u8; 32]),
+                fuel_core_types::fuel_asm::PanicInstruction::error(
+                    fuel_core_types::fuel_asm::PanicReason::ArithmeticOverflow,
+                    2,
+                ),
+                3,
+                4,
+            ),
+            ReceiptType::Revert => {
+                fuel_tx::Receipt::revert(fuel_tx::ContractId::from([1u8; 32]), 2, 3, 4)
+            }
+            ReceiptType::Log => fuel_tx::Receipt::log(
+                fuel_tx::ContractId::from([1u8; 32]),
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+            ),
+            ReceiptType::LogData => fuel_tx::Receipt::log_data(
+                fuel_tx::ContractId::from([1u8; 32]),
+                2,
+                3,
+                4,
+                5,
+                6,
+                vec![7; 30],
+            ),
+            ReceiptType::Transfer => fuel_tx::Receipt::transfer(
+                fuel_tx::ContractId::from([1u8; 32]),
+                fuel_tx::ContractId::from([2u8; 32]),
+                3,
+                fuel_tx::AssetId::from([4u8; 32]),
+                5,
+                6,
+            ),
+            ReceiptType::TransferOut => fuel_tx::Receipt::transfer_out(
+                fuel_tx::ContractId::from([1u8; 32]),
+                fuel_tx::Address::from([2u8; 32]),
+                3,
+                fuel_tx::AssetId::from([4u8; 32]),
+                5,
+                6,
+            ),
+            ReceiptType::ScriptResult => fuel_tx::Receipt::script_result(
+                fuel_tx::ScriptExecutionResult::Success,
+                1,
+            ),
+            ReceiptType::MessageOut => fuel_tx::Receipt::message_out(
+                &Default::default(),
+                1,
+                fuel_tx::Address::from([2u8; 32]),
+                fuel_tx::Address::from([3u8; 32]),
+                4,
+                vec![5; 30],
+            ),
+            ReceiptType::Mint => fuel_tx::Receipt::mint(
+                fuel_tx::Bytes32::from([1u8; 32]),
+                fuel_tx::ContractId::from([2u8; 32]),
+                3,
+                4,
+                5,
+            ),
+            ReceiptType::Burn => fuel_tx::Receipt::burn(
+                fuel_tx::Bytes32::from([1u8; 32]),
+                fuel_tx::ContractId::from([2u8; 32]),
+                3,
+                4,
+                5,
+            ),
+        };
+        receipts.push(receipt);
+    }
+    receipts
 }

--- a/tests/tests/tx.rs
+++ b/tests/tests/tx.rs
@@ -2,6 +2,7 @@ use crate::helpers::TestContext;
 use fuel_core::{
     database::Database,
     executor::Executor,
+    schema::tx::receipt::all_receipts,
     service::{
         adapters::MaybeRelayerAdapter,
         Config,
@@ -208,6 +209,15 @@ async fn receipts() {
     // run test
     let receipts = client.receipts(&id).await.unwrap();
     assert!(receipts.is_some());
+}
+
+#[tokio::test]
+async fn receipts_decoding() {
+    let srv = FuelService::new_node(Config::local_node()).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    let actual_receipts = client.all_receipts().await.unwrap();
+    assert_eq!(actual_receipts, all_receipts())
 }
 
 #[tokio::test]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 clap = { workspace = true, features = ["env", "derive"] }
-fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["dap"] }
+fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["dap", "test-helpers"] }
 
 [features]
 default = ["fuel-core/default"]


### PR DESCRIPTION
Fixed wrong encoding of the `Mint` and `Burn` receipts.
Added an integration test to decode all receipts.