### PR TITLE
Moved insertion of the blocks into the `BlockImporter` instead of the executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Description of the upcoming release here.
 
 ### Changed
 
-- [#1577](https://github.com/FuelLabs/fuel-core/pull/1577): Moved insertion of the blocks into the `BlockImporter` instead of the executor.
+- [#1577](https://github.com/FuelLabs/fuel-core/pull/1577): Moved insertion of sealed blocks into the `BlockImporter` instead of the executor.
 
 ## [Version 0.22.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+
+### Changed
+
+- [#1577](https://github.com/FuelLabs/fuel-core/pull/1577): Moved insertion of the blocks into the `BlockImporter` instead of the executor.
+
 ## [Version 0.22.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2843,6 +2843,7 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "derive_more",
+ "fuel-core-chain-config",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -300,6 +300,9 @@ impl Command {
             max_wait_time: max_wait_time.into(),
         };
 
+        let block_importer =
+            fuel_core::service::config::fuel_core_importer::Config::new(&chain_conf);
+
         let config = Config {
             addr,
             api_request_timeout: api_request_timeout.into(),
@@ -328,8 +331,7 @@ impl Command {
                 coinbase_recipient,
                 metrics,
             },
-            block_executor: Default::default(),
-            block_importer: Default::default(),
+            block_importer,
             #[cfg(feature = "relayer")]
             relayer: relayer_cfg,
             #[cfg(feature = "p2p")]

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -150,6 +150,8 @@ pub enum Column {
     ContractsStateMerkleData = 23,
     /// See [`ContractsStateMerkleMetadata`](storage::ContractsStateMerkleMetadata)
     ContractsStateMerkleMetadata = 24,
+    /// See [`ProcessedTransactions`](storage::ProcessedTransactions)
+    ProcessedTransactions = 25,
 }
 
 impl Column {

--- a/crates/fuel-core/src/database/storage.rs
+++ b/crates/fuel-core/src/database/storage.rs
@@ -3,6 +3,7 @@ use crate::database::{
     Database,
 };
 use fuel_core_storage::{
+    tables::ProcessedTransactions,
     Error as StorageError,
     Mappable,
     MerkleRoot,
@@ -157,6 +158,12 @@ pub trait DatabaseColumn {
 impl DatabaseColumn for FuelBlockSecondaryKeyBlockHeights {
     fn column() -> Column {
         Column::FuelBlockSecondaryKeyBlockHeights
+    }
+}
+
+impl DatabaseColumn for ProcessedTransactions {
+    fn column() -> Column {
+        Column::ProcessedTransactions
     }
 }
 

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -20,7 +20,6 @@ mod tests {
             ContractsRawCode,
             Messages,
             Receipts,
-            Transactions,
         },
         StorageAsMut,
     };
@@ -1571,7 +1570,7 @@ mod tests {
             .into();
         let db = &mut Database::default();
 
-        let mut executor = create_executor(
+        let executor = create_executor(
             db.clone(),
             Config {
                 utxo_validation_default: false,
@@ -1607,16 +1606,6 @@ mod tests {
         assert_eq!(executed_tx.inputs()[0].balance_root(), Some(&empty_state));
         assert_eq!(executed_tx.outputs()[0].state_root(), Some(&empty_state));
         assert_eq!(executed_tx.outputs()[0].balance_root(), Some(&empty_state));
-
-        let expected_tx = block.transactions()[1].clone();
-        let storage_tx = executor
-            .database
-            .storage::<Transactions>()
-            .get(&executed_tx.id(&ChainId::default()))
-            .unwrap()
-            .unwrap()
-            .into_owned();
-        assert_eq!(storage_tx, expected_tx);
     }
 
     #[test]
@@ -1638,7 +1627,7 @@ mod tests {
             .into();
         let db = &mut Database::default();
 
-        let mut executor = create_executor(
+        let executor = create_executor(
             db.clone(),
             Config {
                 utxo_validation_default: false,
@@ -1680,16 +1669,6 @@ mod tests {
         );
         assert_eq!(executed_tx.inputs()[0].state_root(), Some(&empty_state));
         assert_eq!(executed_tx.inputs()[0].balance_root(), Some(&empty_state));
-
-        let expected_tx = block.transactions()[1].clone();
-        let storage_tx = executor
-            .database
-            .storage::<Transactions>()
-            .get(&expected_tx.id(&ChainId::default()))
-            .unwrap()
-            .unwrap()
-            .into_owned();
-        assert_eq!(storage_tx, expected_tx);
     }
 
     #[test]
@@ -1751,7 +1730,7 @@ mod tests {
             .clone();
         let db = &mut Database::default();
 
-        let mut executor = create_executor(
+        let executor = create_executor(
             db.clone(),
             Config {
                 utxo_validation_default: false,
@@ -1793,16 +1772,6 @@ mod tests {
             executed_tx.inputs()[0].balance_root(),
             executed_tx.outputs()[0].balance_root()
         );
-
-        let expected_tx = block.transactions()[1].clone();
-        let storage_tx = executor
-            .database
-            .storage::<Transactions>()
-            .get(&expected_tx.id(&ChainId::default()))
-            .unwrap()
-            .unwrap()
-            .into_owned();
-        assert_eq!(storage_tx, expected_tx);
     }
 
     #[test]

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -19,6 +19,7 @@ pub use config::{
 };
 pub use fuel_core_services::Service as ServiceTrait;
 
+use crate::service::adapters::PoAAdapter;
 pub use fuel_core_consensus_module::RelayerVerifierConfig;
 
 use self::adapters::BlockImporterAdapter;
@@ -32,6 +33,8 @@ pub mod sub_services;
 
 #[derive(Clone)]
 pub struct SharedState {
+    /// The PoA adaptor around the shared state of the consensus module.
+    pub poa_adapter: PoAAdapter,
     /// The transaction pool shared state.
     pub txpool: fuel_core_txpool::service::SharedState<P2PAdapter, Database>,
     /// The P2P network shared state.

--- a/crates/fuel-core/src/service/adapters/block_importer.rs
+++ b/crates/fuel-core/src/service/adapters/block_importer.rs
@@ -130,11 +130,11 @@ impl ImporterDatabase for Database {
 }
 
 impl ExecutorDatabase for Database {
-    fn store_block(
+    fn store_new_block(
         &mut self,
         chain_id: &ChainId,
         block: &SealedBlock,
-    ) -> StorageResult<Option<()>> {
+    ) -> StorageResult<bool> {
         let block_id = block.entity.id();
         let mut found = self
             .storage::<FuelBlocks>()
@@ -152,7 +152,7 @@ impl ExecutorDatabase for Database {
                 .insert(&tx.id(chain_id), tx)?
                 .is_some();
         }
-        Ok(found.then_some(()))
+        Ok(!found)
     }
 }
 

--- a/crates/fuel-core/src/service/adapters/block_importer.rs
+++ b/crates/fuel-core/src/service/adapters/block_importer.rs
@@ -6,7 +6,6 @@ use crate::{
         VerifierAdapter,
     },
 };
-use fuel_core_chain_config::ChainConfig;
 use fuel_core_importer::{
     ports::{
         BlockVerifier,
@@ -56,12 +55,11 @@ use super::{
 impl BlockImporterAdapter {
     pub fn new(
         config: Config,
-        chain_config: &ChainConfig,
         database: Database,
         executor: ExecutorAdapter,
         verifier: VerifierAdapter,
     ) -> Self {
-        let importer = Importer::new(config, chain_config, database, executor, verifier);
+        let importer = Importer::new(config, database, executor, verifier);
         importer.init_metrics();
         Self {
             block_importer: Arc::new(importer),

--- a/crates/fuel-core/src/service/adapters/block_importer.rs
+++ b/crates/fuel-core/src/service/adapters/block_importer.rs
@@ -132,7 +132,7 @@ impl ImporterDatabase for Database {
 }
 
 impl ExecutorDatabase for Database {
-    fn block(
+    fn store_block(
         &mut self,
         chain_id: &ChainId,
         block: &SealedBlock,

--- a/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module/poa.rs
@@ -18,13 +18,19 @@ use fuel_core_poa::{
         P2pPort,
         TransactionPool,
     },
-    service::SharedState,
+    service::{
+        Mode,
+        SharedState,
+    },
 };
 use fuel_core_services::stream::BoxStream;
 use fuel_core_storage::transactional::StorageTransaction;
 use fuel_core_types::{
     fuel_asm::Word,
-    fuel_tx::TxId,
+    fuel_tx::{
+        Transaction,
+        TxId,
+    },
     fuel_types::BlockHeight,
     services::{
         block_importer::{
@@ -45,6 +51,18 @@ impl PoAAdapter {
     pub fn new(shared_state: Option<SharedState>) -> Self {
         Self { shared_state }
     }
+
+    pub async fn manually_produce_blocks(
+        &self,
+        start_time: Option<Tai64>,
+        mode: Mode,
+    ) -> anyhow::Result<()> {
+        self.shared_state
+            .as_ref()
+            .ok_or(anyhow!("The block production is disabled"))?
+            .manually_produce_block(start_time, mode)
+            .await
+    }
 }
 
 #[async_trait::async_trait]
@@ -54,10 +72,7 @@ impl ConsensusModulePort for PoAAdapter {
         start_time: Option<Tai64>,
         number_of_blocks: u32,
     ) -> anyhow::Result<()> {
-        self.shared_state
-            .as_ref()
-            .ok_or(anyhow!("The block production is disabled"))?
-            .manually_produce_block(start_time, number_of_blocks)
+        self.manually_produce_blocks(start_time, Mode::Blocks { number_of_blocks })
             .await
     }
 }
@@ -91,11 +106,18 @@ impl fuel_core_poa::ports::BlockProducer for BlockProducerAdapter {
         &self,
         height: BlockHeight,
         block_time: Tai64,
+        txs: Option<Vec<Transaction>>,
         max_gas: Word,
     ) -> anyhow::Result<UncommittedResult<StorageTransaction<Database>>> {
-        self.block_producer
-            .produce_and_execute_block(height, block_time, max_gas)
-            .await
+        if let Some(txs) = txs {
+            self.block_producer
+                .produce_and_execute_block_transactions(height, block_time, txs, max_gas)
+                .await
+        } else {
+            self.block_producer
+                .produce_and_execute_block_txpool(height, block_time, max_gas)
+                .await
+        }
     }
 }
 

--- a/crates/fuel-core/src/service/adapters/executor.rs
+++ b/crates/fuel-core/src/service/adapters/executor.rs
@@ -50,10 +50,13 @@ impl fuel_core_executor::ports::TransactionsSource for TransactionsSource {
 }
 
 impl ExecutorAdapter {
-    pub(crate) fn _execute_without_commit(
+    pub(crate) fn _execute_without_commit<TxSource>(
         &self,
-        block: ExecutionBlockWithSource<TransactionsSource>,
-    ) -> ExecutorResult<UncommittedResult<StorageTransaction<Database>>> {
+        block: ExecutionBlockWithSource<TxSource>,
+    ) -> ExecutorResult<UncommittedResult<StorageTransaction<Database>>>
+    where
+        TxSource: fuel_core_executor::ports::TransactionsSource,
+    {
         let executor = Executor {
             database: self.relayer.database.clone(),
             relayer: self.relayer.clone(),

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -30,6 +30,7 @@ use fuel_core_p2p::config::{
 #[cfg(feature = "relayer")]
 use fuel_core_relayer::Config as RelayerConfig;
 
+pub use fuel_core_importer;
 pub use fuel_core_poa::Trigger;
 
 #[derive(Clone, Debug)]
@@ -51,7 +52,6 @@ pub struct Config {
     pub vm: VMConfig,
     pub txpool: fuel_core_txpool::Config,
     pub block_producer: fuel_core_producer::Config,
-    pub block_executor: fuel_core_executor::Config,
     pub block_importer: fuel_core_importer::Config,
     #[cfg(feature = "relayer")]
     pub relayer: Option<RelayerConfig>,
@@ -73,6 +73,7 @@ pub struct Config {
 impl Config {
     pub fn local_node() -> Self {
         let chain_conf = ChainConfig::local_testnet();
+        let block_importer = fuel_core_importer::Config::new(&chain_conf);
         let utxo_validation = false;
         let min_gas_price = 0;
 
@@ -99,8 +100,7 @@ impl Config {
                 ..fuel_core_txpool::Config::default()
             },
             block_producer: Default::default(),
-            block_executor: Default::default(),
-            block_importer: Default::default(),
+            block_importer,
             #[cfg(feature = "relayer")]
             relayer: None,
             #[cfg(feature = "p2p")]

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -16,7 +16,6 @@ use fuel_core_storage::{
         ContractsInfo,
         ContractsLatestUtxo,
         ContractsRawCode,
-        FuelBlocks,
         Messages,
     },
     transactional::Transactional,
@@ -125,11 +124,6 @@ fn import_genesis_block(
         &[],
     );
 
-    let block_id = block.id();
-    database.storage::<FuelBlocks>().insert(
-        &block_id,
-        &block.compress(&config.chain_conf.consensus_parameters.chain_id),
-    )?;
     let consensus = Consensus::Genesis(genesis);
     let block = SealedBlock {
         entity: block,
@@ -138,6 +132,7 @@ fn import_genesis_block(
 
     let importer = Importer::new(
         config.block_importer.clone(),
+        &config.chain_conf,
         original_database.clone(),
         (),
         (),

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -132,7 +132,6 @@ fn import_genesis_block(
 
     let importer = Importer::new(
         config.block_importer.clone(),
-        &config.chain_conf,
         original_database.clone(),
         (),
         (),

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -89,6 +89,7 @@ pub fn init_sub_services(
 
     let importer_adapter = BlockImporterAdapter::new(
         config.block_importer.clone(),
+        &config.chain_conf,
         database.clone(),
         executor.clone(),
         verifier.clone(),
@@ -205,13 +206,14 @@ pub fn init_sub_services(
         Box::new(database.clone()),
         Box::new(tx_pool_adapter),
         Box::new(producer_adapter),
-        Box::new(poa_adapter),
+        Box::new(poa_adapter.clone()),
         Box::new(p2p_adapter),
         config.query_log_threshold_time,
         config.api_request_timeout,
     )?;
 
     let shared = SharedState {
+        poa_adapter,
         txpool: txpool.shared.clone(),
         #[cfg(feature = "p2p")]
         network: network.as_ref().map(|n| n.shared.clone()),

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -89,7 +89,6 @@ pub fn init_sub_services(
 
     let importer_adapter = BlockImporterAdapter::new(
         config.block_importer.clone(),
-        &config.chain_conf,
         database.clone(),
         executor.clone(),
         verifier.clone(),

--- a/crates/services/consensus_module/poa/src/ports.rs
+++ b/crates/services/consensus_module/poa/src/ports.rs
@@ -43,6 +43,14 @@ pub trait TransactionPool: Send + Sync {
 #[cfg(test)]
 use fuel_core_storage::test_helpers::EmptyStorage;
 
+/// The source of transactions for the block.
+pub enum TransactionsSource {
+    /// The source of transactions for the block is the `TxPool`.
+    TxPool,
+    /// Use specific transactions for the block.
+    SpecificTransactions(Vec<Transaction>),
+}
+
 #[cfg_attr(test, mockall::automock(type Database=EmptyStorage;))]
 #[async_trait::async_trait]
 pub trait BlockProducer: Send + Sync {
@@ -52,7 +60,7 @@ pub trait BlockProducer: Send + Sync {
         &self,
         height: BlockHeight,
         block_time: Tai64,
-        txs: Option<Vec<Transaction>>,
+        source: TransactionsSource,
         max_gas: Word,
     ) -> anyhow::Result<UncommittedExecutionResult<StorageTransaction<Self::Database>>>;
 }

--- a/crates/services/consensus_module/poa/src/ports.rs
+++ b/crates/services/consensus_module/poa/src/ports.rs
@@ -9,7 +9,10 @@ use fuel_core_types::{
         primitives::DaBlockHeight,
     },
     fuel_asm::Word,
-    fuel_tx::TxId,
+    fuel_tx::{
+        Transaction,
+        TxId,
+    },
     fuel_types::{
         BlockHeight,
         Bytes32,
@@ -49,6 +52,7 @@ pub trait BlockProducer: Send + Sync {
         &self,
         height: BlockHeight,
         block_time: Tai64,
+        txs: Option<Vec<Transaction>>,
         max_gas: Word,
     ) -> anyhow::Result<UncommittedExecutionResult<StorageTransaction<Self::Database>>>;
 }

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -42,7 +42,10 @@ use fuel_core_types::{
     },
     fuel_asm::Word,
     fuel_crypto::Signature,
-    fuel_tx::TxId,
+    fuel_tx::{
+        Transaction,
+        TxId,
+    },
     fuel_types::BlockHeight,
     secrecy::{
         ExposeSecret,
@@ -81,16 +84,13 @@ impl SharedState {
     pub async fn manually_produce_block(
         &self,
         start_time: Option<Tai64>,
-        number_of_blocks: u32,
+        mode: Mode,
     ) -> anyhow::Result<()> {
         let (sender, receiver) = oneshot::channel();
 
         self.request_sender
             .send(Request::ManualBlocks((
-                ManualProduction {
-                    start_time,
-                    number_of_blocks,
-                },
+                ManualProduction { start_time, mode },
                 sender,
             )))
             .await?;
@@ -98,9 +98,16 @@ impl SharedState {
     }
 }
 
+pub enum Mode {
+    /// Produces `number_of_blocks` blocks using `TxPool` as a source of transactions.
+    Blocks { number_of_blocks: u32 },
+    /// Produces one block with the given transactions.
+    BlockWithTransactions(Vec<Transaction>),
+}
+
 struct ManualProduction {
     pub start_time: Option<Tai64>,
-    pub number_of_blocks: u32,
+    pub mode: Mode,
 }
 
 /// Requests accepted by the task.
@@ -248,9 +255,10 @@ where
         &self,
         height: BlockHeight,
         block_time: Tai64,
+        txs: Option<Vec<Transaction>>,
     ) -> anyhow::Result<UncommittedExecutionResult<StorageTransaction<D>>> {
         self.block_producer
-            .produce_and_execute_block(height, block_time, self.block_gas_limit)
+            .produce_and_execute_block(height, block_time, txs, self.block_gas_limit)
             .await
     }
 
@@ -258,6 +266,7 @@ where
         self.produce_block(
             self.next_height(),
             self.next_time(RequestType::Trigger)?,
+            None,
             RequestType::Trigger,
         )
         .await
@@ -272,10 +281,28 @@ where
         } else {
             self.next_time(RequestType::Manual)?
         };
-        for _ in 0..block_production.number_of_blocks {
-            self.produce_block(self.next_height(), block_time, RequestType::Manual)
+        match block_production.mode {
+            Mode::Blocks { number_of_blocks } => {
+                for _ in 0..number_of_blocks {
+                    self.produce_block(
+                        self.next_height(),
+                        block_time,
+                        None,
+                        RequestType::Manual,
+                    )
+                    .await?;
+                    block_time = self.next_time(RequestType::Manual)?;
+                }
+            }
+            Mode::BlockWithTransactions(txs) => {
+                self.produce_block(
+                    self.next_height(),
+                    block_time,
+                    Some(txs),
+                    RequestType::Manual,
+                )
                 .await?;
-            block_time = self.next_time(RequestType::Manual)?;
+            }
         }
         Ok(())
     }
@@ -284,6 +311,7 @@ where
         &mut self,
         height: BlockHeight,
         block_time: Tai64,
+        txs: Option<Vec<Transaction>>,
         request_type: RequestType,
     ) -> anyhow::Result<()> {
         let last_block_created = Instant::now();
@@ -304,7 +332,10 @@ where
                 tx_status,
             },
             db_transaction,
-        ) = self.signal_produce_block(height, block_time).await?.into();
+        ) = self
+            .signal_produce_block(height, block_time, txs)
+            .await?
+            .into();
 
         let mut tx_ids_to_remove = Vec::with_capacity(skipped_transactions.len());
         for (tx_id, err) in skipped_transactions {

--- a/crates/services/consensus_module/poa/src/service_test.rs
+++ b/crates/services/consensus_module/poa/src/service_test.rs
@@ -123,7 +123,7 @@ impl TestContextBuilder {
             let mut producer = MockBlockProducer::default();
             producer
                 .expect_produce_and_execute_block()
-                .returning(|_, _, _| {
+                .returning(|_, _, _, _| {
                     Ok(UncommittedResult::new(
                         ExecutionResult {
                             block: Default::default(),
@@ -272,7 +272,7 @@ async fn remove_skipped_transactions() {
     block_producer
         .expect_produce_and_execute_block()
         .times(1)
-        .returning(move |_, _, _| {
+        .returning(move |_, _, _, _| {
             Ok(UncommittedResult::new(
                 ExecutionResult {
                     block: Default::default(),
@@ -357,7 +357,7 @@ async fn does_not_produce_when_txpool_empty_in_instant_mode() {
 
     block_producer
         .expect_produce_and_execute_block()
-        .returning(|_, _, _| panic!("Block production should not be called"));
+        .returning(|_, _, _, _| panic!("Block production should not be called"));
 
     let mut block_importer = MockBlockImporter::default();
 

--- a/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/manually_produce_tests.rs
@@ -1,3 +1,4 @@
+use crate::service::Mode;
 use fuel_core_types::{
     blockchain::block::Block,
     tai64::Tai64,
@@ -82,7 +83,7 @@ async fn can_manually_produce_block(
     let mut producer = MockBlockProducer::default();
     producer
         .expect_produce_and_execute_block()
-        .returning(|_, time, _| {
+        .returning(|_, time, _, _| {
             let mut block = Block::default();
             block.header_mut().consensus.time = time;
             block.header_mut().recalculate_metadata();
@@ -101,7 +102,7 @@ async fn can_manually_produce_block(
 
     ctx.service
         .shared
-        .manually_produce_block(Some(start_time), number_of_blocks)
+        .manually_produce_block(Some(start_time), Mode::Blocks { number_of_blocks })
         .await
         .unwrap();
     for tx in txs {

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -13,9 +13,9 @@ use fuel_core_storage::{
         ContractsInfo,
         ContractsLatestUtxo,
         Messages,
+        ProcessedTransactions,
         Receipts,
         SpentMessages,
-        Transactions,
     },
     transactional::{
         StorageTransaction,
@@ -617,7 +617,7 @@ where
         // Throw a clear error if the transaction id is a duplicate
         if tx_st_transaction
             .as_ref()
-            .storage::<Transactions>()
+            .storage::<ProcessedTransactions>()
             .contains_key(tx_id)?
         {
             return Err(ExecutorError::TransactionIdCollision(*tx_id))
@@ -811,8 +811,8 @@ where
 
         if block_st_transaction
             .as_mut()
-            .storage::<Transactions>()
-            .insert(&coinbase_id, &tx)?
+            .storage::<ProcessedTransactions>()
+            .insert(&coinbase_id, &())?
             .is_some()
         {
             return Err(ExecutorError::TransactionIdCollision(coinbase_id))
@@ -967,8 +967,8 @@ where
         // Store tx into the block db transaction
         tx_st_transaction
             .as_mut()
-            .storage::<Transactions>()
-            .insert(&tx_id, &final_tx)?;
+            .storage::<ProcessedTransactions>()
+            .insert(&tx_id, &())?;
 
         // persist receipts
         self.persist_receipts(&tx_id, &receipts, tx_st_transaction.as_mut())?;

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -12,7 +12,6 @@ use fuel_core_storage::{
         Coins,
         ContractsInfo,
         ContractsLatestUtxo,
-        FuelBlocks,
         Messages,
         Receipts,
         SpentMessages,
@@ -457,17 +456,6 @@ where
         self.index_tx_owners_for_block(&result.block, block_st_transaction.as_mut())?;
 
         // ------------ GraphQL API Functionality   END ------------
-
-        // insert block into database
-        block_st_transaction
-            .as_mut()
-            .storage::<FuelBlocks>()
-            .insert(
-                &finalized_block_id,
-                &result
-                    .block
-                    .compress(&self.config.consensus_parameters.chain_id),
-            )?;
 
         // Get the complete fuel block.
         Ok(UncommittedResult::new(result, block_st_transaction))

--- a/crates/services/executor/src/ports.rs
+++ b/crates/services/executor/src/ports.rs
@@ -7,9 +7,9 @@ use fuel_core_storage::{
         ContractsRawCode,
         ContractsState,
         Messages,
+        ProcessedTransactions,
         Receipts,
         SpentMessages,
-        Transactions,
     },
     transactional::Transactional,
     vm_storage::VmStorageRequirements,
@@ -109,7 +109,7 @@ pub trait TxIdOwnerRecorder {
 // TODO: Remove `Clone` bound
 pub trait ExecutorDatabaseTrait<D>:
     StorageMutate<Receipts, Error = StorageError>
-    + StorageMutate<Transactions, Error = StorageError>
+    + StorageMutate<ProcessedTransactions, Error = StorageError>
     + MerkleRootStorage<ContractId, ContractsAssets, Error = StorageError>
     + MessageIsSpent<Error = StorageError>
     + StorageMutate<Coins, Error = StorageError>

--- a/crates/services/executor/src/ports.rs
+++ b/crates/services/executor/src/ports.rs
@@ -6,7 +6,6 @@ use fuel_core_storage::{
         ContractsLatestUtxo,
         ContractsRawCode,
         ContractsState,
-        FuelBlocks,
         Messages,
         Receipts,
         SpentMessages,
@@ -109,11 +108,9 @@ pub trait TxIdOwnerRecorder {
 
 // TODO: Remove `Clone` bound
 pub trait ExecutorDatabaseTrait<D>:
-    StorageMutate<FuelBlocks, Error = StorageError>
-    + StorageMutate<Receipts, Error = StorageError>
+    StorageMutate<Receipts, Error = StorageError>
     + StorageMutate<Transactions, Error = StorageError>
-    + MerkleRootStorage<ContractId, ContractsAssets>
-    + StorageInspect<ContractsAssets, Error = StorageError>
+    + MerkleRootStorage<ContractId, ContractsAssets, Error = StorageError>
     + MessageIsSpent<Error = StorageError>
     + StorageMutate<Coins, Error = StorageError>
     + StorageMutate<SpentMessages, Error = StorageError>

--- a/crates/services/importer/Cargo.toml
+++ b/crates/services/importer/Cargo.toml
@@ -12,6 +12,7 @@ description = "Fuel Block Importer"
 [dependencies]
 anyhow = { workspace = true }
 derive_more = { workspace = true }
+fuel-core-chain-config = { workspace = true }
 fuel-core-metrics = { workspace = true }
 fuel-core-storage = { workspace = true }
 fuel-core-types = { workspace = true }

--- a/crates/services/importer/src/config.rs
+++ b/crates/services/importer/src/config.rs
@@ -1,14 +1,30 @@
+use fuel_core_chain_config::ChainConfig;
+use fuel_core_types::fuel_types::ChainId;
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub max_block_notify_buffer: usize,
     pub metrics: bool,
+    pub chain_id: ChainId,
 }
 
+impl Config {
+    pub fn new(chain_config: &ChainConfig) -> Self {
+        Self {
+            max_block_notify_buffer: 1 << 10,
+            metrics: false,
+            chain_id: chain_config.consensus_parameters.chain_id,
+        }
+    }
+}
+
+#[cfg(test)]
 impl Default for Config {
     fn default() -> Self {
         Self {
             max_block_notify_buffer: 1 << 10,
             metrics: false,
+            chain_id: ChainId::default(),
         }
     }
 }

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -245,9 +245,9 @@ where
             ))
         }
 
-        db_after_execution
-            .store_block(&self.chain_id, &result.sealed_block)?
-            .should_be_unique(&expected_next_height)?;
+        if !db_after_execution.store_new_block(&self.chain_id, &result.sealed_block)? {
+            return Err(Error::NotUnique(expected_next_height))
+        }
 
         // Update the total tx count in chain metadata
         let total_txs = db_after_execution

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -199,7 +199,6 @@ where
         let (result, mut db_tx) = result.into();
         let block = &result.sealed_block.entity;
         let consensus = &result.sealed_block.consensus;
-        let block_id = block.id();
         let actual_next_height = *block.header().height();
 
         // During importing of the genesis block, the database should not be initialized
@@ -254,10 +253,7 @@ where
         }
 
         db_after_execution
-            .block(&block_id, &block.compress(&self.chain_id))?
-            .should_be_unique(&expected_next_height)?;
-        db_after_execution
-            .seal_block(&block_id, &result.sealed_block.consensus)?
+            .block(&self.chain_id, &result.sealed_block)?
             .should_be_unique(&expected_next_height)?;
 
         // Update the total tx count in chain metadata

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     Config,
 };
-use fuel_core_chain_config::ChainConfig;
 use fuel_core_metrics::importer::importer_metrics;
 use fuel_core_storage::{
     not_found,
@@ -114,20 +113,14 @@ pub struct Importer<D, E, V> {
 }
 
 impl<D, E, V> Importer<D, E, V> {
-    pub fn new(
-        config: Config,
-        chain_config: &ChainConfig,
-        database: D,
-        executor: E,
-        verifier: V,
-    ) -> Self {
+    pub fn new(config: Config, database: D, executor: E, verifier: V) -> Self {
         let (broadcast, _) = broadcast::channel(config.max_block_notify_buffer);
 
         Self {
             database,
             executor,
             verifier,
-            chain_id: chain_config.consensus_parameters.chain_id,
+            chain_id: config.chain_id,
             broadcast,
             guard: tokio::sync::Semaphore::new(1),
         }

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -253,7 +253,7 @@ where
         }
 
         db_after_execution
-            .block(&self.chain_id, &result.sealed_block)?
+            .store_block(&self.chain_id, &result.sealed_block)?
             .should_be_unique(&expected_next_height)?;
 
         // Update the total tx count in chain metadata

--- a/crates/services/importer/src/importer/test.rs
+++ b/crates/services/importer/src/importer/test.rs
@@ -358,13 +358,7 @@ fn commit_result_assert(
     executor_db: MockDatabase,
 ) -> Result<(), Error> {
     let expected_to_broadcast = sealed_block.clone();
-    let importer = Importer::new(
-        Default::default(),
-        &Default::default(),
-        underlying_db,
-        (),
-        (),
-    );
+    let importer = Importer::new(Default::default(), underlying_db, (), ());
     let uncommitted_result = UncommittedResult::new(
         ImportResult::new_from_local(sealed_block, vec![]),
         StorageTransaction::new(executor_db),
@@ -394,13 +388,7 @@ fn execute_and_commit_assert(
     verifier: MockBlockVerifier,
 ) -> Result<(), Error> {
     let expected_to_broadcast = sealed_block.clone();
-    let importer = Importer::new(
-        Default::default(),
-        &Default::default(),
-        underlying_db,
-        executor,
-        verifier,
-    );
+    let importer = Importer::new(Default::default(), underlying_db, executor, verifier);
 
     let mut imported_blocks = importer.subscribe();
     let result = importer.execute_and_commit(sealed_block);
@@ -421,13 +409,7 @@ fn execute_and_commit_assert(
 
 #[test]
 fn commit_result_fail_when_locked() {
-    let importer = Importer::new(
-        Default::default(),
-        &Default::default(),
-        MockDatabase::default(),
-        (),
-        (),
-    );
+    let importer = Importer::new(Default::default(), MockDatabase::default(), (), ());
     let uncommitted_result = UncommittedResult::new(
         ImportResult::default(),
         StorageTransaction::new(MockDatabase::default()),
@@ -444,7 +426,6 @@ fn commit_result_fail_when_locked() {
 fn execute_and_commit_fail_when_locked() {
     let importer = Importer::new(
         Default::default(),
-        &Default::default(),
         MockDatabase::default(),
         MockExecutor::default(),
         MockBlockVerifier::default(),
@@ -461,7 +442,6 @@ fn execute_and_commit_fail_when_locked() {
 fn one_lock_at_the_same_time() {
     let importer = Importer::new(
         Default::default(),
-        &Default::default(),
         MockDatabase::default(),
         MockExecutor::default(),
         MockBlockVerifier::default(),
@@ -556,7 +536,6 @@ where
 {
     let importer = Importer::new(
         Default::default(),
-        &Default::default(),
         MockDatabase::default(),
         executor(block_after_execution, MockDatabase::default()),
         verifier(verifier_result),
@@ -569,7 +548,6 @@ where
 fn verify_and_execute_allowed_when_locked() {
     let importer = Importer::new(
         Default::default(),
-        &Default::default(),
         MockDatabase::default(),
         executor(ok(ex_result(13, 0)), MockDatabase::default()),
         verifier(ok(())),

--- a/crates/services/importer/src/importer/test.rs
+++ b/crates/services/importer/src/importer/test.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use anyhow::anyhow;
 use fuel_core_storage::{
-    not_found,
     transactional::{
         StorageTransaction,
         Transaction as TransactionTrait,
@@ -20,7 +19,10 @@ use fuel_core_storage::{
 };
 use fuel_core_types::{
     blockchain::{
-        block::Block,
+        block::{
+            Block,
+            CompressedBlock,
+        },
         consensus::Consensus,
         primitives::BlockId,
         SealedBlock,
@@ -50,7 +52,7 @@ mockall::mock! {
     pub Database {}
 
     impl ImporterDatabase for Database {
-        fn latest_block_height(&self) -> StorageResult<BlockHeight>;
+        fn latest_block_height(&self) -> StorageResult<Option<BlockHeight>>;
         fn increase_tx_count(&self, new_txs_count: u64) -> StorageResult<u64>;
     }
 
@@ -59,7 +61,10 @@ mockall::mock! {
             &mut self,
             block_id: &BlockId,
             consensus: &Consensus,
-        ) -> StorageResult<Option<Consensus>>;
+        ) -> StorageResult<Option<()>>;
+
+        fn block(&mut self, block_id: &BlockId, block: &CompressedBlock)
+            -> StorageResult<Option<()>>;
     }
 
     impl TransactionTrait<MockDatabase> for Database {
@@ -109,30 +114,38 @@ fn poa_block(height: u32) -> SealedBlock {
 
 fn underlying_db<R>(result: R) -> impl Fn() -> MockDatabase
 where
-    R: Fn() -> StorageResult<u32> + Send + Clone + 'static,
+    R: Fn() -> StorageResult<Option<u32>> + Send + Clone + 'static,
 {
     move || {
         let result = result.clone();
         let mut db = MockDatabase::default();
         db.expect_latest_block_height()
-            .returning(move || result().map(Into::into));
+            .returning(move || result().map(|v| v.map(Into::into)));
         db.expect_increase_tx_count().returning(Ok);
         db
     }
 }
 
-fn executor_db<H, S>(height: H, seal: S, commits: usize) -> impl Fn() -> MockDatabase
+fn executor_db<H, S, B>(
+    height: H,
+    seal: S,
+    block: B,
+    commits: usize,
+) -> impl Fn() -> MockDatabase
 where
-    H: Fn() -> StorageResult<u32> + Send + Clone + 'static,
-    S: Fn() -> StorageResult<Option<Consensus>> + Send + Clone + 'static,
+    H: Fn() -> StorageResult<Option<u32>> + Send + Clone + 'static,
+    S: Fn() -> StorageResult<Option<()>> + Send + Clone + 'static,
+    B: Fn() -> StorageResult<Option<()>> + Send + Clone + 'static,
 {
     move || {
         let height = height.clone();
         let seal = seal.clone();
+        let block = block.clone();
         let mut db = MockDatabase::default();
         db.expect_latest_block_height()
-            .returning(move || height().map(Into::into));
+            .returning(move || height().map(|v| v.map(Into::into)));
         db.expect_seal_block().returning(move |_, _| seal());
+        db.expect_block().returning(move |_, _| block());
         db.expect_commit().times(commits).returning(|| Ok(()));
         db.expect_increase_tx_count().returning(Ok);
         db
@@ -143,16 +156,12 @@ fn ok<T: Clone, Err>(entity: T) -> impl Fn() -> Result<T, Err> + Clone {
     move || Ok(entity.clone())
 }
 
-fn not_found<T>() -> StorageResult<T> {
-    Err(not_found!("Not found"))
-}
-
 fn storage_failure<T>() -> StorageResult<T> {
     Err(StorageError::Other(anyhow!("Some failure")))
 }
 
 fn storage_failure_error() -> Error {
-    Error::StorageError(StorageError::Other(anyhow!("Some failure")))
+    storage_failure::<()>().unwrap_err().into()
 }
 
 fn ex_result(height: u32, skipped_transactions: usize) -> MockExecutionResult {
@@ -200,7 +209,7 @@ fn verification_failure<T>() -> anyhow::Result<T> {
 }
 
 fn verification_failure_error() -> Error {
-    Error::FailedVerification(anyhow!("Not verified"))
+    Error::FailedVerification(verification_failure::<()>().unwrap_err())
 }
 
 fn verifier<R>(result: R) -> MockBlockVerifier
@@ -219,45 +228,52 @@ where
 //////////////// //////////// Genesis Block /////////// ////////////////
 #[test_case(
     genesis(0),
-    underlying_db(not_found),
-    executor_db(ok(0), ok(None), 1)
+    underlying_db(ok(None)),
+    executor_db(ok(None), ok(None), ok(None), 1)
     => Ok(());
     "successfully imports genesis block when latest block not found"
 )]
 #[test_case(
     genesis(113),
-    underlying_db(not_found),
-    executor_db(ok(113), ok(None), 1)
+    underlying_db(ok(None)),
+    executor_db(ok(None), ok(None), ok(None), 1)
     => Ok(());
     "successfully imports block at arbitrary height when executor db expects it and last block not found" 
 )]
 #[test_case(
     genesis(0),
     underlying_db(storage_failure),
-    executor_db(ok(0), ok(None), 0)
-    => Err(Error::InvalidUnderlyingDatabaseGenesisState);
+    executor_db(ok(Some(0)), ok(None), ok(None), 0)
+    => Err(storage_failure_error());
     "fails to import genesis when underlying database fails"
 )]
 #[test_case(
     genesis(0),
-    underlying_db(ok(0)),
-    executor_db(ok(0), ok(None), 0)
+    underlying_db(ok(Some(0))),
+    executor_db(ok(Some(0)), ok(None), ok(None), 0)
     => Err(Error::InvalidUnderlyingDatabaseGenesisState);
     "fails to import genesis block when already exists"
 )]
 #[test_case(
     genesis(1),
-    underlying_db(not_found),
-    executor_db(ok(0), ok(None), 0)
-    => Err(Error::InvalidDatabaseStateAfterExecution(1u32.into(), 0u32.into()));
+    underlying_db(ok(None)),
+    executor_db(ok(Some(0)), ok(None), ok(None), 0)
+    => Err(Error::InvalidDatabaseStateAfterExecution(None, Some(0u32.into())));
     "fails to import genesis block when next height is not 0"
 )]
 #[test_case(
     genesis(0),
-    underlying_db(not_found),
-    executor_db(ok(0), ok(Some(Consensus::Genesis(Default::default()))), 0)
+    underlying_db(ok(None)),
+    executor_db(ok(None), ok(Some(())), ok(None), 0)
     => Err(Error::NotUnique(0u32.into()));
     "fails to import genesis block when consensus exists for height 0"
+)]
+#[test_case(
+    genesis(0),
+    underlying_db(ok(None)),
+    executor_db(ok(None), ok(None), ok(Some(())), 0)
+    => Err(Error::NotUnique(0u32.into()));
+    "fails to import genesis block when block exists for height 0"
 )]
 fn commit_result_genesis(
     sealed_block: SealedBlock,
@@ -270,66 +286,80 @@ fn commit_result_genesis(
 //////////////////////////// PoA Block ////////////////////////////
 #[test_case(
     poa_block(1),
-    underlying_db(ok(0)),
-    executor_db(ok(1), ok(None), 1)
+    underlying_db(ok(Some(0))),
+    executor_db(ok(Some(0)), ok(None), ok(None), 1)
     => Ok(());
     "successfully imports block at height 1 when latest block is genesis"
 )]
 #[test_case(
     poa_block(113),
-    underlying_db(ok(112)),
-    executor_db(ok(113), ok(None), 1)
+    underlying_db(ok(Some(112))),
+    executor_db(ok(Some(112)), ok(None), ok(None), 1)
     => Ok(());
     "successfully imports block at arbitrary height when latest block height is one fewer and executor db expects it"
 )]
 #[test_case(
     poa_block(0),
-    underlying_db(ok(0)),
-    executor_db(ok(1), ok(None), 0)
+    underlying_db(ok(Some(0))),
+    executor_db(ok(Some(1)), ok(None), ok(None), 0)
     => Err(Error::ZeroNonGenericHeight);
     "fails to import PoA block with height 0"
 )]
 #[test_case(
     poa_block(113),
-    underlying_db(ok(111)),
-    executor_db(ok(113), ok(None), 0)
+    underlying_db(ok(Some(111))),
+    executor_db(ok(Some(113)), ok(None), ok(None), 0)
     => Err(Error::IncorrectBlockHeight(112u32.into(), 113u32.into()));
     "fails to import block at height 113 when latest block height is 111"
 )]
 #[test_case(
     poa_block(113),
-    underlying_db(ok(114)),
-    executor_db(ok(113), ok(None), 0)
+    underlying_db(ok(Some(114))),
+    executor_db(ok(Some(113)), ok(None), ok(None), 0)
     => Err(Error::IncorrectBlockHeight(115u32.into(), 113u32.into()));
     "fails to import block at height 113 when latest block height is 114"
 )]
 #[test_case(
     poa_block(113),
-    underlying_db(ok(112)),
-    executor_db(ok(114), ok(None), 0)
-    => Err(Error::InvalidDatabaseStateAfterExecution(113u32.into(), 114u32.into()));
+    underlying_db(ok(Some(112))),
+    executor_db(ok(Some(114)), ok(None), ok(None), 0)
+    => Err(Error::InvalidDatabaseStateAfterExecution(Some(112u32.into()), Some(114u32.into())));
     "fails to import block 113 when executor db expects height 114"
 )]
 #[test_case(
     poa_block(113),
-    underlying_db(ok(112)),
-    executor_db(storage_failure, ok(None), 0)
+    underlying_db(ok(Some(112))),
+    executor_db(storage_failure, ok(None), ok(None), 0)
     => Err(storage_failure_error());
     "fails to import block when executor db fails to find latest block"
 )]
 #[test_case(
     poa_block(113),
-    underlying_db(ok(112)),
-    executor_db(ok(113), ok(Some(Consensus::PoA(Default::default()))), 0)
+    underlying_db(ok(Some(112))),
+    executor_db(ok(Some(112)), ok(Some(())), ok(None), 0)
     => Err(Error::NotUnique(113u32.into()));
     "fails to import block when consensus exists for block"
 )]
 #[test_case(
     poa_block(113),
-    underlying_db(ok(112)),
-    executor_db(ok(113), storage_failure, 0)
+    underlying_db(ok(Some(112))),
+    executor_db(ok(Some(112)), storage_failure, ok(None), 0)
     => Err(storage_failure_error());
     "fails to import block when executor db fails to find consensus"
+)]
+#[test_case(
+    poa_block(113),
+    underlying_db(ok(Some(112))),
+    executor_db(ok(Some(112)), ok(None), ok(Some(())), 0)
+    => Err(Error::NotUnique(113u32.into()));
+    "fails to import block when block exists"
+)]
+#[test_case(
+    poa_block(113),
+    underlying_db(ok(Some(112))),
+    executor_db(ok(Some(112)), ok(None), storage_failure, 0)
+    => Err(storage_failure_error());
+    "fails to import block when executor db fails to find block"
 )]
 fn commit_result_and_execute_and_commit_poa(
     sealed_block: SealedBlock,
@@ -357,7 +387,13 @@ fn commit_result_assert(
     executor_db: MockDatabase,
 ) -> Result<(), Error> {
     let expected_to_broadcast = sealed_block.clone();
-    let importer = Importer::new(Default::default(), underlying_db, (), ());
+    let importer = Importer::new(
+        Default::default(),
+        &Default::default(),
+        underlying_db,
+        (),
+        (),
+    );
     let uncommitted_result = UncommittedResult::new(
         ImportResult::new_from_local(sealed_block, vec![]),
         StorageTransaction::new(executor_db),
@@ -387,7 +423,13 @@ fn execute_and_commit_assert(
     verifier: MockBlockVerifier,
 ) -> Result<(), Error> {
     let expected_to_broadcast = sealed_block.clone();
-    let importer = Importer::new(Default::default(), underlying_db, executor, verifier);
+    let importer = Importer::new(
+        Default::default(),
+        &Default::default(),
+        underlying_db,
+        executor,
+        verifier,
+    );
 
     let mut imported_blocks = importer.subscribe();
     let result = importer.execute_and_commit(sealed_block);
@@ -408,7 +450,13 @@ fn execute_and_commit_assert(
 
 #[test]
 fn commit_result_fail_when_locked() {
-    let importer = Importer::new(Default::default(), MockDatabase::default(), (), ());
+    let importer = Importer::new(
+        Default::default(),
+        &Default::default(),
+        MockDatabase::default(),
+        (),
+        (),
+    );
     let uncommitted_result = UncommittedResult::new(
         ImportResult::default(),
         StorageTransaction::new(MockDatabase::default()),
@@ -425,6 +473,7 @@ fn commit_result_fail_when_locked() {
 fn execute_and_commit_fail_when_locked() {
     let importer = Importer::new(
         Default::default(),
+        &Default::default(),
         MockDatabase::default(),
         MockExecutor::default(),
         MockBlockVerifier::default(),
@@ -441,6 +490,7 @@ fn execute_and_commit_fail_when_locked() {
 fn one_lock_at_the_same_time() {
     let importer = Importer::new(
         Default::default(),
+        &Default::default(),
         MockDatabase::default(),
         MockExecutor::default(),
         MockBlockVerifier::default(),
@@ -513,10 +563,10 @@ where
     let previous_height = expected_height.checked_sub(1).unwrap_or_default();
     let execute_and_commit_result = execute_and_commit_assert(
         sealed_block,
-        underlying_db(ok(previous_height))(),
+        underlying_db(ok(Some(previous_height)))(),
         executor(
             block_after_execution,
-            executor_db(ok(expected_height), ok(None), commits)(),
+            executor_db(ok(Some(previous_height)), ok(None), ok(None), commits)(),
         ),
         verifier(verifier_result),
     );
@@ -535,6 +585,7 @@ where
 {
     let importer = Importer::new(
         Default::default(),
+        &Default::default(),
         MockDatabase::default(),
         executor(block_after_execution, MockDatabase::default()),
         verifier(verifier_result),
@@ -547,6 +598,7 @@ where
 fn verify_and_execute_allowed_when_locked() {
     let importer = Importer::new(
         Default::default(),
+        &Default::default(),
         MockDatabase::default(),
         executor(ok(ex_result(13, 0)), MockDatabase::default()),
         verifier(ok(())),

--- a/crates/services/importer/src/ports.rs
+++ b/crates/services/importer/src/ports.rs
@@ -43,14 +43,16 @@ pub trait ImporterDatabase {
 
 /// The port for returned database from the executor.
 pub trait ExecutorDatabase: ImporterDatabase {
-    /// Inserts the `SealedBlock` under the `block_id`.
+    /// Inserts the `SealedBlock`.
+    ///
+    /// The method returns `true` if the block is a new, otherwise `false`.
     // TODO: Remove `chain_id` from the signature, but for that transactions inside
     //  the block should have `cached_id`. We need to guarantee that from the Rust-type system.
-    fn store_block(
+    fn store_new_block(
         &mut self,
         chain_id: &ChainId,
         block: &SealedBlock,
-    ) -> StorageResult<Option<()>>;
+    ) -> StorageResult<bool>;
 }
 
 #[cfg_attr(test, mockall::automock)]

--- a/crates/services/importer/src/ports.rs
+++ b/crates/services/importer/src/ports.rs
@@ -4,14 +4,14 @@ use fuel_core_storage::{
 };
 use fuel_core_types::{
     blockchain::{
-        block::{
-            Block,
-            CompressedBlock,
-        },
+        block::Block,
         consensus::Consensus,
-        primitives::BlockId,
+        SealedBlock,
     },
-    fuel_types::BlockHeight,
+    fuel_types::{
+        BlockHeight,
+        ChainId,
+    },
     services::executor::{
         Result as ExecutorResult,
         UncommittedResult,
@@ -43,19 +43,13 @@ pub trait ImporterDatabase {
 
 /// The port for returned database from the executor.
 pub trait ExecutorDatabase: ImporterDatabase {
-    /// Assigns the `Consensus` data to the block under the `block_id`.
-    /// Return the previous value at the `height`, if any.
-    fn seal_block(
-        &mut self,
-        block_id: &BlockId,
-        consensus: &Consensus,
-    ) -> StorageResult<Option<()>>;
-
-    /// Inserts the `CompressedBlock` under the `block_id`.
+    /// Inserts the `SealedBlock` under the `block_id`.
+    // TODO: Remove `chain_id` from the signature, but for that transactions inside
+    //  the block should have `cached_id`. We need to guarantee that from the Rust-type system.
     fn block(
         &mut self,
-        block_id: &BlockId,
-        block: &CompressedBlock,
+        chain_id: &ChainId,
+        block: &SealedBlock,
     ) -> StorageResult<Option<()>>;
 }
 

--- a/crates/services/importer/src/ports.rs
+++ b/crates/services/importer/src/ports.rs
@@ -46,7 +46,7 @@ pub trait ExecutorDatabase: ImporterDatabase {
     /// Inserts the `SealedBlock` under the `block_id`.
     // TODO: Remove `chain_id` from the signature, but for that transactions inside
     //  the block should have `cached_id`. We need to guarantee that from the Rust-type system.
-    fn block(
+    fn store_block(
         &mut self,
         chain_id: &ChainId,
         block: &SealedBlock,

--- a/crates/services/importer/src/ports.rs
+++ b/crates/services/importer/src/ports.rs
@@ -4,7 +4,10 @@ use fuel_core_storage::{
 };
 use fuel_core_types::{
     blockchain::{
-        block::Block,
+        block::{
+            Block,
+            CompressedBlock,
+        },
         consensus::Consensus,
         primitives::BlockId,
     },
@@ -32,7 +35,7 @@ pub trait Executor: Send + Sync {
 /// The database port used by the block importer.
 pub trait ImporterDatabase {
     /// Returns the latest block height.
-    fn latest_block_height(&self) -> StorageResult<BlockHeight>;
+    fn latest_block_height(&self) -> StorageResult<Option<BlockHeight>>;
     /// Update metadata about the total number of transactions on the chain.
     /// Returns the total count after the update.
     fn increase_tx_count(&self, new_txs_count: u64) -> StorageResult<u64>;
@@ -46,7 +49,14 @@ pub trait ExecutorDatabase: ImporterDatabase {
         &mut self,
         block_id: &BlockId,
         consensus: &Consensus,
-    ) -> StorageResult<Option<Consensus>>;
+    ) -> StorageResult<Option<()>>;
+
+    /// Inserts the `CompressedBlock` under the `block_id`.
+    fn block(
+        &mut self,
+        block_id: &BlockId,
+        block: &CompressedBlock,
+    ) -> StorageResult<Option<()>>;
 }
 
 #[cfg_attr(test, mockall::automock)]

--- a/crates/services/producer/src/block_producer/tests.rs
+++ b/crates/services/producer/src/block_producer/tests.rs
@@ -42,7 +42,7 @@ async fn cant_produce_at_genesis_height() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_and_execute_block(0u32.into(), Tai64::now(), 1_000_000_000)
+        .produce_and_execute_block_txpool(0u32.into(), Tai64::now(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 
@@ -58,7 +58,7 @@ async fn can_produce_initial_block() {
     let producer = ctx.producer();
 
     let result = producer
-        .produce_and_execute_block(1u32.into(), Tai64::now(), 1_000_000_000)
+        .produce_and_execute_block_txpool(1u32.into(), Tai64::now(), 1_000_000_000)
         .await;
 
     assert!(result.is_ok());
@@ -93,7 +93,7 @@ async fn can_produce_next_block() {
     let ctx = TestContext::default_from_db(db);
     let producer = ctx.producer();
     let result = producer
-        .produce_and_execute_block(
+        .produce_and_execute_block_txpool(
             prev_height
                 .succ()
                 .expect("The block height should be valid"),
@@ -112,7 +112,7 @@ async fn cant_produce_if_no_previous_block() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_and_execute_block(100u32.into(), Tai64::now(), 1_000_000_000)
+        .produce_and_execute_block_txpool(100u32.into(), Tai64::now(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 
@@ -156,7 +156,7 @@ async fn cant_produce_if_previous_block_da_height_too_high() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_and_execute_block(
+        .produce_and_execute_block_txpool(
             prev_height
                 .succ()
                 .expect("The block height should be valid"),
@@ -187,7 +187,7 @@ async fn production_fails_on_execution_error() {
     let producer = ctx.producer();
 
     let err = producer
-        .produce_and_execute_block(1u32.into(), Tai64::now(), 1_000_000_000)
+        .produce_and_execute_block_txpool(1u32.into(), Tai64::now(), 1_000_000_000)
         .await
         .expect_err("expected failure");
 

--- a/crates/services/producer/src/ports.rs
+++ b/crates/services/producer/src/ports.rs
@@ -58,19 +58,19 @@ pub trait Relayer: Send + Sync {
     ) -> anyhow::Result<DaBlockHeight>;
 }
 
-pub trait Executor: Send + Sync {
+pub trait Executor<TxSource>: Send + Sync {
     /// The database used by the executor.
     type Database;
-    /// The source of transaction used by the executor.
-    type TxSource;
 
     /// Executes the block and returns the result of execution with uncommitted database
     /// transaction.
     fn execute_without_commit(
         &self,
-        component: Components<Self::TxSource>,
+        component: Components<TxSource>,
     ) -> ExecutorResult<UncommittedResult<StorageTransaction<Self::Database>>>;
+}
 
+pub trait DryRunner: Send + Sync {
     /// Executes the block without committing it to the database. During execution collects the
     /// receipts to return them. The `utxo_validation` field can be used to disable the validation
     /// of utxos during execution.

--- a/crates/storage/src/tables.rs
+++ b/crates/storage/src/tables.rs
@@ -121,5 +121,16 @@ impl Mappable for Transactions {
     type OwnedValue = Transaction;
 }
 
+/// The storage table of processed transactions that were executed in the past.
+/// The table helps to drop duplicated transactions.
+pub struct ProcessedTransactions;
+
+impl Mappable for ProcessedTransactions {
+    type Key = Self::OwnedKey;
+    type OwnedKey = TxId;
+    type Value = Self::OwnedValue;
+    type OwnedValue = ();
+}
+
 // TODO: Add macro to define all common tables to avoid copy/paste of the code.
 // TODO: Add macro to define common unit tests.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,7 +24,7 @@ ethers = "2"
 fuel-core = { path = "../crates/fuel-core", default-features = false, features = ["test-helpers"] }
 fuel-core-benches = { path = "../benches" }
 fuel-core-client = { path = "../crates/client", features = ["test-helpers"] }
-fuel-core-executor = { workspace = true, features = ["test-helpers"] }
+fuel-core-executor = { workspace = true }
 fuel-core-p2p = { path = "../crates/services/p2p", features = ["test-helpers"], optional = true }
 fuel-core-poa = { path = "../crates/services/consensus_module/poa" }
 fuel-core-relayer = { path = "../crates/services/relayer", features = [

--- a/tests/tests/tx.rs
+++ b/tests/tests/tx.rs
@@ -1,9 +1,7 @@
 use crate::helpers::TestContext;
 use fuel_core::{
-    database::Database,
     schema::tx::receipt::all_receipts,
     service::{
-        adapters::MaybeRelayerAdapter,
         Config,
         FuelService,
     },
@@ -16,20 +14,12 @@ use fuel_core_client::client::{
     types::TransactionStatus,
     FuelClient,
 };
-use fuel_core_executor::executor::Executor;
+use fuel_core_poa::service::Mode;
 use fuel_core_types::{
-    blockchain::{
-        block::PartialFuelBlock,
-        header::{
-            ConsensusHeader,
-            PartialBlockHeader,
-        },
-    },
     fuel_asm::*,
+    fuel_crypto::SecretKey,
     fuel_tx::*,
     fuel_types::ChainId,
-    services::executor::ExecutionBlock,
-    tai64::Tai64,
 };
 use itertools::Itertools;
 use rand::{
@@ -503,55 +493,30 @@ async fn get_transactions_by_owner_supports_cursor(direction: PageDirection) {
 
 #[tokio::test]
 async fn get_transactions_from_manual_blocks() {
-    let (executor, db) = get_executor_and_db();
-    // get access to a client
-    let context = initialize_client(db).await;
+    let context = TestContext::new(100).await;
 
     // create 10 txs
-    let txs: Vec<Transaction> = (0..10).map(create_mock_tx).collect();
+    let txs: Vec<_> = (0..10).map(create_mock_tx).collect();
 
     // make 1st test block
-    let first_test_block = PartialFuelBlock {
-        header: PartialBlockHeader {
-            consensus: ConsensusHeader {
-                height: 1u32.into(),
-                time: Tai64::now(),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-
-        // set the first 5 ids of the manually saved txs
-        transactions: txs.iter().take(5).cloned().collect(),
-    };
+    let first_batch = txs.iter().take(5).cloned().collect();
+    context
+        .srv
+        .shared
+        .poa_adapter
+        .manually_produce_blocks(None, Mode::BlockWithTransactions(first_batch))
+        .await
+        .expect("Should produce first block with first 5 transactions.");
 
     // make 2nd test block
-    let second_test_block = PartialFuelBlock {
-        header: PartialBlockHeader {
-            consensus: ConsensusHeader {
-                height: 2u32.into(),
-                time: Tai64::now(),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        // set the last 5 ids of the manually saved txs
-        transactions: txs.iter().skip(5).take(5).cloned().collect(),
-    };
-
-    // process blocks and save block height
-    executor
-        .execute_and_commit(
-            ExecutionBlock::Production(first_test_block),
-            Default::default(),
-        )
-        .unwrap();
-    executor
-        .execute_and_commit(
-            ExecutionBlock::Production(second_test_block),
-            Default::default(),
-        )
-        .unwrap();
+    let second_batch = txs.iter().skip(5).take(5).cloned().collect();
+    context
+        .srv
+        .shared
+        .poa_adapter
+        .manually_produce_blocks(None, Mode::BlockWithTransactions(second_batch))
+        .await
+        .expect("Should produce block with last 5 transactions.");
 
     // Query for first 4: [0, 1, 2, 3]
     let page_request_forwards = PaginationRequest {
@@ -672,38 +637,18 @@ async fn get_owned_transactions() {
     assert_eq!(&charlie_txs, &[tx1, tx2, tx3]);
 }
 
-fn get_executor_and_db() -> (Executor<MaybeRelayerAdapter, Database>, Database) {
-    let db = Database::default();
-    let relayer = MaybeRelayerAdapter {
-        database: db.clone(),
-        #[cfg(feature = "relayer")]
-        relayer_synced: None,
-        #[cfg(feature = "relayer")]
-        da_deploy_height: 0u64.into(),
-    };
-    let executor = Executor {
-        relayer,
-        database: db.clone(),
-        config: Default::default(),
-    };
-
-    (executor, db)
-}
-
-async fn initialize_client(db: Database) -> TestContext {
-    let config = Config::local_node();
-    let srv = FuelService::from_database(db, config).await.unwrap();
-    let client = FuelClient::from(srv.bound_address);
-    TestContext {
-        srv,
-        rng: StdRng::seed_from_u64(0x123),
-        client,
-    }
-}
-
 // add random val for unique tx
 fn create_mock_tx(val: u64) -> Transaction {
+    let mut rng = StdRng::seed_from_u64(val);
+
     TransactionBuilder::script(val.to_be_bytes().to_vec(), Default::default())
-        .add_random_fee_input()
+        .add_unsigned_coin_input(
+            SecretKey::random(&mut rng),
+            rng.gen(),
+            1_000_000,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        )
         .finalize_as_transaction()
 }


### PR DESCRIPTION
Related to https://github.com/FuelLabs/fuel-core/issues/1549

We don't need to insert the block in the executor because it is the block importer's responsibility. It verifies the block's validity and decides whether we want to insert a new block or not. Plus, storing blocks and transactions is not part of the state transition.

This change also adds the ability to produce the block with a defined order of the transactions. It may be useful in the tests.