### PR TITLE
feat: Retrieve finalized blocks from Ethereum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Description of the upcoming release here.
 - [#1342](https://github.com/FuelLabs/fuel-core/pull/1342): Add error handling for P2P requests to return `None` to requester and log error.
 - [#1383](https://github.com/FuelLabs/fuel-core/pull/1383): Disallow usage of `log` crate internally in favor of `tracing` crate.
 - [#1390](https://github.com/FuelLabs/fuel-core/pull/1390): Up the `ethers` version to `2` to fix an issue with `tungstenite`.
+- [#1392](https://github.com/FuelLabs/fuel-core/pull/1392): Fixed an overflow in `message_proof`.
 - [#1393](https://github.com/FuelLabs/fuel-core/pull/1393): Increase heartbeat timeout from `2` to `60` seconds, as suggested in [this issue](https://github.com/FuelLabs/fuel-core/issues/1330).
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1399](https://github.com/FuelLabs/fuel-core/pull/1399): The Relayer now queries Ethereum for its latest finalized block instead of using a configurable "finalization period" to presume finality.
 - [#1349](https://github.com/FuelLabs/fuel-core/pull/1349): Updated peer-to-peer transactions API to support multiple blocks in a single request, and updated block synchronization to request multiple blocks based on the configured range of headers.
 - [#1380](https://github.com/FuelLabs/fuel-core/pull/1380): Add preliminary, hard-coded config values for heartbeat peer reputation, removing `todo`.
 - [#1377](https://github.com/FuelLabs/fuel-core/pull/1377): Remove `DiscoveryEvent` and use `KademliaEvent` directly in `DiscoveryBehavior`.
@@ -62,5 +63,6 @@ Description of the upcoming release here.
 ### Removed
 
 #### Breaking
+- [#1399](https://github.com/FuelLabs/fuel-core/pull/1399): Removed `relayer-da-finalization` parameter from the relayer CLI.
 - [#1338](https://github.com/FuelLabs/fuel-core/pull/1338): Updated GraphQL client to use `DependentCost` for `k256`, `mcpi`, `s256`, `scwq`, `swwq` opcodes.
 - [#1322](https://github.com/FuelLabs/fuel-core/pull/1322): The `manual_blocks_enabled` flag is removed from the CLI. The analog is a `debug` flag.

--- a/bin/fuel-core/src/cli/run/relayer.rs
+++ b/bin/fuel-core/src/cli/run/relayer.rs
@@ -31,10 +31,6 @@ pub struct RelayerArgs {
     #[arg(long = "relayer-v2-listening-contracts", value_parser = parse_h160, env)]
     pub eth_v2_listening_contracts: Vec<H160>,
 
-    /// Number of da block after which messages/stakes/validators become finalized.
-    #[clap(long = "relayer-da-finalization", default_value_t = Config::DEFAULT_DA_FINALIZATION, env)]
-    pub da_finalization: u64,
-
     /// Number of da block that the contract is deployed at.
     #[clap(long = "relayer-da-deploy-height", default_value_t = Config::DEFAULT_DA_DEPLOY_HEIGHT, env)]
     pub da_deploy_height: u64,
@@ -70,7 +66,6 @@ impl RelayerArgs {
 
         let config = Config {
             da_deploy_height: DaBlockHeight(self.da_deploy_height),
-            da_finalization: DaBlockHeight(self.da_finalization),
             relayer: self.relayer,
             eth_v2_listening_contracts: self.eth_v2_listening_contracts,
             log_page_size: self.log_page_size,

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -205,7 +205,12 @@ pub fn message_proof<T: MessageProofData + ?Sized>(
         None => return Ok(None),
     };
 
-    let verifiable_commit_block_height = *commit_block_header.height() - 1u32.into();
+    let block_height = *commit_block_header.height();
+    if block_height == 0u32.into() {
+        // Cannot look beyond the genesis block
+        return Ok(None)
+    }
+    let verifiable_commit_block_height = block_height - 1u32.into();
     let block_proof = database.block_history_proof(
         message_block_header.height(),
         &verifiable_commit_block_height,

--- a/crates/services/relayer/src/config.rs
+++ b/crates/services/relayer/src/config.rs
@@ -19,8 +19,6 @@ pub(crate) static ETH_LOG_MESSAGE: Lazy<H256> =
 pub struct Config {
     /// The da block to which the contract was deployed.
     pub da_deploy_height: DaBlockHeight,
-    /// Number of da blocks after which messages/stakes/validators become finalized.
-    pub da_finalization: DaBlockHeight,
     /// Uri address to ethereum client.
     pub relayer: Option<url::Url>,
     // TODO: Create `EthAddress` into `fuel_core_types`.
@@ -46,7 +44,6 @@ pub struct Config {
 #[allow(missing_docs)]
 impl Config {
     pub const DEFAULT_LOG_PAGE_SIZE: u64 = 10_000;
-    pub const DEFAULT_DA_FINALIZATION: u64 = 100;
     pub const DEFAULT_DA_DEPLOY_HEIGHT: u64 = 0;
     pub const DEFAULT_SYNC_MINIMUM_DURATION: Duration = Duration::from_secs(5);
     pub const DEFAULT_SYNCING_CALL_FREQ: Duration = Duration::from_secs(5);
@@ -57,7 +54,6 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             da_deploy_height: DaBlockHeight::from(Self::DEFAULT_DA_DEPLOY_HEIGHT),
-            da_finalization: DaBlockHeight::from(Self::DEFAULT_DA_FINALIZATION),
             relayer: None,
             eth_v2_listening_contracts: vec![H160::from_str(
                 "0x03E4538018285e1c03CCce2F92C9538c87606911",

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -314,19 +314,6 @@ where
     P: Middleware<Error = ProviderError>,
     D: RelayerDb + 'static,
 {
-    async fn current(&self) -> anyhow::Result<u64> {
-        let mut shutdown = self.shutdown.clone();
-        tokio::select! {
-            biased;
-            _ = shutdown.while_started() => {
-                Err(anyhow::anyhow!("The relayer got a stop signal"))
-            },
-            block_number = self.eth_node.get_block_number() => {
-                Ok(block_number?.as_u64())
-            }
-        }
-    }
-
     async fn finalized(&self) -> anyhow::Result<u64> {
         let mut shutdown = self.shutdown.clone();
         tokio::select! {

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -322,10 +322,14 @@ where
                 Err(anyhow::anyhow!("The relayer got a stop signal"))
             },
             block = self.eth_node.get_block(ethers_core::types::BlockNumber::Finalized) => {
-                let block_number = if let Ok(Some(block)) = block {
-                    block.number.ok_or(anyhow::anyhow!("Pending"))
-                } else {
-                    Err(anyhow::anyhow!("error"))
+                let block_number = match block {
+                    Ok(Some(block)) => {
+                        // If the block number is missing, it means the block
+                        // is pending
+                        block.number.ok_or(anyhow::anyhow!("Block pending"))
+                    },
+                    Ok(_) => Err(anyhow::anyhow!("Block missing")),
+                    Err(e) => Err(anyhow::anyhow!(e))
                 };
                 Ok(block_number?.as_u64())
             }

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -322,16 +322,11 @@ where
                 Err(anyhow::anyhow!("The relayer got a stop signal"))
             },
             block = self.eth_node.get_block(ethers_core::types::BlockNumber::Finalized) => {
-                let block_number = match block {
-                    Ok(Some(block)) => {
-                        // If the block number is missing, it means the block
-                        // is pending
-                        block.number.ok_or(anyhow::anyhow!("Block pending"))
-                    },
-                    Ok(_) => Err(anyhow::anyhow!("Block missing")),
-                    Err(e) => Err(anyhow::anyhow!(e))
-                };
-                Ok(block_number?.as_u64())
+                let block_number = block?
+                    .and_then(|block| block.number)
+                    .ok_or(anyhow::anyhow!("Block pending"))?
+                    .as_u64();
+                Ok(block_number)
             }
         }
     }

--- a/crates/services/relayer/src/service/get_logs/test.rs
+++ b/crates/services/relayer/src/service/get_logs/test.rs
@@ -119,7 +119,7 @@ async fn can_paginate_logs(input: Input) -> Expected {
 
     eth_node.update_data(|data| {
         data.logs_batch = vec![logs];
-        data.best_block.number = Some((eth_gap.end() + 100).into());
+        data.best_block.number = Some((*eth_gap.end()).into());
     });
     let count = std::sync::Arc::new(AtomicUsize::new(0));
     let num_calls = count.clone();

--- a/crates/services/relayer/src/service/get_logs/test.rs
+++ b/crates/services/relayer/src/service/get_logs/test.rs
@@ -119,8 +119,7 @@ async fn can_paginate_logs(input: Input) -> Expected {
 
     eth_node.update_data(|data| {
         data.logs_batch = vec![logs];
-        data.best_block.number =
-            Some((eth_gap.end() + Config::DEFAULT_DA_FINALIZATION).into());
+        data.best_block.number = Some((eth_gap.end() + 100).into());
     });
     let count = std::sync::Arc::new(AtomicUsize::new(0));
     let num_calls = count.clone();

--- a/crates/services/relayer/src/service/run/test.rs
+++ b/crates/services/relayer/src/service/run/test.rs
@@ -11,8 +11,7 @@ async fn can_set_da_height() {
     test_data_source(
         &mut relayer,
         TestDataSource {
-            eth_remote_current: 300,
-            eth_remote_finalization_period: 100,
+            eth_remote_finalized: 200,
             eth_local_finalized: None,
         },
     );
@@ -31,8 +30,7 @@ async fn logs_are_downloaded_and_written() {
     test_data_source(
         &mut relayer,
         TestDataSource {
-            eth_remote_current: 300,
-            eth_remote_finalization_period: 100,
+            eth_remote_finalized: 200,
             eth_local_finalized: None,
         },
     );
@@ -44,7 +42,6 @@ mockall::mock! {
 
     #[async_trait]
     impl EthRemote for RelayerData {
-        async fn current(&self) -> anyhow::Result<u64>;
         async fn finalized(&self) -> anyhow::Result<u64>;
     }
 
@@ -66,8 +63,7 @@ mockall::mock! {
 }
 
 fn test_data_source(mock: &mut MockRelayerData, data: TestDataSource) {
-    let out = data.eth_remote_current;
-    mock.expect_current().returning(move || Ok(out));
+    let out = data.eth_remote_finalized;
     mock.expect_finalized().returning(move || Ok(out));
     let out = data.eth_local_finalized;
     mock.expect_observed().returning(move || out);

--- a/crates/services/relayer/src/service/run/test.rs
+++ b/crates/services/relayer/src/service/run/test.rs
@@ -45,11 +45,11 @@ mockall::mock! {
     #[async_trait]
     impl EthRemote for RelayerData {
         async fn current(&self) -> anyhow::Result<u64>;
-        fn finalization_period(&self) -> u64;
+        async fn finalized(&self) -> anyhow::Result<u64>;
     }
 
     impl EthLocal for RelayerData {
-        fn finalized(&self) -> Option<u64>;
+        fn observed(&self) -> Option<u64>;
     }
 
     #[async_trait]
@@ -68,8 +68,7 @@ mockall::mock! {
 fn test_data_source(mock: &mut MockRelayerData, data: TestDataSource) {
     let out = data.eth_remote_current;
     mock.expect_current().returning(move || Ok(out));
-    let out = data.eth_remote_finalization_period;
-    mock.expect_finalization_period().returning(move || out);
+    mock.expect_finalized().returning(move || Ok(out));
     let out = data.eth_local_finalized;
-    mock.expect_finalized().returning(move || out);
+    mock.expect_observed().returning(move || out);
 }

--- a/crates/services/relayer/src/service/state.rs
+++ b/crates/services/relayer/src/service/state.rs
@@ -3,7 +3,6 @@
 
 use core::ops::RangeInclusive;
 pub use state_builder::*;
-// use std::ops::Deref;
 
 mod state_builder;
 

--- a/crates/services/relayer/src/service/state.rs
+++ b/crates/services/relayer/src/service/state.rs
@@ -71,10 +71,8 @@ impl EthState {
 impl EthHeights {
     /// Create a new Ethereum block height from the current
     /// block height and the desired finalization period.
-    fn new(current: u64, finalization_period: u64) -> Self {
-        Self(Heights(
-            current.saturating_sub(finalization_period)..=current,
-        ))
+    fn new(current: u64, finalized: u64) -> Self {
+        Self(Heights(current.saturating_sub(finalized)..=current))
     }
 
     /// Get the finalized eth block height.

--- a/crates/services/relayer/src/service/state.rs
+++ b/crates/services/relayer/src/service/state.rs
@@ -56,10 +56,9 @@ impl EthState {
     /// a sync is required.
     pub fn needs_to_sync_eth(&self) -> Option<EthSyncGap> {
         (!self.is_synced()).then(|| {
-            EthSyncGap::new(
-                self.local.map(|l| l.saturating_add(1)).unwrap_or(0),
-                self.remote,
-            )
+            let local = self.local.map(|l| l.saturating_add(1)).unwrap_or(0);
+            let remote = self.remote;
+            EthSyncGap::new(local, remote)
         })
     }
 }

--- a/crates/services/relayer/src/service/state.rs
+++ b/crates/services/relayer/src/service/state.rs
@@ -63,19 +63,6 @@ impl EthState {
     }
 }
 
-// impl EthHeights {
-//     /// Create a new Ethereum block height from the current
-//     /// block height and the desired finalization period.
-//     fn new(current: u64, finalized: u64) -> Self {
-//         Self(Heights(current.saturating_sub(finalized)..=current))
-//     }
-//
-//     /// Get the finalized eth block height.
-//     fn finalized(&self) -> u64 {
-//         *self.0 .0.start()
-//     }
-// }
-
 impl EthSyncGap {
     /// Create a new sync gap between the relayer and Ethereum node.
     pub(crate) fn new(local: u64, remote: u64) -> Self {
@@ -139,11 +126,3 @@ impl EthSyncPage {
         *self.current.end()
     }
 }
-
-// impl Deref for EthHeights {
-//     type Target = Heights<u64>;
-//
-//     fn deref(&self) -> &Self::Target {
-//         &self.0
-//     }
-// }

--- a/crates/services/relayer/src/service/state/test.rs
+++ b/crates/services/relayer/src/service/state/test.rs
@@ -7,45 +7,33 @@ use test_case::test_case;
 
 #[test_case(
     TestDataSource {
-        eth_remote_current: 300,
-        eth_remote_finalization_period: 100,
+        eth_remote_finalized: 200,
         eth_local_finalized: None,
     } => Some(0..=200); "empty so needs to sync"
 )]
 #[test_case(
     TestDataSource {
-        eth_remote_current: 300,
-        eth_remote_finalization_period: 100,
+        eth_remote_finalized: 200,
         eth_local_finalized: Some(0),
     } => Some(1..=200); "behind so needs to sync"
 )]
 #[test_case(
     TestDataSource {
-        eth_remote_current: 300,
-        eth_remote_finalization_period: 100,
+        eth_remote_finalized: 200,
         eth_local_finalized: Some(200),
     } => None; "same so doesn't need to sync"
 )]
 #[test_case(
     TestDataSource {
-        eth_remote_current: 300,
-        eth_remote_finalization_period: 100,
+        eth_remote_finalized: 200,
         eth_local_finalized: Some(201),
     } => None; "ahead so doesn't need to sync"
 )]
 #[test_case(
     TestDataSource {
-        eth_remote_current: 300,
-        eth_remote_finalization_period: 100,
+        eth_remote_finalized: 200,
         eth_local_finalized: Some(50),
     } => Some(51..=200); "behind by less so needs to sync"
-)]
-#[test_case(
-    TestDataSource {
-        eth_remote_current: 75,
-        eth_remote_finalization_period: 100,
-        eth_local_finalized: Some(50),
-    } => None; "behind by less then finalization period so doesn't needs to sync"
 )]
 #[tokio::test]
 async fn test_eth_state_needs_to_sync_eth(
@@ -55,7 +43,7 @@ async fn test_eth_state_needs_to_sync_eth(
         .await
         .unwrap()
         .needs_to_sync_eth()
-        .map(|g| g.0 .0)
+        .map(Into::into)
 }
 
 #[test_case(EthSyncGap::new(0, 0), 0 => None; "0 page size results in no page with no gap")]

--- a/crates/services/relayer/src/service/test.rs
+++ b/crates/services/relayer/src/service/test.rs
@@ -23,8 +23,7 @@ async fn can_download_logs() {
     eth_node.update_data(|data| data.logs_batch = vec![logs.clone()]);
 
     let eth_state = super::state::test_builder::TestDataSource {
-        eth_remote_current: 20,
-        eth_remote_finalization_period: 15,
+        eth_remote_finalized: 5,
         eth_local_finalized: Some(1),
     };
     let eth_state = state::build_eth(&eth_state).await.unwrap();

--- a/crates/services/relayer/src/service/test.rs
+++ b/crates/services/relayer/src/service/test.rs
@@ -51,7 +51,6 @@ async fn deploy_height_does_not_override() {
         .unwrap();
     let config = Config {
         da_deploy_height: 20u64.into(),
-        da_finalization: 1u64.into(),
         ..Default::default()
     };
     let eth_node = MockMiddleware::default();
@@ -69,7 +68,6 @@ async fn deploy_height_does_override() {
         .unwrap();
     let config = Config {
         da_deploy_height: 52u64.into(),
-        da_finalization: 1u64.into(),
         ..Default::default()
     };
     let eth_node = MockMiddleware::default();

--- a/crates/services/relayer/tests/integration.rs
+++ b/crates/services/relayer/tests/integration.rs
@@ -7,7 +7,10 @@ use fuel_core_relayer::{
     new_service_test,
     ports::RelayerDb,
     test_helpers::{
-        middleware::MockMiddleware,
+        middleware::{
+            MockMiddleware,
+            TriggerType,
+        },
         EvtToLog,
         LogTestHelper,
     },
@@ -23,7 +26,7 @@ async fn can_set_da_height() {
     let eth_node = MockMiddleware::default();
     // Setup the eth node with a block high enough that there
     // will be some finalized blocks.
-    eth_node.update_data(|data| data.best_block.number = Some(200.into()));
+    eth_node.update_data(|data| data.best_block.number = Some(100.into()));
     let relayer = new_service_test(eth_node, mock_db.clone(), Default::default());
     relayer.start_and_await().await.unwrap();
 
@@ -41,7 +44,7 @@ async fn stop_service_at_the_begin() {
     let eth_node = MockMiddleware::default();
     // Setup the eth node with a block high enough that there
     // will be some finalized blocks.
-    eth_node.update_data(|data| data.best_block.number = Some(200.into()));
+    eth_node.update_data(|data| data.best_block.number = Some(100.into()));
     let relayer = new_service_test(eth_node, mock_db.clone(), Default::default());
     relayer.start_and_await().await.unwrap();
     relayer.stop();
@@ -58,7 +61,7 @@ async fn stop_service_at_the_middle() {
     // `tokio::task::yield_now().await` in each method of the `MockMiddleware`.
     let mock_db = MockDb::default();
     let eth_node = MockMiddleware::default();
-    eth_node.update_data(|data| data.best_block.number = Some(200.into()));
+    eth_node.update_data(|data| data.best_block.number = Some(100.into()));
     let config = Config {
         log_page_size: 5,
         ..Default::default()
@@ -110,7 +113,7 @@ async fn can_get_messages() {
     eth_node.update_data(|data| data.logs_batch = vec![logs.clone()]);
     // Setup the eth node with a block high enough that there
     // will be some finalized blocks.
-    eth_node.update_data(|data| data.best_block.number = Some(200.into()));
+    eth_node.update_data(|data| data.best_block.number = Some(100.into()));
     let relayer = new_service_test(eth_node, mock_db.clone(), config);
     relayer.start_and_await().await.unwrap();
 
@@ -133,18 +136,17 @@ async fn deploy_height_is_set() {
     let (tx, rx) = tokio::sync::oneshot::channel();
     let mut tx = Some(tx);
     eth_node.set_before_event(move |_, evt| {
-        if let fuel_core_relayer::test_helpers::middleware::TriggerType::GetLogs(evt) = evt {
+        if let TriggerType::GetLogs(evt) = evt {
             assert!(
                 matches!(
                     evt,
-                        ethers_core::types::Filter {
-                            block_option: ethers_core::types::FilterBlockOption::Range {
-                                from_block: Some(ethers_core::types::BlockNumber::Number(f)),
-                                to_block: Some(ethers_core::types::BlockNumber::Number(t))
-                            },
-                            ..
-                        }
-                    if f.as_u64() == 51 && t.as_u64() == 53
+                    ethers_core::types::Filter {
+                        block_option: ethers_core::types::FilterBlockOption::Range {
+                            from_block: Some(ethers_core::types::BlockNumber::Number(f)),
+                            to_block: Some(ethers_core::types::BlockNumber::Number(t))
+                        },
+                        ..
+                    } if f.as_u64() == 51 && t.as_u64() == 54
                 ),
                 "{evt:?}"
             );
@@ -155,9 +157,7 @@ async fn deploy_height_is_set() {
     });
     let relayer = new_service_test(eth_node, mock_db.clone(), config);
     relayer.start_and_await().await.unwrap();
-
     relayer.shared.await_synced().await.unwrap();
     rx.await.unwrap();
-
-    assert_eq!(*mock_db.get_finalized_da_height().unwrap(), 53);
+    assert_eq!(*mock_db.get_finalized_da_height().unwrap(), 54);
 }

--- a/crates/services/relayer/tests/integration.rs
+++ b/crates/services/relayer/tests/integration.rs
@@ -126,7 +126,6 @@ async fn deploy_height_is_set() {
     let mock_db = MockDb::default();
     let config = Config {
         da_deploy_height: 50u64.into(),
-        da_finalization: 1u64.into(),
         ..Default::default()
     };
     let eth_node = MockMiddleware::default();

--- a/tests/tests/relayer.rs
+++ b/tests/tests/relayer.rs
@@ -305,10 +305,6 @@ async fn handle(
     let id = o.get("id").unwrap().as_u64().unwrap();
     let method = o.get("method").unwrap().as_str().unwrap();
     let r = match method {
-        "eth_blockNumber" => {
-            let r = mock.get_block_number().await.unwrap();
-            json!({ "id": id, "jsonrpc": "2.0", "result": r })
-        }
         "eth_getBlockByNumber" => {
             let r = mock.get_block(id).await.unwrap().unwrap();
             json!({ "id": id, "jsonrpc": "2.0", "result": r })

--- a/tests/tests/relayer.rs
+++ b/tests/tests/relayer.rs
@@ -309,6 +309,10 @@ async fn handle(
             let r = mock.get_block_number().await.unwrap();
             json!({ "id": id, "jsonrpc": "2.0", "result": r })
         }
+        "eth_getBlockByNumber" => {
+            let r = mock.get_block(id).await.unwrap().unwrap();
+            json!({ "id": id, "jsonrpc": "2.0", "result": r })
+        }
         "eth_syncing" => {
             let r = mock.syncing().await.unwrap();
             match r {
@@ -330,7 +334,7 @@ async fn handle(
             let r = mock.get_logs(&params[0]).await.unwrap();
             json!({ "id": id, "jsonrpc": "2.0", "result": r })
         }
-        _ => unreachable!(),
+        _ => unreachable!("Mock handler for method not defined"),
     };
 
     let r = serde_json::to_vec(&r).unwrap();


### PR DESCRIPTION
Related issues:
- Closes https://github.com/FuelLabs/fuel-core/issues/1336

This PR changes the approach a Fuel node uses to determine the finalized blocks on the Ethereum blockchain.

**The existing approach:**
- Assume a "finalization period" - a period of time after which we assume a block is finalized. Generally, we assume a block is finalized after 100 new blocks have been produced afterwards
- Observe what the current block height is as reported by the Ethereum client
- Subtract the finalization period from the current height to get an assumed finalized block, i.e. current block height - 100

The problem with this approach, as outlined by Trail of Bits, is that finality cannot be guaranteed simply by the amount of time passed alone. 

**This PR proposes a more robust approach:**
- Use the Ethereum client to query for the most recently finalized block directly. This is done using the `Finalized` tag in the query. See https://github.com/gakonst/ethers-rs/pull/1792

This approach removes any assumption on our side as to what the finalized block is, and gets the canonically accepted finalized block from Ethereum.