### PR TITLE
chore: Use MerkleRootCalculator when only BMT root is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1439](https://github.com/FuelLabs/fuel-core/pull/1439): Reduced memory BMT consumption during creation of the header.
 - [#1434](https://github.com/FuelLabs/fuel-core/pull/1434): Continue gossiping transactions to reserved peers regardless of gossiping reputation score.
 - [#1399](https://github.com/FuelLabs/fuel-core/pull/1399): The Relayer now queries Ethereum for its latest finalized block instead of using a configurable "finalization period" to presume finality.
 - [#1397](https://github.com/FuelLabs/fuel-core/pull/1397): Improved keygen. Created a crate to be included from forc plugins and upgraded internal library to drop requirement of protoc to build

--- a/crates/fuel-core/src/database/storage.rs
+++ b/crates/fuel-core/src/database/storage.rs
@@ -45,7 +45,7 @@ pub struct DenseMerkleMetadata {
 
 impl Default for DenseMerkleMetadata {
     fn default() -> Self {
-        let empty_merkle_tree = binary::in_memory::MerkleTree::new();
+        let empty_merkle_tree = binary::root_calculator::MerkleRootCalculator::new();
         Self {
             root: empty_merkle_tree.root(),
             version: 0,

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -153,7 +153,7 @@ fn init_coin_state(
     db: &mut Database,
     state: &Option<StateConfig>,
 ) -> anyhow::Result<MerkleRoot> {
-    let mut coins_tree = binary::in_memory::MerkleTree::new();
+    let mut coins_tree = binary::root_calculator::MerkleRootCalculator::new();
     // TODO: Store merkle sum tree root over coins with unspecified utxo ids.
     let mut generated_output_index: u64 = 0;
     if let Some(state) = &state {
@@ -213,7 +213,7 @@ fn init_contracts(
     db: &mut Database,
     state: &Option<StateConfig>,
 ) -> anyhow::Result<MerkleRoot> {
-    let mut contracts_tree = binary::in_memory::MerkleTree::new();
+    let mut contracts_tree = binary::root_calculator::MerkleRootCalculator::new();
     // initialize contract state
     if let Some(state) = &state {
         if let Some(contracts) = &state.contracts {
@@ -316,7 +316,7 @@ fn init_da_messages(
     db: &mut Database,
     state: &Option<StateConfig>,
 ) -> anyhow::Result<MerkleRoot> {
-    let mut message_tree = binary::in_memory::MerkleTree::new();
+    let mut message_tree = binary::root_calculator::MerkleRootCalculator::new();
     if let Some(state) = &state {
         if let Some(message_state) = &state.messages {
             for msg in message_state {

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -153,7 +153,7 @@ fn init_coin_state(
     db: &mut Database,
     state: &Option<StateConfig>,
 ) -> anyhow::Result<MerkleRoot> {
-    let mut coins_tree = binary::root_calculator::MerkleRootCalculator::new();
+    let mut coins_tree = binary::in_memory::MerkleTree::new();
     // TODO: Store merkle sum tree root over coins with unspecified utxo ids.
     let mut generated_output_index: u64 = 0;
     if let Some(state) = &state {
@@ -213,7 +213,7 @@ fn init_contracts(
     db: &mut Database,
     state: &Option<StateConfig>,
 ) -> anyhow::Result<MerkleRoot> {
-    let mut contracts_tree = binary::root_calculator::MerkleRootCalculator::new();
+    let mut contracts_tree = binary::in_memory::MerkleTree::new();
     // initialize contract state
     if let Some(state) = &state {
         if let Some(contracts) = &state.contracts {
@@ -316,7 +316,7 @@ fn init_da_messages(
     db: &mut Database,
     state: &Option<StateConfig>,
 ) -> anyhow::Result<MerkleRoot> {
-    let mut message_tree = binary::root_calculator::MerkleRootCalculator::new();
+    let mut message_tree = binary::in_memory::MerkleTree::new();
     if let Some(state) = &state {
         if let Some(message_state) = &state.messages {
             for msg in message_state {

--- a/crates/services/sync/src/import/test_helpers.rs
+++ b/crates/services/sync/src/import/test_helpers.rs
@@ -43,7 +43,8 @@ pub fn empty_header<I: Into<BlockHeight>>(i: I) -> SealedBlockHeader {
     let height = i.into();
     header.consensus.height = height;
     let transaction_tree =
-        fuel_core_types::fuel_merkle::binary::in_memory::MerkleTree::new();
+        fuel_core_types::fuel_merkle::binary::root_calculator::MerkleRootCalculator::new(
+        );
     header.application.generated.transactions_root = transaction_tree.root().into();
 
     let consensus = Consensus::default();

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -244,7 +244,8 @@ impl PartialBlockHeader {
         let transactions_root = generate_txns_root(transactions);
 
         // Generate the message merkle root.
-        let mut message_tree = fuel_merkle::binary::in_memory::MerkleTree::new();
+        let mut message_tree =
+            fuel_merkle::binary::root_calculator::MerkleRootCalculator::new();
         for id in message_ids {
             message_tree.push(id.as_ref());
         }
@@ -285,7 +286,8 @@ fn generate_txns_root(transactions: &[Transaction]) -> Bytes32 {
     //  Remove `clone` when we can use `to_bytes` without mutability.
     let transaction_ids = transactions.iter().map(|tx| tx.clone().to_bytes());
     // Generate the transaction merkle root.
-    let mut transaction_tree = fuel_merkle::binary::in_memory::MerkleTree::new();
+    let mut transaction_tree =
+        fuel_merkle::binary::root_calculator::MerkleRootCalculator::new();
     for id in transaction_ids {
         transaction_tree.push(id.as_ref());
     }


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-vm/issues/610

This PR updates all relevant usages of `binary::in_memory::MerkleTree` inside `fuel-core` to use `binary::root_calculator::MerkleRootCalculator` for calculating BMT roots. 