### PR TITLE
Added validation of the coin's fields during block production and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Description of the upcoming release here.
 - [#1454](https://github.com/FuelLabs/fuel-core/pull/1454): Update gas benchmarks for opcodes that append receipts.
 
 #### Breaking
+- [#1506](https://github.com/FuelLabs/fuel-core/pull/1506): Added validation of the coin's fields during block production and validation. Before, it was possible to submit a transaction that didn't match the coin's values in the database, allowing printing/using unavailable assets.
 - [#1491](https://github.com/FuelLabs/fuel-core/pull/1491): Removed unused request and response variants from the Gossipsub implementation, as well as related definitions and tests. Specifically, this removes gossiping of `ConsensusVote` and `NewBlock` events.
 - [#1472](https://github.com/FuelLabs/fuel-core/pull/1472): Upgraded `fuel-vm` to `v0.42.0`. It introduces transaction policies that changes layout of the transaction. FOr more information check the [v0.42.0](https://github.com/FuelLabs/fuel-vm/pull/635) release.
 - [#1470](https://github.com/FuelLabs/fuel-core/pull/1470): Divide `DependentCost` into "light" and "heavy" operations.

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -11,6 +11,7 @@ use fuel_core_executor::{
 use fuel_core_storage::{
     tables::{
         Coins,
+        ContractsInfo,
         ContractsLatestUtxo,
         FuelBlocks,
         Messages,
@@ -26,6 +27,7 @@ use fuel_core_storage::{
     StorageAsRef,
     StorageInspect,
 };
+use fuel_core_txpool::types::ContractId;
 #[allow(unused_imports)]
 use fuel_core_types::{
     blockchain::{
@@ -123,8 +125,6 @@ use fuel_core_types::{
         txpool::TransactionStatus,
     },
 };
-
-use fuel_core_txpool::types::ContractId;
 use fuel_core_types::{
     fuel_tx::{
         field::{
@@ -1077,8 +1077,6 @@ where
             match input {
                 Input::CoinSigned(CoinSigned { utxo_id, .. })
                 | Input::CoinPredicate(CoinPredicate { utxo_id, .. }) => {
-                    // TODO: Check that fields are equal. We already do that check
-                    //  in the `fuel-core-txpool`, so we need to reuse the code here.
                     if let Some(coin) = db.storage::<Coins>().get(utxo_id)? {
                         let coin_mature_height = coin
                             .tx_pointer
@@ -1091,43 +1089,36 @@ where
                             )
                             .into())
                         }
+
+                        if !coin
+                            .matches_input(input)
+                            .expect("The input is a coin above")
+                        {
+                            return Err(
+                                TransactionValidityError::CoinMismatch(*utxo_id).into()
+                            )
+                        }
                     } else {
                         return Err(
                             TransactionValidityError::CoinDoesNotExist(*utxo_id).into()
                         )
                     }
                 }
-                Input::Contract(_) => {
-                    // TODO: Check that contract exists
+                Input::Contract(contract) => {
+                    if !db
+                        .storage::<ContractsInfo>()
+                        .contains_key(&contract.contract_id)?
+                    {
+                        return Err(TransactionValidityError::ContractDoesNotExist(
+                            contract.contract_id,
+                        )
+                        .into())
+                    }
                 }
-                Input::MessageCoinSigned(MessageCoinSigned {
-                    sender,
-                    recipient,
-                    amount,
-                    nonce,
-                    ..
-                })
-                | Input::MessageCoinPredicate(MessageCoinPredicate {
-                    sender,
-                    recipient,
-                    amount,
-                    nonce,
-                    ..
-                })
-                | Input::MessageDataSigned(MessageDataSigned {
-                    sender,
-                    recipient,
-                    amount,
-                    nonce,
-                    ..
-                })
-                | Input::MessageDataPredicate(MessageDataPredicate {
-                    sender,
-                    recipient,
-                    amount,
-                    nonce,
-                    ..
-                }) => {
+                Input::MessageCoinSigned(MessageCoinSigned { nonce, .. })
+                | Input::MessageCoinPredicate(MessageCoinPredicate { nonce, .. })
+                | Input::MessageDataSigned(MessageDataSigned { nonce, .. })
+                | Input::MessageDataPredicate(MessageDataPredicate { nonce, .. }) => {
                     // Eagerly return already spent if status is known.
                     if db.message_is_spent(nonce)? {
                         return Err(
@@ -1145,42 +1136,14 @@ where
                             )
                             .into())
                         }
-                        if message.sender != *sender {
-                            return Err(TransactionValidityError::MessageSenderMismatch(
-                                *nonce,
-                            )
-                            .into())
-                        }
-                        if message.recipient != *recipient {
+
+                        if !message
+                            .matches_input(input)
+                            .expect("The input is message above")
+                        {
                             return Err(
-                                TransactionValidityError::MessageRecipientMismatch(
-                                    *nonce,
-                                )
-                                .into(),
+                                TransactionValidityError::MessageMismatch(*nonce).into()
                             )
-                        }
-                        if message.amount != *amount {
-                            return Err(TransactionValidityError::MessageAmountMismatch(
-                                *nonce,
-                            )
-                            .into())
-                        }
-                        if message.nonce != *nonce {
-                            return Err(TransactionValidityError::MessageNonceMismatch(
-                                *nonce,
-                            )
-                            .into())
-                        }
-                        let expected_data = if message.data.is_empty() {
-                            None
-                        } else {
-                            Some(message.data.as_slice())
-                        };
-                        if expected_data != input.input_data() {
-                            return Err(TransactionValidityError::MessageDataMismatch(
-                                *nonce,
-                            )
-                            .into())
                         }
                     } else {
                         return Err(
@@ -3041,6 +3004,68 @@ mod tests {
     }
 
     #[test]
+    fn coin_fails_when_mismatches_database() {
+        const AMOUNT: u64 = 100;
+
+        let tx = TxBuilder::new(2322u64)
+            .coin_input(AssetId::default(), AMOUNT)
+            .change_output(AssetId::default())
+            .build()
+            .transaction()
+            .clone();
+
+        let input = tx.inputs()[0].clone();
+        let db = &mut Database::default();
+
+        // Inserting a coin with `AMOUNT - 1` should cause a mismatching error during production.
+        db.storage::<Coins>()
+            .insert(
+                &input.utxo_id().unwrap().clone(),
+                &CompressedCoin {
+                    owner: *input.input_owner().unwrap(),
+                    amount: AMOUNT - 1,
+                    asset_id: AssetId::default(),
+                    maturity: Default::default(),
+                    tx_pointer: Default::default(),
+                },
+            )
+            .unwrap();
+        let executor = Executor::test(
+            db.clone(),
+            Config {
+                utxo_validation_default: true,
+                ..Default::default()
+            },
+        );
+
+        let block = PartialFuelBlock {
+            header: Default::default(),
+            transactions: vec![tx.into()],
+        };
+
+        let ExecutionResult {
+            skipped_transactions,
+            ..
+        } = executor
+            .execute_and_commit(
+                ExecutionBlock::Production(block),
+                ExecutionOptions {
+                    utxo_validation: true,
+                },
+            )
+            .unwrap();
+        // `tx` should be skipped.
+        assert_eq!(skipped_transactions.len(), 1);
+        let err = &skipped_transactions[0].1;
+        assert!(matches!(
+            err,
+            &ExecutorError::TransactionValidity(TransactionValidityError::CoinMismatch(
+                _
+            ))
+        ));
+    }
+
+    #[test]
     fn skipped_txs_not_affect_order() {
         // `tx1` is invalid because it doesn't have inputs for gas.
         // `tx2` is a `Create` transaction with some code inside.
@@ -4193,6 +4218,38 @@ mod tests {
             Err(ExecutorError::TransactionValidity(
                 TransactionValidityError::MessageSpendTooEarly(_)
             ))
+        ));
+    }
+
+    #[test]
+    fn message_fails_when_mismatches_database() {
+        let mut rng = StdRng::seed_from_u64(2322);
+
+        let (tx, mut message) = make_tx_and_message(&mut rng, 0);
+
+        // Modifying the message to make it mismatch
+        message.amount = 123;
+
+        let mut block = Block::default();
+        *block.transactions_mut() = vec![tx.clone()];
+
+        let ExecutionResult {
+            skipped_transactions,
+            ..
+        } = make_executor(&[&message])
+            .execute_and_commit(
+                ExecutionBlock::Production(block.clone().into()),
+                ExecutionOptions {
+                    utxo_validation: true,
+                },
+            )
+            .unwrap();
+        let err = &skipped_transactions[0].1;
+        assert!(matches!(
+            err,
+            &ExecutorError::TransactionValidity(
+                TransactionValidityError::MessageMismatch(_)
+            )
         ));
     }
 

--- a/crates/types/src/entities/coins/coin.rs
+++ b/crates/types/src/entities/coins/coin.rs
@@ -3,6 +3,11 @@
 use crate::{
     fuel_asm::Word,
     fuel_tx::{
+        input::coin::{
+            CoinPredicate,
+            CoinSigned,
+        },
+        Input,
         TxPointer,
         UtxoId,
     },
@@ -73,6 +78,32 @@ impl CompressedCoin {
             asset_id: self.asset_id,
             maturity: self.maturity,
             tx_pointer: self.tx_pointer,
+        }
+    }
+
+    /// Verifies the integrity of the coin.
+    ///
+    /// Returns `None`, if the `input` is not a coin.
+    /// Otherwise returns the result of the field comparison.
+    pub fn matches_input(&self, input: &Input) -> Option<bool> {
+        match input {
+            Input::CoinSigned(CoinSigned {
+                owner,
+                amount,
+                asset_id,
+                ..
+            })
+            | Input::CoinPredicate(CoinPredicate {
+                owner,
+                amount,
+                asset_id,
+                ..
+            }) => Some(
+                owner == &self.owner
+                    && amount == &self.amount
+                    && asset_id == &self.asset_id,
+            ),
+            _ => None,
         }
     }
 }

--- a/crates/types/src/services/executor.rs
+++ b/crates/types/src/services/executor.rs
@@ -329,36 +329,32 @@ impl From<ValidityError> for Error {
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum TransactionValidityError {
-    #[error("Coin input was already spent")]
+    #[error("Coin({0:#x}) input was already spent")]
     CoinAlreadySpent(UtxoId),
-    #[error("Coin has not yet reached maturity")]
+    #[error("Coin({0:#x}) has not yet reached maturity")]
     CoinHasNotMatured(UtxoId),
-    #[error("The specified coin doesn't exist")]
+    #[error("The input coin({0:#x}) doesn't match the coin from database")]
+    CoinMismatch(UtxoId),
+    #[error("The specified coin({0:#x}) doesn't exist")]
     CoinDoesNotExist(UtxoId),
-    #[error("The specified message was already spent")]
+    #[error("The specified message({0:#x}) was already spent")]
     MessageAlreadySpent(Nonce),
     #[error(
-        "Message is not yet spendable, as it's DA height is newer than this block allows"
+        "Message({0:#x}) is not yet spendable, as it's DA height is newer than this block allows"
     )]
     MessageSpendTooEarly(Nonce),
-    #[error("The specified message doesn't exist")]
+    #[error("The specified message({0:#x}) doesn't exist")]
     MessageDoesNotExist(Nonce),
-    #[error("The input message sender doesn't match the relayer message sender")]
-    MessageSenderMismatch(Nonce),
-    #[error("The input message recipient doesn't match the relayer message recipient")]
-    MessageRecipientMismatch(Nonce),
-    #[error("The input message amount doesn't match the relayer message amount")]
-    MessageAmountMismatch(Nonce),
-    #[error("The input message nonce doesn't match the relayer message nonce")]
-    MessageNonceMismatch(Nonce),
-    #[error("The input message data doesn't match the relayer message data")]
-    MessageDataMismatch(Nonce),
+    #[error("The input message({0:#x}) doesn't match the relayer message")]
+    MessageMismatch(Nonce),
+    #[error("The specified contract({0:#x}) doesn't exist")]
+    ContractDoesNotExist(ContractId),
     #[error("Contract output index isn't valid: {0:#x}")]
     InvalidContractInputIndex(UtxoId),
     #[error("The transaction contains predicate inputs which aren't enabled: {0:#x}")]
     PredicateExecutionDisabled(TxId),
     #[error(
-    "The transaction contains a predicate which failed to validate: TransactionId({0:#x})"
+        "The transaction contains a predicate which failed to validate: TransactionId({0:#x})"
     )]
     InvalidPredicate(TxId),
     #[error("Transaction validity: {0:#?}")]

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -245,6 +245,8 @@ pub enum Error {
         "Transaction is not inserted. UTXO requires Contract input {0:#x} that is priced lower"
     )]
     NotInsertedContractPricedLower(ContractId),
+    #[error("Transaction is not inserted. Input coin mismatch the values from database")]
+    NotInsertedIoCoinMismatch,
     #[error("Transaction is not inserted. Input output mismatch. Coin owner is different from expected input")]
     NotInsertedIoWrongOwner,
     #[error("Transaction is not inserted. Input output mismatch. Coin output does not match expected input")]


### PR DESCRIPTION
- Added validation of the coin's fields during block production and validation.
- Moved field comparison to `fuel-core-types` crates from `fuel-core-txpool`. Reused it in the executor.
- Added verification that contract exists. It helps to catch the error before hitting the VM.
- Included `Nonce`, `UtxoId`, `ContractId` into error message.