### PR TITLE
Soften txpool p2p reputation requirements

### DIFF
--- a/crates/fuel-core/src/service/adapters/graphql_api.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api.rs
@@ -61,7 +61,12 @@ impl TxPoolPort for TxPoolAdapter {
         &self,
         txs: Vec<Arc<Transaction>>,
     ) -> Vec<anyhow::Result<InsertionResult>> {
-        self.service.insert(txs).await
+        self.service
+            .insert(txs)
+            .await
+            .into_iter()
+            .map(|res| res.map_err(anyhow::Error::from))
+            .collect()
     }
 
     fn tx_update_subscribe(

--- a/crates/services/txpool/src/containers/dependency.rs
+++ b/crates/services/txpool/src/containers/dependency.rs
@@ -303,7 +303,7 @@ impl Dependency {
                                                 Error::Database(format!("{:?}", e))
                                             })?
                                             .ok_or(
-                                                Error::NotInsertedInputUtxoIdNotExisting(
+                                                Error::NotInsertedInputUtxoIdNotDoesNotExist(
                                                     *utxo_id,
                                                 ),
                                             )?;
@@ -334,7 +334,7 @@ impl Dependency {
                             let coin = db
                                 .utxo(utxo_id)
                                 .map_err(|e| Error::Database(format!("{:?}", e)))?
-                                .ok_or(Error::NotInsertedInputUtxoIdNotExisting(
+                                .ok_or(Error::NotInsertedInputUtxoIdNotDoesNotExist(
                                     *utxo_id,
                                 ))?;
 
@@ -426,7 +426,7 @@ impl Dependency {
                             .contract_exist(contract_id)
                             .map_err(|e| Error::Database(format!("{:?}", e)))?
                         {
-                            return Err(Error::NotInsertedInputContractNotExisting(
+                            return Err(Error::NotInsertedInputContractDoesNotExist(
                                 *contract_id,
                             ))
                         }

--- a/crates/services/txpool/src/containers/dependency.rs
+++ b/crates/services/txpool/src/containers/dependency.rs
@@ -189,31 +189,29 @@ impl Dependency {
                     asset_id,
                 } => {
                     if to != i_owner {
-                        return Err(Error::NotInsertedIoWrongOwner.into())
+                        return Err(Error::NotInsertedIoWrongOwner)
                     }
                     if amount != i_amount {
-                        return Err(Error::NotInsertedIoWrongAmount.into())
+                        return Err(Error::NotInsertedIoWrongAmount)
                     }
                     if asset_id != i_asset_id {
-                        return Err(Error::NotInsertedIoWrongAssetId.into())
+                        return Err(Error::NotInsertedIoWrongAssetId)
                     }
                 }
-                Output::Contract(_) => {
-                    return Err(Error::NotInsertedIoContractOutput.into())
-                }
+                Output::Contract(_) => return Err(Error::NotInsertedIoContractOutput),
                 Output::Change {
                     to,
                     asset_id,
                     amount,
                 } => {
                     if to != i_owner {
-                        return Err(Error::NotInsertedIoWrongOwner.into())
+                        return Err(Error::NotInsertedIoWrongOwner)
                     }
                     if asset_id != i_asset_id {
-                        return Err(Error::NotInsertedIoWrongAssetId.into())
+                        return Err(Error::NotInsertedIoWrongAssetId)
                     }
                     if is_output_filled && amount != i_amount {
-                        return Err(Error::NotInsertedIoWrongAmount.into())
+                        return Err(Error::NotInsertedIoWrongAmount)
                     }
                 }
                 Output::Variable {
@@ -223,19 +221,19 @@ impl Dependency {
                 } => {
                     if is_output_filled {
                         if to != i_owner {
-                            return Err(Error::NotInsertedIoWrongOwner.into())
+                            return Err(Error::NotInsertedIoWrongOwner)
                         }
                         if amount != i_amount {
-                            return Err(Error::NotInsertedIoWrongAmount.into())
+                            return Err(Error::NotInsertedIoWrongAmount)
                         }
                         if asset_id != i_asset_id {
-                            return Err(Error::NotInsertedIoWrongAssetId.into())
+                            return Err(Error::NotInsertedIoWrongAssetId)
                         }
                     }
                     // else do nothing, everything is variable and can be only check on execution
                 }
                 Output::ContractCreated { .. } => {
-                    return Err(Error::NotInsertedIoContractOutput.into())
+                    return Err(Error::NotInsertedIoContractOutput)
                 }
             };
         } else {
@@ -282,7 +280,7 @@ impl Dependency {
                         max_depth =
                             core::cmp::max(state.depth.saturating_add(1), max_depth);
                         if max_depth > self.max_depth {
-                            return Err(Error::NotInsertedMaxDepth.into())
+                            return Err(Error::NotInsertedMaxDepth)
                         }
                         // output is present but is it spend by other tx?
                         if let Some(ref spend_by) = state.is_spend_by {
@@ -294,8 +292,7 @@ impl Dependency {
                             if txpool_tx.price() > tx.price() {
                                 return Err(Error::NotInsertedCollision(
                                     *spend_by, *utxo_id,
-                                )
-                                .into())
+                                ))
                             } else {
                                 if state.is_in_database() {
                                     // this means it is loaded from db. Get tx to compare output.
@@ -314,9 +311,7 @@ impl Dependency {
                                             .matches_input(input)
                                             .expect("The input is coin above")
                                         {
-                                            return Err(
-                                                Error::NotInsertedIoCoinMismatch.into()
-                                            )
+                                            return Err(Error::NotInsertedIoCoinMismatch)
                                         }
                                     }
                                 } else {
@@ -347,7 +342,7 @@ impl Dependency {
                                 .matches_input(input)
                                 .expect("The input is coin above")
                             {
-                                return Err(Error::NotInsertedIoCoinMismatch.into())
+                                return Err(Error::NotInsertedIoCoinMismatch)
                             }
                         }
                         max_depth = core::cmp::max(1, max_depth);
@@ -379,21 +374,17 @@ impl Dependency {
                                 .matches_input(input)
                                 .expect("Input is a message above")
                             {
-                                return Err(Error::NotInsertedIoMessageMismatch.into())
+                                return Err(Error::NotInsertedIoMessageMismatch)
                             }
                             // return an error if spent block is set
                             if db
                                 .is_message_spent(nonce)
                                 .map_err(|e| Error::Database(format!("{:?}", e)))?
                             {
-                                return Err(
-                                    Error::NotInsertedInputMessageSpent(*nonce).into()
-                                )
+                                return Err(Error::NotInsertedInputMessageSpent(*nonce))
                             }
                         } else {
-                            return Err(
-                                Error::NotInsertedInputMessageUnknown(*nonce).into()
-                            )
+                            return Err(Error::NotInsertedInputMessageUnknown(*nonce))
                         }
                     }
 
@@ -403,8 +394,7 @@ impl Dependency {
                             return Err(Error::NotInsertedCollisionMessageId(
                                 state.spent_by,
                                 *nonce,
-                            )
-                            .into())
+                            ))
                         } else {
                             collided.push(state.spent_by);
                         }
@@ -424,13 +414,12 @@ impl Dependency {
                         if tx.price() > state.gas_price {
                             return Err(Error::NotInsertedContractPricedLower(
                                 *contract_id,
-                            )
-                            .into())
+                            ))
                         }
                         // check depth.
                         max_depth = core::cmp::max(state.depth, max_depth);
                         if max_depth > self.max_depth {
-                            return Err(Error::NotInsertedMaxDepth.into())
+                            return Err(Error::NotInsertedMaxDepth)
                         }
                     } else {
                         if !db
@@ -439,8 +428,7 @@ impl Dependency {
                         {
                             return Err(Error::NotInsertedInputContractNotExisting(
                                 *contract_id,
-                            )
-                            .into())
+                            ))
                         }
                         // add depth
                         max_depth = core::cmp::max(1, max_depth);
@@ -468,16 +456,12 @@ impl Dependency {
                 if let Some(contract) = self.contracts.get(contract_id) {
                     // we have a collision :(
                     if contract.is_in_database() {
-                        return Err(
-                            Error::NotInsertedContractIdAlreadyTaken(*contract_id).into()
-                        )
+                        return Err(Error::NotInsertedContractIdAlreadyTaken(*contract_id))
                     }
                     // check who is priced more
                     if contract.gas_price > tx.price() {
                         // new tx is priced less then current tx
-                        return Err(
-                            Error::NotInsertedCollisionContractId(*contract_id).into()
-                        )
+                        return Err(Error::NotInsertedCollisionContractId(*contract_id))
                     }
                     // if we are prices more, mark current contract origin for removal.
                     let origin = contract.origin.expect(

--- a/crates/services/txpool/src/service.rs
+++ b/crates/services/txpool/src/service.rs
@@ -251,9 +251,11 @@ where
                                 Some(Ok(_)) => {
                                     GossipsubMessageAcceptance::Accept
                                 },
-                                Some(Err(_)) => {
+                                // Use similar p2p punishment rules as bitcoin
+                                // https://github.com/bitcoin/bitcoin/blob/6ff0aa089c01ff3e610ecb47814ed739d685a14c/src/net_processing.cpp#L1856
+                                Some(Err(Error::ConsensusValidity(_))) => {
                                     GossipsubMessageAcceptance::Reject
-                                }
+                                },
                                 _ => GossipsubMessageAcceptance::Ignore
                             }
                         }
@@ -355,7 +357,7 @@ where
     pub async fn insert(
         &self,
         txs: Vec<Arc<Transaction>>,
-    ) -> Vec<anyhow::Result<InsertionResult>> {
+    ) -> Vec<Result<InsertionResult, Error>> {
         // verify txs
         let current_height = *self.current_height.lock();
 

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -284,7 +284,7 @@ where
         });
 
         if !tx.is_computed() {
-            return Err(Error::NoMetadata.into())
+            return Err(Error::NoMetadata)
         }
 
         // verify max gas is less than block limit
@@ -292,12 +292,11 @@ where
             return Err(Error::NotInsertedMaxGasLimit {
                 tx_gas: tx.max_gas(),
                 block_limit: self.config.chain_config.block_gas_limit,
-            }
-            .into())
+            })
         }
 
         if self.by_hash.contains_key(&tx.id()) {
-            return Err(Error::NotInsertedTxKnown.into())
+            return Err(Error::NotInsertedTxKnown)
         }
 
         let mut max_limit_hit = false;
@@ -307,7 +306,7 @@ where
             // limit is hit, check if we can push out lowest priced tx
             let lowest_price = self.by_gas_price.lowest_value().unwrap_or_default();
             if lowest_price >= tx.price() {
-                return Err(Error::NotInsertedLimitHit.into())
+                return Err(Error::NotInsertedLimitHit)
             }
         }
         if self.config.metrics {
@@ -417,7 +416,7 @@ pub async fn check_single_tx(
     config: &Config,
 ) -> Result<Checked<Transaction>, Error> {
     if tx.is_mint() {
-        return Err(Error::NotSupportedTransactionType.into())
+        return Err(Error::NotSupportedTransactionType)
     }
 
     verify_tx_min_gas_price(&tx, config)?;

--- a/crates/services/txpool/src/txpool/tests.rs
+++ b/crates/services/txpool/src/txpool/tests.rs
@@ -53,7 +53,7 @@ async fn check_unwrap_tx(tx: Transaction, config: &Config) -> Checked<Transactio
 async fn check_tx(
     tx: Transaction,
     config: &Config,
-) -> anyhow::Result<Checked<Transaction>> {
+) -> Result<Checked<Transaction>, Error> {
     check_single_tx(tx, Default::default(), config).await
 }
 
@@ -156,8 +156,8 @@ async fn faulty_t2_collided_on_contract_id_from_tx1() {
         .insert_single(tx_faulty)
         .expect_err("Tx2 should be Err, got Ok");
     assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedCollisionContractId(id)) if id == &contract_id
+        err,
+        Error::NotInsertedCollisionContractId(id) if id == contract_id
     ));
 }
 
