### PR TITLE
Remove duplicating logic in the `KeyValueStore` trait

### DIFF
--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -425,16 +425,12 @@ async fn shutdown_signal() -> anyhow::Result<()> {
 
         let mut sigint =
             tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
-        loop {
-            tokio::select! {
-                _ = sigterm.recv() => {
-                    tracing::info!("sigterm received");
-                    break;
-                }
-                _ = sigint.recv() => {
-                    tracing::info!("sigint received");
-                    break;
-                }
+        tokio::select! {
+            _ = sigterm.recv() => {
+                tracing::info!("sigterm received");
+            }
+            _ = sigint.recv() => {
+                tracing::info!("sigint received");
             }
         }
     }

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -320,6 +320,10 @@ impl Database {
             .map(|val| postcard::from_bytes(&val).map_err(|_| DatabaseError::Codec))
             .transpose()
     }
+
+    fn take_raw(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
+        self.data.take(key, column)
+    }
 }
 
 /// Read-only methods.

--- a/crates/fuel-core/src/database/balances.rs
+++ b/crates/fuel-core/src/database/balances.rs
@@ -100,7 +100,7 @@ impl StorageMutate<ContractsAssets> for Database {
         &mut self,
         key: &<ContractsAssets as Mappable>::Key,
     ) -> Result<Option<<ContractsAssets as Mappable>::OwnedValue>, Self::Error> {
-        let prev = Database::remove(self, key.as_ref(), Column::ContractsAssets)
+        let prev = Database::take(self, key.as_ref(), Column::ContractsAssets)
             .map_err(Into::into);
 
         // Get latest metadata entry for this contract id

--- a/crates/fuel-core/src/database/block.rs
+++ b/crates/fuel-core/src/database/block.rs
@@ -106,7 +106,7 @@ impl StorageMutate<FuelBlocks> for Database {
 
     fn remove(&mut self, key: &BlockId) -> Result<Option<CompressedBlock>, Self::Error> {
         let prev: Option<CompressedBlock> =
-            Database::remove(self, key.as_slice(), Column::FuelBlocks)?;
+            Database::take(self, key.as_slice(), Column::FuelBlocks)?;
 
         if let Some(block) = &prev {
             let height = block.header().height();

--- a/crates/fuel-core/src/database/coin.rs
+++ b/crates/fuel-core/src/database/coin.rs
@@ -92,7 +92,7 @@ impl StorageMutate<Coins> for Database {
 
     fn remove(&mut self, key: &UtxoId) -> Result<Option<CompressedCoin>, Self::Error> {
         let coin: Option<CompressedCoin> =
-            Database::remove(self, &utxo_id_to_bytes(key), Column::Coins)?;
+            Database::take(self, &utxo_id_to_bytes(key), Column::Coins)?;
 
         // cleanup secondary index
         if let Some(coin) = &coin {

--- a/crates/fuel-core/src/database/contracts.rs
+++ b/crates/fuel-core/src/database/contracts.rs
@@ -22,7 +22,6 @@ use fuel_core_storage::{
     StorageMutate,
     StorageRead,
     StorageSize,
-    StorageWrite,
 };
 use fuel_core_types::{
     entities::contract::ContractUtxoInfo,
@@ -74,19 +73,16 @@ impl StorageMutate<ContractsRawCode> for Database {
         key: &<ContractsRawCode as Mappable>::Key,
         value: &<ContractsRawCode as Mappable>::Value,
     ) -> Result<Option<<ContractsRawCode as Mappable>::OwnedValue>, Self::Error> {
-        let existing =
-            Database::replace(self, key.as_ref(), Column::ContractsRawCode, value)?;
-        Ok(existing.1.map(Contract::from))
+        let result = Database::insert_raw(self, key, Column::ContractsRawCode, value)?;
+
+        Ok(result.map(|v| Contract::from(v.as_ref().clone())))
     }
 
     fn remove(
         &mut self,
         key: &<ContractsRawCode as Mappable>::Key,
     ) -> Result<Option<<ContractsRawCode as Mappable>::OwnedValue>, Self::Error> {
-        Ok(
-            <Self as StorageWrite<ContractsRawCode>>::take(self, key)?
-                .map(Contract::from),
-        )
+        Database::take(self, key.as_ref(), Column::ContractsRawCode).map_err(Into::into)
     }
 }
 
@@ -107,44 +103,6 @@ impl StorageRead<ContractsRawCode> for Database {
 
     fn read_alloc(&self, key: &ContractId) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(self.read_alloc(key.as_ref(), Column::ContractsRawCode)?)
-    }
-}
-
-impl StorageWrite<ContractsRawCode> for Database {
-    fn write(&mut self, key: &ContractId, buf: Vec<u8>) -> Result<usize, Self::Error> {
-        Ok(Database::write(
-            self,
-            key.as_ref(),
-            Column::ContractsRawCode,
-            &buf,
-        )?)
-    }
-
-    fn replace(
-        &mut self,
-        key: &<ContractsRawCode as Mappable>::Key,
-        buf: Vec<u8>,
-    ) -> Result<(usize, Option<Vec<u8>>), <Self as StorageInspect<ContractsRawCode>>::Error>
-    where
-        Self: StorageSize<ContractsRawCode>,
-    {
-        Ok(Database::replace(
-            self,
-            key.as_ref(),
-            Column::ContractsRawCode,
-            &buf,
-        )?)
-    }
-
-    fn take(
-        &mut self,
-        key: &<ContractsRawCode as Mappable>::Key,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(Database::take(
-            self,
-            key.as_ref(),
-            Column::ContractsRawCode,
-        )?)
     }
 }
 

--- a/crates/fuel-core/src/database/contracts.rs
+++ b/crates/fuel-core/src/database/contracts.rs
@@ -82,7 +82,9 @@ impl StorageMutate<ContractsRawCode> for Database {
         &mut self,
         key: &<ContractsRawCode as Mappable>::Key,
     ) -> Result<Option<<ContractsRawCode as Mappable>::OwnedValue>, Self::Error> {
-        Database::take(self, key.as_ref(), Column::ContractsRawCode).map_err(Into::into)
+        let result = Database::take_raw(self, key.as_ref(), Column::ContractsRawCode)?;
+
+        Ok(result.map(|v| Contract::from(v.as_ref().clone())))
     }
 }
 

--- a/crates/fuel-core/src/database/message.rs
+++ b/crates/fuel-core/src/database/message.rs
@@ -67,10 +67,10 @@ impl StorageMutate<Messages> for Database {
 
     fn remove(&mut self, key: &Nonce) -> Result<Option<Message>, Self::Error> {
         let result: Option<Message> =
-            Database::remove(self, key.database_key().as_ref(), Column::Messages)?;
+            Database::take(self, key.database_key().as_ref(), Column::Messages)?;
 
         if let Some(message) = &result {
-            Database::remove::<bool>(
+            Database::take::<bool>(
                 self,
                 &owner_msg_id_key(&message.recipient, key),
                 Column::OwnedMessageIds,

--- a/crates/fuel-core/src/database/state.rs
+++ b/crates/fuel-core/src/database/state.rs
@@ -99,7 +99,7 @@ impl StorageMutate<ContractsState> for Database {
         &mut self,
         key: &<ContractsState as Mappable>::Key,
     ) -> Result<Option<<ContractsState as Mappable>::OwnedValue>, Self::Error> {
-        let prev = Database::remove(self, key.as_ref(), Column::ContractsState)
+        let prev = Database::take(self, key.as_ref(), Column::ContractsState)
             .map_err(Into::into);
 
         // Get latest metadata entry for this contract id

--- a/crates/fuel-core/src/database/storage.rs
+++ b/crates/fuel-core/src/database/storage.rs
@@ -232,8 +232,7 @@ where
     }
 
     fn remove(&mut self, key: &T::Key) -> StorageResult<Option<T::OwnedValue>> {
-        Database::remove(self, key.database_key().as_ref(), T::column())
-            .map_err(Into::into)
+        Database::take(self, key.database_key().as_ref(), T::column()).map_err(Into::into)
     }
 }
 

--- a/crates/fuel-core/src/state.rs
+++ b/crates/fuel-core/src/state.rs
@@ -27,16 +27,9 @@ pub trait KeyValueStore {
 
     fn write(&self, key: &[u8], column: Column, buf: &[u8]) -> DatabaseResult<usize>;
 
-    fn replace(
-        &self,
-        key: &[u8],
-        column: Column,
-        buf: &[u8],
-    ) -> DatabaseResult<(usize, Option<Value>)>;
-
     fn take(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>>;
 
-    fn delete(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>>;
+    fn delete(&self, key: &[u8], column: Column) -> DatabaseResult<()>;
 
     fn exists(&self, key: &[u8], column: Column) -> DatabaseResult<bool>;
 
@@ -50,8 +43,6 @@ pub trait KeyValueStore {
         column: Column,
         buf: &mut [u8],
     ) -> DatabaseResult<Option<usize>>;
-
-    fn read_alloc(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>>;
 
     fn iter_all(
         &self,

--- a/crates/fuel-core/src/state.rs
+++ b/crates/fuel-core/src/state.rs
@@ -13,40 +13,98 @@ use std::{
     sync::Arc,
 };
 
-pub type DataSource = Arc<dyn TransactableStorage>;
+pub type DataSource = Arc<dyn TransactableStorage<Column = Column>>;
 pub type Value = Arc<Vec<u8>>;
 pub type KVItem = DatabaseResult<(Vec<u8>, Value)>;
 
+/// A column of the storage.
+pub trait StorageColumn: Clone {
+    /// Returns the name of the column.
+    fn name(&self) -> &'static str;
+
+    /// Returns the id of the column.
+    fn id(&self) -> u32;
+}
+
 pub trait KeyValueStore {
-    fn put(
+    /// The type of the column.
+    type Column: StorageColumn;
+
+    /// Inserts the `Value` into the storage.
+    fn put(&self, key: &[u8], column: Self::Column, value: Value) -> DatabaseResult<()> {
+        self.write(key, column, value.as_ref()).map(|_| ())
+    }
+
+    /// Put the `Value` into the storage and return the old value.
+    fn replace(
         &self,
         key: &[u8],
-        column: Column,
+        column: Self::Column,
         value: Value,
-    ) -> DatabaseResult<Option<Value>>;
+    ) -> DatabaseResult<Option<Value>> {
+        // FIXME: This is a race condition. We should use a transaction.
+        let old_value = self.get(key, column.clone())?;
+        self.put(key, column, value)?;
+        Ok(old_value)
+    }
 
-    fn write(&self, key: &[u8], column: Column, buf: &[u8]) -> DatabaseResult<usize>;
+    /// Writes the `buf` into the storage and returns the number of written bytes.
+    fn write(
+        &self,
+        key: &[u8],
+        column: Self::Column,
+        buf: &[u8],
+    ) -> DatabaseResult<usize>;
 
-    fn take(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>>;
+    /// Removes the value from the storage and returns it.
+    fn take(&self, key: &[u8], column: Self::Column) -> DatabaseResult<Option<Value>> {
+        // FIXME: This is a race condition. We should use a transaction.
+        let old_value = self.get(key, column.clone())?;
+        self.delete(key, column)?;
+        Ok(old_value)
+    }
 
-    fn delete(&self, key: &[u8], column: Column) -> DatabaseResult<()>;
+    /// Removes the value from the storage.
+    fn delete(&self, key: &[u8], column: Self::Column) -> DatabaseResult<()>;
 
-    fn exists(&self, key: &[u8], column: Column) -> DatabaseResult<bool>;
+    /// Checks if the value exists in the storage.
+    fn exists(&self, key: &[u8], column: Self::Column) -> DatabaseResult<bool> {
+        Ok(self.size_of_value(key, column)?.is_some())
+    }
 
-    fn size_of_value(&self, key: &[u8], column: Column) -> DatabaseResult<Option<usize>>;
+    /// Returns the size of the value in the storage.
+    fn size_of_value(
+        &self,
+        key: &[u8],
+        column: Self::Column,
+    ) -> DatabaseResult<Option<usize>> {
+        Ok(self.get(key, column.clone())?.map(|value| value.len()))
+    }
 
-    fn get(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>>;
+    /// Returns the value from the storage.
+    fn get(&self, key: &[u8], column: Self::Column) -> DatabaseResult<Option<Value>>;
 
+    /// Reads the value from the storage into the `buf` and returns the number of read bytes.
     fn read(
         &self,
         key: &[u8],
-        column: Column,
-        buf: &mut [u8],
-    ) -> DatabaseResult<Option<usize>>;
+        column: Self::Column,
+        mut buf: &mut [u8],
+    ) -> DatabaseResult<Option<usize>> {
+        self.get(key, column.clone())?
+            .map(|value| {
+                let read = value.len();
+                std::io::Write::write_all(&mut buf, value.as_ref())
+                    .map_err(|e| DatabaseError::Other(anyhow::anyhow!(e)))?;
+                Ok(read)
+            })
+            .transpose()
+    }
 
+    /// Returns an iterator over the values in the storage.
     fn iter_all(
         &self,
-        column: Column,
+        column: Self::Column,
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
@@ -56,16 +114,15 @@ pub trait KeyValueStore {
 pub trait BatchOperations: KeyValueStore {
     fn batch_write(
         &self,
-        entries: &mut dyn Iterator<Item = (Vec<u8>, Column, WriteOperation)>,
+        entries: &mut dyn Iterator<Item = (Vec<u8>, Self::Column, WriteOperation)>,
     ) -> DatabaseResult<()> {
         for (key, column, op) in entries {
             match op {
-                // TODO: error handling
                 WriteOperation::Insert(value) => {
-                    let _ = self.put(&key, column, value);
+                    self.put(&key, column, value)?;
                 }
                 WriteOperation::Remove => {
-                    let _ = self.delete(&key, column);
+                    self.delete(&key, column)?;
                 }
             }
         }

--- a/crates/fuel-core/src/state/in_memory/memory_store.rs
+++ b/crates/fuel-core/src/state/in_memory/memory_store.rs
@@ -1,7 +1,6 @@
 use crate::{
     database::{
         Column,
-        Error as DatabaseError,
         Result as DatabaseResult,
     },
     state::{
@@ -100,7 +99,9 @@ impl MemoryStore {
 }
 
 impl KeyValueStore for MemoryStore {
-    fn put(
+    type Column = Column;
+
+    fn replace(
         &self,
         key: &[u8],
         column: Column,
@@ -129,26 +130,7 @@ impl KeyValueStore for MemoryStore {
     }
 
     fn delete(&self, key: &[u8], column: Column) -> DatabaseResult<()> {
-        self.inner[column.as_usize()]
-            .lock()
-            .expect("poisoned")
-            .remove(&key.to_vec());
-        Ok(())
-    }
-
-    fn exists(&self, key: &[u8], column: Column) -> DatabaseResult<bool> {
-        Ok(self.inner[column.as_usize()]
-            .lock()
-            .expect("poisoned")
-            .contains_key(&key.to_vec()))
-    }
-
-    fn size_of_value(&self, key: &[u8], column: Column) -> DatabaseResult<Option<usize>> {
-        Ok(self.inner[column.as_usize()]
-            .lock()
-            .expect("poisoned")
-            .get(&key.to_vec())
-            .map(|v| v.len()))
+        self.take(key, column).map(|_| ())
     }
 
     fn get(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
@@ -157,25 +139,6 @@ impl KeyValueStore for MemoryStore {
             .expect("poisoned")
             .get(&key.to_vec())
             .cloned())
-    }
-
-    fn read(
-        &self,
-        key: &[u8],
-        column: Column,
-        mut buf: &mut [u8],
-    ) -> DatabaseResult<Option<usize>> {
-        self.inner[column.as_usize()]
-            .lock()
-            .expect("poisoned")
-            .get(&key.to_vec())
-            .map(|value| {
-                let read = value.len();
-                std::io::Write::write_all(&mut buf, value.as_ref())
-                    .map_err(|e| DatabaseError::Other(anyhow::anyhow!(e)))?;
-                Ok(read)
-            })
-            .transpose()
     }
 
     fn iter_all(

--- a/crates/fuel-core/src/state/in_memory/transaction.rs
+++ b/crates/fuel-core/src/state/in_memory/transaction.rs
@@ -69,20 +69,6 @@ impl MemoryTransactionView {
 }
 
 impl KeyValueStore for MemoryTransactionView {
-    fn get(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
-        // try to fetch data from View layer if any changes to the key
-        if self.changes[column.as_usize()]
-            .lock()
-            .expect("poisoned lock")
-            .contains_key(&key.to_vec())
-        {
-            self.view_layer.get(key, column)
-        } else {
-            // fall-through to original data source
-            self.data_source.get(key, column)
-        }
-    }
-
     fn put(
         &self,
         key: &[u8],
@@ -103,19 +89,38 @@ impl KeyValueStore for MemoryTransactionView {
         }
     }
 
-    fn delete(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
+    fn write(&self, key: &[u8], column: Column, buf: &[u8]) -> DatabaseResult<usize> {
         let k = key.to_vec();
-        let contained_key = self.changes[column.as_usize()]
+        self.changes[column.as_usize()]
             .lock()
             .expect("poisoned lock")
-            .insert(k, WriteOperation::Remove)
-            .is_some();
-        let res = self.view_layer.delete(key, column);
+            .insert(k, WriteOperation::Insert(Arc::new(buf.to_vec())));
+        self.view_layer.write(key, column, buf)
+    }
+
+    fn take(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
+        let k = key.to_vec();
+        let contained_key = {
+            let mut lock = self.changes[column.as_usize()]
+                .lock()
+                .expect("poisoned lock");
+            lock.insert(k, WriteOperation::Remove).is_some()
+        };
+        let res = self.view_layer.take(key, column);
         if contained_key {
             res
         } else {
             self.data_source.get(key, column)
         }
+    }
+
+    fn delete(&self, key: &[u8], column: Column) -> DatabaseResult<()> {
+        let k = key.to_vec();
+        self.changes[column.as_usize()]
+            .lock()
+            .expect("poisoned lock")
+            .insert(k, WriteOperation::Remove);
+        self.view_layer.delete(key, column)
     }
 
     fn exists(&self, key: &[u8], column: Column) -> DatabaseResult<bool> {
@@ -128,6 +133,53 @@ impl KeyValueStore for MemoryTransactionView {
             self.view_layer.exists(key, column)
         } else {
             self.data_source.exists(key, column)
+        }
+    }
+
+    fn size_of_value(&self, key: &[u8], column: Column) -> DatabaseResult<Option<usize>> {
+        // try to fetch data from View layer if any changes to the key
+        if self.changes[column.as_usize()]
+            .lock()
+            .expect("poisoned lock")
+            .contains_key(&key.to_vec())
+        {
+            self.view_layer.size_of_value(key, column)
+        } else {
+            // fall-through to original data source
+            self.data_source.size_of_value(key, column)
+        }
+    }
+
+    fn get(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
+        // try to fetch data from View layer if any changes to the key
+        if self.changes[column.as_usize()]
+            .lock()
+            .expect("poisoned lock")
+            .contains_key(&key.to_vec())
+        {
+            self.view_layer.get(key, column)
+        } else {
+            // fall-through to original data source
+            self.data_source.get(key, column)
+        }
+    }
+
+    fn read(
+        &self,
+        key: &[u8],
+        column: Column,
+        buf: &mut [u8],
+    ) -> DatabaseResult<Option<usize>> {
+        // try to fetch data from View layer if any changes to the key
+        if self.changes[column.as_usize()]
+            .lock()
+            .expect("poisoned lock")
+            .contains_key(&key.to_vec())
+        {
+            self.view_layer.read(key, column, buf)
+        } else {
+            // fall-through to original data source
+            self.data_source.read(key, column, buf)
         }
     }
 
@@ -185,100 +237,6 @@ impl KeyValueStore for MemoryTransactionView {
                         true
                     }
                 }).into_boxed()
-    }
-
-    fn size_of_value(&self, key: &[u8], column: Column) -> DatabaseResult<Option<usize>> {
-        // try to fetch data from View layer if any changes to the key
-        if self.changes[column.as_usize()]
-            .lock()
-            .expect("poisoned lock")
-            .contains_key(&key.to_vec())
-        {
-            self.view_layer.size_of_value(key, column)
-        } else {
-            // fall-through to original data source
-            self.data_source.size_of_value(key, column)
-        }
-    }
-
-    fn read(
-        &self,
-        key: &[u8],
-        column: Column,
-        buf: &mut [u8],
-    ) -> DatabaseResult<Option<usize>> {
-        // try to fetch data from View layer if any changes to the key
-        if self.changes[column.as_usize()]
-            .lock()
-            .expect("poisoned lock")
-            .contains_key(&key.to_vec())
-        {
-            self.view_layer.read(key, column, buf)
-        } else {
-            // fall-through to original data source
-            self.data_source.read(key, column, buf)
-        }
-    }
-
-    fn read_alloc(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
-        if self.changes[column.as_usize()]
-            .lock()
-            .expect("poisoned lock")
-            .contains_key(&key.to_vec())
-        {
-            self.view_layer.read_alloc(key, column)
-        } else {
-            // fall-through to original data source
-            self.data_source.read_alloc(key, column)
-        }
-    }
-
-    fn write(&self, key: &[u8], column: Column, buf: &[u8]) -> DatabaseResult<usize> {
-        let k = key.to_vec();
-        self.changes[column.as_usize()]
-            .lock()
-            .expect("poisoned lock")
-            .insert(k, WriteOperation::Insert(Arc::new(buf.to_vec())));
-        self.view_layer.write(key, column, buf)
-    }
-
-    fn replace(
-        &self,
-        key: &[u8],
-        column: Column,
-        buf: &[u8],
-    ) -> DatabaseResult<(usize, Option<Value>)> {
-        let k = key.to_vec();
-        let contained_key = {
-            let mut lock = self.changes[column.as_usize()]
-                .lock()
-                .expect("poisoned lock");
-            lock.insert(k, WriteOperation::Insert(Arc::new(buf.to_vec())))
-                .is_some()
-        };
-        let res = self.view_layer.replace(key, column, buf)?;
-        let num_written = res.0;
-        if contained_key {
-            Ok(res)
-        } else {
-            Ok((num_written, self.data_source.read_alloc(key, column)?))
-        }
-    }
-
-    fn take(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
-        let k = key.to_vec();
-        let contained_key = {
-            let mut lock = self.changes[column.as_usize()]
-                .lock()
-                .expect("poisoned lock");
-            lock.insert(k, WriteOperation::Remove).is_some()
-        };
-        let res = self.view_layer.take(key, column);
-        if contained_key {
-            res
-        } else {
-            self.data_source.read_alloc(key, column)
-        }
     }
 }
 
@@ -370,7 +328,7 @@ mod tests {
         let expected = Arc::new(vec![1, 2, 3]);
         view.put(&key, Column::Metadata, expected.clone()).unwrap();
         // test
-        let ret = view.delete(&key, Column::Metadata).unwrap();
+        let ret = view.take(&key, Column::Metadata).unwrap();
         let get = view.get(&key, Column::Metadata).unwrap();
         // verify
         assert_eq!(ret, Some(expected));
@@ -386,7 +344,7 @@ mod tests {
         store.put(&key, Column::Metadata, expected.clone()).unwrap();
         let view = MemoryTransactionView::new(store);
         // test
-        let ret = view.delete(&key, Column::Metadata).unwrap();
+        let ret = view.take(&key, Column::Metadata).unwrap();
         let get = view.get(&key, Column::Metadata).unwrap();
         // verify
         assert_eq!(ret, Some(expected));
@@ -402,8 +360,8 @@ mod tests {
         store.put(&key, Column::Metadata, expected.clone()).unwrap();
         let view = MemoryTransactionView::new(store);
         // test
-        let ret1 = view.delete(&key, Column::Metadata).unwrap();
-        let ret2 = view.delete(&key, Column::Metadata).unwrap();
+        let ret1 = view.take(&key, Column::Metadata).unwrap();
+        let ret2 = view.take(&key, Column::Metadata).unwrap();
         let get = view.get(&key, Column::Metadata).unwrap();
         // verify
         assert_eq!(ret1, Some(expected));
@@ -578,8 +536,8 @@ mod tests {
 
         let view = MemoryTransactionView::new(store);
         // test
-        let _ = view.delete(&[0], Column::Metadata).unwrap();
-        let _ = view.delete(&[6], Column::Metadata).unwrap();
+        view.delete(&[0], Column::Metadata).unwrap();
+        view.delete(&[6], Column::Metadata).unwrap();
 
         let ret: Vec<_> = view
             .iter_all(Column::Metadata, None, None, IterDirection::Forward)
@@ -611,10 +569,7 @@ mod tests {
             vec![(key.clone(), expected.clone())]
         );
 
-        assert_eq!(
-            db.delete(&key, Column::Metadata).unwrap().unwrap(),
-            expected
-        );
+        assert_eq!(db.take(&key, Column::Metadata).unwrap().unwrap(), expected);
 
         assert!(!db.exists(&key, Column::Metadata).unwrap());
 
@@ -653,10 +608,7 @@ mod tests {
             vec![(key.clone(), expected.clone())]
         );
 
-        assert_eq!(
-            db.delete(&key, Column::Metadata).unwrap().unwrap(),
-            expected
-        );
+        assert_eq!(db.take(&key, Column::Metadata).unwrap().unwrap(), expected);
 
         assert!(!db.exists(&key, Column::Metadata).unwrap());
 
@@ -695,10 +647,7 @@ mod tests {
             vec![(key.clone(), expected.clone())]
         );
 
-        assert_eq!(
-            db.delete(&key, Column::Metadata).unwrap().unwrap(),
-            expected
-        );
+        assert_eq!(db.take(&key, Column::Metadata).unwrap().unwrap(), expected);
 
         assert!(!db.exists(&key, Column::Metadata).unwrap());
 

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -307,20 +307,6 @@ impl RocksDb {
 }
 
 impl KeyValueStore for RocksDb {
-    fn get(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
-        database_metrics().read_meter.inc();
-        let value = self
-            .db
-            .get_cf(&self.cf(column), key)
-            .map_err(|e| DatabaseError::Other(e.into()));
-
-        if let Ok(Some(value)) = &value {
-            database_metrics().bytes_read.observe(value.len() as f64);
-        }
-
-        value.map(|value| value.map(Arc::new))
-    }
-
     fn put(
         &self,
         key: &[u8],
@@ -339,7 +325,20 @@ impl KeyValueStore for RocksDb {
             .map(|_| prev)
     }
 
-    fn delete(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
+    fn write(&self, key: &[u8], column: Column, buf: &[u8]) -> DatabaseResult<usize> {
+        database_metrics().write_meter.inc();
+
+        let r = buf.len();
+        self.db
+            .put_cf(&self.cf(column), key, buf)
+            .map_err(|e| DatabaseError::Other(e.into()))?;
+
+        database_metrics().bytes_written.observe(r as f64);
+
+        Ok(r)
+    }
+
+    fn take(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
         // FIXME: This is a race condition. We should use a transaction.
         let prev = self.get(key, column)?;
         // FIXME: This is a race condition. We should use a transaction.
@@ -349,6 +348,12 @@ impl KeyValueStore for RocksDb {
             .map(|_| prev)
     }
 
+    fn delete(&self, key: &[u8], column: Column) -> DatabaseResult<()> {
+        self.db
+            .delete_cf(&self.cf(column), key)
+            .map_err(|e| DatabaseError::Other(e.into()))
+    }
+
     fn exists(&self, key: &[u8], column: Column) -> DatabaseResult<bool> {
         // use pinnable mem ref to avoid memcpy of values associated with the key
         // since we're just checking for the existence of the key
@@ -356,6 +361,58 @@ impl KeyValueStore for RocksDb {
             .get_pinned_cf(&self.cf(column), key)
             .map_err(|e| DatabaseError::Other(e.into()))
             .map(|v| v.is_some())
+    }
+
+    fn size_of_value(&self, key: &[u8], column: Column) -> DatabaseResult<Option<usize>> {
+        database_metrics().read_meter.inc();
+
+        Ok(self
+            .db
+            .get_pinned_cf(&self.cf(column), key)
+            .map_err(|e| DatabaseError::Other(e.into()))?
+            .map(|value| value.len()))
+    }
+
+    fn get(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
+        database_metrics().read_meter.inc();
+
+        let value = self
+            .db
+            .get_cf(&self.cf(column), key)
+            .map_err(|e| DatabaseError::Other(e.into()))?;
+
+        if let Some(value) = &value {
+            database_metrics().bytes_read.observe(value.len() as f64);
+        }
+
+        Ok(value.map(Arc::new))
+    }
+
+    fn read(
+        &self,
+        key: &[u8],
+        column: Column,
+        mut buf: &mut [u8],
+    ) -> DatabaseResult<Option<usize>> {
+        database_metrics().read_meter.inc();
+
+        let r = self
+            .db
+            .get_pinned_cf(&self.cf(column), key)
+            .map_err(|e| DatabaseError::Other(e.into()))?
+            .map(|value| {
+                let read = value.len();
+                std::io::Write::write_all(&mut buf, value.as_ref())
+                    .map_err(|e| DatabaseError::Other(anyhow::anyhow!(e)))?;
+                DatabaseResult::Ok(read)
+            })
+            .transpose()?;
+
+        if let Some(r) = &r {
+            database_metrics().bytes_read.observe(*r as f64);
+        }
+
+        Ok(r)
     }
 
     fn iter_all(
@@ -422,95 +479,6 @@ impl KeyValueStore for RocksDb {
                     .into_boxed()
             }
         }
-    }
-
-    fn size_of_value(&self, key: &[u8], column: Column) -> DatabaseResult<Option<usize>> {
-        database_metrics().read_meter.inc();
-
-        Ok(self
-            .db
-            .get_pinned_cf(&self.cf(column), key)
-            .map_err(|e| DatabaseError::Other(e.into()))?
-            .map(|value| value.len()))
-    }
-
-    fn read(
-        &self,
-        key: &[u8],
-        column: Column,
-        mut buf: &mut [u8],
-    ) -> DatabaseResult<Option<usize>> {
-        database_metrics().read_meter.inc();
-
-        let r = self
-            .db
-            .get_pinned_cf(&self.cf(column), key)
-            .map_err(|e| DatabaseError::Other(e.into()))?
-            .map(|value| {
-                let read = value.len();
-                std::io::Write::write_all(&mut buf, value.as_ref())
-                    .map_err(|e| DatabaseError::Other(anyhow::anyhow!(e)))?;
-                DatabaseResult::Ok(read)
-            })
-            .transpose()?;
-
-        if let Some(r) = &r {
-            database_metrics().bytes_read.observe(*r as f64);
-        }
-
-        Ok(r)
-    }
-
-    fn write(&self, key: &[u8], column: Column, buf: &[u8]) -> DatabaseResult<usize> {
-        database_metrics().write_meter.inc();
-        database_metrics().bytes_written.observe(buf.len() as f64);
-
-        let r = buf.len();
-        self.db
-            .put_cf(&self.cf(column), key, buf)
-            .map_err(|e| DatabaseError::Other(e.into()))?;
-
-        Ok(r)
-    }
-
-    fn read_alloc(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
-        database_metrics().read_meter.inc();
-
-        let r = self
-            .db
-            .get_pinned_cf(&self.cf(column), key)
-            .map_err(|e| DatabaseError::Other(e.into()))?
-            .map(|value| value.to_vec());
-
-        if let Some(r) = &r {
-            database_metrics().bytes_read.observe(r.len() as f64);
-        }
-
-        Ok(r.map(Arc::new))
-    }
-
-    fn replace(
-        &self,
-        key: &[u8],
-        column: Column,
-        buf: &[u8],
-    ) -> DatabaseResult<(usize, Option<Value>)> {
-        // FIXME: This is a race condition. We should use a transaction.
-        let existing = self.read_alloc(key, column)?;
-        // FIXME: This is a race condition. We should use a transaction.
-        let r = self.write(key, column, buf)?;
-
-        Ok((r, existing))
-    }
-
-    fn take(&self, key: &[u8], column: Column) -> DatabaseResult<Option<Value>> {
-        // FIXME: This is a race condition. We should use a transaction.
-        let prev = self.read_alloc(key, column)?;
-        // FIXME: This is a race condition. We should use a transaction.
-        self.db
-            .delete_cf(&self.cf(column), key)
-            .map_err(|e| DatabaseError::Other(e.into()))
-            .map(|_| prev)
     }
 }
 
@@ -687,10 +655,7 @@ mod tests {
             (key.clone(), expected.clone())
         );
 
-        assert_eq!(
-            db.delete(&key, Column::Metadata).unwrap().unwrap(),
-            expected
-        );
+        assert_eq!(db.take(&key, Column::Metadata).unwrap().unwrap(), expected);
 
         assert!(!db.exists(&key, Column::Metadata).unwrap());
     }
@@ -714,10 +679,7 @@ mod tests {
             (key.clone(), expected.clone())
         );
 
-        assert_eq!(
-            db.delete(&key, Column::Metadata).unwrap().unwrap(),
-            expected
-        );
+        assert_eq!(db.take(&key, Column::Metadata).unwrap().unwrap(), expected);
 
         assert!(!db.exists(&key, Column::Metadata).unwrap());
     }
@@ -741,10 +703,7 @@ mod tests {
             (key.clone(), expected.clone())
         );
 
-        assert_eq!(
-            db.delete(&key, Column::Metadata).unwrap().unwrap(),
-            expected
-        );
+        assert_eq!(db.take(&key, Column::Metadata).unwrap().unwrap(), expected);
 
         assert!(!db.exists(&key, Column::Metadata).unwrap());
     }


### PR DESCRIPTION
Preparation before start work on https://github.com/FuelLabs/fuel-core/issues/1548.

The `KeyValueStore` trait has some duplicated logic. This PR removes it, minimizing the number of methods that we need to implement. Also I applied the original ordering of the method as in the trait.

