### PR TITLE
Bumping `fuel-vm` to `v0.40.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1468](https://github.com/FuelLabs/fuel-core/pull/1468): Bumped version of the `fuel-vm` to `v0.40.0`. It brings some breaking changes into consensus parameters API because of changes in the underlying types.
 - [#1460](https://github.com/FuelLabs/fuel-core/pull/1460): Change tracking branch from main to master for releasy tests.
 - [#1440](https://github.com/FuelLabs/fuel-core/pull/1440): Don't report reserved nodes that send invalid transactions.
 - [#1439](https://github.com/FuelLabs/fuel-core/pull/1439): Reduced memory BMT consumption during creation of the header.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e79e6f14f8df22e2c61956fcfc4505b38fe16b48b7a4c7cc46c5d73b90664aa"
+checksum = "4a2dce6ade2d7804096e6dfd51e6fd9a16a87ee32b28bcc7a47674c2b497f363"
 dependencies = [
  "bitflags 1.3.2",
  "fuel-types",
@@ -3210,9 +3210,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92ed9e3741b068beef7748973d82a8f6637fbc76427e3d822bfb19eed93a804"
+checksum = "e2c58f23beb866369a194b21635f969fd94538cf3cea8e9bebd9d828042f0cf2"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -3231,9 +3231,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92fb2450e57506fc9176adf80ac7280b66f53de683c6187351225695e609d5fe"
+checksum = "adba9deee62a53830736cfdd6a08192c399a3f92f67d26b6c550b544f24bd1e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3243,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afe7705ca2760598b1b35a6f2a114ebec8331ac4d05d78682854faecfa0cc4"
+checksum = "6dd20b9ea8b953040507c39bc498478cfa17ecb9831f9fac9b6ca1f7f5ffd921"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
@@ -3258,15 +3258,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc3d59dadd998c035bb65040be9d6eaead1d9bba1bd106b0b9e8c28b293c9ee"
+checksum = "636d286c2c195f44587c69ae73d08ae9801ac8ee310ef4e87f1d493ed87f2e47"
 
 [[package]]
 name = "fuel-tx"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c077189abf9e558be50ec5459ad11366b17368a62da9221facdf7efe9d88ac0"
+checksum = "b0e23732f33ace2ec5b48f17085ec9397f35c465538070269b1965723ed351fa"
 dependencies = [
  "derivative",
  "derive_more",
@@ -3286,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea56d08a2958fb8f6969acc0130513e44796d66282b741f92aa6f33f6e4c5bc"
+checksum = "1465ab5a63b2d867ab1900d34dd6eee2e7cf1e1ad54d23fb6cd89f892367ff02"
 dependencies = [
  "fuel-derive",
  "hex",
@@ -3298,9 +3298,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3b5d3b2913553bb15c26ed644bc94b6ee06725eda6ace3001927a710c71564"
+checksum = "13437b5beecd473be158198bcd2ec0c1979783db3d4ed82ffff4fb8d9acb890f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.39.0", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.40.0", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
@@ -13,7 +13,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -191,6 +192,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
@@ -25,7 +25,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -203,6 +204,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
@@ -25,7 +25,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -203,6 +204,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
@@ -21,7 +21,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -199,6 +200,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
@@ -21,7 +21,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -199,6 +200,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
@@ -39,7 +39,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -217,6 +218,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
@@ -24,7 +24,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -202,6 +203,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
@@ -19,7 +19,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -197,6 +198,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
@@ -22,7 +22,8 @@ expression: json
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -200,6 +201,14 @@ expression: json
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -386,6 +386,8 @@ type GasCosts {
 	scwq: DependentCost!
 	smo: DependentCost!
 	srwq: DependentCost!
+	contractRoot: DependentCost!
+	stateRoot: DependentCost!
 	swwq: DependentCost!
 }
 
@@ -903,10 +905,11 @@ scalar TransactionId
 union TransactionStatus = SubmittedStatus | SuccessStatus | SqueezedOutStatus | FailureStatus
 
 type TxParameters {
-	maxInputs: U64!
-	maxOutputs: U64!
-	maxWitnesses: U64!
+	maxInputs: U8!
+	maxOutputs: U8!
+	maxWitnesses: U32!
 	maxGasPerTx: U64!
+	maxSize: U64!
 }
 
 scalar TxPointer
@@ -914,6 +917,8 @@ scalar TxPointer
 scalar U32
 
 scalar U64
+
+scalar U8
 
 scalar UtxoId
 

--- a/crates/client/src/client/schema/chain.rs
+++ b/crates/client/src/client/schema/chain.rs
@@ -2,7 +2,9 @@ use crate::client::schema::{
     block::Block,
     schema,
     AssetId,
+    U32,
     U64,
+    U8,
 };
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -21,10 +23,11 @@ pub struct ConsensusParameters {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct TxParameters {
-    pub max_inputs: U64,
-    pub max_outputs: U64,
-    pub max_witnesses: U64,
+    pub max_inputs: U8,
+    pub max_outputs: U8,
+    pub max_witnesses: U32,
     pub max_gas_per_tx: U64,
+    pub max_size: U64,
 }
 
 impl From<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
@@ -34,6 +37,7 @@ impl From<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
             max_outputs: params.max_outputs.into(),
             max_witnesses: params.max_witnesses.into(),
             max_gas_per_tx: params.max_gas_per_tx.into(),
+            max_size: params.max_size.into(),
         }
     }
 }
@@ -236,6 +240,10 @@ include_from_impls_and_cynic! {
         pub smo: DependentCost,
         pub srwq: DependentCost,
         pub swwq: DependentCost,
+
+        // Non-opcodes prices
+        pub contract_root: DependentCost,
+        pub state_root: DependentCost,
     }
 }
 

--- a/crates/client/src/client/schema/primitives.rs
+++ b/crates/client/src/client/schema/primitives.rs
@@ -272,6 +272,7 @@ macro_rules! number_scalar {
 
 number_scalar!(U64, u64);
 number_scalar!(U32, u32);
+number_scalar!(U8, u8);
 
 impl TryFrom<U64> for PanicInstruction {
     type Error = ConversionError;

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -43,6 +43,7 @@ query {
         maxOutputs
         maxWitnesses
         maxGasPerTx
+        maxSize
       }
       predicateParams {
         maxPredicateLength
@@ -219,6 +220,14 @@ query {
           depPerUnit
         }
         swwq {
+          base
+          depPerUnit
+        }
+        contractRoot {
+          base
+          depPerUnit
+        }
+        stateRoot {
           base
           depPerUnit
         }

--- a/crates/client/src/client/types/gas_costs.rs
+++ b/crates/client/src/client/types/gas_costs.rs
@@ -139,6 +139,11 @@ include_from_impls! {
         pub smo: DependentCost,
         pub srwq: DependentCost,
         pub swwq: DependentCost,
+
+        // Non-opcode prices
+
+        pub state_root: DependentCost,
+        pub contract_root: DependentCost,
     }
 }
 

--- a/crates/fuel-core/src/database/vm_database.rs
+++ b/crates/fuel-core/src/database/vm_database.rs
@@ -225,7 +225,7 @@ impl InterpreterStorage for VmDatabase {
         &self,
         contract_id: &ContractId,
         start_key: &Bytes32,
-        range: Word,
+        range: usize,
     ) -> Result<Vec<Option<Cow<Bytes32>>>, Self::DataError> {
         // TODO: Optimization: Iterate only over `range` elements.
         let mut iterator = self.database.iter_all_filtered::<Vec<u8>, Bytes32, _, _>(
@@ -234,8 +234,6 @@ impl InterpreterStorage for VmDatabase {
             Some(ContractsStateKey::new(contract_id, start_key)),
             Some(IterDirection::Forward),
         );
-        let range = usize::try_from(range)
-            .expect("Corresponding PR in `fuel-vm` https://github.com/FuelLabs/fuel-vm/pull/619 will use `usize`");
 
         let mut expected_key = U256::from_big_endian(start_key.as_ref());
         let mut results = vec![];
@@ -313,7 +311,7 @@ impl InterpreterStorage for VmDatabase {
         &mut self,
         contract_id: &ContractId,
         start_key: &Bytes32,
-        range: Word,
+        range: usize,
     ) -> Result<Option<()>, Self::DataError> {
         let mut found_unset = false;
 
@@ -417,7 +415,7 @@ mod tests {
     fn read_sequential_range(
         prefilled_slots: &[([u8; 32], [u8; 32])],
         start_key: [u8; 32],
-        range: u64,
+        range: usize,
     ) -> Result<Vec<Option<[u8; 32]>>, ()> {
         let mut db = VmDatabase::default();
 
@@ -583,7 +581,7 @@ mod tests {
     fn remove_range(
         prefilled_slots: &[([u8; 32], [u8; 32])],
         start_key: [u8; 32],
-        remove_count: Word,
+        remove_count: usize,
     ) -> (Vec<[u8; 32]>, bool) {
         let mut db = VmDatabase::default();
 

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -1798,7 +1798,6 @@ mod tests {
                 Outputs,
                 Script as ScriptField,
             },
-            Chargeable,
             CheckError,
             ConsensusParameters,
             Create,
@@ -2032,7 +2031,6 @@ mod tests {
             // state transition between blocks.
             let price = 1;
             let limit = 0;
-            let gas_used_by_predicates = 0;
             let gas_price_factor = 1;
             let script = TxBuilder::new(1u64)
                 .gas_limit(limit)
@@ -2067,12 +2065,10 @@ mod tests {
 
             let producer = Executor::test(database.clone(), config);
 
-            let expected_fee_amount_1 = TransactionFee::checked_from_values(
+            let expected_fee_amount_1 = TransactionFee::checked_from_tx(
+                producer.config.consensus_parameters.gas_costs(),
                 producer.config.consensus_parameters.fee_params(),
-                script.metered_bytes_size() as Word,
-                gas_used_by_predicates,
-                limit,
-                price,
+                &script,
             )
             .unwrap()
             .max_fee();
@@ -2138,12 +2134,10 @@ mod tests {
                 .transaction()
                 .clone();
 
-            let expected_fee_amount_2 = TransactionFee::checked_from_values(
+            let expected_fee_amount_2 = TransactionFee::checked_from_tx(
+                producer.config.consensus_parameters.gas_costs(),
                 producer.config.consensus_parameters.fee_params(),
-                script.metered_bytes_size() as Word,
-                gas_used_by_predicates,
-                limit,
-                price,
+                &script,
             )
             .unwrap()
             .max_fee();

--- a/crates/fuel-core/src/schema/chain.rs
+++ b/crates/fuel-core/src/schema/chain.rs
@@ -11,7 +11,9 @@ use crate::{
         block::Block,
         scalars::{
             AssetId,
+            U32,
             U64,
+            U8,
         },
     },
 };
@@ -113,20 +115,24 @@ impl ConsensusParameters {
 
 #[Object]
 impl TxParameters {
-    async fn max_inputs(&self) -> U64 {
+    async fn max_inputs(&self) -> U8 {
         self.0.max_inputs.into()
     }
 
-    async fn max_outputs(&self) -> U64 {
+    async fn max_outputs(&self) -> U8 {
         self.0.max_outputs.into()
     }
 
-    async fn max_witnesses(&self) -> U64 {
+    async fn max_witnesses(&self) -> U32 {
         self.0.max_witnesses.into()
     }
 
     async fn max_gas_per_tx(&self) -> U64 {
         self.0.max_gas_per_tx.into()
+    }
+
+    async fn max_size(&self) -> U64 {
+        self.0.max_size.into()
     }
 }
 
@@ -602,6 +608,16 @@ impl GasCosts {
 
     async fn srwq(&self) -> DependentCost {
         self.0.srwq.into()
+    }
+
+    // Non-opcode prices
+
+    async fn contract_root(&self) -> DependentCost {
+        self.0.contract_root.into()
+    }
+
+    async fn state_root(&self) -> DependentCost {
+        self.0.state_root.into()
     }
 
     async fn swwq(&self) -> DependentCost {

--- a/crates/fuel-core/src/schema/scalars.rs
+++ b/crates/fuel-core/src/schema/scalars.rs
@@ -81,6 +81,7 @@ macro_rules! number_scalar {
 
 number_scalar!(U64, u64, "U64");
 number_scalar!(U32, u32, "U32");
+number_scalar!(U8, u8, "U8");
 
 impl From<BlockHeight> for U32 {
     fn from(h: BlockHeight) -> Self {

--- a/crates/services/txpool/src/transaction_selector.rs
+++ b/crates/services/txpool/src/transaction_selector.rs
@@ -53,6 +53,7 @@ mod tests {
         },
         fuel_tx::{
             FeeParameters,
+            GasCosts,
             Output,
             TransactionBuilder,
         },
@@ -105,6 +106,7 @@ mod tests {
                     asset_id: Default::default(),
                 })
                 .with_fee_params(fee_params)
+                .with_gas_costs(GasCosts::free())
                 // The block producer assumes transactions are already checked
                 // so it doesn't need to compute valid sigs for tests
                 .finalize_checked_basic(Default::default()).into()

--- a/deployment/scripts/chainspec/beta_chainspec.json
+++ b/deployment/scripts/chainspec/beta_chainspec.json
@@ -45,7 +45,8 @@
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 10000000
+      "max_gas_per_tx": 10000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -223,6 +224,14 @@
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"

--- a/deployment/scripts/chainspec/dev_chainspec.json
+++ b/deployment/scripts/chainspec/dev_chainspec.json
@@ -15,7 +15,8 @@
       "max_inputs": 255,
       "max_outputs": 255,
       "max_witnesses": 255,
-      "max_gas_per_tx": 100000000
+      "max_gas_per_tx": 100000000,
+      "max_size": 17825792
     },
     "predicate_params": {
       "max_predicate_length": 1048576,
@@ -193,6 +194,14 @@
       "swwq": {
         "base": 44,
         "dep_per_unit": 5
+      },
+      "contract_root": {
+        "base": 75,
+        "dep_per_unit": 1
+      },
+      "state_root": {
+        "base": 412,
+        "dep_per_unit": 1
       }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
The new version of `fuel-vm`:
- Adds a new `max_size` into `TxParameters` and breaks the old API.
- `max_inputs` and `max_outputs` are `u8` now.
- `max_witnesses` is `u32` now.
- Add two new fields into `GasCosts.
- Charges additional `min_fee` for each Signed/Predicate input and for `Create` transaction.