@@ -202,8 +202,8 @@ async fn fail_to_insert_tx_with_dependency_on_invalid_utxo_type() {
         .insert_single(tx)
         .expect_err("Tx2 should be Err, got Ok");
     assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedInputUtxoIdNotExisting(id)) if id == &UtxoId::new(tx_faulty_id, 0)
+        err,
+        Error::NotInsertedInputUtxoIdNotExisting(id) if id == UtxoId::new(tx_faulty_id, 0)
     ));
 }
 
@@ -226,10 +226,7 @@ async fn not_inserted_known_tx() {
     let err = txpool
         .insert_single(tx)
         .expect_err("Second insertion of Tx1 should be Err, got Ok");
-    assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedTxKnown)
-    ));
+    assert!(matches!(err, Error::NotInsertedTxKnown));
 }
 
 #[tokio::test]
@@ -249,10 +246,7 @@ async fn try_to_insert_tx2_missing_utxo() {
     let err = txpool
         .insert_single(tx)
         .expect_err("Tx should be Err, got Ok");
-    assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedInputUtxoIdNotExisting(_))
-    ));
+    assert!(matches!(err, Error::NotInsertedInputUtxoIdNotExisting(_)));
 }
 
 #[tokio::test]
@@ -332,8 +326,8 @@ async fn underpriced_tx1_not_included_coin_collision() {
         .insert_single(tx3_checked)
         .expect_err("Tx3 should be Err, got Ok");
     assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedCollision(id, utxo_id)) if id == &tx2.id(&Default::default()) && utxo_id == &UtxoId::new(tx1.id(&Default::default()), 0)
