### PR TITLE
Fixing incorrect measurement for fast(µs) opcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Description of the upcoming release here.
 
 ### Added
+- [#1457](https://github.com/FuelLabs/fuel-core/pull/1457): Fixing incorrect measurement for fast(µs) opcodes.
 - [#1449](https://github.com/FuelLabs/fuel-core/pull/1449): fix coin pagination in e2e test client
 - [#1447](https://github.com/FuelLabs/fuel-core/pull/1447): Add timeout for continuous e2e tests
 - [#1444](https://github.com/FuelLabs/fuel-core/pull/1444): Add "sanity" benchmarks for memory opcodes.


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/1431

In the case of super-fast opcodes(< than 1 µs), the `elapse` method is not accurate enough, which leads to unstable results from benchmarks.

The change aims to stabilize the results from measurements by subtracting the time required to reset the VM from the total time of the benchmark.