### PR TITLE
feat: Add `enable-p2p` flag to `fuel-core` CLI

### DIFF
--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -217,7 +217,6 @@ impl P2PArgs {
         self,
         metrics: bool,
     ) -> anyhow::Result<Option<Config<NotInitialized>>> {
-        dbg!(self.disable_p2p);
         if self.disable_p2p {
             Ok(None)
         } else {

--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -34,7 +34,7 @@ const MAX_RESPONSE_SIZE_STR: &str = const_format::formatcp!("{MAX_RESPONSE_SIZE}
 pub struct P2PArgs {
     /// Disable P2P. By default, P2P is enabled when the binary is compiled with the "p2p" feature
     /// flag. Providing `--disable-p2p` will disable the P2P service.
-    #[clap(long, short, action, default_value = "false")]
+    #[clap(long, short, action)]
     pub disable_p2p: bool,
 
     /// Peering secret key. Supports either a hex encoded secret key inline or a path to bip32 mnemonic encoded secret file.
@@ -218,6 +218,7 @@ impl P2PArgs {
         metrics: bool,
     ) -> anyhow::Result<Option<Config<NotInitialized>>> {
         if self.disable_p2p {
+            tracing::info!("P2P service disabled");
             Ok(None)
         } else {
             let local_keypair = {

--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -32,13 +32,19 @@ const MAX_RESPONSE_SIZE_STR: &str = const_format::formatcp!("{MAX_RESPONSE_SIZE}
 
 #[derive(Debug, Clone, Args)]
 pub struct P2PArgs {
+    /// Disable P2P. By default, P2P is enabled when the binary is compiled with the "p2p" feature
+    /// flag. Providing `--disable-p2p` will disable the P2P service.
+    #[clap(long, short, action, default_value = "false")]
+    pub disable_p2p: bool,
+
     /// Peering secret key. Supports either a hex encoded secret key inline or a path to bip32 mnemonic encoded secret file.
     #[clap(long = "keypair", env, value_parser = KeypairArg::try_from_string)]
+    #[arg(required_unless_present("disable_p2p"))]
     pub keypair: Option<KeypairArg>,
 
     /// The name of the p2p Network
-    /// If this value is not provided the p2p network won't start
     #[clap(long = "network", env)]
+    #[arg(required_unless_present("disable_p2p"))]
     pub network: Option<String>,
 
     /// p2p network's IP Address
@@ -211,57 +217,58 @@ impl P2PArgs {
         self,
         metrics: bool,
     ) -> anyhow::Result<Option<Config<NotInitialized>>> {
-        let local_keypair = {
-            match self.keypair {
-                Some(KeypairArg::Path(path)) => {
-                    let phrase = std::fs::read_to_string(path)?;
-
-                    let secret_key =
-                        fuel_crypto::SecretKey::new_from_mnemonic_phrase_with_path(
-                            &phrase,
-                            "m/44'/60'/0'/0/0",
-                        )?;
-
-                    Some(convert_to_libp2p_keypair(&mut secret_key.to_vec())?)
-                }
-                Some(KeypairArg::InlineSecret(secret_key)) => {
-                    Some(convert_to_libp2p_keypair(&mut secret_key.to_vec())?)
-                }
-                _ => None,
-            }
-        };
-
-        let gossipsub_config = default_gossipsub_builder()
-            .mesh_n(self.ideal_mesh_size)
-            .mesh_n_low(self.min_mesh_size)
-            .mesh_n_high(self.max_mesh_size)
-            .history_length(self.history_length)
-            .history_gossip(self.history_gossip)
-            .heartbeat_interval(Duration::from_secs(self.gossip_heartbeat_interval))
-            .max_transmit_size(self.max_transmit_size)
-            .build()
-            .expect("valid gossipsub configuration");
-
-        let random_walk = if self.random_walk == 0 {
-            None
+        dbg!(self.disable_p2p);
+        if self.disable_p2p {
+            Ok(None)
         } else {
-            Some(Duration::from_secs(self.random_walk))
-        };
+            let local_keypair = {
+                match self.keypair.expect("mandatory value") {
+                    KeypairArg::Path(path) => {
+                        let phrase = std::fs::read_to_string(path)?;
+                        let secret_key =
+                            fuel_crypto::SecretKey::new_from_mnemonic_phrase_with_path(
+                                &phrase,
+                                "m/44'/60'/0'/0/0",
+                            )?;
 
-        let heartbeat_config = {
-            let send_duration = Duration::from_secs(self.heartbeat_send_duration);
-            let idle_duration = Duration::from_secs(self.heartbeat_idle_duration);
-            HeartbeatConfig::new(
-                send_duration,
-                idle_duration,
-                self.heartbeat_max_failures,
-            )
-        };
+                        convert_to_libp2p_keypair(&mut secret_key.to_vec())?
+                    }
+                    KeypairArg::InlineSecret(secret_key) => {
+                        convert_to_libp2p_keypair(&mut secret_key.to_vec())?
+                    }
+                }
+            };
 
-        let config = || -> Option<Config<NotInitialized>> {
-            Some(Config {
-                keypair: local_keypair?,
-                network_name: self.network?,
+            let gossipsub_config = default_gossipsub_builder()
+                .mesh_n(self.ideal_mesh_size)
+                .mesh_n_low(self.min_mesh_size)
+                .mesh_n_high(self.max_mesh_size)
+                .history_length(self.history_length)
+                .history_gossip(self.history_gossip)
+                .heartbeat_interval(Duration::from_secs(self.gossip_heartbeat_interval))
+                .max_transmit_size(self.max_transmit_size)
+                .build()
+                .expect("valid gossipsub configuration");
+
+            let random_walk = if self.random_walk == 0 {
+                None
+            } else {
+                Some(Duration::from_secs(self.random_walk))
+            };
+
+            let heartbeat_config = {
+                let send_duration = Duration::from_secs(self.heartbeat_send_duration);
+                let idle_duration = Duration::from_secs(self.heartbeat_idle_duration);
+                HeartbeatConfig::new(
+                    send_duration,
+                    idle_duration,
+                    self.heartbeat_max_failures,
+                )
+            };
+
+            let config = Config {
+                keypair: local_keypair,
+                network_name: self.network.expect("mandatory value"),
                 checksum: Default::default(),
                 address: self
                     .address
@@ -290,9 +297,9 @@ impl P2PArgs {
                 identify_interval: Some(Duration::from_secs(self.identify_interval)),
                 metrics,
                 state: NotInitialized,
-            })
-        };
-
-        Ok(config())
+            };
+            let config = self.disable_p2p.then_some(config);
+            Ok(config)
+        }
     }
 }

--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -297,8 +297,7 @@ impl P2PArgs {
                 metrics,
                 state: NotInitialized,
             };
-            let config = self.disable_p2p.then_some(config);
-            Ok(config)
+            Ok(Some(config))
         }
     }
 }


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-core/issues/1236

This PR disables P2P by default, and adds a new flag to the `fuel-core` CLI to allow users to expressly enable P2P:
```
--enable-p2p
```
Currently, the P2P service is only enabled when the user provides CLI arguments for `keypair` and `network`. If either of these values are missing, P2P is implicitly disabled without warning to the user. There is no way to tell if the user accidentally omitted these values, or deliberately omitted them in order to disable P2P. 

A better user experience is to enable P2P explicitly using `--enable-p2p` and to make `keypair` and `network` mandatory. This will raise an error if either of these values is missing. P2P should be disabled by default. This flag replaces having to add or remove the `network` argument to enable or disable P2P implicitly. 

If a user wants to run `fuel-core` with P2P, and supplies `--enable-p2p`, but forgets to include `keypair` and/or `network`, they will encounter an error:
```
error: the following required arguments were not provided:
  --keypair <KEYPAIR>
  --network <NETWORK>
  ```