### PR TITLE
Add timeout to E2E test

### DIFF
--- a/.github/workflows/e2e-test-beta4-dev.yml
+++ b/.github/workflows/e2e-test-beta4-dev.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   e2e_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v3
       - name: Setup e2e config secrets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Description of the upcoming release here.
 
 ### Added
 
+- [#1447](https://github.com/FuelLabs/fuel-core/pull/1447): Add timeout for continuous e2e tests
 - [#1444](https://github.com/FuelLabs/fuel-core/pull/1444): Add "sanity" benchmarks for memory opcodes.
 - [#1437](https://github.com/FuelLabs/fuel-core/pull/1437): Add some transaction throughput tests for basic transfers.
 - [#1436](https://github.com/FuelLabs/fuel-core/pull/1436): Add a github action to continuously test beta-4.


### PR DESCRIPTION
prevent e2e jobs from running for more than 4 minutes