### PR TITLE
chore: Upgrade Rust 1.73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.72.0
+  RUST_VERSION: 1.73.0
   NIGHTLY_RUST_VERSION: nightly-2023-10-29
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,7 +16,7 @@ defaults:
 env:
   # So cargo doesn't complain about unstable features
   RUSTC_BOOTSTRAP: 1
-  RUST_VERSION: 1.72.0
+  RUST_VERSION: 1.73.0
   PR_TITLE: Weekly `cargo update`
   PR_MESSAGE: |
     Automation to keep dependencies in `Cargo.lock` current.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1477](https://github.com/FuelLabs/fuel-core/pull/1477): Upgraded the Rust version used in CI and containers to 1.73.0. Also includes associated Clippy changes.
 - [#1469](https://github.com/FuelLabs/fuel-core/pull/1469): Replaced usage of `MemoryTransactionView` by `Checkpoint` database in the benchmarks.
 - [#1466](https://github.com/FuelLabs/fuel-core/pull/1466): Handling overflows during arithmetic operations.
 - [#1468](https://github.com/FuelLabs/fuel-core/pull/1468): Bumped version of the `fuel-vm` to `v0.40.0`. It brings some breaking changes into consensus parameters API because of changes in the underlying types.

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -3,7 +3,7 @@
 # The script runs almost all CI checks locally.
 #
 # Requires installed:
-# - Rust `1.72.0`
+# - Rust `1.73.0`
 # - Nightly rust formatter
 # - `cargo install cargo-sort`
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
-FROM --platform=$BUILDPLATFORM rust:1.72.0 AS chef
+FROM --platform=$BUILDPLATFORM rust:1.73.0 AS chef
 
 ARG TARGETPLATFORM
 RUN cargo install cargo-chef

--- a/deployment/e2e-client.Dockerfile
+++ b/deployment/e2e-client.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM rust:1.72.0 AS chef
+FROM rust:1.73.0 AS chef
 RUN cargo install cargo-chef
 WORKDIR /build/
 # hadolint ignore=DL3008


### PR DESCRIPTION
Now that `fuel-vm` is using Rust 1.73, along with features from 1.73, we are required to upgrade `fuel-core` accordingly.