### PR TITLE
dev: update vm initialization benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bcff07c5aa5367e4b3c5e47e0a3c1db152c1ee44e2fcb0a19e37753b4fe3b55"
+checksum = "3cee560e1eeac4d292e38111f694f21983377176eb600b57cacaed86b747ffa2"
 dependencies = [
  "bitflags 2.4.1",
  "fuel-types",
@@ -3245,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52166525e18d71898a7dbe877c73ba43e3ca6a28e4e51439e91a94d6f29be430"
+checksum = "fca614c332efaeaae796a80c72c0a29a3853eab6c2af67379bd01473e0277449"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -3266,9 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b322f3999ad9d93dfa38cdeec07650b1bc9b16f93d86a85733d0323cf00f2ec"
+checksum = "1efdc9a47d14947cd50e88161eb2b6c85e0ce34a00a321103f1f7764e8d6b0d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3278,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a023a4f5be24ffc5b892b76f68664df98d0b2f575cf78c144d106c4162ca553c"
+checksum = "eeb0d0661a655f7753afa5124ccd90a7b9218cb6d777235060b09f4da9feb22d"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
@@ -3293,15 +3293,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fa7d49a8219ff2d994a130044cdc50c32739b63365b2c10c7b95d572f59288"
+checksum = "97697cb72cb86e33dd5a3ef5509a233a290174f4b3b5c43b4be4484ccb6b2fc0"
 
 [[package]]
 name = "fuel-tx"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aade465a32b29bff40ddc167cbf529f6fa71862bc87d332c594ac8d2d02e3e48"
+checksum = "194617f09afa17e8cc4c4127ceed1d0fb1549680eb9b2a90c743605298a1c33e"
 dependencies = [
  "bitflags 2.4.1",
  "derivative",
@@ -3321,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c7d8bfdc40cc6818c921a60c866fc5c762afab169d8d458226a2a6e227d47"
+checksum = "c0a170bd25f8cc3def3833b2032646bf1ca77460353dfa8b2b89c4d83ad1f2cf"
 dependencies = [
  "fuel-derive",
  "hex",
@@ -3333,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b41f6df2addb193bd69939bec36df633e3b4a2a8d6b5633e5d2c1caae7e012"
+checksum = "c3e24e0f8e58c08192dd012eef70f47063aa48e4222209df6044aa0a471e0fd6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,8 +2726,7 @@ dependencies = [
 [[package]]
 name = "fuel-asm"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13417c82e9e9e90c94c5fedb7b86bff7b0ea13ed1f4c81339e555b82e67e84e"
+source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
 dependencies = [
  "bitflags 2.4.1",
  "fuel-types",
@@ -3246,8 +3245,7 @@ dependencies = [
 [[package]]
 name = "fuel-crypto"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8e6ca339ad11d35fe5946a3df82145e278aac047ba0df144049c5dea17c0c"
+source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -3267,8 +3265,7 @@ dependencies = [
 [[package]]
 name = "fuel-derive"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6aff693526d00fd02aa7142ac8d4f90d23dec568894ebda7aa103efee36040"
+source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3279,8 +3276,7 @@ dependencies = [
 [[package]]
 name = "fuel-merkle"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725b6cf70f38dc7f46b7b4b6aa9b3c7e6b50af0a08da8e7c615ffddc54287ff3"
+source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
@@ -3294,14 +3290,12 @@ dependencies = [
 [[package]]
 name = "fuel-storage"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc29ddcc34d400dcad6b7d9c25216b9cd515eaf3cc289aebbbd1a860aa80c73f"
+source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
 
 [[package]]
 name = "fuel-tx"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793f11642d2b015207c0f695ae849d259fd9c52513b67765d43b8f2e027c82a4"
+source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
 dependencies = [
  "bitflags 2.4.1",
  "derivative",
@@ -3322,8 +3316,7 @@ dependencies = [
 [[package]]
 name = "fuel-types"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87f58ab7b1673b603b0c579a6603213b1327f5788ddf1436a9369ddf49d0402"
+source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
 dependencies = [
  "fuel-derive",
  "hex",
@@ -3334,8 +3327,7 @@ dependencies = [
 [[package]]
 name = "fuel-vm"
 version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dd8074481f0b6b4bdf30cdcb5cefb81b9b2b8108fb1de2abf96161dcf4d3d3"
+source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,8 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.42.1"
-source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bcff07c5aa5367e4b3c5e47e0a3c1db152c1ee44e2fcb0a19e37753b4fe3b55"
 dependencies = [
  "bitflags 2.4.1",
  "fuel-types",
@@ -3244,8 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.42.1"
-source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52166525e18d71898a7dbe877c73ba43e3ca6a28e4e51439e91a94d6f29be430"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -3264,8 +3266,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.42.1"
-source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b322f3999ad9d93dfa38cdeec07650b1bc9b16f93d86a85733d0323cf00f2ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3275,8 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.42.1"
-source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a023a4f5be24ffc5b892b76f68664df98d0b2f575cf78c144d106c4162ca553c"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
@@ -3289,13 +3293,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.42.1"
-source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12fa7d49a8219ff2d994a130044cdc50c32739b63365b2c10c7b95d572f59288"
 
 [[package]]
 name = "fuel-tx"
-version = "0.42.1"
-source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aade465a32b29bff40ddc167cbf529f6fa71862bc87d332c594ac8d2d02e3e48"
 dependencies = [
  "bitflags 2.4.1",
  "derivative",
@@ -3315,8 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.42.1"
-source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c7d8bfdc40cc6818c921a60c866fc5c762afab169d8d458226a2a6e227d47"
 dependencies = [
  "fuel-derive",
  "hex",
@@ -3326,8 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.42.1"
-source = "git+https://github.com/FuelLabs/fuel-vm?branch=bvrooman/chore/vm-initialization-as-dependent-cost#4a2eae4080e4b2fc84ea3869242da1b0039a065c"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b41f6df2addb193bd69939bec36df633e3b4a2a8d6b5633e5d2c1caae7e012"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,3 +116,6 @@ itertools = "0.10"
 insta = "1.8"
 tempfile = "3.4"
 tikv-jemallocator = "0.5"
+
+[patch.crates-io]
+fuel-vm = { git = "https://github.com/FuelLabs/fuel-vm", branch = "bvrooman/chore/vm-initialization-as-dependent-cost" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.42.2", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.43.0", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.42.1", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.42.2", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"
@@ -116,6 +116,3 @@ itertools = "0.10"
 insta = "1.8"
 tempfile = "3.4"
 tikv-jemallocator = "0.5"
-
-[patch.crates-io]
-fuel-vm = { git = "https://github.com/FuelLabs/fuel-vm", branch = "bvrooman/chore/vm-initialization-as-dependent-cost" }

--- a/benches/benches-outputs/Cargo.toml
+++ b/benches/benches-outputs/Cargo.toml
@@ -9,3 +9,6 @@ publish = false
 fuel-core-types = { path = "../../crates/types", default-features = false, features = ["random", "test-helpers"] }
 
 [workspace]
+
+[patch.crates-io]
+fuel-vm = { git = "https://github.com/FuelLabs/fuel-vm", branch = "bvrooman/chore/vm-initialization-as-dependent-cost" }

--- a/benches/benches-outputs/Cargo.toml
+++ b/benches/benches-outputs/Cargo.toml
@@ -9,6 +9,3 @@ publish = false
 fuel-core-types = { path = "../../crates/types", default-features = false, features = ["random", "test-helpers"] }
 
 [workspace]
-
-[patch.crates-io]
-fuel-vm = { git = "https://github.com/FuelLabs/fuel-vm", branch = "bvrooman/chore/vm-initialization-as-dependent-cost" }

--- a/benches/benches/block_target_gas_set/default_gas_costs.rs
+++ b/benches/benches/block_target_gas_set/default_gas_costs.rs
@@ -43,7 +43,10 @@ pub fn default_gas_costs() -> GasCostsValues {
         lw: 2,
         mint: 25515,
         mlog: 2,
-        vm_initialization: 1,
+        vm_initialization: DependentCost::HeavyOperation {
+            base: 2000,
+            gas_per_unit: 0,
+        },
         modi: 2,
         mod_op: 2,
         movi: 2,

--- a/benches/benches/vm_initialization.rs
+++ b/benches/benches/vm_initialization.rs
@@ -22,7 +22,6 @@ use fuel_core_types::{
     fuel_vm::{
         checked_transaction::{
             Checked,
-            CheckedTransaction,
             IntoChecked,
         },
         interpreter::NotSupportedEcal,
@@ -40,7 +39,7 @@ fn transaction<R: Rng>(
     script: Vec<u8>,
     script_data: Vec<u8>,
 ) -> Checked<Script> {
-    let mut consensus_params = ConsensusParameters::default();
+    let consensus_params = ConsensusParameters::default();
     let inputs = (0..consensus_params.tx_params.max_inputs)
         .map(|_| {
             Input::coin_predicate(

--- a/benches/benches/vm_initialization.rs
+++ b/benches/benches/vm_initialization.rs
@@ -40,7 +40,7 @@ fn transaction<R: Rng>(
     script_data: Vec<u8>,
 ) -> Checked<Script> {
     let consensus_params = ConsensusParameters::default();
-    let inputs = (0..consensus_params.tx_params.max_inputs)
+    let inputs = (0..1)
         .map(|_| {
             Input::coin_predicate(
                 rng.gen(),
@@ -50,23 +50,13 @@ fn transaction<R: Rng>(
                 rng.gen(),
                 rng.gen(),
                 0,
-                vec![
-                    255;
-                    (consensus_params.predicate_params.max_predicate_length
-                        / consensus_params.tx_params.max_inputs as u64)
-                        as usize
-                ],
-                vec![
-                    255;
-                    (consensus_params.predicate_params.max_predicate_data_length
-                        / consensus_params.tx_params.max_inputs as u64)
-                        as usize
-                ],
+                vec![255; 1],
+                vec![255; 1],
             )
         })
         .collect();
 
-    let outputs = (0..consensus_params.tx_params.max_outputs)
+    let outputs = (0..1)
         .map(|_| {
             Output::variable(Default::default(), Default::default(), Default::default())
         })
@@ -82,7 +72,7 @@ fn transaction<R: Rng>(
             .with_max_fee(Word::MAX),
         inputs,
         outputs,
-        vec![vec![123; 100].into(); consensus_params.tx_params.max_witnesses as usize],
+        vec![vec![123; 32].into(); 1],
     )
     .into_checked_basic(Default::default(), &consensus_params)
     .expect("Should produce a valid transaction")
@@ -94,17 +84,17 @@ pub fn vm_initialization(c: &mut Criterion) {
     let mut group = c.benchmark_group("vm_initialization");
 
     // Generate N data points
-    const N: usize = 20;
-    for i in 0..N {
-        let size = 1 << i;
+    const N: usize = 18;
+    for i in 5..N {
+        let size = 8 * 1 << i;
         let script = vec![op::ret(1); size / Instruction::SIZE]
             .into_iter()
             .collect();
         let script_data = vec![255; size];
         let tx = transaction(&mut rng, script, script_data);
-        let size = tx.transaction().size();
-        let name = format!("vm_initialization_with_tx_size_{}", size);
-        group.throughput(Throughput::Bytes(size as u64));
+        let tx_size = tx.transaction().size();
+        let name = format!("vm_initialization_with_tx_size_{}", tx_size);
+        group.throughput(Throughput::Bytes(tx_size as u64));
         group.bench_function(name, |b| {
             b.iter(|| {
                 let mut vm = black_box(

--- a/benches/benches/vm_initialization.rs
+++ b/benches/benches/vm_initialization.rs
@@ -73,7 +73,7 @@ fn transaction<R: Rng>(
         })
         .collect();
 
-    let tx = Transaction::script(
+    Transaction::script(
         1_000_000,
         script,
         script_data,
@@ -86,9 +86,7 @@ fn transaction<R: Rng>(
         vec![vec![123; 100].into(); consensus_params.tx_params.max_witnesses as usize],
     )
     .into_checked_basic(Default::default(), &consensus_params)
-    .expect("Should produce a valid transaction");
-
-    tx
+    .expect("Should produce a valid transaction")
 }
 
 pub fn vm_initialization(c: &mut Criterion) {

--- a/benches/benches/vm_initialization.rs
+++ b/benches/benches/vm_initialization.rs
@@ -97,15 +97,13 @@ pub fn vm_initialization(c: &mut Criterion) {
     let mut group = c.benchmark_group("vm_initialization");
 
     // Generate N data points
-    const N: usize = 16;
+    const N: usize = 20;
     for i in 0..N {
-        let increment = 1024 / N;
-        let script_size = 1024 * increment * i;
-        let script = vec![op::ret(1); script_size / Instruction::SIZE]
+        let size = 1 << i;
+        let script = vec![op::ret(1); size / Instruction::SIZE]
             .into_iter()
             .collect();
-        let script_data_size = 1024 * increment * i;
-        let script_data = vec![255; script_data_size];
+        let script_data = vec![255; size];
         let tx = transaction(&mut rng, script, script_data);
         let size = tx.transaction().size();
         let name = format!("vm_initialization_with_tx_size_{}", size);

--- a/benches/benches/vm_initialization.rs
+++ b/benches/benches/vm_initialization.rs
@@ -92,6 +92,7 @@ pub fn vm_initialization(c: &mut Criterion) {
             let mut vm = black_box(
                 Interpreter::<_, Script, NotSupportedEcal>::with_memory_storage(),
             );
+            // dbg!(tx.size());
             black_box(vm.init_script(tx.clone()))
                 .expect("Should be able to execute transaction");
         })

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_configurable_block_height.snap
@@ -240,7 +240,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_balances.snap
@@ -252,7 +252,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_state.snap
@@ -252,7 +252,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_tx_pointer.snap
@@ -248,7 +248,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_contract_with_utxo_id.snap
@@ -248,7 +248,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_local_testnet_config.snap
@@ -266,7 +266,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_coin_state.snap
@@ -251,7 +251,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_contract.snap
@@ -246,7 +246,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
+++ b/crates/chain-config/src/snapshots/fuel_core_chain_config__config__tests__snapshot_simple_message_state.snap
@@ -249,7 +249,12 @@ expression: json
         }
       },
       "new_storage_per_byte": 1,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -386,7 +386,7 @@ type GasCosts {
 	swwq: DependentCost!
 	contractRoot: DependentCost!
 	stateRoot: DependentCost!
-	vmInitialization: U64!
+	vmInitialization: DependentCost!
 	newStoragePerByte: U64!
 }
 

--- a/crates/client/src/client/schema/chain.rs
+++ b/crates/client/src/client/schema/chain.rs
@@ -244,7 +244,7 @@ include_from_impls_and_cynic! {
         // Non-opcodes prices
         pub contract_root: DependentCost,
         pub state_root: DependentCost,
-        pub vm_initialization: U64,
+        pub vm_initialization: DependentCost,
         pub new_storage_per_byte: U64,
     }
 }

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -364,7 +364,17 @@ query {
             gasPerUnit
           }
         }
-        vmInitialization
+        vmInitialization {
+          __typename
+          ... on LightOperation {
+            base
+            unitsPerGas
+          }
+          ... on HeavyOperation {
+            base
+            gasPerUnit
+          }
+        }
         newStoragePerByte
       }
     }

--- a/crates/client/src/client/types/gas_costs.rs
+++ b/crates/client/src/client/types/gas_costs.rs
@@ -143,7 +143,7 @@ include_from_impls! {
         // Non-opcode prices
         pub contract_root: DependentCost,
         pub state_root: DependentCost,
-        pub vm_initialization: u64,
+        pub vm_initialization: DependentCost,
         pub new_storage_per_byte: u64,
     }
 }

--- a/crates/fuel-core/src/schema/chain.rs
+++ b/crates/fuel-core/src/schema/chain.rs
@@ -649,7 +649,7 @@ impl GasCosts {
         self.0.state_root.into()
     }
 
-    async fn vm_initialization(&self) -> U64 {
+    async fn vm_initialization(&self) -> DependentCost {
         self.0.vm_initialization.into()
     }
 

--- a/deployment/scripts/chainspec/beta_chainspec.json
+++ b/deployment/scripts/chainspec/beta_chainspec.json
@@ -272,7 +272,12 @@
         }
       },
       "new_storage_per_byte": 100,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },

--- a/deployment/scripts/chainspec/dev_chainspec.json
+++ b/deployment/scripts/chainspec/dev_chainspec.json
@@ -242,7 +242,12 @@
         }
       },
       "new_storage_per_byte": 100,
-      "vm_initialization": 2000
+      "vm_initialization": {
+        "HeavyOperation": {
+          "base": 2000,
+          "gas_per_unit": 0
+        }
+      }
     },
     "base_asset_id": "0000000000000000000000000000000000000000000000000000000000000000"
   },


### PR DESCRIPTION
Updates https://github.com/FuelLabs/fuel-core/pull/1502 to use dependent gas price for `vm_initialization`.

This PR:
- Adapts the `vm_initialization` gas cost to a dependent cost
- Modifies the VM initialization benchmark to use a variable size transaction
- Updates `fuel-vm` to the newly created `v0.42.2`

This adds the following benchmarks to the suite:

```
vm_initialization/vm_initialization_with_tx_size_2191080                                                                            
                        time:   [385.44 µs 387.54 µs 389.67 µs]
                        thrpt:  [5.2368 GiB/s 5.2655 GiB/s 5.2942 GiB/s]
vm_initialization/vm_initialization_with_tx_size_2322152                                                                            
                        time:   [407.82 µs 409.68 µs 411.57 µs]
                        thrpt:  [5.2547 GiB/s 5.2790 GiB/s 5.3030 GiB/s]
vm_initialization/vm_initialization_with_tx_size_2453224                                                                            
                        time:   [424.74 µs 426.49 µs 428.23 µs]
                        thrpt:  [5.3354 GiB/s 5.3570 GiB/s 5.3791 GiB/s]
vm_initialization/vm_initialization_with_tx_size_2584296                                                                            
                        time:   [445.98 µs 450.28 µs 456.29 µs]
                        thrpt:  [5.2748 GiB/s 5.3452 GiB/s 5.3966 GiB/s]
vm_initialization/vm_initialization_with_tx_size_2715368                                                                            
                        time:   [468.75 µs 473.45 µs 479.25 µs]
                        thrpt:  [5.2767 GiB/s 5.3414 GiB/s 5.3949 GiB/s]
vm_initialization/vm_initialization_with_tx_size_2846440                                                                            
                        time:   [490.47 µs 494.15 µs 498.82 µs]
                        thrpt:  [5.3145 GiB/s 5.3647 GiB/s 5.4049 GiB/s]
vm_initialization/vm_initialization_with_tx_size_2977512                                                                            
                        time:   [505.35 µs 509.33 µs 513.98 µs]
                        thrpt:  [5.3952 GiB/s 5.4445 GiB/s 5.4873 GiB/s]
vm_initialization/vm_initialization_with_tx_size_3108584                                                                            
                        time:   [526.05 µs 529.11 µs 532.63 µs]
                        thrpt:  [5.4355 GiB/s 5.4717 GiB/s 5.5035 GiB/s]
vm_initialization/vm_initialization_with_tx_size_3239656                                                                            
                        time:   [547.18 µs 550.45 µs 553.83 µs]
                        thrpt:  [5.4478 GiB/s 5.4813 GiB/s 5.5140 GiB/s]
vm_initialization/vm_initialization_with_tx_size_3370728                                                                            
                        time:   [565.98 µs 568.75 µs 571.58 µs]
                        thrpt:  [5.4923 GiB/s 5.5195 GiB/s 5.5465 GiB/s]
vm_initialization/vm_initialization_with_tx_size_3501800                                                                            
                        time:   [585.76 µs 588.62 µs 591.47 µs]
                        thrpt:  [5.5139 GiB/s 5.5406 GiB/s 5.5677 GiB/s]
vm_initialization/vm_initialization_with_tx_size_3632872                                                                            
                        time:   [607.51 µs 610.83 µs 614.26 µs]
                        thrpt:  [5.5080 GiB/s 5.5390 GiB/s 5.5693 GiB/s]
vm_initialization/vm_initialization_with_tx_size_3763944                                                                            
                        time:   [630.00 µs 635.47 µs 642.49 µs]
                        thrpt:  [5.4560 GiB/s 5.5163 GiB/s 5.5642 GiB/s]
vm_initialization/vm_initialization_with_tx_size_3895016                                                                            
                        time:   [652.06 µs 656.04 µs 660.74 µs]
                        thrpt:  [5.4901 GiB/s 5.5294 GiB/s 5.5632 GiB/s]
vm_initialization/vm_initialization_with_tx_size_4026088                                                                            
                        time:   [664.38 µs 667.29 µs 670.21 µs]
                        thrpt:  [5.5946 GiB/s 5.6191 GiB/s 5.6438 GiB/s]
vm_initialization/vm_initialization_with_tx_size_4157160                                                                            
                        time:   [712.86 µs 718.35 µs 724.60 µs]
                        thrpt:  [5.3431 GiB/s 5.3896 GiB/s 5.4311 GiB/s]
```

Locally, this produces the following dependent cost for VM initialization:

```
        vm_initialization: DependentCost::LightOperation {
             base: 55476,
             units_per_gas: 39,
         },
```