### PR TITLE
Fix for the long database initialization after restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Publish crate check
-        uses: katyo/publish-crates@v2
+        uses: xgreenx/publish-crates@v1
         with:
           dry-run: true
           check-repo: false
@@ -237,7 +237,7 @@ jobs:
           sudo apt-get install protobuf-compiler
 
       - name: Publish crate
-        uses: katyo/publish-crates@v2
+        uses: xgreenx/publish-crates@v1
         with:
           publish-delay: 60000
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.73.0
+  RUST_VERSION: 1.74.0
   NIGHTLY_RUST_VERSION: nightly-2023-10-29
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,7 +16,7 @@ defaults:
 env:
   # So cargo doesn't complain about unstable features
   RUSTC_BOOTSTRAP: 1
-  RUST_VERSION: 1.73.0
+  RUST_VERSION: 1.74.0
   PR_TITLE: Weekly `cargo update`
   PR_MESSAGE: |
     Automation to keep dependencies in `Cargo.lock` current.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+## [Version 0.22.1]
+
+### Fixed
+- [#1664](https://github.com/FuelLabs/fuel-core/pull/1664): Fixed long database initialization after restart of the node by setting limit to the WAL file.
+
+
 ## [Version 0.22.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8174,7 +8174,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
@@ -8428,7 +8428,7 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.22.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
@@ -8454,7 +8454,7 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.22.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2775,6 +2775,7 @@ dependencies = [
  "hyper",
  "itertools 0.10.5",
  "mockall",
+ "num_cpus",
  "postcard",
  "proptest",
  "rand 0.8.5",
@@ -2827,11 +2828,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.22.0"
+version = "0.22.1"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "clap 4.4.11",
@@ -2857,7 +2858,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2876,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2899,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "clap 4.4.11",
  "fuel-core-client",
@@ -2910,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2922,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2933,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2958,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2972,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2988,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "clap 4.4.11",
@@ -2999,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -3012,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "axum",
  "once_cell",
@@ -3026,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3070,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3088,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3105,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3133,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3147,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3159,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3211,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "ctor",
  "tracing",
@@ -3221,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3247,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "bs58 0.5.0",
@@ -8173,7 +8174,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
@@ -8427,7 +8428,7 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
@@ -8453,7 +8454,7 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,33 +46,33 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.22.0"
+version = "0.22.1"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.22.0", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.22.0", path = "./bin/client" }
-fuel-core-bin = { version = "0.22.0", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.22.0", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.22.0", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.22.0", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.22.0", path = "./crates/client" }
-fuel-core-database = { version = "0.22.0", path = "./crates/database" }
-fuel-core-metrics = { version = "0.22.0", path = "./crates/metrics" }
-fuel-core-services = { version = "0.22.0", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.22.0", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.22.0", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.22.0", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.22.0", path = "./crates/services/executor" }
-fuel-core-importer = { version = "0.22.0", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.22.0", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.22.0", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.22.0", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.22.0", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.22.0", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.22.0", path = "./crates/storage" }
-fuel-core-trace = { version = "0.22.0", path = "./crates/trace" }
-fuel-core-types = { version = "0.22.0", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.22.1", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.22.1", path = "./bin/client" }
+fuel-core-bin = { version = "0.22.1", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.22.1", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.22.1", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.22.1", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.22.1", path = "./crates/client" }
+fuel-core-database = { version = "0.22.1", path = "./crates/database" }
+fuel-core-metrics = { version = "0.22.1", path = "./crates/metrics" }
+fuel-core-services = { version = "0.22.1", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.22.1", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.22.1", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.22.1", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.22.1", path = "./crates/services/executor" }
+fuel-core-importer = { version = "0.22.1", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.22.1", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.22.1", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.22.1", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.22.1", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.22.1", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.22.1", path = "./crates/storage" }
+fuel-core-trace = { version = "0.22.1", path = "./crates/trace" }
+fuel-core-types = { version = "0.22.1", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -425,16 +425,12 @@ async fn shutdown_signal() -> anyhow::Result<()> {
 
         let mut sigint =
             tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
-        loop {
-            tokio::select! {
-                _ = sigterm.recv() => {
-                    tracing::info!("sigterm received");
-                    break;
-                }
-                _ = sigint.recv() => {
-                    tracing::info!("sigint received");
-                    break;
-                }
+        tokio::select! {
+            _ = sigterm.recv() => {
+                tracing::info!("sigterm received");
+            }
+            _ = sigint.recv() => {
+                tracing::info!("sigint received");
             }
         }
     }

--- a/ci_checks.sh
+++ b/ci_checks.sh
@@ -3,7 +3,7 @@
 # The script runs almost all CI checks locally.
 #
 # Requires installed:
-# - Rust `1.73.0`
+# - Rust `1.74.0`
 # - Nightly rust formatter
 # - `cargo install cargo-sort`
 

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -41,7 +41,7 @@ futures = { workspace = true }
 hex = { version = "0.4", features = ["serde"] }
 hyper = { workspace = true }
 itertools = { workspace = true }
-num_cpus = "1.16.0"
+num_cpus = { version = "1.16.0", optional = true }
 postcard = { workspace = true, features = ["use-std"] }
 rand = { workspace = true }
 rocksdb = { version = "0.21", default-features = false, features = [
@@ -76,7 +76,7 @@ test-strategy = { workspace = true }
 default = ["rocksdb"]
 p2p = ["dep:fuel-core-p2p", "dep:fuel-core-sync"]
 relayer = ["dep:fuel-core-relayer"]
-rocksdb = ["dep:rocksdb", "dep:tempfile"]
+rocksdb = ["dep:rocksdb", "dep:tempfile", "dep:num_cpus"]
 test-helpers = ["fuel-core-p2p?/test-helpers"]
 # features to enable in production, but increase build times
 rocksdb-production = ["rocksdb", "rocksdb/jemalloc"]

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -41,6 +41,7 @@ futures = { workspace = true }
 hex = { version = "0.4", features = ["serde"] }
 hyper = { workspace = true }
 itertools = { workspace = true }
+num_cpus = "1.16.0"
 postcard = { workspace = true, features = ["use-std"] }
 rand = { workspace = true }
 rocksdb = { version = "0.21", default-features = false, features = [

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -138,11 +138,13 @@ impl RocksDb {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.set_compression_type(DBCompressionType::Lz4);
-        opts.set_bytes_per_sync(1 * 1024 * 1024);
+        opts.set_bytes_per_sync(1024 * 1024);
         // TODO: Use value from the database config from https://github.com/FuelLabs/fuel-core/pull/1519
         opts.set_max_total_wal_size(64 * 1024 * 1024);
         opts.set_keep_log_file_num(1);
-        opts.increase_parallelism(cmp::max(1, num_cpus::get() as i32 / 2));
+        let cpu_number =
+            i32::try_from(num_cpus::get()).expect("The number of CPU can't exceed `i32`");
+        opts.increase_parallelism(cmp::max(1, cpu_number / 2));
         if let Some(capacity) = capacity {
             // Set cache size 1/3 of the capacity. Another 1/3 is
             // used by block cache and the last 1 / 3 remains for other purposes:

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -38,6 +38,7 @@ use rocksdb::{
     WriteBatch,
 };
 use std::{
+    cmp,
     env,
     iter,
     path::{
@@ -137,6 +138,11 @@ impl RocksDb {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.set_compression_type(DBCompressionType::Lz4);
+        opts.set_bytes_per_sync(1 * 1024 * 1024);
+        // TODO: Use value from the database config from https://github.com/FuelLabs/fuel-core/pull/1519
+        opts.set_max_total_wal_size(64 * 1024 * 1024);
+        opts.set_keep_log_file_num(1);
+        opts.increase_parallelism(cmp::max(1, num_cpus::get() as i32 / 2));
         if let Some(capacity) = capacity {
             // Set cache size 1/3 of the capacity. Another 1/3 is
             // used by block cache and the last 1 / 3 remains for other purposes:

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -138,10 +138,8 @@ impl RocksDb {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.set_compression_type(DBCompressionType::Lz4);
-        opts.set_bytes_per_sync(1024 * 1024);
-        // TODO: Use value from the database config from https://github.com/FuelLabs/fuel-core/pull/1519
+        // TODO: Make it customizable https://github.com/FuelLabs/fuel-core/issues/1666
         opts.set_max_total_wal_size(64 * 1024 * 1024);
-        opts.set_keep_log_file_num(1);
         let cpu_number =
             i32::try_from(num_cpus::get()).expect("The number of CPU can't exceed `i32`");
         opts.increase_parallelism(cmp::max(1, cpu_number / 2));

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
-FROM --platform=$BUILDPLATFORM rust:1.73.0 AS chef
+FROM --platform=$BUILDPLATFORM rust:1.74.0 AS chef
 
 ARG TARGETPLATFORM
 RUN cargo install cargo-chef

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.22.0"
+appVersion: "0.22.1"
 version: 0.1.0

--- a/deployment/e2e-client.Dockerfile
+++ b/deployment/e2e-client.Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM rust:1.73.0 AS chef
+FROM rust:1.74.0 AS chef
 RUN cargo install cargo-chef
 WORKDIR /build/
 # hadolint ignore=DL3008


### PR DESCRIPTION
The change adds 64 MB limit for the WAL file. Previously, it was unlimited, causing [long initialization of the database](https://github.com/facebook/rocksdb/wiki/Speed-Up-DB-Open#wal-replaying).

The change also bumps the `fuel-core` version to `0.22.1`. Later, we need to duplicate the same change to the `master` branch.