### PR TITLE
Added changelog in the same way as we did for `fuel-vm`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   release:
     types: [published]
 
@@ -22,6 +23,14 @@ env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
 jobs:
+  check-changelog:
+    name: Check Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@v2
+        with:
+          changelog: CHANGELOG.md
+
   rustfmt:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
@@ -85,6 +94,7 @@ jobs:
       - lint-toml-files
       - prevent-openssl
       - rustfmt
+      - check-changelog
     runs-on: buildjet-4vcpu-ubuntu-2204
     env:
       RUSTFLAGS: -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+Description of the upcoming release here.
+
+### Added
+
+- Something new here 1
+- Something new here 2
+
+### Changed
+
+- Something changed here 1
+- Something changed here 2
+
+#### Breaking
+- Some breaking change here 3
+- Some breaking change here 4
+
+### Fixed
+
+- Some fix here 1
+- Some fix here 2
+
+#### Breaking
+- Some breaking fix here 3
+- Some breaking fix here 4


### PR DESCRIPTION
Added changelog as we did for `fuel-vm`. It should simplify our release process and make it more clear