### PR TITLE
Release/v0.19.2 hotfix for relayer (do not merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "parking_lot 0.12.1",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "clap 4.3.4",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "bech32 0.9.1",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "clap 4.3.4",
  "fuel-core-client",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "clap 4.3.4",
@@ -2804,7 +2804,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "axum",
  "lazy_static",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "fuel-core-types",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "ctor",
  "tracing",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,32 +45,32 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.19.1"
+version = "0.19.2"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.19.1", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.19.1", path = "./bin/client" }
-fuel-core-bin = { version = "0.19.1", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.19.1", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.19.1", path = "./crates/chain-config" }
-fuel-core-client = { version = "0.19.1", path = "./crates/client" }
-fuel-core-database = { version = "0.19.1", path = "./crates/database" }
-fuel-core-metrics = { version = "0.19.1", path = "./crates/metrics" }
-fuel-core-services = { version = "0.19.1", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.19.1", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.19.1", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.19.1", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.19.1", path = "./crates/services/executor" }
-fuel-core-importer = { version = "0.19.1", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.19.1", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.19.1", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.19.1", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.19.1", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.19.1", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.19.1", path = "./crates/storage" }
-fuel-core-trace = { version = "0.19.1", path = "./crates/trace" }
-fuel-core-types = { version = "0.19.1", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.19.2", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.19.2", path = "./bin/client" }
+fuel-core-bin = { version = "0.19.2", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.19.2", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.19.2", path = "./crates/chain-config" }
+fuel-core-client = { version = "0.19.2", path = "./crates/client" }
+fuel-core-database = { version = "0.19.2", path = "./crates/database" }
+fuel-core-metrics = { version = "0.19.2", path = "./crates/metrics" }
+fuel-core-services = { version = "0.19.2", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.19.2", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.19.2", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.19.2", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.19.2", path = "./crates/services/executor" }
+fuel-core-importer = { version = "0.19.2", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.19.2", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.19.2", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.19.2", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.19.2", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.19.2", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.19.2", path = "./crates/storage" }
+fuel-core-trace = { version = "0.19.2", path = "./crates/trace" }
+fuel-core-types = { version = "0.19.2", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 

--- a/crates/services/relayer/src/config.rs
+++ b/crates/services/relayer/src/config.rs
@@ -45,7 +45,7 @@ pub struct Config {
 
 #[allow(missing_docs)]
 impl Config {
-    pub const DEFAULT_LOG_PAGE_SIZE: u64 = 5;
+    pub const DEFAULT_LOG_PAGE_SIZE: u64 = 10_000;
     pub const DEFAULT_DA_FINALIZATION: u64 = 100;
     pub const DEFAULT_DA_DEPLOY_HEIGHT: u64 = 0;
     pub const DEFAULT_SYNC_MINIMUM_DURATION: Duration = Duration::from_secs(5);

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -226,7 +226,9 @@ where
 
         let result = run::run(self).await;
 
-        if self.shutdown.borrow_and_update().started() && self.synced.borrow().is_some() {
+        if self.shutdown.borrow_and_update().started()
+            && (result.is_err() | self.synced.borrow().is_some())
+        {
             // Sleep the loop so the da node is not spammed.
             tokio::time::sleep(
                 self.config

--- a/crates/services/relayer/src/service/get_logs/test.rs
+++ b/crates/services/relayer/src/service/get_logs/test.rs
@@ -79,6 +79,8 @@ struct Expected {
     m: Vec<Log>,
 }
 
+const DEFAULT_LOG_PAGE_SIZE: u64 = 5;
+
 #[test_case(
     Input {
         eth_gap: 0..=1,
@@ -132,7 +134,7 @@ async fn can_paginate_logs(input: Input) -> Expected {
         &EthSyncGap::new(*eth_gap.start(), *eth_gap.end()),
         contracts,
         &eth_node,
-        Config::DEFAULT_LOG_PAGE_SIZE,
+        DEFAULT_LOG_PAGE_SIZE,
     )
     .map_ok(|(_, l)| l)
     .try_concat()

--- a/crates/services/relayer/src/service/test.rs
+++ b/crates/services/relayer/src/service/test.rs
@@ -3,6 +3,8 @@ use futures::TryStreamExt;
 
 use super::*;
 
+const DEFAULT_LOG_PAGE_SIZE: u64 = 5;
+
 #[tokio::test]
 async fn can_download_logs() {
     let eth_node = MockMiddleware::default();
@@ -32,7 +34,7 @@ async fn can_download_logs() {
         &eth_state.needs_to_sync_eth().unwrap(),
         contracts,
         &eth_node,
-        Config::DEFAULT_LOG_PAGE_SIZE,
+        DEFAULT_LOG_PAGE_SIZE,
     )
     .map_ok(|(_, l)| l)
     .try_concat()

--- a/crates/services/relayer/tests/integration.rs
+++ b/crates/services/relayer/tests/integration.rs
@@ -59,7 +59,11 @@ async fn stop_service_at_the_middle() {
     let mock_db = MockDb::default();
     let eth_node = MockMiddleware::default();
     eth_node.update_data(|data| data.best_block.number = Some(200.into()));
-    let relayer = new_service_test(eth_node, mock_db.clone(), Default::default());
+    let config = Config {
+        log_page_size: 5,
+        ..Default::default()
+    };
+    let relayer = new_service_test(eth_node, mock_db.clone(), config);
     relayer.start_and_await().await.unwrap();
 
     // Skip the initial requests to start the synchronization.

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.19.1"
+appVersion: "0.19.2"
 version: 0.1.0


### PR DESCRIPTION
Hotfix patch to fuel-core 0.19 to avoid spamming eth rpc when errors occur.

This PR diff is just to show the changes between 0.19.1, but it should not get merged.