### PR TITLE
fix committed gql schema

### DIFF
--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -651,14 +651,29 @@ type PageInfo {
 }
 
 type PeerInfo {
+	"""
+	The libp2p peer id
+	"""
 	id: String!
+	"""
+	The advertised multi-addrs that can be used to connect to this peer
+	"""
 	addresses: [String!]!
+	"""
+	The self-reported version of the client the peer is using
+	"""
 	clientVersion: String
+	"""
+	The last reported height of the peer
+	"""
 	blockHeight: U32
 	"""
 	The last heartbeat from this peer in unix epoch time ms
 	"""
 	lastHeartbeatMs: U64!
+	"""
+	The internal fuel p2p reputation of this peer
+	"""
 	appScore: Float!
 }
 


### PR DESCRIPTION
Fixes a CI bug introduced in https://github.com/FuelLabs/fuel-core/pull/1524

The latest gql schema wasn't properly committed to the branch and for some reason it wasn't caught in CI until pushed to master.

Failing job:
https://github.com/FuelLabs/fuel-core/actions/runs/7172572694/job/19530049697