+        err,
+        Error::NotInsertedCollision(id, utxo_id) if id == tx2.id(&Default::default()) && utxo_id == UtxoId::new(tx1.id(&Default::default()), 0)
     ));
 }
 
@@ -378,8 +372,8 @@ async fn overpriced_tx_contract_input_not_inserted() {
         .expect_err("Tx2 should be Err, got Ok");
     assert!(
         matches!(
-            err.downcast_ref::<Error>(),
-            Some(Error::NotInsertedContractPricedLower(id)) if id == &contract_id
+            err,
+            Error::NotInsertedContractPricedLower(id) if id == contract_id
         ),
         "wrong err {err:?}"
     );
@@ -554,10 +548,7 @@ async fn tx_limit_hit() {
     let err = txpool
         .insert_single(tx2)
         .expect_err("Tx2 should be Err, got Ok");
-    assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedLimitHit)
-    ));
+    assert!(matches!(err, Error::NotInsertedLimitHit));
 }
 
 #[tokio::test]
@@ -604,10 +595,7 @@ async fn tx_depth_hit() {
     let err = txpool
         .insert_single(tx3)
         .expect_err("Tx3 should be Err, got Ok");
-    assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedMaxDepth)
-    ));
+    assert!(matches!(err, Error::NotInsertedMaxDepth));
 }
 
 #[tokio::test]
