### PR TITLE
Rollback modification of the chain specification

### DIFF
--- a/benches/benches/block_target_gas.rs
+++ b/benches/benches/block_target_gas.rs
@@ -117,12 +117,12 @@ fn run(
                 let res = sub.recv().await.expect("Should produce a block");
                 assert_eq!(res.tx_status.len(), 2);
                 assert_eq!(res.sealed_block.entity.transactions().len(), 2);
-                assert_eq!(res.tx_status[1].id, tx_id);
+                assert_eq!(res.tx_status[0].id, tx_id);
 
                 let fuel_core_types::services::executor::TransactionExecutionResult::Failed {
                     reason,
                     ..
-                } = &res.tx_status[1].result
+                } = &res.tx_status[0].result
                     else {
                         panic!("The execution should fails with out of gas")
                     };

--- a/deployment/scripts/chainspec/beta_chainspec.json
+++ b/deployment/scripts/chainspec/beta_chainspec.json
@@ -45,13 +45,13 @@
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 10000000
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
       "max_predicate_data_length": 1048576,
       "max_message_data_length": 1048576,
-      "max_gas_per_predicate": 100000000
+      "max_gas_per_predicate": 10000000
     },
     "script_params": {
       "max_script_length": 1048576,
@@ -62,7 +62,7 @@
       "max_storage_slots": 255
     },
     "fee_params": {
-      "gas_price_factor": 1000000000,
+      "gas_price_factor": 92,
       "gas_per_byte": 4
     },
     "chain_id": 0,


### PR DESCRIPTION
- Rollback modification of the chain specification.
- Fixed benchmarks after the `Mint` transaction rework.