### PR TITLE
Fix an interger overflow in message_proof when looking beyond genesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Description of the upcoming release here.
 - [#1342](https://github.com/FuelLabs/fuel-core/pull/1342): Add error handling for P2P requests to return `None` to requester and log error.
 - [#1383](https://github.com/FuelLabs/fuel-core/pull/1383): Disallow usage of `log` crate internally in favor of `tracing` crate.
 - [#1390](https://github.com/FuelLabs/fuel-core/pull/1390): Up the `ethers` version to `2` to fix an issue with `tungstenite`.
+- [#1392](https://github.com/FuelLabs/fuel-core/pull/1392): Fixed an overflow in `message_proof`.
 
 #### Breaking
 - [#1374](https://github.com/FuelLabs/fuel-core/pull/1374): Renamed `base_chain_height` to `da_height` and return current relayer height instead of latest Fuel block height.

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -205,8 +205,8 @@ pub fn message_proof<T: MessageProofData + ?Sized>(
         None => return Ok(None),
     };
 
-    let block_heigth = *commit_block_header.height();
-    if block_heigth == 0u32.into() {
+    let block_height = *commit_block_header.height();
+    if block_height == 0u32.into() {
         // Cannot look beyond the genesis block
         return Ok(None)
     }

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -205,7 +205,11 @@ pub fn message_proof<T: MessageProofData + ?Sized>(
         None => return Ok(None),
     };
 
-    let verifiable_commit_block_height = *commit_block_header.height() - 1u32.into();
+    let block_heigth = *commit_block_header.height();
+    if block_heigth == 0u32.into() { // Cannot look beyond the genesis block
+        return Ok(None)
+    }
+    let verifiable_commit_block_height = block_heigth - 1u32.into();
     let block_proof = database.block_history_proof(
         message_block_header.height(),
         &verifiable_commit_block_height,

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -206,7 +206,8 @@ pub fn message_proof<T: MessageProofData + ?Sized>(
     };
 
     let block_heigth = *commit_block_header.height();
-    if block_heigth == 0u32.into() { // Cannot look beyond the genesis block
+    if block_heigth == 0u32.into() {
+        // Cannot look beyond the genesis block
         return Ok(None)
     }
     let verifiable_commit_block_height = block_heigth - 1u32.into();

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -210,7 +210,7 @@ pub fn message_proof<T: MessageProofData + ?Sized>(
         // Cannot look beyond the genesis block
         return Ok(None)
     }
-    let verifiable_commit_block_height = block_heigth - 1u32.into();
+    let verifiable_commit_block_height = block_height - 1u32.into();
     let block_proof = database.block_history_proof(
         message_block_header.height(),
         &verifiable_commit_block_height,


### PR DESCRIPTION
Fixes https://github.com/FuelLabs/fuel-core/issues/1334

See https://github.com/FuelLabs/fuel-vm/pull/596 for follow-up work.