### PR TITLE
chore: fix releasy test tracking branch from `main` to `master`

### DIFF
--- a/.github/workflows/releasy-dependency-commits.yml
+++ b/.github/workflows/releasy-dependency-commits.yml
@@ -3,7 +3,7 @@ name: Notify downstream repos
 on:
   push:
     branches:
-    - main 
+    - master
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1460](https://github.com/FuelLabs/fuel-core/pull/1460): Change tracking branch from main to master for releasy tests.
 - [#1440](https://github.com/FuelLabs/fuel-core/pull/1440): Don't report reserved nodes that send invalid transactions.
 - [#1439](https://github.com/FuelLabs/fuel-core/pull/1439): Reduced memory BMT consumption during creation of the header.
 - [#1434](https://github.com/FuelLabs/fuel-core/pull/1434): Continue gossiping transactions to reserved peers regardless of gossiping reputation score.


### PR DESCRIPTION
As it can be seen from https://github.com/FuelLabs/fuels-rs/pull/1174 releasy only worked for self commits. This is because we were tracking the wrong branch. This PR fixes the tracking branch for this repo, from `main` to `master`.