### PR TITLE
setup docker auth for binary publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,19 @@ jobs:
         if: matrix.job.cross_image
         uses: docker/setup-buildx-action@v1
 
+      - name: Log in to the ghcr.io registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the docker.io registry
+        uses: docker/login-action@v2
+        with:
+          username: fuellabs
+          password: ${{ secrets.DOCKER_IO_READ_ONLY_TOKEN }}
+
       - name: Setup custom cross env ${{ matrix.job.cross_image }}
         if: matrix.job.cross_image
         uses: docker/build-push-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Description of the upcoming release here.
 
 ### Added
 
+- [#1488](https://github.com/FuelLabs/fuel-core/pull/1488): Add docker login for cross binaries that use docker
 - [#1485](https://github.com/FuelLabs/fuel-core/pull/1485): Prepare rc release of fuel core v0.21
 - [#1473](https://github.com/FuelLabs/fuel-core/pull/1473): Expose fuel-core version as a constant
 - [#1469](https://github.com/FuelLabs/fuel-core/pull/1469): Added support of bloom filter for RocksDB tables and increased the block cache.


### PR DESCRIPTION
After moving away from gha cache for docker images, I missed adding a docker login step for the binary publish job.