### PR TITLE
Fix typos

### DIFF
--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -117,7 +117,7 @@ pub struct P2PArgs {
     #[clap(long = "connection-idle-timeout", default_value = "120", env)]
     pub connection_idle_timeout: u64,
 
-    /// Choose how often to recieve PeerInfo from other nodes
+    /// Choose how often to receive PeerInfo from other nodes
     #[clap(long = "info-interval", default_value = "3", env)]
     pub info_interval: u64,
 

--- a/crates/fuel-core/src/graphql_api/service.rs
+++ b/crates/fuel-core/src/graphql_api/service.rs
@@ -155,7 +155,7 @@ impl RunnableTask for Task {
     }
 }
 
-// Need a seperate Data Object for each Query endpoint, cannot be avoided
+// Need a separate Data Object for each Query endpoint, cannot be avoided
 pub fn new_service(
     config: Config,
     schema: CoreSchemaBuilder,

--- a/crates/services/p2p/src/heartbeat/handler.rs
+++ b/crates/services/p2p/src/heartbeat/handler.rs
@@ -218,7 +218,7 @@ impl ConnectionHandler for HeartbeatHandler {
                     match outbound_block_height.poll_unpin(cx) {
                         Poll::Pending => {
                             if self.timer.poll_unpin(cx).is_ready() {
-                                // Time for successfull send expired!
+                                // Time for successful send expired!
                                 self.failure_count += 1;
                                 debug!(target: "fuel-libp2p", "Sending Heartbeat timed out, this is {} time it failed with this connection", self.failure_count);
                             } else {

--- a/crates/services/p2p/src/request_response/messages.rs
+++ b/crates/services/p2p/src/request_response/messages.rs
@@ -58,7 +58,7 @@ pub enum ResponseChannelItem {
 }
 
 /// Response that is sent over the wire
-/// and then additionaly deserialized into `ResponseMessage`
+/// and then additionally deserialized into `ResponseMessage`
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum NetworkResponse {
     Block(Option<Vec<u8>>),

--- a/tests/tests/blocks.rs
+++ b/tests/tests/blocks.rs
@@ -213,7 +213,7 @@ async fn produce_block_bad_start_time() {
     // produce block with current timestamp
     let _ = client.produce_blocks(1, None).await.unwrap();
 
-    // try producing block with an ealier timestamp
+    // try producing block with an earlier timestamp
     let err = client
         .produce_blocks(1, Some(100u64))
         .await


### PR DESCRIPTION
fix some typos:
  recieve->receive
  seperate->separate
  successfull->successful
  additionaly->additionally
  ealier->earlier