### PR TITLE
avoid gha caching for docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,8 +333,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/fuellabs/fuel-core-debug-build-cache:latest
+          cache-to: type=registry,ref=ghcr.io/fuellabs/fuel-core-debug-build-cache:latest,mode=max
 
       - uses: FuelLabs/.github/.github/actions/slack-notify-template@master
         if: always() && (github.ref == 'refs/heads/master' || github.ref_type == 'tag')
@@ -443,8 +443,8 @@ jobs:
           file: ci/Dockerfile.${{ matrix.job.target }}-clang
           tags: ${{ matrix.job.cross_image }}:latest
           load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/fuellabs/${{ matrix.job.cross_image }}-build-cache:latest
+          cache-to: type=registry,ref=ghcr.io/fuellabs/${{ matrix.job.cross_image }}-build-cache:latest,mode=max
 
       - name: Install packages (macOS)
         if: matrix.job.os == 'macos-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1366](https://github.com/FuelLabs/fuel-core/pull/1366): Improve caching during docker builds in CI by replacing gha
 - [#1358](https://github.com/FuelLabs/fuel-core/pull/1358): Upgraded the Rust version used in CI to 1.72.0. Also includes associated Clippy changes.
 - [#1318](https://github.com/FuelLabs/fuel-core/pull/1318): Modified block synchronization to use asynchronous task execution when retrieving block headers.
 - [#1314](https://github.com/FuelLabs/fuel-core/pull/1314): Removed `types::ConsensusParameters` in favour of `fuel_tx:ConsensusParameters`.


### PR DESCRIPTION
remove remaining uses of gha caching for docker builds. The github cache is very unreliable and slow.