### PR TITLE
Mark reserved peers as explicit for gossipsub to avoid reputation decreasing

### DIFF
--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -86,12 +86,13 @@ pub fn init_sub_services(
 
     #[cfg(feature = "p2p")]
     let mut network = {
-        if let Some(config) = config.p2p.clone() {
+        if let Some(p2p_config) = config.p2p.clone() {
             let p2p_db = database.clone();
             let genesis = p2p_db.get_genesis()?;
-            let p2p_config = config.init(genesis)?;
+            let p2p_config = p2p_config.init(genesis)?;
 
             Some(fuel_core_p2p::service::new_service(
+                config.chain_conf.transaction_parameters.chain_id,
                 p2p_config,
                 p2p_db,
                 importer_adapter.clone(),

--- a/crates/services/p2p/src/config.rs
+++ b/crates/services/p2p/src/config.rs
@@ -301,7 +301,7 @@ pub(crate) fn build_transport(
     (transport, connection_state)
 }
 
-fn peer_ids_set_from(multiaddr: &[Multiaddr]) -> HashSet<PeerId> {
+pub fn peer_ids_set_from(multiaddr: &[Multiaddr]) -> HashSet<PeerId> {
     multiaddr
         .iter()
         // Safety: as is the case with `bootstrap_nodes` it is assumed that `reserved_nodes` [`Multiadr`]

--- a/crates/services/p2p/src/gossipsub/config.rs
+++ b/crates/services/p2p/src/gossipsub/config.rs
@@ -175,7 +175,7 @@ fn initialize_peer_score_thresholds() -> PeerScoreThresholds {
 
 /// Given a `P2pConfig` containing `GossipsubConfig` creates a Gossipsub Behaviour
 pub(crate) fn build_gossipsub_behaviour(p2p_config: &Config) -> Gossipsub {
-    if p2p_config.metrics {
+    let mut gossipsub = if p2p_config.metrics {
         // Move to Metrics related feature flag
         let mut p2p_registry = Registry::default();
 
@@ -208,7 +208,12 @@ pub(crate) fn build_gossipsub_behaviour(p2p_config: &Config) -> Gossipsub {
         initialize_gossipsub(&mut gossipsub, p2p_config);
 
         gossipsub
+    };
+    for peer_id in crate::config::peer_ids_set_from(&p2p_config.reserved_nodes) {
+        gossipsub.add_explicit_peer(&peer_id);
     }
+
+    gossipsub
 }
 
 fn initialize_gossipsub(gossipsub: &mut Gossipsub, p2p_config: &Config) {

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -201,8 +201,8 @@ where
                 should_continue = true;
                 match next_service_request {
                     Some(TaskRequest::BroadcastTransaction(transaction)) => {
-                        let broadcast = GossipsubBroadcastRequest::NewTx(transaction);
                         let tx_id = transaction.id(&self.chain_id);
+                        let broadcast = GossipsubBroadcastRequest::NewTx(transaction);
                         let result = self.p2p_service.publish_message(broadcast);
                         if let Err(e) = result {
                             tracing::error!("Got an error during transaction {} broadcasting {}", tx_id, e);


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/1384

After debugging the issue with transaction broadcasting in the Beta 4 network, I can confirm that it is related to the gossipsub reputation.

At some point, no one sends transactions to the authority node. When I manually restart one sentry node, this node starts to send transactions to the authority node. It sends transactions via gossiping and publishing:
- Publishing: I send a transaction to sentry 1, which sends it to authority.
- Gossiping: I send the transaction to sentry 0, it sends the transaction to sentry 1, and it sends the transaction to authority.

But at some point, gossiping doesn't work while publishing still works(Sentry 0 gossips transaction to Sentry 1, and Sentry 1 doesn't gossip it to authority).

After some time, the publishing doesn't work either.

The gossipsub has two thresholds, one for gossiping and one for publishing. We use these values:

<img width="652" alt="image" src="https://github.com/FuelLabs/fuel-core/assets/18346821/bcb1585c-239b-4cf9-9fae-c9376b958201">

So, the described behavior aligns with authority reputation decreasing. I don't know the reason why it happens(maybe decay), but adding all reserved peers to explicit peers should solve the problem.
