### PR TITLE
Renamed `base_chain_height` to `da_height` and return current relayer height instead of latest Fuel block height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,15 +36,16 @@ Description of the upcoming release here.
 - [#1270](https://github.com/FuelLabs/fuel-core/pull/1270): Modify the way block headers are retrieved from peers to be done in batches.
 - [#1342](https://github.com/FuelLabs/fuel-core/pull/1342): Add error handling for P2P requests to return `None` to requester and log error
 
-### Breaking
+#### Breaking
+- [#1374](https://github.com/FuelLabs/fuel-core/pull/1374): Renamed `base_chain_height` to `da_height` and return current relayer height instead of latest Fuel block height.
 - [#1363](https://github.com/FuelLabs/fuel-core/pull/1363): Change message_proof api to take `nonce` instead of `message_id`
 - [#1339](https://github.com/FuelLabs/fuel-core/pull/1339): Added a new required field called `base_asset_id` to the `FeeParameters` definition in `ConsensusParameters`, as well as default values for `base_asset_id` in the `beta` and `dev` chainspecs.
 - [#1355](https://github.com/FuelLabs/fuel-core/pull/1355): Removed the `metrics` feature flag from the fuel-core crate, and metrics are now included by default.
 - [#1322](https://github.com/FuelLabs/fuel-core/pull/1322):
   The `debug` flag is added to the CLI. The flag should be used for local development only. Enabling debug mode:
-    - Allows GraphQL Endpoints to arbitrarily advance blocks.
-    - Enables debugger GraphQL Endpoints.
-    - Allows setting `utxo_validation` to `false`.
+      - Allows GraphQL Endpoints to arbitrarily advance blocks.
+      - Enables debugger GraphQL Endpoints.
+      - Allows setting `utxo_validation` to `false`.
 - [#1318](https://github.com/FuelLabs/fuel-core/pull/1318): Removed the `--sync-max-header-batch-requests` CLI argument, and renamed `--sync-max-get-txns` to `--sync-block-stream-buffer-size` to better represent the current behavior in the import.
 - [#1290](https://github.com/FuelLabs/fuel-core/pull/1290): Standardize CLI args to use `-` instead of `_`.
 - [#1279](https://github.com/FuelLabs/fuel-core/pull/1279): Added a new CLI flag to enable the Relayer service `--enable-relayer`, and disabled the Relayer service by default. When supplying the `--enable-relayer` flag, the `--relayer` argument becomes mandatory, and omitting it is an error. Similarly, providing a `--relayer` argument without the `--enable-relayer` flag is an error. Lastly, providing the `--keypair` or `--network` arguments will also produce an error if the `--enable-p2p` flag is not set.

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -93,7 +93,7 @@ scalar Bytes32
 type ChainInfo {
 	name: String!
 	latestBlock: Block!
-	baseChainHeight: U32!
+	daHeight: U64!
 	peerCount: Int!
 	consensusParameters: ConsensusParameters!
 	gasCosts: GasCosts!

--- a/crates/client/src/client/schema/chain.rs
+++ b/crates/client/src/client/schema/chain.rs
@@ -2,7 +2,6 @@ use crate::client::schema::{
     block::Block,
     schema,
     AssetId,
-    U32,
     U64,
 };
 
@@ -280,7 +279,7 @@ pub struct ChainQuery {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ChainInfo {
-    pub base_chain_height: U32,
+    pub da_height: U64,
     pub name: String,
     pub peer_count: i32,
     pub latest_block: Block,

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -4,7 +4,7 @@ expression: operation.query
 ---
 query {
   chain {
-    baseChainHeight
+    daHeight
     name
     peerCount
     latestBlock {

--- a/crates/client/src/client/types/chain_info.rs
+++ b/crates/client/src/client/types/chain_info.rs
@@ -5,7 +5,7 @@ use crate::client::{
 use fuel_core_types::fuel_tx::ConsensusParameters;
 
 pub struct ChainInfo {
-    pub base_chain_height: u32,
+    pub da_height: u64,
     pub name: String,
     pub peer_count: i32,
     pub latest_block: Block,
@@ -17,7 +17,7 @@ pub struct ChainInfo {
 impl From<schema::chain::ChainInfo> for ChainInfo {
     fn from(value: schema::chain::ChainInfo) -> Self {
         Self {
-            base_chain_height: value.base_chain_height.into(),
+            da_height: value.da_height.into(),
             name: value.name,
             peer_count: value.peer_count,
             latest_block: value.latest_block.into(),

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -155,7 +155,7 @@ pub trait DatabaseContracts:
 pub trait DatabaseChain {
     fn chain_name(&self) -> StorageResult<String>;
 
-    fn base_chain_height(&self) -> StorageResult<DaBlockHeight>;
+    fn da_height(&self) -> StorageResult<DaBlockHeight>;
 }
 
 #[async_trait]

--- a/crates/fuel-core/src/query/chain.rs
+++ b/crates/fuel-core/src/query/chain.rs
@@ -5,7 +5,7 @@ use fuel_core_types::blockchain::primitives::DaBlockHeight;
 pub trait ChainQueryData: Send + Sync {
     fn name(&self) -> StorageResult<String>;
 
-    fn base_chain_height(&self) -> StorageResult<DaBlockHeight>;
+    fn da_height(&self) -> StorageResult<DaBlockHeight>;
 }
 
 impl<D: DatabasePort + ?Sized> ChainQueryData for D {
@@ -13,7 +13,7 @@ impl<D: DatabasePort + ?Sized> ChainQueryData for D {
         self.chain_name()
     }
 
-    fn base_chain_height(&self) -> StorageResult<DaBlockHeight> {
-        self.base_chain_height()
+    fn da_height(&self) -> StorageResult<DaBlockHeight> {
+        self.da_height()
     }
 }

--- a/crates/fuel-core/src/schema/chain.rs
+++ b/crates/fuel-core/src/schema/chain.rs
@@ -11,7 +11,6 @@ use crate::{
         block::Block,
         scalars::{
             AssetId,
-            U32,
             U64,
         },
     },
@@ -635,14 +634,14 @@ impl ChainInfo {
         Ok(latest_block)
     }
 
-    async fn base_chain_height(&self, ctx: &Context<'_>) -> U32 {
+    async fn da_height(&self, ctx: &Context<'_>) -> U64 {
         let query: &Database = ctx.data_unchecked();
 
         let height = query
-            .latest_block_height()
+            .da_height()
             .expect("The blockchain always should have genesis block");
 
-        height.into()
+        height.0.into()
     }
 
     async fn peer_count(&self) -> u16 {

--- a/crates/fuel-core/src/service/adapters/graphql_api.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api.rs
@@ -197,7 +197,7 @@ impl DatabaseChain for Database {
             .unwrap_or_else(|| DEFAULT_NAME.to_string()))
     }
 
-    fn base_chain_height(&self) -> StorageResult<DaBlockHeight> {
+    fn da_height(&self) -> StorageResult<DaBlockHeight> {
         #[cfg(feature = "relayer")]
         {
             use fuel_core_relayer::ports::RelayerDb;

--- a/crates/services/relayer/src/ports.rs
+++ b/crates/services/relayer/src/ports.rs
@@ -2,7 +2,6 @@
 
 use async_trait::async_trait;
 use fuel_core_storage::{
-    not_found,
     tables::Messages,
     transactional::Transactional,
     Error as StorageError,
@@ -96,7 +95,7 @@ where
     fn get_finalized_da_height(&self) -> StorageResult<DaBlockHeight> {
         Ok(*StorageAsRef::storage::<RelayerMetadata>(&self)
             .get(&METADATA_KEY)?
-            .ok_or(not_found!("DaBlockHeight missing for relayer"))?)
+            .unwrap_or_default())
     }
 }
 

--- a/tests/tests/chain.rs
+++ b/tests/tests/chain.rs
@@ -12,6 +12,7 @@ async fn chain_info() {
 
     let chain_info = client.chain_info().await.unwrap();
 
+    assert_eq!(0, chain_info.da_height);
     assert_eq!(node_config.chain_conf.chain_name, chain_info.name);
     assert_eq!(
         node_config.chain_conf.consensus_parameters,


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/1373