### PR TITLE
Move `KeyValueStore` to the `fuel-core-storage` crate

### DIFF
--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -13,7 +13,6 @@
 
 use fuel_core_storage::Error as StorageError;
 use fuel_core_types::services::executor::Error as ExecutorError;
-use std::array::TryFromSliceError;
 
 /// The error occurred during work with any of databases.
 #[derive(Debug, derive_more::Display, derive_more::From)]
@@ -53,12 +52,6 @@ impl From<Error> for anyhow::Error {
 impl From<Error> for StorageError {
     fn from(e: Error) -> Self {
         StorageError::DatabaseError(Box::new(e))
-    }
-}
-
-impl From<TryFromSliceError> for Error {
-    fn from(e: TryFromSliceError) -> Self {
-        Self::Other(anyhow::anyhow!(e))
     }
 }
 

--- a/crates/fuel-core/src/database/block.rs
+++ b/crates/fuel-core/src/database/block.rs
@@ -9,7 +9,6 @@ use crate::database::{
     Column,
     Database,
     Error as DatabaseError,
-    Result as DatabaseResult,
 };
 use fuel_core_storage::{
     iter::IterDirection,
@@ -161,7 +160,7 @@ impl Database {
         &self,
         start: Option<BlockHeight>,
         direction: IterDirection,
-    ) -> impl Iterator<Item = DatabaseResult<(BlockHeight, BlockId)>> + '_ {
+    ) -> impl Iterator<Item = StorageResult<(BlockHeight, BlockId)>> + '_ {
         let start = start.map(|b| b.to_bytes());
         self.iter_all_by_start::<Vec<u8>, BlockId, _>(
             Column::FuelBlockSecondaryKeyBlockHeights,
@@ -178,7 +177,7 @@ impl Database {
         })
     }
 
