### PR TITLE
Run beta 4 e2e test each 30 minutes

### DIFF
--- a/.github/workflows/e2e-test-beta4-dev.yml
+++ b/.github/workflows/e2e-test-beta4-dev.yml
@@ -2,7 +2,7 @@ name: E2E Test Beta-4
 
 on:
   schedule:
-    - cron: '* * * * *'
+    - cron: '*/30 * * * *'
 
 jobs:
   e2e_test:


### PR DESCRIPTION
After the introduction of the limit to the number of requests, CI started to fail sometimes. Increasing the time between runs to avoid spamming.