### PR TITLE
Call `flush` during end of the `FuelService`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Description of the upcoming release here.
 
 ### Added
-- [#1449](https://github.com/FuelLabs/fuel-core/pull/1449): fix coin pagination in e2e test client
+- [#1456](https://github.com/FuelLabs/fuel-core/pull/1456): Added flushing of the RocksDB during a graceful shutdown.
+- [#1456](https://github.com/FuelLabs/fuel-core/pull/1456): Added more logs to track the service lifecycle.
+- [#1449](https://github.com/FuelLabs/fuel-core/pull/1449): Fix coin pagination in e2e test client.
 - [#1447](https://github.com/FuelLabs/fuel-core/pull/1447): Add timeout for continuous e2e tests
 - [#1444](https://github.com/FuelLabs/fuel-core/pull/1444): Add "sanity" benchmarks for memory opcodes.
 - [#1437](https://github.com/FuelLabs/fuel-core/pull/1437): Add some transaction throughput tests for basic transfers.

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -232,6 +232,10 @@ impl Database {
     pub fn transaction(&self) -> DatabaseTransaction {
         self.into()
     }
+
+    pub fn flush(self) -> DatabaseResult<()> {
+        self.data.flush()
+    }
 }
 
 /// Mutable methods.

--- a/crates/fuel-core/src/state.rs
+++ b/crates/fuel-core/src/state.rs
@@ -86,7 +86,9 @@ pub enum WriteOperation {
     Remove,
 }
 
-pub trait TransactableStorage: BatchOperations + Debug + Send + Sync {}
+pub trait TransactableStorage: BatchOperations + Debug + Send + Sync {
+    fn flush(&self) -> DatabaseResult<()>;
+}
 
 pub mod in_memory;
 #[cfg(feature = "rocksdb")]

--- a/crates/fuel-core/src/state/in_memory/memory_store.rs
+++ b/crates/fuel-core/src/state/in_memory/memory_store.rs
@@ -212,7 +212,14 @@ impl KeyValueStore for MemoryStore {
 
 impl BatchOperations for MemoryStore {}
 
-impl TransactableStorage for MemoryStore {}
+impl TransactableStorage for MemoryStore {
+    fn flush(&self) -> DatabaseResult<()> {
+        for lock in self.inner.iter() {
+            lock.lock().expect("poisoned").clear();
+        }
+        Ok(())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/fuel-core/src/state/in_memory/transaction.rs
+++ b/crates/fuel-core/src/state/in_memory/transaction.rs
@@ -286,9 +286,11 @@ impl BatchOperations for MemoryTransactionView {}
 
 impl TransactableStorage for MemoryTransactionView {
     fn flush(&self) -> DatabaseResult<()> {
-        self.commit()?;
-        self.data_source.flush()?;
-        self.view_layer.flush()
+        for lock in self.changes.iter() {
+            lock.lock().expect("poisoned lock").clear();
+        }
+        self.view_layer.flush()?;
+        self.data_source.flush()
     }
 }
 

--- a/crates/fuel-core/src/state/in_memory/transaction.rs
+++ b/crates/fuel-core/src/state/in_memory/transaction.rs
@@ -284,7 +284,13 @@ impl KeyValueStore for MemoryTransactionView {
 
 impl BatchOperations for MemoryTransactionView {}
 
-impl TransactableStorage for MemoryTransactionView {}
+impl TransactableStorage for MemoryTransactionView {
+    fn flush(&self) -> DatabaseResult<()> {
+        self.commit()?;
+        self.data_source.flush()?;
+        self.view_layer.flush()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/services/src/service.rs
+++ b/crates/services/src/service.rs
@@ -295,6 +295,8 @@ where
                 }
             });
 
+            tracing::info!("The service {} is shut down", S::NAME);
+
             if let State::StoppedWithError(err) = stopped_state {
                 std::panic::resume_unwind(Box::new(err));
             }
@@ -325,6 +327,7 @@ async fn run<S>(
     }
 
     // We can panic here, because it is inside of the task.
+    tracing::info!("Starting {} service", S::NAME);
     let mut task = service
         .into_task(&state, params)
         .await
@@ -375,6 +378,7 @@ async fn run<S>(
         }
     }
 
+    tracing::info!("Shutting down {} service", S::NAME);
     let shutdown = std::panic::AssertUnwindSafe(task.shutdown());
     match shutdown.catch_unwind().await {
         Ok(Ok(_)) => {}

--- a/crates/services/sync/src/service.rs
+++ b/crates/services/sync/src/service.rs
@@ -124,7 +124,6 @@ where
     }
 
     async fn shutdown(self) -> anyhow::Result<()> {
-        tracing::info!("Sync task shutting down");
         self.import_task_handle.stop_and_await().await?;
         Ok(())
     }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/1428

Call the `flush` function during the end of the `FuelService` to move the processing of WAL and SST fiels from the node's launching to the node's shutdown.

Added additional logs to track the performance of the starting/shutdown process.