### PR TITLE
Add docs for GraphQL DAP endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Description of the upcoming release here.
 - [#1579](https://github.com/FuelLabs/fuel-core/pull/1579): The change extracts the off-chain-related logic from the executor and moves it to the GraphQL off-chain worker. It creates two new concepts - Off-chain and On-chain databases where the GraphQL worker has exclusive ownership of the database and may modify it without intersecting with the On-chain database.
 - [#1577](https://github.com/FuelLabs/fuel-core/pull/1577): Moved insertion of sealed blocks into the `BlockImporter` instead of the executor.
 - [#1601](https://github.com/FuelLabs/fuel-core/pull/1601): Fix formatting in docs and check that `cargo doc` passes in the CI.
+- [#1636](https://github.com/FuelLabs/fuel-core/pull/1636): Add more docs to GraphQL DAP API.
 
 #### Breaking
 - [#1628](https://github.com/FuelLabs/fuel-core/pull/1628): Make `CompressedCoin` type a version-able enum

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -83,6 +83,9 @@ type BlockEdge {
 scalar BlockId
 
 
+"""
+Breakpoint, defined as a tuple of contract ID and relative PC offset inside it
+"""
 input Breakpoint {
 	contract: ContractId!
 	pc: U64!
@@ -578,13 +581,42 @@ type MessageStatus {
 }
 
 type Mutation {
+	"""
+	Initialize a new debugger session, returning its ID.
+	A new VM instance is spawned for each session.
+	The session is run in a separate database transaction,
+	on top of the most recent node state.
+	"""
 	startSession: ID!
+	"""
+	End debugger session.
+	"""
 	endSession(id: ID!): Boolean!
+	"""
+	Reset the VM instance to the initial state.
+	"""
 	reset(id: ID!): Boolean!
+	"""
+	Execute a single fuel-asm instruction.
+	"""
 	execute(id: ID!, op: String!): Boolean!
+	"""
+	Set single-stepping mode for the VM instance.
+	"""
 	setSingleStepping(id: ID!, enable: Boolean!): Boolean!
+	"""
+	Set a breakpoint for a VM instance.
+	"""
 	setBreakpoint(id: ID!, breakpoint: Breakpoint!): Boolean!
+	"""
+	Run a single transaction in given session until it
+	hits a breakpoint or completes.
+	"""
 	startTx(id: ID!, txJson: String!): RunResult!
+	"""
+	Resume execution of the VM instance after a breakpoint.
+	Runs until the next breakpoint or until the transaction completes.
+	"""
 	continueTx(id: ID!): RunResult!
 	"""
 	Execute a dry-run of the transaction using a fork of current state, no changes are committed.
@@ -704,7 +736,13 @@ type ProgramState {
 }
 
 type Query {
+	"""
+	Read register value by index.
+	"""
 	register(id: ID!, register: U32!): U64!
+	"""
+	Read read a range of memory bytes.
+	"""
 	memory(id: ID!, start: U32!, size: U32!): String!
 	balance(owner: Address!, assetId: AssetId!): Balance!
 	balances(filter: BalanceFilterInput!, first: Int, after: String, last: Int, before: String): BalanceConnection!


### PR DESCRIPTION
Note that the DAP GraphQL API needs updates after #1600, as some new things (like clearing breakpoints) are available. That will be a follow-up.