### PR TITLE
fix owns_coins to properly paginate

### DIFF
--- a/.github/workflows/e2e-test-beta4-dev.yml
+++ b/.github/workflows/e2e-test-beta4-dev.yml
@@ -17,4 +17,4 @@ jobs:
           envsubst < ${{ github.workspace }}/.github/workflows/e2e_config/beta-4.toml.template > ${{ github.workspace }}/.github/workflows/e2e_config/beta-4.toml
 
       - name: Run e2e tests with docker
-        run: docker run -v ${{ github.workspace }}/.github/workflows/e2e_config:/etc/e2e_config -e FUEL_CORE_E2E_CONFIG='/etc/e2e_config/beta-4.toml' ghcr.io/fuellabs/fuel-core-e2e-client:v0.20.7 ./fuel-core-e2e-client -- alice
+        run: docker run -v ${{ github.workspace }}/.github/workflows/e2e_config:/etc/e2e_config -e FUEL_CORE_E2E_CONFIG='/etc/e2e_config/beta-4.toml' ghcr.io/fuellabs/fuel-core-e2e-client:sha-ccba276 ./fuel-core-e2e-client -- alice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Description of the upcoming release here.
 
 ### Added
-
+- [#1449](https://github.com/FuelLabs/fuel-core/pull/1449): fix coin pagination in e2e test client
 - [#1447](https://github.com/FuelLabs/fuel-core/pull/1447): Add timeout for continuous e2e tests
 - [#1444](https://github.com/FuelLabs/fuel-core/pull/1444): Add "sanity" benchmarks for memory opcodes.
 - [#1437](https://github.com/FuelLabs/fuel-core/pull/1437): Add some transaction throughput tests for basic transfers.


### PR DESCRIPTION
There was an issue with the e2e tests causing them to fail once wallet_b had more than 100 coins due to improper pagination over coins.

This also updates the e2e tests targeting beta4 by using a docker image sha generated from this branch: https://github.com/FuelLabs/fuel-core/pull/1448