### PR TITLE
Fix typos in fee_calculations.md

### DIFF
--- a/docs/fee_calculations.md
+++ b/docs/fee_calculations.md
@@ -3,13 +3,13 @@
 ### Storage fees
 
 Fuel doesn't currently support separate fees for execution costs vs storage costs.
-This is a planned future feature, but in the mean time we need a system for
+This is a planned future feature, but in the meantime we need a system for
 compensating the network for storing contract data. The temporary solution is
 to include an additional cost to op codes that write new data to storage or to
 transactions that add new contracts to the chain.
 
 There are a number of ways we might calculate this value; we have decided to go 
-with a simple calculatoin based on the our target storage growth and working
+with a simple calculation based on the our target storage growth and working
 backward from there.
 
 #### Pessimistic Estimate
@@ -29,7 +29,7 @@ all blocks would be maxing out the storage.
 #### Generous Estimate
 
 Additionally, this will only apply to our early networks, which won't be long-live.
-This allows us to take a bigger risk on the storage price and increas it over 
+This allows us to take a bigger risk on the storage price and increase it over 
 time to compensate for users adding a lot of data.
 
 All this included, if we re-estimate the yearly storage limit as 5 TB we get:
@@ -56,7 +56,7 @@ blocks_per_year = 365 * 24 * 60 * ~5 = ~2628000
 
 yearly_new_contract_bytes = blocks_per_year * contracts_per_block * max_contract_size = **378,432,000,000**
 
-Which rougly lines up with our pessimistic estimate.
+Which roughly lines up with our pessimistic estimate.
 
 #### Conclusion
 


### PR DESCRIPTION
fix some typos in docs/
'mean time' -> meantime
'calculatoin' -> calculation
'increas' -> increase
'rougly' -> roughly