### PR TITLE
Release v0.20.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,18 +475,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -722,13 +722,13 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.10",
+ "prettyplease 0.2.12",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.15"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f644d0dac522c8b05ddc39aaaccc5b136d5dc4ff216610c5641e3be5becf56c"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1113,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.15"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af410122b9778e024f9e0fb35682cc09cc3f85cad5e8d3ba8f47a9702df6e73d"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1132,7 +1132,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1969,7 +1969,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der 0.7.7",
  "digest 0.10.7",
@@ -2047,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
@@ -2136,7 +2136,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2504,6 +2504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,26 +2596,25 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fuel-asm"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d37b53266287a6c9b866c8472e69cae6abf819692bd3587f1b52c54683d0d6b"
+checksum = "a57c4a0ab68940adf3b5e177d44c823b3ef9e316b455befbcb91518c817090da"
 dependencies = [
  "bitflags 1.3.2",
- "fuel-types",
  "serde",
  "strum",
 ]
 
 [[package]]
 name = "fuel-core"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "assert_matches",
  "async-graphql",
  "async-trait",
  "axum",
- "clap 4.3.15",
+ "clap 4.3.19",
  "derive_more",
  "enum-iterator",
  "fuel-core-chain-config",
@@ -2658,7 +2663,7 @@ dependencies = [
 name = "fuel-core-benches"
 version = "0.0.0"
 dependencies = [
- "clap 4.3.15",
+ "clap 4.3.19",
  "criterion",
  "ctrlc",
  "ethnum",
@@ -2674,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "parking_lot 0.12.1",
@@ -2683,10 +2688,10 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
- "clap 4.3.15",
+ "clap 4.3.19",
  "const_format",
  "dirs",
  "fuel-core",
@@ -2703,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2722,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2745,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
- "clap 4.3.15",
+ "clap 4.3.19",
  "fuel-core-client",
  "fuel-core-types",
  "serde_json",
@@ -2756,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2768,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2779,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2804,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2815,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2830,10 +2835,10 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
- "clap 4.3.15",
+ "clap 4.3.19",
  "fuel-core-types",
  "libp2p-core 0.38.0",
  "serde_json",
@@ -2841,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "axum",
  "lazy_static",
@@ -2852,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2895,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2913,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2930,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2958,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2971,7 +2976,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -2982,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3028,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "ctor",
  "tracing",
@@ -3038,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3064,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3078,14 +3083,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee5ec3f6eea0373259c056ca75c7e78fc737b33f05cb17a148137b806f38d5a"
+checksum = "fd5d33d0ed9480b5f504525a743ea64debe841821441309abaa7ebba36f5c044"
 dependencies = [
  "borrown",
  "coins-bip32 0.8.3",
  "coins-bip39 0.8.6",
- "ecdsa 0.16.7",
+ "ecdsa 0.16.8",
  "ed25519-dalek",
  "fuel-types",
  "lazy_static",
@@ -3099,9 +3104,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0418abd5748d7e633b95f064a78eda25ea0a53d4659e74a6797053bc400abe13"
+checksum = "28cba3da0ad955661cc5ed0f0a2455ddc93894686b1f2c663e9b70a56540a40e"
 dependencies = [
  "digest 0.10.7",
  "fuel-storage",
@@ -3113,15 +3118,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f468410da392762f278b0f6dd2bd41f08dd9200aa9b72bf42cf8c421abed0c"
+checksum = "a775c857dacc6ff884ef8d8281175631335ca13b0e2bcd2f99f2a6369b69c8b6"
 
 [[package]]
 name = "fuel-tx"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f926878f9279de0e045fc9ce8a90d947f79be30ce39ac207d5d8d19007c2008"
+checksum = "21d40d60760a637643699e6e1cf49a325648c45252ed045a8902f63aaa673415"
 dependencies = [
  "derivative",
  "fuel-asm",
@@ -3139,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51ec6cfd59eda4c235738a1fccb1c336828d40d06fad3361d8fad53b588c849"
+checksum = "21e3c065a9b7dfc554952dbac612fedcbf18132cf32cfa01f17df735b813a964"
 dependencies = [
  "hex",
  "rand 0.8.5",
@@ -3150,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66170ef7c94d7b769c10c41eaa2fa8979845ece825fcf5e150d9da4aa7a79b0"
+checksum = "1dac3828450b53af5d6e0c69570e26f5608a8cd46a2e8504c2a4141e4583f63a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3236,7 +3241,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -3263,7 +3268,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3631,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -4016,7 +4021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.7",
+ "ecdsa 0.16.8",
  "elliptic-curve 0.13.5",
  "once_cell",
  "sha2 0.10.7",
@@ -4619,16 +4624,16 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
 dependencies = [
- "clap 4.3.15",
+ "clap 4.3.19",
  "termcolor",
  "threadpool",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.9"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5087,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm 0.2.7",
@@ -5216,7 +5221,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.7",
+ "ecdsa 0.16.8",
  "elliptic-curve 0.13.5",
  "primeorder",
  "sha2 0.10.7",
@@ -5439,7 +5444,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -5573,9 +5578,9 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa512cd0d087cc9f99ad30a1bf64795b67871edbead083ffc3a4dfafa59aa00"
+checksum = "c9ee729232311d3cd113749948b689627618133b1c5012b77342c1950b25eaeb"
 dependencies = [
  "cobs",
  "heapless",
@@ -5642,12 +5647,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
+checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -5906,9 +5911,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
+checksum = "f31999cfc7927c4e212e60fd50934ab40e8e8bfd2d493d6095d2d306bc0764d9"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -5924,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -6431,7 +6436,7 @@ checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.1",
+ "rustls-webpki 0.101.2",
  "sct 0.7.0",
 ]
 
@@ -6480,9 +6485,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
 dependencies = [
  "ring",
  "untrusted",
@@ -6708,9 +6713,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -6721,9 +6726,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6746,9 +6751,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "76dc28c9523c5d70816e393136b86d48909cfb27cecaa902d338c19ed47164dc"
 dependencies = [
  "serde_derive",
 ]
@@ -6765,20 +6770,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "a4e7b8c5dc823e3b90651ff1d3808419cd14e5ad76de04feaf37da114e7a306f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -6821,9 +6826,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.24"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f51e3fdb5b9cdd1577e1cb7a733474191b1aca6a72c2e50913241632c1180"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -7093,7 +7098,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -7104,7 +7109,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -7176,9 +7181,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7241,15 +7246,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg",
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.37.23",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -7299,7 +7303,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -7310,22 +7314,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -7349,9 +7353,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.5.3+5.3.0-patched"
+version = "0.5.4+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
 dependencies = [
  "cc",
  "libc",
@@ -7359,9 +7363,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.5.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -7466,7 +7470,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -7643,7 +7647,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -8060,7 +8064,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -8094,7 +8098,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8710,7 +8714,7 @@ dependencies = [
 name = "xtask"
 version = "0.0.0"
 dependencies = [
- "clap 4.3.15",
+ "clap 4.3.19",
  "fuel-core",
 ]
 
@@ -8763,5 +8767,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,32 +45,32 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.20.1"
+version = "0.20.2"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.20.1", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.20.1", path = "./bin/client" }
-fuel-core-bin = { version = "0.20.1", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.20.1", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.20.1", path = "./crates/chain-config" }
-fuel-core-client = { version = "0.20.1", path = "./crates/client" }
-fuel-core-database = { version = "0.20.1", path = "./crates/database" }
-fuel-core-metrics = { version = "0.20.1", path = "./crates/metrics" }
-fuel-core-services = { version = "0.20.1", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.20.1", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.20.1", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.20.1", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.20.1", path = "./crates/services/executor" }
-fuel-core-importer = { version = "0.20.1", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.20.1", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.20.1", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.20.1", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.20.1", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.20.1", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.20.1", path = "./crates/storage" }
-fuel-core-trace = { version = "0.20.1", path = "./crates/trace" }
-fuel-core-types = { version = "0.20.1", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.20.2", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.20.2", path = "./bin/client" }
+fuel-core-bin = { version = "0.20.2", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.20.2", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.20.2", path = "./crates/chain-config" }
+fuel-core-client = { version = "0.20.2", path = "./crates/client" }
+fuel-core-database = { version = "0.20.2", path = "./crates/database" }
+fuel-core-metrics = { version = "0.20.2", path = "./crates/metrics" }
+fuel-core-services = { version = "0.20.2", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.20.2", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.20.2", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.20.2", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.20.2", path = "./crates/services/executor" }
+fuel-core-importer = { version = "0.20.2", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.20.2", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.20.2", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.20.2", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.20.2", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.20.2", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.20.2", path = "./crates/storage" }
+fuel-core-trace = { version = "0.20.2", path = "./crates/trace" }
+fuel-core-types = { version = "0.20.2", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 

--- a/benches/benches/set/blockchain.rs
+++ b/benches/benches/set/blockchain.rs
@@ -10,7 +10,11 @@ use fuel_core::database::vm_database::VmDatabase;
 use fuel_core_benches::*;
 use fuel_core_storage::ContractsAssetsStorage;
 use fuel_core_types::{
-    fuel_asm::*,
+    fuel_asm::{
+        op,
+        GTFArgs,
+        RegId,
+    },
     fuel_tx::{
         ConsensusParameters,
         Input,

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,9 +1,14 @@
 use fuel_core::database::vm_database::VmDatabase;
 pub use fuel_core::database::Database;
 use fuel_core_types::{
-    fuel_asm::*,
+    fuel_asm::{
+        op,
+        GTFArgs,
+        Instruction,
+        RegId,
+    },
     fuel_tx::*,
-    fuel_types::BlockHeight,
+    fuel_types::*,
     fuel_vm::{
         checked_transaction::{
             EstimatePredicates,

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.20.1"
+appVersion: "0.20.2"
 version: 0.1.0

--- a/tests/tests/messages.rs
+++ b/tests/tests/messages.rs
@@ -17,7 +17,11 @@ use fuel_core_client::client::{
     FuelClient,
 };
 use fuel_core_types::{
-    fuel_asm::*,
+    fuel_asm::{
+        op,
+        GTFArgs,
+        RegId,
+    },
     fuel_crypto::*,
     fuel_merkle,
     fuel_tx::{


### PR DESCRIPTION
## Release v0.20.2

The release adds parallel predicate verification and fixes the `Receipt` GraphQL serialization bug.

## What's Changed
* parallel predicate verification by @leviathanbeak in https://github.com/FuelLabs/fuel-core/pull/1253
* Fixed wrong encoding of the `Mint` and `Burn` receipts. by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1264


**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.20.1...v0.20.2