### PR TITLE
Let `NetworkBehaviour` macro generate `FuelBehaviorEvent` in p2p

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1585](https://github.com/FuelLabs/fuel-core/pull/1585): Let `NetworkBehaviour` macro generate `FuelBehaviorEvent` in p2p
 - [#1517](https://github.com/FuelLabs/fuel-core/pull/1517): Changed default gossip heartbeat interval to 500ms. 
 - [#1520](https://github.com/FuelLabs/fuel-core/pull/1520): Extract `executor` into `fuel-core-executor` crate.
 

--- a/crates/client/src/client/schema/primitives.rs
+++ b/crates/client/src/client/schema/primitives.rs
@@ -278,8 +278,7 @@ impl TryFrom<U64> for PanicInstruction {
     type Error = ConversionError;
 
     fn try_from(s: U64) -> Result<Self, Self::Error> {
-        s.0.try_into()
-            .map_err(|_| ConversionError::IntegerConversion)
+        Ok(s.0.into())
     }
 }
 

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -680,7 +680,7 @@ mod tests {
                     .unwrap()
                     .unwrap();
 
-                if let Some(Receipt::Return { val, .. }) = receipts.get(0) {
+                if let Some(Receipt::Return { val, .. }) = receipts.first() {
                     *val == 1
                 } else {
                     panic!("Execution of the `CB` script failed failed")

--- a/crates/services/p2p/src/behavior.rs
+++ b/crates/services/p2p/src/behavior.rs
@@ -1,5 +1,8 @@
 use crate::{
-    codecs::NetworkCodec,
+    codecs::{
+        postcard::PostcardCodec,
+        NetworkCodec,
+    },
     config::Config,
     discovery::{
         DiscoveryBehaviour,
@@ -44,21 +47,21 @@ use libp2p_allow_block_list as allow_block_list;
 use libp2p_kad::Event as KademliaEvent;
 use libp2p_request_response::OutboundRequestId;
 
-#[derive(Debug)]
-pub enum FuelBehaviourEvent {
-    Discovery(KademliaEvent),
-    PeerReport(PeerReportEvent),
-    Gossipsub(GossipsubEvent),
-    RequestResponse(RequestResponseEvent<RequestMessage, NetworkResponse>),
-    BlockedPeers(void::Void),
-    Identify(identify::Event),
-    Heartbeat(heartbeat::HeartbeatEvent),
-}
+// #[derive(Debug)]
+// pub enum FuelBehaviourEvent {
+//     Discovery(KademliaEvent),
+//     PeerReport(PeerReportEvent),
+//     Gossipsub(GossipsubEvent),
+//     RequestResponse(RequestResponseEvent<RequestMessage, NetworkResponse>),
+//     BlockedPeers(void::Void),
+//     Identify(identify::Event),
+//     Heartbeat(heartbeat::HeartbeatEvent),
+// }
 
 /// Handles all p2p protocols needed for Fuel.
 #[derive(NetworkBehaviour)]
-#[behaviour(to_swarm = "FuelBehaviourEvent")]
-pub struct FuelBehaviour<Codec: NetworkCodec> {
+// #[behaviour(to_swarm = "FuelBehaviourEvent")]
+pub struct FuelBehaviour {
     /// **WARNING**: The order of the behaviours is important and fragile, at least for the tests.
 
     /// The Behaviour to manage connections to blocked peers.
@@ -80,11 +83,11 @@ pub struct FuelBehaviour<Codec: NetworkCodec> {
     discovery: DiscoveryBehaviour,
 
     /// RequestResponse protocol
-    request_response: RequestResponse<Codec>,
+    request_response: RequestResponse<PostcardCodec>,
 }
 
-impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
-    pub(crate) fn new(p2p_config: &Config, codec: Codec) -> Self {
+impl FuelBehaviour {
+    pub(crate) fn new(p2p_config: &Config, codec: PostcardCodec) -> Self {
         let local_public_key = p2p_config.keypair.public();
         let local_peer_id = PeerId::from_public_key(&local_public_key);
 
@@ -231,44 +234,44 @@ impl<Codec: NetworkCodec> FuelBehaviour<Codec> {
     }
 }
 
-impl From<KademliaEvent> for FuelBehaviourEvent {
-    fn from(event: KademliaEvent) -> Self {
-        FuelBehaviourEvent::Discovery(event)
-    }
-}
-
-impl From<PeerReportEvent> for FuelBehaviourEvent {
-    fn from(event: PeerReportEvent) -> Self {
-        FuelBehaviourEvent::PeerReport(event)
-    }
-}
-
-impl From<GossipsubEvent> for FuelBehaviourEvent {
-    fn from(event: GossipsubEvent) -> Self {
-        FuelBehaviourEvent::Gossipsub(event)
-    }
-}
-
-impl From<RequestResponseEvent<RequestMessage, NetworkResponse>> for FuelBehaviourEvent {
-    fn from(event: RequestResponseEvent<RequestMessage, NetworkResponse>) -> Self {
-        FuelBehaviourEvent::RequestResponse(event)
-    }
-}
-
-impl From<identify::Event> for FuelBehaviourEvent {
-    fn from(event: identify::Event) -> Self {
-        FuelBehaviourEvent::Identify(event)
-    }
-}
-
-impl From<heartbeat::HeartbeatEvent> for FuelBehaviourEvent {
-    fn from(event: heartbeat::HeartbeatEvent) -> Self {
-        FuelBehaviourEvent::Heartbeat(event)
-    }
-}
-
-impl From<void::Void> for FuelBehaviourEvent {
-    fn from(event: void::Void) -> Self {
-        FuelBehaviourEvent::BlockedPeers(event)
-    }
-}
+// impl From<KademliaEvent> for FuelBehaviourEvent {
+//     fn from(event: KademliaEvent) -> Self {
+//         FuelBehaviourEvent::Discovery(event)
+//     }
+// }
+//
+// impl From<PeerReportEvent> for FuelBehaviourEvent {
+//     fn from(event: PeerReportEvent) -> Self {
+//         FuelBehaviourEvent::PeerReport(event)
+//     }
+// }
+//
+// impl From<GossipsubEvent> for FuelBehaviourEvent {
+//     fn from(event: GossipsubEvent) -> Self {
+//         FuelBehaviourEvent::Gossipsub(event)
+//     }
+// }
+//
+// impl From<RequestResponseEvent<RequestMessage, NetworkResponse>> for FuelBehaviourEvent {
+//     fn from(event: RequestResponseEvent<RequestMessage, NetworkResponse>) -> Self {
+//         FuelBehaviourEvent::RequestResponse(event)
+//     }
+// }
+//
+// impl From<identify::Event> for FuelBehaviourEvent {
+//     fn from(event: identify::Event) -> Self {
+//         FuelBehaviourEvent::Identify(event)
+//     }
+// }
+//
+// impl From<heartbeat::HeartbeatEvent> for FuelBehaviourEvent {
+//     fn from(event: heartbeat::HeartbeatEvent) -> Self {
+//         FuelBehaviourEvent::Heartbeat(event)
+//     }
+// }
+//
+// impl From<void::Void> for FuelBehaviourEvent {
+//     fn from(event: void::Void) -> Self {
+//         FuelBehaviourEvent::BlockedPeers(event)
+//     }
+// }

--- a/crates/services/p2p/src/behavior.rs
+++ b/crates/services/p2p/src/behavior.rs
@@ -13,10 +13,7 @@ use crate::{
         topics::GossipTopic,
     },
     heartbeat,
-    peer_report::{
-        PeerReportBehaviour,
-        PeerReportEvent,
-    },
+    peer_report::PeerReportBehaviour,
     request_response::messages::{
         NetworkResponse,
         RequestMessage,
@@ -26,7 +23,6 @@ use fuel_core_types::fuel_types::BlockHeight;
 use libp2p::{
     gossipsub::{
         Behaviour as Gossipsub,
-        Event as GossipsubEvent,
         MessageAcceptance,
         MessageId,
         PublishError,
@@ -35,7 +31,6 @@ use libp2p::{
     request_response::{
         Behaviour as RequestResponse,
         Config as RequestResponseConfig,
-        Event as RequestResponseEvent,
         ProtocolSupport,
         ResponseChannel,
     },
@@ -44,23 +39,10 @@ use libp2p::{
     PeerId,
 };
 use libp2p_allow_block_list as allow_block_list;
-use libp2p_kad::Event as KademliaEvent;
 use libp2p_request_response::OutboundRequestId;
-
-// #[derive(Debug)]
-// pub enum FuelBehaviourEvent {
-//     Discovery(KademliaEvent),
-//     PeerReport(PeerReportEvent),
-//     Gossipsub(GossipsubEvent),
-//     RequestResponse(RequestResponseEvent<RequestMessage, NetworkResponse>),
-//     BlockedPeers(void::Void),
-//     Identify(identify::Event),
-//     Heartbeat(heartbeat::HeartbeatEvent),
-// }
 
 /// Handles all p2p protocols needed for Fuel.
 #[derive(NetworkBehaviour)]
-// #[behaviour(to_swarm = "FuelBehaviourEvent")]
 pub struct FuelBehaviour {
     /// **WARNING**: The order of the behaviours is important and fragile, at least for the tests.
 
@@ -233,45 +215,3 @@ impl FuelBehaviour {
         self.blocked_peer.block_peer(peer_id)
     }
 }
-
-// impl From<KademliaEvent> for FuelBehaviourEvent {
-//     fn from(event: KademliaEvent) -> Self {
-//         FuelBehaviourEvent::Discovery(event)
-//     }
-// }
-//
-// impl From<PeerReportEvent> for FuelBehaviourEvent {
-//     fn from(event: PeerReportEvent) -> Self {
-//         FuelBehaviourEvent::PeerReport(event)
-//     }
-// }
-//
-// impl From<GossipsubEvent> for FuelBehaviourEvent {
-//     fn from(event: GossipsubEvent) -> Self {
-//         FuelBehaviourEvent::Gossipsub(event)
-//     }
-// }
-//
-// impl From<RequestResponseEvent<RequestMessage, NetworkResponse>> for FuelBehaviourEvent {
-//     fn from(event: RequestResponseEvent<RequestMessage, NetworkResponse>) -> Self {
-//         FuelBehaviourEvent::RequestResponse(event)
-//     }
-// }
-//
-// impl From<identify::Event> for FuelBehaviourEvent {
-//     fn from(event: identify::Event) -> Self {
-//         FuelBehaviourEvent::Identify(event)
-//     }
-// }
-//
-// impl From<heartbeat::HeartbeatEvent> for FuelBehaviourEvent {
-//     fn from(event: heartbeat::HeartbeatEvent) -> Self {
-//         FuelBehaviourEvent::Heartbeat(event)
-//     }
-// }
-//
-// impl From<void::Void> for FuelBehaviourEvent {
-//     fn from(event: void::Void) -> Self {
-//         FuelBehaviourEvent::BlockedPeers(event)
-//     }
-// }

--- a/crates/services/p2p/src/p2p_service.rs
+++ b/crates/services/p2p/src/p2p_service.rs
@@ -3,7 +3,6 @@ use crate::{
         FuelBehaviour,
         FuelBehaviourEvent,
     },
-    codecs::NetworkCodec,
     config::{
         build_transport_function,
         Config,

--- a/crates/services/p2p/src/p2p_service.rs
+++ b/crates/services/p2p/src/p2p_service.rs
@@ -61,7 +61,14 @@ use libp2p::{
 };
 use libp2p_gossipsub::PublishError;
 
-use crate::heartbeat::HeartbeatEvent;
+use crate::{
+    codecs::{
+        postcard::PostcardCodec,
+        GossipsubCodec,
+        RequestResponseConverter,
+    },
+    heartbeat::HeartbeatEvent,
+};
 use rand::seq::IteratorRandom;
 use std::{
     collections::HashMap,
@@ -75,7 +82,7 @@ use tracing::{
 /// Maximum amount of peer's addresses that we are ready to store per peer
 const MAX_IDENTIFY_ADDRESSES: usize = 10;
 
-impl<Codec: NetworkCodec> Punisher for Swarm<FuelBehaviour<Codec>> {
+impl Punisher for Swarm<FuelBehaviour> {
     fn ban_peer(&mut self, peer_id: PeerId) {
         self.behaviour_mut().block_peer(peer_id)
     }
@@ -83,7 +90,7 @@ impl<Codec: NetworkCodec> Punisher for Swarm<FuelBehaviour<Codec>> {
 
 /// Listens to the events on the p2p network
 /// And forwards them to the Orchestrator
-pub struct FuelP2PService<Codec: NetworkCodec> {
+pub struct FuelP2PService {
     /// Store the local peer id
     pub local_peer_id: PeerId,
 
@@ -94,7 +101,7 @@ pub struct FuelP2PService<Codec: NetworkCodec> {
     tcp_port: u16,
 
     /// Swarm handler for FuelBehaviour
-    swarm: Swarm<FuelBehaviour<Codec>>,
+    swarm: Swarm<FuelBehaviour>,
 
     /// Holds the Sender(s) part of the Oneshot Channel from the NetworkOrchestrator
     /// Once the ResponseMessage is received from the p2p Network
@@ -107,7 +114,7 @@ pub struct FuelP2PService<Codec: NetworkCodec> {
     inbound_requests_table: HashMap<InboundRequestId, ResponseChannel<NetworkResponse>>,
 
     /// NetworkCodec used as <GossipsubCodec> for encoding and decoding of Gossipsub messages    
-    network_codec: Codec,
+    network_codec: PostcardCodec,
 
     /// Stores additional p2p network info    
     network_metadata: NetworkMetadata,
@@ -157,8 +164,8 @@ pub enum FuelP2PEvent {
     },
 }
 
-impl<Codec: NetworkCodec> FuelP2PService<Codec> {
-    pub fn new(config: Config, codec: Codec) -> Self {
+impl FuelP2PService {
+    pub fn new(config: Config, codec: PostcardCodec) -> Self {
         let gossipsub_data =
             GossipsubData::with_topics(GossipsubTopics::new(&config.network_name));
         let network_metadata = NetworkMetadata { gossipsub_data };
@@ -771,7 +778,7 @@ mod tests {
     };
     use tracing_attributes::instrument;
 
-    type P2PService = FuelP2PService<PostcardCodec>;
+    type P2PService = FuelP2PService;
 
     /// helper function for building FuelP2PService
     async fn build_service_from_config(mut p2p_config: Config) -> P2PService {

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -427,7 +427,7 @@ impl<P: TaskP2PService, D, B: Broadcast> Task<P, D, B> {
 }
 
 fn convert_peer_id(peer_id: &PeerId) -> anyhow::Result<FuelPeerId> {
-    let inner = Vec::try_from(*peer_id)?;
+    let inner = Vec::from(*peer_id);
     Ok(FuelPeerId::from(inner))
 }
 

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -1,8 +1,5 @@
 use crate::{
-    codecs::{
-        postcard::PostcardCodec,
-        NetworkCodec,
-    },
+    codecs::postcard::PostcardCodec,
     config::Config,
     gossipsub::messages::{
         GossipsubBroadcastRequest,

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -85,7 +85,7 @@ use tokio::{
 };
 use tracing::warn;
 
-pub type Service<D> = ServiceRunner<Task<FuelP2PService<PostcardCodec>, D, SharedState>>;
+pub type Service<D> = ServiceRunner<Task<FuelP2PService, D, SharedState>>;
 
 enum TaskRequest {
     // Broadcast requests to p2p network
@@ -194,7 +194,7 @@ pub trait TaskP2PService: Send {
     fn update_block_height(&mut self, height: BlockHeight) -> anyhow::Result<()>;
 }
 
-impl TaskP2PService for FuelP2PService<PostcardCodec> {
+impl TaskP2PService for FuelP2PService {
     fn get_peer_ids(&self) -> Vec<PeerId> {
         self.get_peers_ids_iter().copied().collect()
     }
@@ -328,7 +328,7 @@ pub struct HeartbeatPeerReputationConfig {
     low_heartbeat_frequency_penalty: AppScore,
 }
 
-impl<D> Task<FuelP2PService<PostcardCodec>, D, SharedState> {
+impl<D> Task<FuelP2PService, D, SharedState> {
     pub fn new<B: BlockHeightImporter>(
         chain_id: ChainId,
         config: Config,
@@ -435,14 +435,14 @@ fn convert_peer_id(peer_id: &PeerId) -> anyhow::Result<FuelPeerId> {
 }
 
 #[async_trait::async_trait]
-impl<D> RunnableService for Task<FuelP2PService<PostcardCodec>, D, SharedState>
+impl<D> RunnableService for Task<FuelP2PService, D, SharedState>
 where
     Self: RunnableTask,
 {
     const NAME: &'static str = "P2P";
 
     type SharedData = SharedState;
-    type Task = Task<FuelP2PService<PostcardCodec>, D, SharedState>;
+    type Task = Task<FuelP2PService, D, SharedState>;
     type TaskParams = ();
 
     fn shared_data(&self) -> Self::SharedData {
@@ -829,8 +829,8 @@ pub fn to_message_acceptance(
     }
 }
 
-fn report_message<T: NetworkCodec>(
-    p2p_service: &mut FuelP2PService<T>,
+fn report_message(
+    p2p_service: &mut FuelP2PService,
     message: GossipsubMessageInfo,
     acceptance: GossipsubMessageAcceptance,
 ) {


### PR DESCRIPTION
closes https://github.com/FuelLabs/fuel-core/issues/1555

This PR also removes the unnecessary `Codec` generic and uses a concrete `PostcardCodec` everywhere, because that's what we always use in practice. YAGNI.
