### PR TITLE
fix: fuel-core-keygen support --version arg

### DIFF
--- a/bin/keygen/src/main.rs
+++ b/bin/keygen/src/main.rs
@@ -17,7 +17,6 @@ use termion::screen::IntoAlternateScreen;
 
 /// Parse a secret key to view the associated public key
 #[derive(Debug, clap::Args)]
-#[clap(author, version, about)]
 pub struct ParseSecret {
     /// A private key in hex format
     secret: String,
@@ -36,7 +35,6 @@ pub struct ParseSecret {
 
 /// Generate a random new secret & public key in the format expected by fuel-core
 #[derive(Debug, clap::Args)]
-#[clap(author, version, about)]
 pub struct NewKey {
     /// Print the JSON in pretty format
     #[clap(long = "pretty", short = 'p')]
@@ -53,6 +51,7 @@ pub struct NewKey {
 
 /// Key management utilities for configuring fuel-core
 #[derive(Debug, Parser)]
+#[clap(author, version, about)]
 pub(crate) enum Command {
     New(NewKey),
     Parse(ParseSecret),


### PR DESCRIPTION
Close #1495 

![image](https://github.com/FuelLabs/fuel-core/assets/30857671/861f55d7-0552-467a-bb05-f67ad52f146a)