@@ -764,10 +752,7 @@ async fn tx_below_min_gas_price_is_not_insertable() {
     .await
     .expect_err("expected insertion failure");
 
-    assert!(matches!(
-        err.root_cause().downcast_ref::<Error>().unwrap(),
-        Error::NotInsertedGasPriceTooLow
-    ));
+    assert!(matches!(err, Error::NotInsertedGasPriceTooLow));
 }
 
 #[tokio::test]
@@ -811,8 +796,8 @@ async fn tx_rejected_when_input_message_id_is_spent() {
 
     // check error
     assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedInputMessageSpent(msg_id)) if msg_id == message.id()
+        err,
+        Error::NotInsertedInputMessageSpent(msg_id) if msg_id == *message.id()
     ));
 }
 
@@ -833,8 +818,8 @@ async fn tx_rejected_from_pool_when_input_message_id_does_not_exist_in_db() {
 
     // check error
     assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedInputMessageUnknown(msg_id)) if msg_id == message.id()
+        err,
+        Error::NotInsertedInputMessageUnknown(msg_id) if msg_id == *message.id()
     ));
 }
 
@@ -881,8 +866,8 @@ async fn tx_rejected_from_pool_when_gas_price_is_lower_than_another_tx_with_same
 
     // check error
     assert!(matches!(
-        err.downcast_ref::<Error>(),
-        Some(Error::NotInsertedCollisionMessageId(tx_id, msg_id)) if tx_id == &tx_high_id && msg_id == message.id()
+        err,
+        Error::NotInsertedCollisionMessageId(tx_id, msg_id) if tx_id == tx_high_id && msg_id == *message.id()
     ));
 }
 

--- a/crates/services/txpool/src/txpool/tests.rs
+++ b/crates/services/txpool/src/txpool/tests.rs
@@ -203,7 +203,7 @@ async fn fail_to_insert_tx_with_dependency_on_invalid_utxo_type() {
         .expect_err("Tx2 should be Err, got Ok");
     assert!(matches!(
         err,
-        Error::NotInsertedInputUtxoIdNotExisting(id) if id == UtxoId::new(tx_faulty_id, 0)
+        Error::NotInsertedInputUtxoIdNotDoesNotExist(id) if id == UtxoId::new(tx_faulty_id, 0)
     ));
 }
 
@@ -246,7 +246,10 @@ async fn try_to_insert_tx2_missing_utxo() {
     let err = txpool
         .insert_single(tx)
         .expect_err("Tx should be Err, got Ok");
-    assert!(matches!(err, Error::NotInsertedInputUtxoIdNotExisting(_)));
+    assert!(matches!(
+        err,
+        Error::NotInsertedInputUtxoIdNotDoesNotExist(_)
+    ));
 }
 
 #[tokio::test]

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -33,7 +33,10 @@ use crate::{
     },
     services::executor::TransactionExecutionResult,
 };
