### PR TITLE
Expose fuel-core version as a constant

### DIFF
--- a/crates/fuel-core/src/lib.rs
+++ b/crates/fuel-core/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(unused_crate_dependencies)]
 #![deny(warnings)]
 
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[doc(no_inline)]
 pub use fuel_core_chain_config as chain_config;
 #[cfg(feature = "p2p")]


### PR DESCRIPTION
Necessary for https://github.com/FuelLabs/fuels-rs/issues/1189. This allows `fuels-rs` to make compatibility checks against the version of `fuel-core` it was compiled with.