### PR TITLE
Remove nested contract resolvers in GQL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Description of the upcoming release here.
 - [#1636](https://github.com/FuelLabs/fuel-core/pull/1636): Add more docs to GraphQL DAP API.
 
 #### Breaking
+- [#1675](https://github.com/FuelLabs/fuel-core/pull/1675): Simplify GQL schema by disabling contract resolvers in most cases, and just return a ContractId scalar instead.
 - [#1658](https://github.com/FuelLabs/fuel-core/pull/1658): Receipts are part of the transaction status. 
     Removed `reason` from the `TransactionExecutionResult::Failed`. It can be calculated based on the program state and receipts.
     Also, it is not possible to fetch `receipts` from the `Transaction` directly anymore. Instead, you need to fetch `status` and its receipts.

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -236,7 +236,7 @@ input ContractBalanceFilterInput {
 }
 
 type ContractCreated {
-	contract: Contract!
+	contract: ContractId!
 	stateRoot: Bytes32!
 }
 
@@ -508,7 +508,7 @@ type InputContract {
 	balanceRoot: Bytes32!
 	stateRoot: Bytes32!
 	txPointer: TxPointer!
-	contract: Contract!
+	contract: ContractId!
 }
 
 type InputMessage {
@@ -826,10 +826,10 @@ type Query {
 }
 
 type Receipt {
-	contract: Contract
+	contract: ContractId
 	pc: U64
 	is: U64
-	to: Contract
+	to: ContractId
 	toAddress: Address
 	amount: U64
 	assetId: AssetId
@@ -957,7 +957,7 @@ scalar Tai64Timestamp
 type Transaction {
 	id: TransactionId!
 	inputAssetIds: [AssetId!]
-	inputContracts: [Contract!]
+	inputContracts: [ContractId!]
 	inputContract: InputContract
 	policies: Policies
 	gasPrice: U64

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -508,7 +508,7 @@ type InputContract {
 	balanceRoot: Bytes32!
 	stateRoot: Bytes32!
 	txPointer: TxPointer!
-	contract: ContractId!
+	contractId: ContractId!
 }
 
 type InputMessage {
@@ -826,7 +826,7 @@ type Query {
 }
 
 type Receipt {
-	contract: ContractId
+	id: ContractId
 	pc: U64
 	is: U64
 	to: ContractId
@@ -852,6 +852,9 @@ type Receipt {
 	sender: Address
 	recipient: Address
 	nonce: Nonce
+	"""
+	Set in the case of a Panic receipt to indicate a missing contract input id
+	"""
 	contractId: ContractId
 	subId: Bytes32
 }

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__dry_run_tx_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__dry_run_tx_gql_output.snap
@@ -19,7 +19,7 @@ mutation($txs: [HexString!]!, $utxoValidation: Boolean) {
           assetId
           gas
           digest
-          contract
+          id
           is
           pc
           ptr
@@ -55,7 +55,7 @@ mutation($txs: [HexString!]!, $utxoValidation: Boolean) {
           assetId
           gas
           digest
-          contract
+          id
           is
           pc
           ptr

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__dry_run_tx_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__dry_run_tx_gql_output.snap
@@ -19,9 +19,7 @@ mutation($txs: [HexString!]!, $utxoValidation: Boolean) {
           assetId
           gas
           digest
-          contract {
-            id
-          }
+          contract
           is
           pc
           ptr
@@ -31,9 +29,7 @@ mutation($txs: [HexString!]!, $utxoValidation: Boolean) {
           rd
           reason
           receiptType
-          to {
-            id
-          }
+          to
           toAddress
           val
           len
@@ -59,9 +55,7 @@ mutation($txs: [HexString!]!, $utxoValidation: Boolean) {
           assetId
           gas
           digest
-          contract {
-            id
-          }
+          contract
           is
           pc
           ptr
@@ -71,9 +65,7 @@ mutation($txs: [HexString!]!, $utxoValidation: Boolean) {
           rd
           reason
           receiptType
-          to {
-            id
-          }
+          to
           toAddress
           val
           len

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__opaque_transaction_by_id_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__opaque_transaction_by_id_query_gql_output.snap
@@ -27,9 +27,7 @@ query($id: TransactionId!) {
           assetId
           gas
           digest
-          contract {
-            id
-          }
+          contract
           is
           pc
           ptr
@@ -39,9 +37,7 @@ query($id: TransactionId!) {
           rd
           reason
           receiptType
-          to {
-            id
-          }
+          to
           toAddress
           val
           len
@@ -76,9 +72,7 @@ query($id: TransactionId!) {
           assetId
           gas
           digest
-          contract {
-            id
-          }
+          contract
           is
           pc
           ptr
@@ -88,9 +82,7 @@ query($id: TransactionId!) {
           rd
           reason
           receiptType
-          to {
-            id
-          }
+          to
           toAddress
           val
           len

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__opaque_transaction_by_id_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__opaque_transaction_by_id_query_gql_output.snap
@@ -27,7 +27,7 @@ query($id: TransactionId!) {
           assetId
           gas
           digest
-          contract
+          id
           is
           pc
           ptr
@@ -72,7 +72,7 @@ query($id: TransactionId!) {
           assetId
           gas
           digest
-          contract
+          id
           is
           pc
           ptr

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transactions_by_owner_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transactions_by_owner_gql_output.snap
@@ -30,9 +30,7 @@ query($owner: Address!, $after: String, $before: String, $first: Int, $last: Int
               assetId
               gas
               digest
-              contract {
-                id
-              }
+              contract
               is
               pc
               ptr
@@ -42,9 +40,7 @@ query($owner: Address!, $after: String, $before: String, $first: Int, $last: Int
               rd
               reason
               receiptType
-              to {
-                id
-              }
+              to
               toAddress
               val
               len
@@ -79,9 +75,7 @@ query($owner: Address!, $after: String, $before: String, $first: Int, $last: Int
               assetId
               gas
               digest
-              contract {
-                id
-              }
+              contract
               is
               pc
               ptr
@@ -91,9 +85,7 @@ query($owner: Address!, $after: String, $before: String, $first: Int, $last: Int
               rd
               reason
               receiptType
-              to {
-                id
-              }
+              to
               toAddress
               val
               len

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transactions_by_owner_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transactions_by_owner_gql_output.snap
@@ -30,7 +30,7 @@ query($owner: Address!, $after: String, $before: String, $first: Int, $last: Int
               assetId
               gas
               digest
-              contract
+              id
               is
               pc
               ptr
@@ -75,7 +75,7 @@ query($owner: Address!, $after: String, $before: String, $first: Int, $last: Int
               assetId
               gas
               digest
-              contract
+              id
               is
               pc
               ptr

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transactions_connection_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transactions_connection_query_gql_output.snap
@@ -30,9 +30,7 @@ query($after: String, $before: String, $first: Int, $last: Int) {
               assetId
               gas
               digest
-              contract {
-                id
-              }
+              contract
               is
               pc
               ptr
@@ -42,9 +40,7 @@ query($after: String, $before: String, $first: Int, $last: Int) {
               rd
               reason
               receiptType
-              to {
-                id
-              }
+              to
               toAddress
               val
               len
@@ -79,9 +75,7 @@ query($after: String, $before: String, $first: Int, $last: Int) {
               assetId
               gas
               digest
-              contract {
-                id
-              }
+              contract
               is
               pc
               ptr
@@ -91,9 +85,7 @@ query($after: String, $before: String, $first: Int, $last: Int) {
               rd
               reason
               receiptType
-              to {
-                id
-              }
+              to
               toAddress
               val
               len

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transactions_connection_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transactions_connection_query_gql_output.snap
@@ -30,7 +30,7 @@ query($after: String, $before: String, $first: Int, $last: Int) {
               assetId
               gas
               digest
-              contract
+              id
               is
               pc
               ptr
@@ -75,7 +75,7 @@ query($after: String, $before: String, $first: Int, $last: Int) {
               assetId
               gas
               digest
-              contract
+              id
               is
               pc
               ptr

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -14,7 +14,7 @@ query($id: TransactionId!) {
       balanceRoot
       stateRoot
       txPointer
-      contract
+      contractId
     }
     inputs {
       __typename
@@ -35,7 +35,7 @@ query($id: TransactionId!) {
         balanceRoot
         stateRoot
         txPointer
-        contract
+        contractId
       }
       ... on InputMessage {
         sender
@@ -109,7 +109,7 @@ query($id: TransactionId!) {
           assetId
           gas
           digest
-          contract
+          id
           is
           pc
           ptr
@@ -154,7 +154,7 @@ query($id: TransactionId!) {
           assetId
           gas
           digest
-          contract
+          id
           is
           pc
           ptr

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__transparent_transaction_by_id_query_gql_output.snap
@@ -8,17 +8,13 @@ query($id: TransactionId!) {
     id
     txPointer
     inputAssetIds
-    inputContracts {
-      id
-    }
+    inputContracts
     inputContract {
       utxoId
       balanceRoot
       stateRoot
       txPointer
-      contract {
-        id
-      }
+      contract
     }
     inputs {
       __typename
@@ -39,9 +35,7 @@ query($id: TransactionId!) {
         balanceRoot
         stateRoot
         txPointer
-        contract {
-          id
-        }
+        contract
       }
       ... on InputMessage {
         sender
@@ -81,9 +75,7 @@ query($id: TransactionId!) {
         assetId
       }
       ... on ContractCreated {
-        contract {
-          id
-        }
+        contract
         stateRoot
       }
     }
@@ -117,9 +109,7 @@ query($id: TransactionId!) {
           assetId
           gas
           digest
-          contract {
-            id
-          }
+          contract
           is
           pc
           ptr
@@ -129,9 +119,7 @@ query($id: TransactionId!) {
           rd
           reason
           receiptType
-          to {
-            id
-          }
+          to
           toAddress
           val
           len
@@ -166,9 +154,7 @@ query($id: TransactionId!) {
           assetId
           gas
           digest
-          contract {
-            id
-          }
+          contract
           is
           pc
           ptr
@@ -178,9 +164,7 @@ query($id: TransactionId!) {
           rd
           reason
           receiptType
-          to {
-            id
-          }
+          to
           toAddress
           val
           len

--- a/crates/client/src/client/schema/tx/transparent_receipt.rs
+++ b/crates/client/src/client/schema/tx/transparent_receipt.rs
@@ -24,7 +24,7 @@ pub struct Receipt {
     pub asset_id: Option<AssetId>,
     pub gas: Option<U64>,
     pub digest: Option<Bytes32>,
-    pub contract: Option<ContractId>,
+    pub id: Option<ContractId>,
     pub is: Option<U64>,
     pub pc: Option<U64>,
     pub ptr: Option<U64>,
@@ -72,7 +72,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
     fn try_from(schema: Receipt) -> Result<Self, Self::Error> {
         Ok(match schema.receipt_type {
             ReceiptType::Call => fuel_tx::Receipt::Call {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 to: schema
                     .to
                     .ok_or_else(|| MissingField("to".to_string()))?
@@ -107,7 +107,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::Return => fuel_tx::Receipt::Return {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 val: schema
                     .val
                     .ok_or_else(|| MissingField("val".to_string()))?
@@ -122,7 +122,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::ReturnData => fuel_tx::Receipt::ReturnData {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 ptr: schema
                     .ptr
                     .ok_or_else(|| MissingField("ptr".to_string()))?
@@ -151,7 +151,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::Panic => fuel_tx::Receipt::Panic {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 reason: schema
                     .reason
                     .ok_or_else(|| MissingField("reason".to_string()))?
@@ -167,7 +167,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                 contract_id: schema.contract_id.map(Into::into),
             },
             ReceiptType::Revert => fuel_tx::Receipt::Revert {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 ra: schema
                     .ra
                     .ok_or_else(|| MissingField("ra".to_string()))?
@@ -182,7 +182,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::Log => fuel_tx::Receipt::Log {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 ra: schema
                     .ra
                     .ok_or_else(|| MissingField("ra".to_string()))?
@@ -209,7 +209,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::LogData => fuel_tx::Receipt::LogData {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 ra: schema
                     .ra
                     .ok_or_else(|| MissingField("ra".to_string()))?
@@ -246,7 +246,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::Transfer => fuel_tx::Receipt::Transfer {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 to: schema
                     .to
                     .ok_or_else(|| MissingField("to".to_string()))?
@@ -269,7 +269,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::TransferOut => fuel_tx::Receipt::TransferOut {
-                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 to: schema
                     .to_address
                     .ok_or_else(|| MissingField("to_address".to_string()))?
@@ -340,7 +340,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .sub_id
                     .ok_or_else(|| MissingField("sub_id".to_string()))?
                     .into(),
-                contract_id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                contract_id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 val: schema
                     .val
                     .ok_or_else(|| MissingField("val".to_string()))?
@@ -359,7 +359,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .sub_id
                     .ok_or_else(|| MissingField("sub_id".to_string()))?
                     .into(),
-                contract_id: schema.contract.map(|id| id.into()).unwrap_or_default(),
+                contract_id: schema.id.map(|id| id.into()).unwrap_or_default(),
                 val: schema
                     .val
                     .ok_or_else(|| MissingField("val".to_string()))?

--- a/crates/client/src/client/schema/tx/transparent_receipt.rs
+++ b/crates/client/src/client/schema/tx/transparent_receipt.rs
@@ -1,5 +1,4 @@
 use crate::client::schema::{
-    contract::ContractIdFragment,
     schema,
     Address,
     AssetId,
@@ -25,7 +24,7 @@ pub struct Receipt {
     pub asset_id: Option<AssetId>,
     pub gas: Option<U64>,
     pub digest: Option<Bytes32>,
-    pub contract: Option<ContractIdFragment>,
+    pub contract: Option<ContractId>,
     pub is: Option<U64>,
     pub pc: Option<U64>,
     pub ptr: Option<U64>,
@@ -35,7 +34,7 @@ pub struct Receipt {
     pub rd: Option<U64>,
     pub reason: Option<U64>,
     pub receipt_type: ReceiptType,
-    pub to: Option<ContractIdFragment>,
+    pub to: Option<ContractId>,
     pub to_address: Option<Address>,
     pub val: Option<U64>,
     pub len: Option<U64>,
@@ -73,11 +72,10 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
     fn try_from(schema: Receipt) -> Result<Self, Self::Error> {
         Ok(match schema.receipt_type {
             ReceiptType::Call => fuel_tx::Receipt::Call {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 to: schema
                     .to
                     .ok_or_else(|| MissingField("to".to_string()))?
-                    .id
                     .into(),
                 amount: schema
                     .amount
@@ -109,7 +107,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::Return => fuel_tx::Receipt::Return {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 val: schema
                     .val
                     .ok_or_else(|| MissingField("val".to_string()))?
@@ -124,7 +122,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::ReturnData => fuel_tx::Receipt::ReturnData {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 ptr: schema
                     .ptr
                     .ok_or_else(|| MissingField("ptr".to_string()))?
@@ -153,7 +151,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::Panic => fuel_tx::Receipt::Panic {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 reason: schema
                     .reason
                     .ok_or_else(|| MissingField("reason".to_string()))?
@@ -169,7 +167,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                 contract_id: schema.contract_id.map(Into::into),
             },
             ReceiptType::Revert => fuel_tx::Receipt::Revert {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 ra: schema
                     .ra
                     .ok_or_else(|| MissingField("ra".to_string()))?
@@ -184,7 +182,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::Log => fuel_tx::Receipt::Log {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 ra: schema
                     .ra
                     .ok_or_else(|| MissingField("ra".to_string()))?
@@ -211,7 +209,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::LogData => fuel_tx::Receipt::LogData {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 ra: schema
                     .ra
                     .ok_or_else(|| MissingField("ra".to_string()))?
@@ -248,11 +246,10 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::Transfer => fuel_tx::Receipt::Transfer {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 to: schema
                     .to
                     .ok_or_else(|| MissingField("to".to_string()))?
-                    .id
                     .into(),
                 amount: schema
                     .amount
@@ -272,7 +269,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .into(),
             },
             ReceiptType::TransferOut => fuel_tx::Receipt::TransferOut {
-                id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 to: schema
                     .to_address
                     .ok_or_else(|| MissingField("to_address".to_string()))?
@@ -343,7 +340,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .sub_id
                     .ok_or_else(|| MissingField("sub_id".to_string()))?
                     .into(),
-                contract_id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                contract_id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 val: schema
                     .val
                     .ok_or_else(|| MissingField("val".to_string()))?
@@ -362,7 +359,7 @@ impl TryFrom<Receipt> for fuel_tx::Receipt {
                     .sub_id
                     .ok_or_else(|| MissingField("sub_id".to_string()))?
                     .into(),
-                contract_id: schema.contract.map(|id| id.id.into()).unwrap_or_default(),
+                contract_id: schema.contract.map(|id| id.into()).unwrap_or_default(),
                 val: schema
                     .val
                     .ok_or_else(|| MissingField("val".to_string()))?

--- a/crates/client/src/client/schema/tx/transparent_tx.rs
+++ b/crates/client/src/client/schema/tx/transparent_tx.rs
@@ -1,5 +1,4 @@
 use crate::client::schema::{
-    contract::ContractIdFragment,
     schema,
     tx::{
         TransactionStatus,
@@ -9,6 +8,7 @@ use crate::client::schema::{
     AssetId,
     Bytes32,
     ConnectionArgs,
+    ContractId,
     ConversionError,
     HexString,
     Nonce,
@@ -95,7 +95,7 @@ pub struct Transaction {
     ///
     /// The result of a `input_contracts()` helper function is stored here.
     /// It is not an original field of the `Transaction`.
-    pub input_contracts: Option<Vec<ContractIdFragment>>,
+    pub input_contracts: Option<Vec<ContractId>>,
     /// The field of the `Transaction::Mint` transaction.
     pub input_contract: Option<InputContract>,
     /// The field of the `Transaction` type.
@@ -324,7 +324,7 @@ pub struct InputContract {
     pub balance_root: Bytes32,
     pub state_root: Bytes32,
     pub tx_pointer: TxPointer,
-    pub contract: ContractIdFragment,
+    pub contract: ContractId,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -465,7 +465,7 @@ pub struct ContractOutput {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractCreated {
-    contract: ContractIdFragment,
+    contract: ContractId,
     state_root: Bytes32,
 }
 
@@ -491,7 +491,7 @@ impl TryFrom<Output> for fuel_tx::Output {
                 asset_id: variable.asset_id.into(),
             },
             Output::ContractCreated(contract) => Self::ContractCreated {
-                contract_id: contract.contract.id.into(),
+                contract_id: contract.contract.into(),
                 state_root: contract.state_root.into(),
             },
             Output::Unknown => return Err(Self::Error::UnknownVariant("Output")),
@@ -506,7 +506,7 @@ impl From<InputContract> for input::contract::Contract {
             balance_root: contract.balance_root.into(),
             state_root: contract.state_root.into(),
             tx_pointer: contract.tx_pointer.into(),
-            contract_id: contract.contract.id.into(),
+            contract_id: contract.contract.into(),
         }
     }
 }

--- a/crates/client/src/client/schema/tx/transparent_tx.rs
+++ b/crates/client/src/client/schema/tx/transparent_tx.rs
@@ -324,7 +324,7 @@ pub struct InputContract {
     pub balance_root: Bytes32,
     pub state_root: Bytes32,
     pub tx_pointer: TxPointer,
-    pub contract: ContractId,
+    pub contract_id: ContractId,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -506,7 +506,7 @@ impl From<InputContract> for input::contract::Contract {
             balance_root: contract.balance_root.into(),
             state_root: contract.state_root.into(),
             tx_pointer: contract.tx_pointer.into(),
-            contract_id: contract.contract.into(),
+            contract_id: contract.contract_id.into(),
         }
     }
 }

--- a/crates/fuel-core/src/schema/tx/input.rs
+++ b/crates/fuel-core/src/schema/tx/input.rs
@@ -1,17 +1,14 @@
-use crate::schema::{
-    contract::Contract,
-    scalars::{
-        Address,
-        AssetId,
-        Bytes32,
-        ContractId,
-        HexString,
-        Nonce,
-        TxPointer,
-        UtxoId,
-        U32,
-        U64,
-    },
+use crate::schema::scalars::{
+    Address,
+    AssetId,
+    Bytes32,
+    ContractId,
+    HexString,
+    Nonce,
+    TxPointer,
+    UtxoId,
+    U32,
+    U64,
 };
 use async_graphql::{
     Object,
@@ -108,8 +105,8 @@ impl InputContract {
         self.tx_pointer
     }
 
-    async fn contract(&self) -> Contract {
-        self.contract_id.0.into()
+    async fn contract(&self) -> ContractId {
+        self.contract_id
     }
 }
 

--- a/crates/fuel-core/src/schema/tx/input.rs
+++ b/crates/fuel-core/src/schema/tx/input.rs
@@ -105,7 +105,7 @@ impl InputContract {
         self.tx_pointer
     }
 
-    async fn contract(&self) -> ContractId {
+    async fn contract_id(&self) -> ContractId {
         self.contract_id
     }
 }

--- a/crates/fuel-core/src/schema/tx/output.rs
+++ b/crates/fuel-core/src/schema/tx/output.rs
@@ -1,11 +1,9 @@
-use crate::schema::{
-    contract::Contract,
-    scalars::{
-        Address,
-        AssetId,
-        Bytes32,
-        U64,
-    },
+use crate::schema::scalars::{
+    Address,
+    AssetId,
+    Bytes32,
+    ContractId,
+    U64,
 };
 use async_graphql::{
     Object,
@@ -110,7 +108,7 @@ pub struct ContractCreated {
 
 #[Object]
 impl ContractCreated {
-    async fn contract(&self) -> Contract {
+    async fn contract(&self) -> ContractId {
         self.contract_id.into()
     }
 

--- a/crates/fuel-core/src/schema/tx/receipt.rs
+++ b/crates/fuel-core/src/schema/tx/receipt.rs
@@ -59,7 +59,7 @@ pub struct Receipt(pub fuel_tx::Receipt);
 
 #[Object]
 impl Receipt {
-    async fn contract(&self) -> Option<ContractId> {
+    async fn id(&self) -> Option<ContractId> {
         Some((*self.0.id()?).into())
     }
     async fn pc(&self) -> Option<U64> {
@@ -137,6 +137,8 @@ impl Receipt {
     async fn nonce(&self) -> Option<Nonce> {
         self.0.nonce().copied().map(Nonce)
     }
+
+    /// Set in the case of a Panic receipt to indicate a missing contract input id
     async fn contract_id(&self) -> Option<ContractId> {
         self.0.contract_id().map(|id| ContractId(*id))
     }

--- a/crates/fuel-core/src/schema/tx/receipt.rs
+++ b/crates/fuel-core/src/schema/tx/receipt.rs
@@ -1,14 +1,11 @@
-use crate::schema::{
-    contract::Contract,
-    scalars::{
-        Address,
-        AssetId,
-        Bytes32,
-        ContractId,
-        HexString,
-        Nonce,
-        U64,
-    },
+use crate::schema::scalars::{
+    Address,
+    AssetId,
+    Bytes32,
+    ContractId,
+    HexString,
+    Nonce,
+    U64,
 };
 use async_graphql::{
     Enum,
@@ -62,7 +59,7 @@ pub struct Receipt(pub fuel_tx::Receipt);
 
 #[Object]
 impl Receipt {
-    async fn contract(&self) -> Option<Contract> {
+    async fn contract(&self) -> Option<ContractId> {
         Some((*self.0.id()?).into())
     }
     async fn pc(&self) -> Option<U64> {
@@ -71,7 +68,7 @@ impl Receipt {
     async fn is(&self) -> Option<U64> {
         self.0.is().map(Into::into)
     }
-    async fn to(&self) -> Option<Contract> {
+    async fn to(&self) -> Option<ContractId> {
         self.0.to().copied().map(Into::into)
     }
     async fn to_address(&self) -> Option<Address> {

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -17,10 +17,10 @@ use crate::{
     },
     schema::{
         block::Block,
-        contract::Contract,
         scalars::{
             AssetId,
             Bytes32,
+            ContractId,
             HexString,
             Salt,
             Tai64Timestamp,
@@ -365,16 +365,16 @@ impl Transaction {
         }
     }
 
-    async fn input_contracts(&self) -> Option<Vec<Contract>> {
+    async fn input_contracts(&self) -> Option<Vec<ContractId>> {
         match &self.0 {
             fuel_tx::Transaction::Script(script) => {
-                Some(script.input_contracts().map(|v| Contract(*v)).collect())
+                Some(script.input_contracts().map(|v| (*v).into()).collect())
             }
             fuel_tx::Transaction::Create(create) => {
-                Some(create.input_contracts().map(|v| Contract(*v)).collect())
+                Some(create.input_contracts().map(|v| (*v).into()).collect())
             }
             fuel_tx::Transaction::Mint(mint) => {
-                Some(vec![Contract(mint.input_contract().contract_id)])
+                Some(vec![mint.input_contract().contract_id.into()])
             }
         }
     }


### PR DESCRIPTION
closes: #1652

Having the ability to fetch all data related to a contract is overkill and costly in most cases, and usually done by accident. This api change simplifies the GQL schema to simply return a contractId instead of a contract resolver for tx inputs, receipts, and more.

Note that the full contract details (such as the contract bytecode) can still be fetched directly via the contract query endpoint.