### PR TITLE
Bump up rust to 1.75

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.74.0
+  RUST_VERSION: 1.75.0
   NIGHTLY_RUST_VERSION: nightly-2023-10-29
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,7 +16,7 @@ defaults:
 env:
   # So cargo doesn't complain about unstable features
   RUSTC_BOOTSTRAP: 1
-  RUST_VERSION: 1.74.0
+  RUST_VERSION: 1.75.0
   PR_TITLE: Weekly `cargo update`
   PR_MESSAGE: |
     Automation to keep dependencies in `Cargo.lock` current.

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -3,7 +3,7 @@
 # The script runs almost all CI checks locally.
 #
 # Requires installed:
-# - Rust `1.74.0`
+# - Rust `1.75.0`
 # - Nightly rust formatter
 # - `cargo install cargo-sort`
 

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
-FROM --platform=$BUILDPLATFORM rust:1.74.0 AS chef
+FROM --platform=$BUILDPLATFORM rust:1.75.0 AS chef
 
 ARG TARGETPLATFORM
 RUN cargo install cargo-chef

--- a/deployment/e2e-client.Dockerfile
+++ b/deployment/e2e-client.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM rust:1.74.0 AS chef
+FROM rust:1.75.0 AS chef
 RUN cargo install cargo-chef
 WORKDIR /build/
 # hadolint ignore=DL3008


### PR DESCRIPTION
WE've got these broken deps:
```
error: package `clap_builder v4.5.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.73.0
```