-use fuel_vm_private::checked_transaction::CheckedTransaction;
+use fuel_vm_private::checked_transaction::{
+    CheckError,
+    CheckedTransaction,
+};
 use std::{
     sync::Arc,
     time::Duration,
@@ -234,7 +237,7 @@ pub fn from_executor_to_status(
 }
 
 #[allow(missing_docs)]
-#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
+#[derive(thiserror::Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum Error {
     #[error("TxPool required that transaction contains metadata")]
@@ -306,7 +309,19 @@ pub enum Error {
     TTLReason,
     #[error("Transaction squeezed out because {0}")]
     SqueezedOut(String),
+    #[error("Invalid transaction data: {0:?}")]
+    ConsensusValidity(CheckError),
+    #[error("Mint transactions are disallowed from the txpool")]
+    MintIsDisallowed,
+    #[error("Database error: {0}")]
+    Database(String),
     // TODO: We need it for now until channels are removed from TxPool.
     #[error("Got some unexpected error: {0}")]
     Other(String),
+}
+
+impl From<CheckError> for Error {
+    fn from(e: CheckError) -> Self {
+        Error::ConsensusValidity(e)
+    }
 }

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -262,16 +262,14 @@ pub enum Error {
         "Transaction is not inserted. A higher priced tx {0:#x} is already spending this message: {1:#x}"
     )]
     NotInsertedCollisionMessageId(TxId, Nonce),
-    #[error(
-        "Transaction is not inserted. Dependent UTXO output is not existing: {0:#x}"
-    )]
-    NotInsertedOutputNotExisting(UtxoId),
-    #[error("Transaction is not inserted. UTXO input contract is not existing: {0:#x}")]
-    NotInsertedInputContractNotExisting(ContractId),
+    #[error("Transaction is not inserted. UTXO input does not exist: {0:#x}")]
+    NotInsertedOutputDoesNotExist(UtxoId),
+    #[error("Transaction is not inserted. UTXO input contract does not exist or was already spent: {0:#x}")]
+    NotInsertedInputContractDoesNotExist(ContractId),
     #[error("Transaction is not inserted. ContractId is already taken {0:#x}")]
     NotInsertedContractIdAlreadyTaken(ContractId),
-    #[error("Transaction is not inserted. UTXO is not existing: {0:#x}")]
-    NotInsertedInputUtxoIdNotExisting(UtxoId),
+    #[error("Transaction is not inserted. UTXO does not exist: {0:#x}")]
+    NotInsertedInputUtxoIdNotDoesNotExist(UtxoId),
     #[error("Transaction is not inserted. UTXO is spent: {0:#x}")]
     NotInsertedInputUtxoIdSpent(UtxoId),
     #[error("Transaction is not inserted. Message is spent: {0:#x}")]

--- a/tests/tests/tx_gossip.rs
+++ b/tests/tests/tx_gossip.rs
@@ -12,7 +12,13 @@ use fuel_core_client::client::{
 };
 use fuel_core_poa::ports::BlockImporter;
 use fuel_core_types::{
-    fuel_tx::*,
+    fuel_tx::{
+        input::{
+            coin::CoinSigned,
+            Empty,
+        },
+        *,
+    },
     fuel_vm::*,
 };
 use futures::StreamExt;
@@ -162,14 +168,19 @@ async fn test_tx_gossiping_invalid_txs(
 
     for _ in 0..NUMBER_OF_INVALID_TXS {
         let invalid_tx = TransactionBuilder::script(vec![], vec![])
-            .add_unsigned_coin_input(
-                SecretKey::random(&mut rng),
-                rng.gen(),
-                rng.gen(),
-                rng.gen(),
-                Default::default(),
-                Default::default(),
-            )
+            .add_input(Input::CoinSigned(CoinSigned {
+                utxo_id: rng.gen(),
+                owner: rng.gen(),
+                amount: 0,
+                asset_id: rng.gen(),
+                tx_pointer: Default::default(),
+                witness_index: 0,
+                maturity: Default::default(),
+                predicate_gas_used: Empty::new(),
+                predicate: Empty::new(),
+                predicate_data: Empty::new(),
+            }))
+            .add_witness(Witness::default())
             .finalize()
             .into();
 


### PR DESCRIPTION
It is fairly common for gossipped transactions to fail due to transient reasons such as UTXO's being spent before the transaction is included. A transaction that was valid when broadcast could become invalid if its inputs were spent in a newly confirmed block. Penalizing nodes for this could unfairly punish nodes that are simply "behind" in their view of the blockchain state.

In bitcoin, only incorrectly formatted transactions (i.e. invalid signatures or corrupt data according to consensus rules) is considered immediately punishable, and all transient failures are ignored. https://github.com/bitcoin/bitcoin/blob/6ff0aa089c01ff3e610ecb47814ed739d685a14c/src/net_processing.cpp#L1849

However, bitcoin does implement rate limiting on peers to prevent spam of either valid or invalid transactions to work around this. That is not currently implemented in this PR.

Note that in the event of transactions with high validation costs due to predicates, this would still be punishable.