### PR TITLE
feat: Versionable `Message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Description of the upcoming release here.
 - [#1601](https://github.com/FuelLabs/fuel-core/pull/1601): Fix formatting in docs and check that `cargo doc` passes in the CI.
 
 #### Breaking
+- [#16232](https://github.com/FuelLabs/fuel-core/pull/1632): Make `Message` type a version-able enum
 - [#1628](https://github.com/FuelLabs/fuel-core/pull/1628): Make `CompressedCoin` type a version-able enum
 - [#1616](https://github.com/FuelLabs/fuel-core/pull/1616): Make `BlockHeader` type a version-able enum
 - [#1614](https://github.com/FuelLabs/fuel-core/pull/1614): Use the default consensus key regardless of trigger mode. The change is breaking because it removes the `--dev-keys` argument. If the `debug` flag is set, the default consensus key will be used, regardless of the trigger mode.

--- a/crates/chain-config/src/config/message.rs
+++ b/crates/chain-config/src/config/message.rs
@@ -8,7 +8,10 @@ use crate::{
 use fuel_core_storage::MerkleRoot;
 use fuel_core_types::{
     blockchain::primitives::DaBlockHeight,
-    entities::message::Message,
+    entities::message::{
+        Message,
+        MessageV1,
+    },
     fuel_asm::Word,
     fuel_crypto::Hasher,
     fuel_types::{
@@ -42,7 +45,7 @@ pub struct MessageConfig {
 
 impl From<MessageConfig> for Message {
     fn from(msg: MessageConfig) -> Self {
-        Message {
+        MessageV1 {
             sender: msg.sender,
             recipient: msg.recipient,
             nonce: msg.nonce,
@@ -50,19 +53,18 @@ impl From<MessageConfig> for Message {
             data: msg.data,
             da_height: msg.da_height,
         }
+        .into()
     }
 }
 
 impl GenesisCommitment for Message {
     fn root(&self) -> anyhow::Result<MerkleRoot> {
-        let Self {
-            sender,
-            recipient,
-            nonce,
-            amount,
-            data,
-            da_height,
-        } = self;
+        let sender = self.sender();
+        let recipient = self.recipient();
+        let nonce = self.nonce();
+        let amount = self.amount();
+        let data = self.data();
+        let da_height = self.da_height();
 
         let message_hash = *Hasher::default()
             .chain(sender)

--- a/crates/fuel-core/src/coins_query.rs
+++ b/crates/fuel-core/src/coins_query.rs
@@ -251,7 +251,10 @@ mod tests {
                 Coin,
                 CompressedCoin,
             },
-            message::Message,
+            message::{
+                Message,
+                MessageV1,
+            },
         },
         fuel_asm::Word,
         fuel_tx::*,
@@ -783,7 +786,7 @@ mod tests {
             let excluded_ids = db
                 .owned_messages(&owner)
                 .into_iter()
-                .filter(|message| message.amount == 5)
+                .filter(|message| message.amount() == 5)
                 .map(|message| CoinId::Message(*message.id()))
                 .collect_vec();
 
@@ -799,7 +802,7 @@ mod tests {
             let excluded_ids = db
                 .owned_messages(&owner)
                 .into_iter()
-                .filter(|message| message.amount == 5)
+                .filter(|message| message.amount() == 5)
                 .map(|message| CoinId::Message(*message.id()))
                 .collect_vec();
 
@@ -965,14 +968,15 @@ mod tests {
             let nonce = self.last_message_index.into();
             self.last_message_index += 1;
 
-            let message = Message {
+            let message: Message = MessageV1 {
                 sender: Default::default(),
                 recipient: owner,
                 nonce,
                 amount,
                 data: vec![],
                 da_height: DaBlockHeight::from(1u64),
-            };
+            }
+            .into();
 
             let db = &mut self.database;
             StorageMutate::<Messages>::insert(db, message.id(), &message).unwrap();

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -2335,8 +2335,8 @@ mod tests {
 
         let exec = make_executor(&messages);
         let view = exec.database_view_provider.latest_view();
-        assert!(!view.message_is_spent(&message_coin.nonce).unwrap());
-        assert!(!view.message_is_spent(&message_data.nonce).unwrap());
+        assert!(!view.message_is_spent(message_coin.nonce()).unwrap());
+        assert!(!view.message_is_spent(message_data.nonce()).unwrap());
 
         let ExecutionResult {
             skipped_transactions,
@@ -2353,8 +2353,8 @@ mod tests {
 
         // Successful execution consumes `message_coin` and `message_data`.
         let view = exec.database_view_provider.latest_view();
-        assert!(view.message_is_spent(&message_coin.nonce).unwrap());
-        assert!(view.message_is_spent(&message_data.nonce).unwrap());
+        assert!(view.message_is_spent(message_coin.nonce()).unwrap());
+        assert!(view.message_is_spent(message_data.nonce()).unwrap());
         assert_eq!(
             *view.coin(&UtxoId::new(tx_id, 0)).unwrap().amount(),
             amount + amount
@@ -2389,8 +2389,8 @@ mod tests {
 
         let exec = make_executor(&messages);
         let view = exec.database_view_provider.latest_view();
-        assert!(!view.message_is_spent(&message_coin.nonce).unwrap());
-        assert!(!view.message_is_spent(&message_data.nonce).unwrap());
+        assert!(!view.message_is_spent(message_coin.nonce()).unwrap());
+        assert!(!view.message_is_spent(message_data.nonce()).unwrap());
 
         let ExecutionResult {
             skipped_transactions,
@@ -2407,8 +2407,8 @@ mod tests {
 
         // We should spend only `message_coin`. The `message_data` should be unspent.
         let view = exec.database_view_provider.latest_view();
-        assert!(view.message_is_spent(&message_coin.nonce).unwrap());
-        assert!(!view.message_is_spent(&message_data.nonce).unwrap());
+        assert!(view.message_is_spent(message_coin.nonce()).unwrap());
+        assert!(!view.message_is_spent(message_data.nonce()).unwrap());
         assert_eq!(*view.coin(&UtxoId::new(tx_id, 0)).unwrap().amount(), amount);
     }
 

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -2428,10 +2428,10 @@ mod tests {
         // We should spend only `message_coin`. The `message_data` should be unspent.
         assert_eq!(block_db_transaction.all_messages(None, None).count(), 1);
         assert!(block_db_transaction
-            .message_is_spent(&message_coin.nonce())
+            .message_is_spent(message_coin.nonce())
             .unwrap());
         assert!(!block_db_transaction
-            .message_is_spent(&message_data.nonce())
+            .message_is_spent(message_data.nonce())
             .unwrap());
         assert_eq!(
             *block_db_transaction

--- a/crates/fuel-core/src/query/balance/asset_query.rs
+++ b/crates/fuel-core/src/query/balance/asset_query.rs
@@ -133,7 +133,7 @@ impl<'a> AssetsQuery<'a> {
                     Ok(message)
                 })
             })
-            .filter_ok(|message| message.data.is_empty())
+            .filter_ok(|message| message.data().is_empty())
             .map(|result| {
                 result.map(|message| {
                     CoinType::MessageCoin(

--- a/crates/fuel-core/src/schema/message.rs
+++ b/crates/fuel-core/src/schema/message.rs
@@ -38,27 +38,27 @@ pub struct Message(pub(crate) entities::message::Message);
 #[Object]
 impl Message {
     async fn amount(&self) -> U64 {
-        self.0.amount.into()
+        self.0.amount().into()
     }
 
     async fn sender(&self) -> Address {
-        self.0.sender.into()
+        (*self.0.sender()).into()
     }
 
     async fn recipient(&self) -> Address {
-        self.0.recipient.into()
+        (*self.0.recipient()).into()
     }
 
     async fn nonce(&self) -> Nonce {
-        self.0.nonce.into()
+        (*self.0.nonce()).into()
     }
 
     async fn data(&self) -> HexString {
-        self.0.data.clone().into()
+        self.0.data().clone().into()
     }
 
     async fn da_height(&self) -> U64 {
-        self.0.da_height.as_u64().into()
+        self.0.da_height().as_u64().into()
     }
 }
 
@@ -108,7 +108,7 @@ impl MessageQuery {
 
                 let messages = messages.map(|result| {
                     result
-                        .map(|message| (message.nonce.into(), message.into()))
+                        .map(|message| ((*message.nonce()).into(), message.into()))
                         .map_err(Into::into)
                 });
 

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -44,7 +44,10 @@ use fuel_core_types::{
             CompressedCoinV1,
         },
         contract::ContractUtxoInfo,
-        message::Message,
+        message::{
+            Message,
+            MessageV1,
+        },
     },
     fuel_merkle::binary,
     fuel_tx::{
@@ -331,14 +334,15 @@ fn init_da_messages(
     if let Some(state) = &state {
         if let Some(message_state) = &state.messages {
             for msg in message_state {
-                let message = Message {
+                let message: Message = MessageV1 {
                     sender: msg.sender,
                     recipient: msg.recipient,
                     nonce: msg.nonce,
                     amount: msg.amount,
                     data: msg.data.clone(),
                     da_height: msg.da_height,
-                };
+                }
+                .into();
 
                 if db
                     .storage::<Messages>()

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -1061,7 +1061,7 @@ where
                         .get_message(nonce, &block_da_height)
                         .map_err(|e| ExecutorError::RelayerError(e.into()))?
                     {
-                        if message.da_height > block_da_height {
+                        if message.da_height() > block_da_height {
                             return Err(TransactionValidityError::MessageSpendTooEarly(
                                 *nonce,
                             )

--- a/crates/services/relayer/src/log.rs
+++ b/crates/services/relayer/src/log.rs
@@ -10,7 +10,10 @@ use ethers_core::{
 };
 use fuel_core_types::{
     blockchain::primitives::DaBlockHeight,
-    entities::message::Message,
+    entities::message::{
+        Message,
+        MessageV1,
+    },
     fuel_types::{
         Address,
         Nonce,
@@ -31,7 +34,7 @@ pub struct MessageLog {
 
 impl From<&MessageLog> for Message {
     fn from(message: &MessageLog) -> Self {
-        Self {
+        MessageV1 {
             sender: message.sender,
             recipient: message.recipient,
             nonce: message.nonce,
@@ -39,6 +42,7 @@ impl From<&MessageLog> for Message {
             data: message.data.clone(),
             da_height: message.da_height,
         }
+        .into()
     }
 }
 

--- a/crates/services/relayer/src/mock_db.rs
+++ b/crates/services/relayer/src/mock_db.rs
@@ -56,7 +56,7 @@ impl RelayerDb for MockDb {
         let mut m = self.data.lock().unwrap();
         for message in messages {
             m.messages
-                .entry(message.da_height)
+                .entry(message.da_height())
                 .or_default()
                 .insert(*message.id(), message.clone());
         }

--- a/crates/services/relayer/src/ports.rs
+++ b/crates/services/relayer/src/ports.rs
@@ -73,7 +73,7 @@ where
         for message in messages {
             db.storage::<Messages>().insert(message.id(), message)?;
             let max = max_height.get_or_insert(0u64);
-            *max = (*max).max(message.da_height.0);
+            *max = (*max).max(message.da_height().0);
         }
         if let Some(height) = max_height {
             if **da_height < height {

--- a/crates/services/relayer/src/ports/tests.rs
+++ b/crates/services/relayer/src/ports/tests.rs
@@ -22,13 +22,16 @@ fn test_insert_messages() {
         .returning(|_| Ok(Some(std::borrow::Cow::Owned(9u64.into()))));
     let mut db = db.into_transactional();
 
-    let m = Message {
-        amount: 10,
-        da_height: 12u64.into(),
-        ..Default::default()
-    };
+    // let m = Message {
+    //     amount: 10,
+    //     da_height: 12u64.into(),
+    //     ..Default::default()
+    // };
+    let mut m = Message::default();
+    m.set_amount(10);
+    m.set_da_height(12u64.into());
     let mut m2 = m.clone();
-    m2.nonce = 1.into();
+    m2.set_nonce(1.into());
     assert_ne!(m.id(), m2.id());
     let messages = [m, m2];
     db.insert_messages(&12u64.into(), &messages[..]).unwrap();
@@ -37,11 +40,13 @@ fn test_insert_messages() {
 #[test]
 fn insert_always_raises_da_height_monotonically() {
     let messages: Vec<_> = (0..10)
-        .map(|i| Message {
-            amount: i,
-            da_height: i.into(),
-            ..Default::default()
+        .map(|i| {
+            let mut message = Message::default();
+            message.set_amount(i);
+            message.set_da_height(i.into());
+            message
         })
+        .map(Into::into)
         .collect();
 
     let mut db = MockStorage::default();

--- a/crates/services/relayer/src/ports/tests.rs
+++ b/crates/services/relayer/src/ports/tests.rs
@@ -22,11 +22,6 @@ fn test_insert_messages() {
         .returning(|_| Ok(Some(std::borrow::Cow::Owned(9u64.into()))));
     let mut db = db.into_transactional();
 
-    // let m = Message {
-    //     amount: 10,
-    //     da_height: 12u64.into(),
-    //     ..Default::default()
-    // };
     let mut m = Message::default();
     m.set_amount(10);
     m.set_da_height(12u64.into());

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -295,7 +295,7 @@ impl<D> SharedState<D> {
             .storage::<Messages>()
             .get(id)?
             .map(Cow::into_owned)
-            .filter(|message| message.da_height <= *da_height))
+            .filter(|message| message.da_height() <= *da_height))
     }
 
     /// Get finalized da height that represents last block from da layer that got finalized.

--- a/crates/services/txpool/src/txpool/test_helpers.rs
+++ b/crates/services/txpool/src/txpool/test_helpers.rs
@@ -1,6 +1,9 @@
 use crate::test_helpers::IntoEstimated;
 use fuel_core_types::{
-    entities::message::Message,
+    entities::message::{
+        Message,
+        MessageV1,
+    },
     fuel_asm::op,
     fuel_tx::{
         Contract,
@@ -18,7 +21,7 @@ pub(crate) fn create_message_predicate_from_message(
     nonce: u64,
 ) -> (Message, Input) {
     let predicate = vec![op::ret(1)].into_iter().collect::<Vec<u8>>();
-    let message = Message {
+    let message = MessageV1 {
         sender: Default::default(),
         recipient: Input::predicate_owner(&predicate),
         nonce: nonce.into(),
@@ -28,7 +31,7 @@ pub(crate) fn create_message_predicate_from_message(
     };
 
     (
-        message.clone(),
+        message.clone().into(),
         Input::message_coin_predicate(
             message.sender,
             Input::predicate_owner(&predicate),

--- a/crates/types/src/entities.rs
+++ b/crates/types/src/entities.rs
@@ -1,5 +1,6 @@
 //! Higher level domain types
 
+use crate::entities::message::MessageV1;
 use coins::message_coin::MessageCoin;
 use message::Message;
 
@@ -11,14 +12,12 @@ impl TryFrom<Message> for MessageCoin {
     type Error = anyhow::Error;
 
     fn try_from(message: Message) -> Result<Self, Self::Error> {
-        let Message {
-            sender,
-            recipient,
-            nonce,
-            amount,
-            data,
-            da_height,
-        } = message;
+        let sender = *message.sender();
+        let recipient = *message.recipient();
+        let nonce = *message.nonce();
+        let amount = message.amount();
+        let data = message.data();
+        let da_height = message.da_height();
 
         if !data.is_empty() {
             return Err(anyhow::anyhow!(
@@ -48,7 +47,7 @@ impl From<MessageCoin> for Message {
             da_height,
         } = coin;
 
-        Message {
+        MessageV1 {
             sender,
             recipient,
             nonce,
@@ -56,5 +55,6 @@ impl From<MessageCoin> for Message {
             data: vec![],
             da_height,
         }
+        .into()
     }
 }

--- a/crates/types/src/entities/message.rs
+++ b/crates/types/src/entities/message.rs
@@ -24,7 +24,7 @@ use crate::{
     },
 };
 
-/// Versioned Message
+/// Message sent from DA layer to fuel by relayer bridge.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -40,7 +40,7 @@ impl Default for Message {
     }
 }
 
-/// Message send from Da layer to fuel by bridge
+/// The V1 version of the message from the DA layer.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct MessageV1 {

--- a/crates/types/src/entities/message.rs
+++ b/crates/types/src/entities/message.rs
@@ -72,6 +72,7 @@ impl Message {
     }
 
     /// Set the message sender
+    #[cfg(any(test, feature = "test-helpers"))]
     pub fn set_sender(&mut self, sender: Address) {
         match self {
             Message::V1(message) => message.sender = sender,
@@ -86,6 +87,7 @@ impl Message {
     }
 
     /// Set the message recipient
+    #[cfg(any(test, feature = "test-helpers"))]
     pub fn set_recipient(&mut self, recipient: Address) {
         match self {
             Message::V1(message) => message.recipient = recipient,
@@ -100,6 +102,7 @@ impl Message {
     }
 
     /// Set the message nonce
+    #[cfg(any(test, feature = "test-helpers"))]
     pub fn set_nonce(&mut self, nonce: Nonce) {
         match self {
             Message::V1(message) => message.nonce = nonce,
@@ -114,6 +117,7 @@ impl Message {
     }
 
     /// Set the message amount
+    #[cfg(any(test, feature = "test-helpers"))]
     pub fn set_amount(&mut self, amount: Word) {
         match self {
             Message::V1(message) => message.amount = amount,
@@ -127,6 +131,14 @@ impl Message {
         }
     }
 
+    /// Set the message data
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn set_data(&mut self, data: Vec<u8>) {
+        match self {
+            Message::V1(message) => message.data = data,
+        }
+    }
+
     /// Get the message DA height
     pub fn da_height(&self) -> DaBlockHeight {
         match self {
@@ -135,6 +147,7 @@ impl Message {
     }
 
     /// Set the message DA height
+    #[cfg(any(test, feature = "test-helpers"))]
     pub fn set_da_height(&mut self, da_height: DaBlockHeight) {
         match self {
             Message::V1(message) => message.da_height = da_height,

--- a/crates/types/src/entities/message.rs
+++ b/crates/types/src/entities/message.rs
@@ -24,10 +24,25 @@ use crate::{
     },
 };
 
+/// Versioned Message
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Message {
+    /// Message Version 1
+    V1(MessageV1),
+}
+
+#[cfg(any(test, feature = "test-helpers"))]
+impl Default for Message {
+    fn default() -> Self {
+        Self::V1(Default::default())
+    }
+}
+
 /// Message send from Da layer to fuel by bridge
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Message {
+pub struct MessageV1 {
     /// Account that sent the message from the da layer
     pub sender: Address,
     /// Fuel account receiving the message
@@ -42,27 +57,112 @@ pub struct Message {
     pub da_height: DaBlockHeight,
 }
 
+impl From<MessageV1> for Message {
+    fn from(value: MessageV1) -> Self {
+        Self::V1(value)
+    }
+}
+
 impl Message {
+    /// Get the message sender
+    pub fn sender(&self) -> &Address {
+        match self {
+            Message::V1(message) => &message.sender,
+        }
+    }
+
+    /// Set the message sender
+    pub fn set_sender(&mut self, sender: Address) {
+        match self {
+            Message::V1(message) => message.sender = sender,
+        }
+    }
+
+    /// Get the message recipient
+    pub fn recipient(&self) -> &Address {
+        match self {
+            Message::V1(message) => &message.recipient,
+        }
+    }
+
+    /// Set the message recipient
+    pub fn set_recipient(&mut self, recipient: Address) {
+        match self {
+            Message::V1(message) => message.recipient = recipient,
+        }
+    }
+
+    /// Get the message nonce
+    pub fn nonce(&self) -> &Nonce {
+        match self {
+            Message::V1(message) => &message.nonce,
+        }
+    }
+
+    /// Set the message nonce
+    pub fn set_nonce(&mut self, nonce: Nonce) {
+        match self {
+            Message::V1(message) => message.nonce = nonce,
+        }
+    }
+
+    /// Get the message amount
+    pub fn amount(&self) -> Word {
+        match self {
+            Message::V1(message) => message.amount,
+        }
+    }
+
+    /// Set the message amount
+    pub fn set_amount(&mut self, amount: Word) {
+        match self {
+            Message::V1(message) => message.amount = amount,
+        }
+    }
+
+    /// Get the message data
+    pub fn data(&self) -> &Vec<u8> {
+        match self {
+            Message::V1(message) => &message.data,
+        }
+    }
+
+    /// Get the message DA height
+    pub fn da_height(&self) -> DaBlockHeight {
+        match self {
+            Message::V1(message) => message.da_height,
+        }
+    }
+
+    /// Set the message DA height
+    pub fn set_da_height(&mut self, da_height: DaBlockHeight) {
+        match self {
+            Message::V1(message) => message.da_height = da_height,
+        }
+    }
+
     /// Returns the id of the message
     pub fn id(&self) -> &Nonce {
-        &self.nonce
+        match self {
+            Message::V1(message) => &message.nonce,
+        }
     }
 
     /// Computed message id
     pub fn message_id(&self) -> MessageId {
         compute_message_id(
-            &self.sender,
-            &self.recipient,
-            &self.nonce,
-            self.amount,
-            &self.data,
+            self.sender(),
+            self.recipient(),
+            self.nonce(),
+            self.amount(),
+            self.data(),
         )
     }
 
     /// Verifies the integrity of the message.
     ///
     /// Returns `None`, if the `input` is not a message.
-    /// Otherwise returns the result of the field comparison.
+    /// Otherwise, returns the result of the field comparison.
     pub fn matches_input(&self, input: &Input) -> Option<bool> {
         match input {
             Input::MessageDataSigned(MessageDataSigned {
@@ -93,16 +193,16 @@ impl Message {
                 amount,
                 ..
             }) => {
-                let expected_data = if self.data.is_empty() {
+                let expected_data = if self.data().is_empty() {
                     None
                 } else {
-                    Some(self.data.as_slice())
+                    Some(self.data().as_slice())
                 };
                 Some(
-                    &self.sender == sender
-                        && &self.recipient == recipient
-                        && &self.nonce == nonce
-                        && &self.amount == amount
+                    self.sender() == sender
+                        && self.recipient() == recipient
+                        && self.nonce() == nonce
+                        && &self.amount() == amount
                         && expected_data == input.input_data(),
                 )
             }

--- a/crates/types/src/entities/message.rs
+++ b/crates/types/src/entities/message.rs
@@ -27,6 +27,7 @@ use crate::{
 /// Versioned Message
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Message {
     /// Message Version 1
     V1(MessageV1),


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-core/issues/1552

This PR converts the `Message` struct to an enum that can house multiple variants for versioning. Version variants contain an instance of a versioned struct, e.g., `MessageV1`. The `Message` enum exposes getters to the underlying data and abstracts the version. Setters are exposed only in test environments to allow tests to set up `Messages` in specific ways for the test.   