### PR TITLE
Use correct names for service metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Description of the upcoming release here.
 - [#1274](https://github.com/FuelLabs/fuel-core/pull/1274): Added tests to benchmark block synchronization.
 - [#1263](https://github.com/FuelLabs/fuel-core/pull/1263): Add gas benchmarks for `ED19` and `ECR1` instructions.
 - [#1331](https://github.com/FuelLabs/fuel-core/pull/1331): Add peer reputation reporting to block import code
+- [#1405](https://github.com/FuelLabs/fuel-core/pull/1405): Use correct names for service metrics.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,6 +2970,7 @@ dependencies = [
  "pin-project-lite 0.2.13",
  "prometheus-client 0.18.1",
  "prometheus-client 0.20.0",
+ "regex",
  "tokio",
  "tracing",
 ]

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -16,6 +16,7 @@ libp2p-prom-client = { workspace = true }
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
 prometheus-client = { workspace = true }
+regex = "1"
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/metrics/src/services.rs
+++ b/crates/metrics/src/services.rs
@@ -54,7 +54,7 @@ impl ServicesMetrics {
         let reg = regex::Regex::new(format!("\\b{}\\b", service_name).as_str())
             .expect("It is a valid Regex");
         if reg.is_match(encoded_bytes.as_str()) {
-            tracing::error!("Service with '{}' name is already registered", service_name);
+            tracing::warn!("Service with '{}' name is already registered", service_name);
         }
 
         lock.register(

--- a/crates/metrics/src/services.rs
+++ b/crates/metrics/src/services.rs
@@ -35,6 +35,11 @@ pub struct ServicesMetrics {
 
 impl ServicesMetrics {
     pub fn register_service(&self, service_name: &str) -> ServiceLifecycle {
+        let reg =
+            regex::Regex::new("^[a-zA-Z_:][a-zA-Z0-9_:]*$").expect("It is a valid Regex");
+        if !reg.is_match(service_name) {
+            panic!("The service {} has incorrect name.", service_name);
+        }
         let lifecycle = ServiceLifecycle::default();
         let mut lock = self
             .registry

--- a/crates/metrics/src/services.rs
+++ b/crates/metrics/src/services.rs
@@ -50,8 +50,11 @@ impl ServicesMetrics {
         let mut encoded_bytes = String::new();
         encode(&mut encoded_bytes, lock.deref())
             .expect("Unable to decode service metrics");
-        if encoded_bytes.contains(service_name) {
-            tracing::warn!("Service with '{}' name is already registered", service_name);
+
+        let reg = regex::Regex::new(format!("\\b{}\\b", service_name).as_str())
+            .expect("It is a valid Regex");
+        if reg.is_match(encoded_bytes.as_str()) {
+            tracing::error!("Service with '{}' name is already registered", service_name);
         }
 
         lock.register(

--- a/crates/services/consensus_module/poa/src/sync.rs
+++ b/crates/services/consensus_module/poa/src/sync.rs
@@ -109,7 +109,7 @@ impl SyncTask {
 
 #[async_trait::async_trait]
 impl RunnableService for SyncTask {
-    const NAME: &'static str = "fuel-core-consensus/poa/sync-task";
+    const NAME: &'static str = "PoASyncTask";
 
     type SharedData = watch::Receiver<SyncState>;
     type TaskParams = ();


### PR DESCRIPTION
Added `Regex` to verify validity the name of the service.