### PR TITLE
Notify services about importing of the genesis block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1633](https://github.com/FuelLabs/fuel-core/pull/1633): Notify services about importing of the genesis block.
 - [#1613](https://github.com/FuelLabs/fuel-core/pull/1613): Add api endpoint to retrieve a message by its nonce.
 - [#1612](https://github.com/FuelLabs/fuel-core/pull/1612): Use `AtomicView` in all services for consistent results.
 - [#1597](https://github.com/FuelLabs/fuel-core/pull/1597): Unify namespacing for `libp2p` modules

--- a/crates/fuel-core/src/service/adapters/p2p.rs
+++ b/crates/fuel-core/src/service/adapters/p2p.rs
@@ -7,7 +7,10 @@ use fuel_core_p2p::ports::{
 use fuel_core_services::stream::BoxStream;
 use fuel_core_storage::Result as StorageResult;
 use fuel_core_types::{
-    blockchain::SealedBlockHeader,
+    blockchain::{
+        consensus::Genesis,
+        SealedBlockHeader,
+    },
     fuel_types::BlockHeight,
     services::p2p::Transactions,
 };
@@ -26,6 +29,10 @@ impl P2pDb for Database {
         block_height_range: Range<u32>,
     ) -> StorageResult<Option<Vec<Transactions>>> {
         self.get_transactions_on_blocks(block_height_range)
+    }
+
+    fn get_genesis(&self) -> StorageResult<Genesis> {
+        self.get_genesis()
     }
 }
 

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -196,20 +196,6 @@ where
         self._commit_result(result)
     }
 
-    /// The method works in the same way as [`Importer::commit_result`], but it doesn't
-    /// wait for listeners to process the result.
-    pub fn commit_result_without_awaiting_listeners<ExecutorDatabase>(
-        &self,
-        result: UncommittedResult<StorageTransaction<ExecutorDatabase>>,
-    ) -> Result<(), Error>
-    where
-        ExecutorDatabase: ports::ExecutorDatabase,
-    {
-        let _guard = self.lock()?;
-        self._commit_result(result)?;
-        Ok(())
-    }
-
     /// The method commits the result of the block execution and notifies about a new imported block.
     #[tracing::instrument(
         skip_all,

--- a/crates/services/p2p/src/peer_manager.rs
+++ b/crates/services/p2p/src/peer_manager.rs
@@ -72,14 +72,11 @@ pub struct PeerManager {
 
 impl PeerManager {
     pub fn new(
+        reserved_peers_updates: tokio::sync::broadcast::Sender<usize>,
         reserved_peers: HashSet<PeerId>,
         connection_state: Arc<RwLock<ConnectionState>>,
         max_non_reserved_peers: usize,
     ) -> Self {
-        let (reserved_peers_updates, _) = tokio::sync::broadcast::channel(
-            reserved_peers.len().saturating_mul(2).saturating_add(1),
-        );
-
         Self {
             score_config: ScoreConfig::default(),
             non_reserved_connected_peers: HashMap::with_capacity(max_non_reserved_peers),
@@ -416,8 +413,11 @@ mod tests {
         max_non_reserved_peers: usize,
     ) -> PeerManager {
         let connection_state = ConnectionState::new();
+        let (sender, _) =
+            tokio::sync::broadcast::channel(reserved_peers.len().saturating_add(1));
 
         PeerManager::new(
+            sender,
             reserved_peers.into_iter().collect(),
             connection_state,
             max_non_reserved_peers,

--- a/crates/services/p2p/src/ports.rs
+++ b/crates/services/p2p/src/ports.rs
@@ -1,7 +1,10 @@
 use fuel_core_services::stream::BoxStream;
 use fuel_core_storage::Result as StorageResult;
 use fuel_core_types::{
-    blockchain::SealedBlockHeader,
+    blockchain::{
+        consensus::Genesis,
+        SealedBlockHeader,
+    },
     fuel_types::BlockHeight,
     services::p2p::Transactions,
 };
@@ -17,6 +20,8 @@ pub trait P2pDb: Send + Sync {
         &self,
         block_height_range: Range<u32>,
     ) -> StorageResult<Option<Vec<Transactions>>>;
+
+    fn get_genesis(&self) -> StorageResult<Genesis>;
 }
 
 pub trait BlockHeightImporter: Send + Sync {

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -337,7 +337,7 @@ impl<V> UninitializedTask<V, SharedState> {
         chain_id: ChainId,
         config: Config<NotInitialized>,
         view_provider: V,
-        block_importer: Arc<B>,
+        block_importer: B,
     ) -> Self {
         let (request_sender, request_receiver) = mpsc::channel(1024 * 10);
         let (tx_broadcast, _) = broadcast::channel(1024 * 10);
@@ -822,12 +822,8 @@ where
     V::View: P2pDb,
     B: BlockHeightImporter,
 {
-    let task = UninitializedTask::new(
-        chain_id,
-        p2p_config,
-        view_provider,
-        Arc::new(block_importer),
-    );
+    let task =
+        UninitializedTask::new(chain_id, p2p_config, view_provider, block_importer);
     Service::new(task)
 }
 

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -1,6 +1,9 @@
 use crate::{
     codecs::postcard::PostcardCodec,
-    config::Config,
+    config::{
+        Config,
+        NotInitialized,
+    },
     gossipsub::messages::{
         GossipsubBroadcastRequest,
         GossipsubMessage,
@@ -80,7 +83,7 @@ use tokio::{
 };
 use tracing::warn;
 
-pub type Service<V> = ServiceRunner<Task<FuelP2PService, V, SharedState>>;
+pub type Service<V> = ServiceRunner<UninitializedTask<V, SharedState>>;
 
 enum TaskRequest {
     // Broadcast requests to p2p network
@@ -293,6 +296,17 @@ impl Broadcast for SharedState {
     }
 }
 
+/// Uninitialized task for the p2p that can be upgraded later into [`Task`].
+pub struct UninitializedTask<V, B> {
+    chain_id: ChainId,
+    view_provider: V,
+    next_block_height: BoxStream<BlockHeight>,
+    /// Receive internal Task Requests
+    request_receiver: mpsc::Receiver<TaskRequest>,
+    broadcast: B,
+    config: Config<NotInitialized>,
+}
+
 /// Orchestrates various p2p-related events between the inner `P2pService`
 /// and the top level `NetworkService`.
 pub struct Task<P, V, B> {
@@ -318,64 +332,42 @@ pub struct HeartbeatPeerReputationConfig {
     low_heartbeat_frequency_penalty: AppScore,
 }
 
-impl<V> Task<FuelP2PService, V, SharedState> {
+impl<V> UninitializedTask<V, SharedState> {
     pub fn new<B: BlockHeightImporter>(
         chain_id: ChainId,
-        config: Config,
+        config: Config<NotInitialized>,
         view_provider: V,
         block_importer: Arc<B>,
     ) -> Self {
-        let Config {
-            max_block_size,
-            max_headers_per_request,
-            heartbeat_check_interval,
-            heartbeat_max_avg_interval,
-            heartbeat_max_time_since_last,
-            ..
-        } = config;
         let (request_sender, request_receiver) = mpsc::channel(1024 * 10);
         let (tx_broadcast, _) = broadcast::channel(1024 * 10);
         let (block_height_broadcast, _) = broadcast::channel(1024 * 10);
 
-        // Hardcoded for now, but left here to be configurable in the future.
-        // TODO: https://github.com/FuelLabs/fuel-core/issues/1340
-        let heartbeat_peer_reputation_config = HeartbeatPeerReputationConfig {
-            old_heartbeat_penalty: -5.,
-            low_heartbeat_frequency_penalty: -5.,
-        };
-
+        let (reserved_peers_broadcast, _) = broadcast::channel::<usize>(
+            config
+                .reserved_nodes
+                .len()
+                .saturating_mul(2)
+                .saturating_add(1),
+        );
         let next_block_height = block_importer.next_block_height();
-        let p2p_service = FuelP2PService::new(config, PostcardCodec::new(max_block_size));
-
-        let reserved_peers_broadcast =
-            p2p_service.peer_manager().reserved_peers_updates();
-
-        let next_check_time =
-            Instant::now().checked_add(heartbeat_check_interval).expect(
-                "The heartbeat check interval should be small enough to do frequently",
-            );
 
         Self {
             chain_id,
-            p2p_service,
             view_provider,
-            request_receiver,
             next_block_height,
+            request_receiver,
             broadcast: SharedState {
                 request_sender,
                 tx_broadcast,
                 reserved_peers_broadcast,
                 block_height_broadcast,
             },
-            max_headers_per_request,
-            heartbeat_check_interval,
-            heartbeat_max_avg_interval,
-            heartbeat_max_time_since_last,
-            next_check_time,
-            heartbeat_peer_reputation_config,
+            config,
         }
     }
 }
+
 impl<P: TaskP2PService, V, B: Broadcast> Task<P, V, B> {
     fn peer_heartbeat_reputation_checks(&self) -> anyhow::Result<()> {
         for (peer_id, peer_info) in self.p2p_service.get_all_peer_info() {
@@ -425,9 +417,10 @@ fn convert_peer_id(peer_id: &PeerId) -> anyhow::Result<FuelPeerId> {
 }
 
 #[async_trait::async_trait]
-impl<V> RunnableService for Task<FuelP2PService, V, SharedState>
+impl<V> RunnableService for UninitializedTask<V, SharedState>
 where
-    Self: RunnableTask,
+    V: AtomicView + 'static,
+    V::View: P2pDb,
 {
     const NAME: &'static str = "P2P";
 
@@ -444,8 +437,61 @@ where
         _: &StateWatcher,
         _: Self::TaskParams,
     ) -> anyhow::Result<Self::Task> {
-        self.p2p_service.start().await?;
-        Ok(self)
+        let Self {
+            chain_id,
+            view_provider,
+            next_block_height,
+            request_receiver,
+            broadcast,
+            config,
+        } = self;
+
+        let view = view_provider.latest_view();
+        let genesis = view.get_genesis()?;
+        let config = config.init(genesis)?;
+        let Config {
+            max_block_size,
+            max_headers_per_request,
+            heartbeat_check_interval,
+            heartbeat_max_avg_interval,
+            heartbeat_max_time_since_last,
+            ..
+        } = config;
+
+        // Hardcoded for now, but left here to be configurable in the future.
+        // TODO: https://github.com/FuelLabs/fuel-core/issues/1340
+        let heartbeat_peer_reputation_config = HeartbeatPeerReputationConfig {
+            old_heartbeat_penalty: -5.,
+            low_heartbeat_frequency_penalty: -5.,
+        };
+
+        let mut p2p_service = FuelP2PService::new(
+            broadcast.reserved_peers_broadcast.clone(),
+            config,
+            PostcardCodec::new(max_block_size),
+        );
+        p2p_service.start().await?;
+
+        let next_check_time =
+            Instant::now().checked_add(heartbeat_check_interval).expect(
+                "The heartbeat check interval should be small enough to do frequently",
+            );
+
+        let task = Task {
+            chain_id,
+            p2p_service,
+            view_provider,
+            request_receiver,
+            next_block_height,
+            broadcast,
+            max_headers_per_request,
+            heartbeat_check_interval,
+            heartbeat_max_avg_interval,
+            heartbeat_max_time_since_last,
+            next_check_time,
+            heartbeat_peer_reputation_config,
+        };
+        Ok(task)
     }
 }
 
@@ -767,7 +813,7 @@ impl SharedState {
 
 pub fn new_service<V, B>(
     chain_id: ChainId,
-    p2p_config: Config,
+    p2p_config: Config<NotInitialized>,
     view_provider: V,
     block_importer: B,
 ) -> Service<V>
@@ -776,7 +822,7 @@ where
     V::View: P2pDb,
     B: BlockHeightImporter,
 {
-    let task = Task::new(
+    let task = UninitializedTask::new(
         chain_id,
         p2p_config,
         view_provider,
@@ -829,7 +875,10 @@ pub mod tests {
         State,
     };
     use fuel_core_storage::Result as StorageResult;
-    use fuel_core_types::fuel_types::BlockHeight;
+    use fuel_core_types::{
+        blockchain::consensus::Genesis,
+        fuel_types::BlockHeight,
+    };
     use futures::FutureExt;
     use std::{
         collections::VecDeque,
@@ -871,6 +920,10 @@ pub mod tests {
         ) -> StorageResult<Option<Vec<Transactions>>> {
             unimplemented!()
         }
+
+        fn get_genesis(&self) -> StorageResult<Genesis> {
+            Ok(Default::default())
+        }
     }
 
     #[derive(Clone, Debug)]
@@ -884,7 +937,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn start_and_stop_awaits_works() {
-        let p2p_config = Config::default_initialized("start_stop_works");
+        let p2p_config = Config::<NotInitialized>::default("start_stop_works");
         let service =
             new_service(ChainId::default(), p2p_config, FakeDb, FakeBlockImporter);
 
@@ -994,6 +1047,10 @@ pub mod tests {
             &self,
             _block_height_range: Range<u32>,
         ) -> StorageResult<Option<Vec<Transactions>>> {
+            todo!()
+        }
+
+        fn get_genesis(&self) -> StorageResult<Genesis> {
             todo!()
         }
     }


### PR DESCRIPTION
Part of the https://github.com/FuelLabs/fuel-core/issues/1583.

The change moves the genesis block execution and commitment from the `FuelService::new` to the `FuelService::Task::into_task`.

It allows us to notify other services about the genesis block because all services are already subscribed to the block importer(it is what we need for https://github.com/FuelLabs/fuel-core/issues/1583 to process new messages inside the off-chain worker). Plus, it adds support for the `async` syntax(it will be used by the parallel regenesis process from https://github.com/FuelLabs/fuel-core/pull/1519). 

Moving genesis block initialization from the constructor to the starting level breaks p2p because `P2PService` requires knowing the `Genesis` type to create `FuelP2PService`(It is used to filter connections with peers). Because of that, I moved the creation of the `FuelP2PService` to `UninitializedTask::into_task` where the genesis block is already available.