-    pub fn ids_of_genesis_block(&self) -> DatabaseResult<(BlockHeight, BlockId)> {
+    pub fn ids_of_genesis_block(&self) -> StorageResult<(BlockHeight, BlockId)> {
         self.iter_all(
             Column::FuelBlockSecondaryKeyBlockHeights,
             Some(IterDirection::Forward),
@@ -192,7 +191,7 @@ impl Database {
         })
     }
 
-    pub fn ids_of_latest_block(&self) -> DatabaseResult<Option<(BlockHeight, BlockId)>> {
+    pub fn ids_of_latest_block(&self) -> StorageResult<Option<(BlockHeight, BlockId)>> {
         let ids = self
             .iter_all::<Vec<u8>, BlockId>(
                 Column::FuelBlockSecondaryKeyBlockHeights,

--- a/crates/fuel-core/src/database/message.rs
+++ b/crates/fuel-core/src/database/message.rs
@@ -2,7 +2,6 @@ use crate::database::{
     storage::ToDatabaseKey,
     Column,
     Database,
-    Result as DatabaseResult,
 };
 use fuel_core_chain_config::MessageConfig;
 use fuel_core_storage::{
@@ -93,7 +92,7 @@ impl Database {
         owner: &Address,
         start_message_id: Option<Nonce>,
         direction: Option<IterDirection>,
-    ) -> impl Iterator<Item = DatabaseResult<Nonce>> + '_ {
+    ) -> impl Iterator<Item = StorageResult<Nonce>> + '_ {
         self.iter_all_filtered::<Vec<u8>, bool, _, _>(
             Column::OwnedMessageIds,
             Some(*owner),
@@ -112,7 +111,7 @@ impl Database {
         &self,
         start: Option<Nonce>,
         direction: Option<IterDirection>,
-    ) -> impl Iterator<Item = DatabaseResult<Message>> + '_ {
+    ) -> impl Iterator<Item = StorageResult<Message>> + '_ {
         let start = start.map(|v| v.deref().to_vec());
         self.iter_all_by_start::<Vec<u8>, Message, _>(Column::Messages, start, direction)
             .map(|res| res.map(|(_, message)| message))

--- a/crates/fuel-core/src/database/metadata.rs
+++ b/crates/fuel-core/src/database/metadata.rs
@@ -2,9 +2,9 @@ use crate::database::{
     Column,
     Database,
     Error as DatabaseError,
-    Result as DatabaseResult,
 };
 use fuel_core_chain_config::ChainConfig;
+use fuel_core_storage::Result as StorageResult;
 
 pub(crate) const DB_VERSION_KEY: &[u8] = b"version";
 pub(crate) const CHAIN_NAME_KEY: &[u8] = b"chain_name";
@@ -17,13 +17,13 @@ pub(crate) const DB_VERSION: u32 = 0x00;
 
 impl Database {
     /// Ensures the database is initialized and that the database version is correct
-    pub fn init(&self, config: &ChainConfig) -> DatabaseResult<()> {
+    pub fn init(&self, config: &ChainConfig) -> StorageResult<()> {
         // initialize chain name if not set
         if self.get_chain_name()?.is_none() {
             self.insert(CHAIN_NAME_KEY, Column::Metadata, &config.chain_name)
                 .and_then(|v: Option<String>| {
                     if v.is_some() {
-                        Err(DatabaseError::ChainAlreadyInitialized)
+                        Err(DatabaseError::ChainAlreadyInitialized.into())
                     } else {
                         Ok(())
                     }
@@ -45,11 +45,11 @@ impl Database {
         Ok(())
     }
 
-    pub fn get_chain_name(&self) -> DatabaseResult<Option<String>> {
+    pub fn get_chain_name(&self) -> StorageResult<Option<String>> {
         self.get(CHAIN_NAME_KEY, Column::Metadata)
     }
 
-    pub fn increase_tx_count(&self, new_txs: u64) -> DatabaseResult<u64> {
+    pub fn increase_tx_count(&self, new_txs: u64) -> StorageResult<u64> {
         // TODO: how should tx count be initialized after regenesis?
         let current_tx_count: u64 =
             self.get(TX_COUNT, Column::Metadata)?.unwrap_or_default();
@@ -59,7 +59,7 @@ impl Database {
         Ok(new_tx_count)
     }
 
-    pub fn get_tx_count(&self) -> DatabaseResult<u64> {
+    pub fn get_tx_count(&self) -> StorageResult<u64> {
         self.get(TX_COUNT, Column::Metadata)
             .map(|v| v.unwrap_or_default())
     }

--- a/crates/fuel-core/src/database/transaction.rs
+++ b/crates/fuel-core/src/database/transaction.rs
@@ -58,7 +58,7 @@ impl Default for DatabaseTransaction {
 impl Transaction<Database> for DatabaseTransaction {
     fn commit(&mut self) -> StorageResult<()> {
         // TODO: should commit be fallible if this api is meant to be atomic?
-        Ok(self.changes.commit()?)
+        self.changes.commit()
     }
 }
 

--- a/crates/fuel-core/src/database/transactions.rs
+++ b/crates/fuel-core/src/database/transactions.rs
@@ -2,11 +2,11 @@ use crate::database::{
     storage::DatabaseColumn,
     Column,
     Database,
-    Result as DatabaseResult,
 };
 use fuel_core_storage::{
     iter::IterDirection,
     tables::Transactions,
+    Result as StorageResult,
 };
 use fuel_core_types::{
     self,
@@ -37,7 +37,7 @@ impl Database {
         &self,
         start: Option<&Bytes32>,
         direction: Option<IterDirection>,
-    ) -> impl Iterator<Item = DatabaseResult<Transaction>> + '_ {
+    ) -> impl Iterator<Item = StorageResult<Transaction>> + '_ {
         let start = start.map(|b| b.as_ref().to_vec());
         self.iter_all_by_start::<Vec<u8>, Transaction, _>(
             Column::Transactions,
@@ -56,7 +56,7 @@ impl Database {
         owner: Address,
         start: Option<OwnedTransactionIndexCursor>,
         direction: Option<IterDirection>,
-    ) -> impl Iterator<Item = DatabaseResult<(TxPointer, Bytes32)>> + '_ {
+    ) -> impl Iterator<Item = StorageResult<(TxPointer, Bytes32)>> + '_ {
         let start = start
             .map(|cursor| owned_tx_index_key(&owner, cursor.block_height, cursor.tx_idx));
         self.iter_all_filtered::<OwnedTransactionIndexKey, Bytes32, _, _>(
@@ -76,7 +76,7 @@ impl Database {
         block_height: BlockHeight,
         tx_idx: TransactionIndex,
         tx_id: &Bytes32,
-    ) -> DatabaseResult<Option<Bytes32>> {
+    ) -> StorageResult<Option<Bytes32>> {
         self.insert(
             owned_tx_index_key(owner, block_height, tx_idx),
             Column::TransactionsByOwnerBlockIdx,
@@ -88,14 +88,14 @@ impl Database {
         &self,
         id: &Bytes32,
         status: TransactionStatus,
-    ) -> DatabaseResult<Option<TransactionStatus>> {
+    ) -> StorageResult<Option<TransactionStatus>> {
         self.insert(id, Column::TransactionStatus, &status)
     }
 
     pub fn get_tx_status(
         &self,
         id: &Bytes32,
-    ) -> DatabaseResult<Option<TransactionStatus>> {
+    ) -> StorageResult<Option<TransactionStatus>> {
         self.get(&id.deref()[..], Column::TransactionStatus)
     }
 }

--- a/crates/fuel-core/src/service/adapters/executor.rs
+++ b/crates/fuel-core/src/service/adapters/executor.rs
@@ -99,7 +99,7 @@ impl fuel_core_executor::ports::TxIdOwnerRecorder for Database {
         tx_idx: u16,
         tx_id: &Bytes32,
     ) -> Result<Option<Bytes32>, Self::Error> {
-        Ok(self.record_tx_id_owner(owner, block_height, tx_idx, tx_id)?)
+        self.record_tx_id_owner(owner, block_height, tx_idx, tx_id)
     }
 
     fn update_tx_status(
@@ -107,7 +107,7 @@ impl fuel_core_executor::ports::TxIdOwnerRecorder for Database {
         id: &Bytes32,
         status: TransactionStatus,
     ) -> Result<Option<TransactionStatus>, Self::Error> {
-        Ok(self.update_tx_status(id, status)?)
+        self.update_tx_status(id, status)
     }
 }
 

--- a/crates/fuel-core/src/service/adapters/graphql_api.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api.rs
@@ -95,19 +95,17 @@ impl DatabaseBlocks for Database {
     }
 
     fn ids_of_latest_block(&self) -> StorageResult<(BlockHeight, BlockId)> {
-        Ok(self
-            .ids_of_latest_block()
+        self.ids_of_latest_block()
             .transpose()
-            .ok_or(not_found!("BlockId"))??)
+            .ok_or(not_found!("BlockId"))?
     }
 }
 
 impl DatabaseTransactions for Database {
     fn tx_status(&self, tx_id: &TxId) -> StorageResult<TransactionStatus> {
-        Ok(self
-            .get_tx_status(tx_id)
+        self.get_tx_status(tx_id)
             .transpose()
-            .ok_or(not_found!("TransactionId"))??)
+            .ok_or(not_found!("TransactionId"))?
     }
 
     fn owned_transactions_ids(

--- a/crates/fuel-core/src/service/adapters/txpool.rs
+++ b/crates/fuel-core/src/service/adapters/txpool.rs
@@ -149,9 +149,8 @@ impl fuel_core_txpool::ports::TxPoolDb for Database {
         &self,
         tx_id: &fuel_core_types::fuel_types::Bytes32,
     ) -> StorageResult<fuel_core_types::services::txpool::TransactionStatus> {
-        Ok(self
-            .get_tx_status(tx_id)
+        self.get_tx_status(tx_id)
             .transpose()
-            .ok_or(not_found!("TransactionId"))??)
+            .ok_or(not_found!("TransactionId"))?
     }
 }

--- a/crates/fuel-core/src/state.rs
+++ b/crates/fuel-core/src/state.rs
@@ -4,9 +4,12 @@ use crate::database::{
     Error as DatabaseError,
     Result as DatabaseResult,
 };
-use fuel_core_storage::iter::{
-    BoxedIter,
-    IterDirection,
+use fuel_core_storage::{
+    iter::{
+        IterDirection,
+        IteratorableStore,
+    },
+    kv_store::BatchOperations,
 };
 use std::{
     fmt::Debug,
@@ -14,129 +17,10 @@ use std::{
 };
 
 pub type DataSource = Arc<dyn TransactableStorage<Column = Column>>;
-pub type Value = Arc<Vec<u8>>;
-pub type KVItem = DatabaseResult<(Vec<u8>, Value)>;
 
-/// A column of the storage.
-pub trait StorageColumn: Clone {
-    /// Returns the name of the column.
-    fn name(&self) -> &'static str;
-
-    /// Returns the id of the column.
-    fn id(&self) -> u32;
-}
-
-pub trait KeyValueStore {
-    /// The type of the column.
-    type Column: StorageColumn;
-
-    /// Inserts the `Value` into the storage.
-    fn put(&self, key: &[u8], column: Self::Column, value: Value) -> DatabaseResult<()> {
-        self.write(key, column, value.as_ref()).map(|_| ())
-    }
-
-    /// Put the `Value` into the storage and return the old value.
-    fn replace(
-        &self,
-        key: &[u8],
-        column: Self::Column,
-        value: Value,
-    ) -> DatabaseResult<Option<Value>> {
-        // FIXME: This is a race condition. We should use a transaction.
-        let old_value = self.get(key, column.clone())?;
-        self.put(key, column, value)?;
-        Ok(old_value)
-    }
-
-    /// Writes the `buf` into the storage and returns the number of written bytes.
-    fn write(
-        &self,
-        key: &[u8],
-        column: Self::Column,
-        buf: &[u8],
-    ) -> DatabaseResult<usize>;
-
-    /// Removes the value from the storage and returns it.
-    fn take(&self, key: &[u8], column: Self::Column) -> DatabaseResult<Option<Value>> {
-        // FIXME: This is a race condition. We should use a transaction.
-        let old_value = self.get(key, column.clone())?;
-        self.delete(key, column)?;
-        Ok(old_value)
-    }
-
-    /// Removes the value from the storage.
-    fn delete(&self, key: &[u8], column: Self::Column) -> DatabaseResult<()>;
-
-    /// Checks if the value exists in the storage.
-    fn exists(&self, key: &[u8], column: Self::Column) -> DatabaseResult<bool> {
-        Ok(self.size_of_value(key, column)?.is_some())
-    }
-
-    /// Returns the size of the value in the storage.
-    fn size_of_value(
-        &self,
-        key: &[u8],
-        column: Self::Column,
-    ) -> DatabaseResult<Option<usize>> {
-        Ok(self.get(key, column.clone())?.map(|value| value.len()))
-    }
-
-    /// Returns the value from the storage.
-    fn get(&self, key: &[u8], column: Self::Column) -> DatabaseResult<Option<Value>>;
-
-    /// Reads the value from the storage into the `buf` and returns the number of read bytes.
-    fn read(
-        &self,
-        key: &[u8],
-        column: Self::Column,
-        mut buf: &mut [u8],
-    ) -> DatabaseResult<Option<usize>> {
-        self.get(key, column.clone())?
-            .map(|value| {
-                let read = value.len();
-                std::io::Write::write_all(&mut buf, value.as_ref())
-                    .map_err(|e| DatabaseError::Other(anyhow::anyhow!(e)))?;
-                Ok(read)
-            })
-            .transpose()
-    }
-
-    /// Returns an iterator over the values in the storage.
-    fn iter_all(
-        &self,
-        column: Self::Column,
-        prefix: Option<&[u8]>,
-        start: Option<&[u8]>,
-        direction: IterDirection,
-    ) -> BoxedIter<KVItem>;
-}
-
-pub trait BatchOperations: KeyValueStore {
-    fn batch_write(
-        &self,
-        entries: &mut dyn Iterator<Item = (Vec<u8>, Self::Column, WriteOperation)>,
-    ) -> DatabaseResult<()> {
-        for (key, column, op) in entries {
-            match op {
-                WriteOperation::Insert(value) => {
-                    self.put(&key, column, value)?;
-                }
-                WriteOperation::Remove => {
-                    self.delete(&key, column)?;
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub enum WriteOperation {
-    Insert(Value),
-    Remove,
-}
-
-pub trait TransactableStorage: BatchOperations + Debug + Send + Sync {
+pub trait TransactableStorage:
+    IteratorableStore + BatchOperations + Debug + Send + Sync
+{
     fn checkpoint(&self) -> DatabaseResult<Database> {
         Err(DatabaseError::Other(anyhow::anyhow!(
             "Checkpoint is not supported"

--- a/crates/storage/src/iter.rs
+++ b/crates/storage/src/iter.rs
@@ -1,4 +1,9 @@
-//! Iterators returned by the storage.
+//! The module defines primitives that allow iterating of the storage.
+
+use crate::kv_store::{
+    KVItem,
+    KeyValueStore,
+};
 
 /// A boxed variant of the iterator that can be used as a return type of the traits.
 pub struct BoxedIter<'a, T> {
@@ -43,4 +48,16 @@ impl Default for IterDirection {
     fn default() -> Self {
         Self::Forward
     }
+}
+
+/// A trait for iterating over the storage of [`KeyValueStore`].
+pub trait IteratorableStore: KeyValueStore {
+    /// Returns an iterator over the values in the storage.
+    fn iter_all(
+        &self,
+        column: Self::Column,
+        prefix: Option<&[u8]>,
+        start: Option<&[u8]>,
+        direction: IterDirection,
+    ) -> BoxedIter<KVItem>;
 }

--- a/crates/storage/src/kv_store.rs
+++ b/crates/storage/src/kv_store.rs
@@ -1,0 +1,128 @@
+//! The module provides plain abstract definition of the key-value store.
+
+use crate::{
+    Error as StorageError,
+    Result as StorageResult,
+};
+use std::sync::Arc;
+
+/// The value of the storage. It is wrapped into the `Arc` to provide less cloning of massive objects.
+pub type Value = Arc<Vec<u8>>;
+/// The pair of key and value from the storage.
+pub type KVItem = StorageResult<(Vec<u8>, Value)>;
+
+/// A column of the storage.
+pub trait StorageColumn: Clone {
+    /// Returns the name of the column.
+    fn name(&self) -> &'static str;
+
+    /// Returns the id of the column.
+    fn id(&self) -> u32;
+}
+
+/// The definition of the key-value store.
+pub trait KeyValueStore {
+    /// The type of the column.
+    type Column: StorageColumn;
+
+    /// Inserts the `Value` into the storage.
+    fn put(&self, key: &[u8], column: Self::Column, value: Value) -> StorageResult<()> {
+        self.write(key, column, value.as_ref()).map(|_| ())
+    }
+
+    /// Put the `Value` into the storage and return the old value.
+    fn replace(
+        &self,
+        key: &[u8],
+        column: Self::Column,
+        value: Value,
+    ) -> StorageResult<Option<Value>> {
+        // FIXME: This is a race condition. We should use a transaction.
+        let old_value = self.get(key, column.clone())?;
+        self.put(key, column, value)?;
+        Ok(old_value)
+    }
+
+    /// Writes the `buf` into the storage and returns the number of written bytes.
+    fn write(&self, key: &[u8], column: Self::Column, buf: &[u8])
+        -> StorageResult<usize>;
+
+    /// Removes the value from the storage and returns it.
+    fn take(&self, key: &[u8], column: Self::Column) -> StorageResult<Option<Value>> {
+        // FIXME: This is a race condition. We should use a transaction.
+        let old_value = self.get(key, column.clone())?;
+        self.delete(key, column)?;
+        Ok(old_value)
+    }
+
+    /// Removes the value from the storage.
+    fn delete(&self, key: &[u8], column: Self::Column) -> StorageResult<()>;
+
+    /// Checks if the value exists in the storage.
+    fn exists(&self, key: &[u8], column: Self::Column) -> StorageResult<bool> {
+        Ok(self.size_of_value(key, column)?.is_some())
+    }
+
+    /// Returns the size of the value in the storage.
+    fn size_of_value(
+        &self,
+        key: &[u8],
+        column: Self::Column,
+    ) -> StorageResult<Option<usize>> {
+        Ok(self.get(key, column.clone())?.map(|value| value.len()))
+    }
+
+    /// Returns the value from the storage.
+    fn get(&self, key: &[u8], column: Self::Column) -> StorageResult<Option<Value>>;
+
+    /// Reads the value from the storage into the `buf` and returns the number of read bytes.
+    fn read(
+        &self,
+        key: &[u8],
+        column: Self::Column,
+        buf: &mut [u8],
+    ) -> StorageResult<Option<usize>> {
+        self.get(key, column.clone())?
+            .map(|value| {
+                let read = value.len();
+                if read != buf.len() {
+                    return Err(StorageError::Other(anyhow::anyhow!(
+                        "Buffer size is not equal to the value size"
+                    )));
+                }
+                buf.copy_from_slice(value.as_ref());
+                Ok(read)
+            })
+            .transpose()
+    }
+}
+
+/// The operation to write into the storage.
+#[derive(Debug)]
+pub enum WriteOperation {
+    /// Insert the value into the storage.
+    Insert(Value),
+    /// Remove the value from the storage.
+    Remove,
+}
+
+/// The definition of the key-value store with batch operations.
+pub trait BatchOperations: KeyValueStore {
+    /// Writes the batch of the entries into the storage.
+    fn batch_write(
+        &self,
+        entries: &mut dyn Iterator<Item = (Vec<u8>, Self::Column, WriteOperation)>,
+    ) -> StorageResult<()> {
+        for (key, column, op) in entries {
+            match op {
+                WriteOperation::Insert(value) => {
+                    self.put(&key, column, value)?;
+                }
+                WriteOperation::Remove => {
+                    self.delete(&key, column)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -10,6 +10,7 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
+use core::array::TryFromSliceError;
 use fuel_core_types::services::executor::Error as ExecutorError;
 
 pub use fuel_vm_private::{
@@ -21,6 +22,7 @@ pub use fuel_vm_private::{
 };
 
 pub mod iter;
+pub mod kv_store;
 pub mod tables;
 #[cfg(feature = "test-helpers")]
 pub mod test_helpers;
@@ -75,6 +77,12 @@ impl From<Error> for fuel_vm_private::prelude::InterpreterError<Error> {
 impl From<Error> for fuel_vm_private::prelude::RuntimeError<Error> {
     fn from(e: Error) -> Self {
         fuel_vm_private::prelude::RuntimeError::Storage(e)
+    }
+}
+
+impl From<TryFromSliceError> for Error {
+    fn from(e: TryFromSliceError) -> Self {
+        Self::Other(anyhow::anyhow!(e))
     }
 }
 


### PR DESCRIPTION
Related work to the https://github.com/FuelLabs/fuel-core/issues/1548.

The changes move `KeyValueStore` to the `fuel-core-storage` crate. It requires updating the trait to use `StorageResult` instead of `DatabaseResult`, causing according to changes in the downstream crates.

Also extracted `iter_all` functionality into a separate trait, because it is not used by the state transition logic and more fancy stuff for API.