### PR TITLE
Release v0.20.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -486,7 +486,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -717,7 +717,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -855,7 +855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.4",
  "serde",
 ]
 
@@ -943,11 +943,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -1109,7 +1110,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1821,6 +1822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,7 +1946,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2106,7 +2113,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2117,9 +2124,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -2577,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2650,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "parking_lot 0.12.1",
@@ -2659,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2679,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2698,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2721,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "clap",
  "fuel-core-client",
@@ -2732,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2744,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2755,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2780,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2791,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2806,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2817,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "axum",
  "lazy_static",
@@ -2828,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2871,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2889,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2906,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2934,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2947,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -2958,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3004,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "ctor",
  "tracing",
@@ -3014,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3040,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3239,7 +3246,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3681,7 +3688,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -3926,7 +3933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys 0.48.0",
 ]
 
@@ -4616,9 +4623,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -5355,9 +5362,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -5400,7 +5407,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -5608,7 +5615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -6068,7 +6075,7 @@ checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.4",
  "regex-syntax 0.7.4",
 ]
 
@@ -6083,9 +6090,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6129,7 +6136,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite 0.2.10",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -6348,14 +6355,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -6386,9 +6393,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -6707,9 +6714,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.176"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dc28c9523c5d70816e393136b86d48909cfb27cecaa902d338c19ed47164dc"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
@@ -6726,13 +6733,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.176"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e7b8c5dc823e3b90651ff1d3808419cd14e5ad76de04feaf37da114e7a306f"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7054,7 +7061,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7065,7 +7072,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7137,9 +7144,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7209,7 +7216,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys 0.48.0",
 ]
 
@@ -7259,7 +7266,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7279,7 +7286,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7323,10 +7330,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -7341,9 +7349,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -7420,7 +7428,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -7461,7 +7469,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
 ]
 
@@ -7597,7 +7605,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -8014,7 +8022,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -8048,7 +8056,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8717,5 +8725,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,32 +45,32 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.20.2"
+version = "0.20.3"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.20.2", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.20.2", path = "./bin/client" }
-fuel-core-bin = { version = "0.20.2", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.20.2", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.20.2", path = "./crates/chain-config" }
-fuel-core-client = { version = "0.20.2", path = "./crates/client" }
-fuel-core-database = { version = "0.20.2", path = "./crates/database" }
-fuel-core-metrics = { version = "0.20.2", path = "./crates/metrics" }
-fuel-core-services = { version = "0.20.2", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.20.2", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.20.2", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.20.2", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.20.2", path = "./crates/services/executor" }
-fuel-core-importer = { version = "0.20.2", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.20.2", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.20.2", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.20.2", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.20.2", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.20.2", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.20.2", path = "./crates/storage" }
-fuel-core-trace = { version = "0.20.2", path = "./crates/trace" }
-fuel-core-types = { version = "0.20.2", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.20.3", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.20.3", path = "./bin/client" }
+fuel-core-bin = { version = "0.20.3", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.20.3", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.20.3", path = "./crates/chain-config" }
+fuel-core-client = { version = "0.20.3", path = "./crates/client" }
+fuel-core-database = { version = "0.20.3", path = "./crates/database" }
+fuel-core-metrics = { version = "0.20.3", path = "./crates/metrics" }
+fuel-core-services = { version = "0.20.3", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.20.3", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.20.3", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.20.3", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.20.3", path = "./crates/services/executor" }
+fuel-core-importer = { version = "0.20.3", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.20.3", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.20.3", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.20.3", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.20.3", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.20.3", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.20.3", path = "./crates/storage" }
+fuel-core-trace = { version = "0.20.3", path = "./crates/trace" }
+fuel-core-types = { version = "0.20.3", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.20.2"
+appVersion: "0.20.3"
 version: 0.1.0

--- a/deployment/scripts/chainspec/beta_chainspec.json
+++ b/deployment/scripts/chainspec/beta_chainspec.json
@@ -1,6 +1,6 @@
 {
   "chain_name": "Testnet Beta 4",
-  "block_gas_limit": 5000000000,
+  "block_gas_limit": 30000000,
   "initial_state": {
     "coins": [
       {
@@ -52,7 +52,7 @@
     "max_predicate_length": 1048576,
     "max_predicate_data_length": 1048576,
     "max_gas_per_predicate": 10000000,
-    "gas_price_factor": 1000000000,
+    "gas_price_factor": 92,
     "gas_per_byte": 4,
     "max_message_data_length": 1048576,
     "chain_id": 0


### PR DESCRIPTION
Finalizing the chain specification for the beta 4 network.
Bumping version to `0.20.3`.