### PR TITLE
feat: Versionable `ContractUtxoInfo` for the `ContractsLatestUtxo` table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Breaking
 
+- [#1712](https://github.com/FuelLabs/fuel-core/pull/1712): Make `ContractUtxoInfo` type a version-able enum for use in the `ContractsLatestUtxo`table.
 - [#1657](https://github.com/FuelLabs/fuel-core/pull/1657): Changed `CROO` gas price type from `Word` to `DependentGasPrice`. The dependent gas price values are dummy values while awaiting updated benchmarks.
 - [#1671](https://github.com/FuelLabs/fuel-core/pull/1671): The GraphQL API uses block height instead of the block id where it is possible. The transaction status contains `block_height` instead of the `block_id`.
 - [#1675](https://github.com/FuelLabs/fuel-core/pull/1675): Simplify GQL schema by disabling contract resolvers in most cases, and just return a ContractId scalar instead.

--- a/crates/fuel-core/src/database/contracts.rs
+++ b/crates/fuel-core/src/database/contracts.rs
@@ -13,14 +13,11 @@ use fuel_core_storage::{
     Result as StorageResult,
     StorageAsRef,
 };
-use fuel_core_types::{
-    entities::contract::ContractUtxoInfo,
-    fuel_types::{
-        AssetId,
-        Bytes32,
-        ContractId,
-        Word,
-    },
+use fuel_core_types::fuel_types::{
+    AssetId,
+    Bytes32,
+    ContractId,
+    Word,
 };
 
 impl Database {
@@ -42,15 +39,14 @@ impl Database {
             .expect("Contract does not exist")
             .salt();
 
-        let ContractUtxoInfo {
-            utxo_id,
-            tx_pointer,
-        } = self
+        let latest_utxo = self
             .storage::<ContractsLatestUtxo>()
             .get(&contract_id)
             .unwrap()
             .expect("contract does not exist")
             .into_owned();
+        let utxo_id = latest_utxo.utxo_id();
+        let tx_pointer = latest_utxo.tx_pointer();
 
         let state = Some(
             self.iter_all_by_prefix::<ContractsState, _>(Some(contract_id.as_ref()))

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -261,10 +261,7 @@ fn init_contracts(
                     .storage::<ContractsLatestUtxo>()
                     .insert(
                         &contract_id,
-                        &ContractUtxoInfo {
-                            utxo_id,
-                            tx_pointer,
-                        },
+                        &ContractUtxoInfo::V1((utxo_id, tx_pointer).into()),
                     )?
                     .is_some()
                 {

--- a/crates/services/executor/src/refs/contract.rs
+++ b/crates/services/executor/src/refs/contract.rs
@@ -124,13 +124,13 @@ where
 {
     fn root(&self) -> anyhow::Result<MerkleRoot> {
         let contract_id = *self.contract_id();
-        let utxo = self
+        let utxo = *self
             .database()
             .storage::<ContractsLatestUtxo>()
             .get(&contract_id)?
             .ok_or(not_found!(ContractsLatestUtxo))?
             .into_owned()
-            .utxo_id;
+            .utxo_id();
 
         let state_root = self
             .database()

--- a/crates/types/src/entities/contract.rs
+++ b/crates/types/src/entities/contract.rs
@@ -7,9 +7,31 @@ use crate::fuel_tx::{
 use fuel_vm_private::fuel_tx::UtxoId;
 
 /// Contains information related to the latest contract utxo
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ContractUtxoInfo {
+    /// V1 ContractUtxoInfo
+    V1(ContractUtxoInfoV1),
+}
+
+impl ContractUtxoInfo {
+    pub fn utxo_id(&self) -> &UtxoId {
+        match self {
+            ContractUtxoInfo::V1(info) => &info.utxo_id,
+        }
+    }
+
+    pub fn tx_pointer(&self) -> TxPointer {
+        match self {
+            ContractUtxoInfo::V1(info) => info.tx_pointer,
+        }
+    }
+}
+
+/// Version 1 of the ContractUtxoInfo
 #[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ContractUtxoInfo {
+pub struct ContractUtxoInfoV1 {
     /// the utxo id of the contract
     pub utxo_id: UtxoId,
     /// the tx pointer to the utxo

--- a/crates/types/src/entities/contract.rs
+++ b/crates/types/src/entities/contract.rs
@@ -15,12 +15,14 @@ pub enum ContractUtxoInfo {
 }
 
 impl ContractUtxoInfo {
+    /// Get the Contract UTXO's id
     pub fn utxo_id(&self) -> &UtxoId {
         match self {
             ContractUtxoInfo::V1(info) => &info.utxo_id,
         }
     }
 
+    /// Get the Contract UTXO's transaction pointer
     pub fn tx_pointer(&self) -> TxPointer {
         match self {
             ContractUtxoInfo::V1(info) => info.tx_pointer,

--- a/crates/types/src/entities/contract.rs
+++ b/crates/types/src/entities/contract.rs
@@ -9,12 +9,12 @@ use fuel_vm_private::fuel_tx::UtxoId;
 /// Contains information related to the latest contract utxo
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum ContractUtxoInfo {
     /// V1 ContractUtxoInfo
     V1(ContractUtxoInfoV1),
 }
 
-#[cfg(any(test, feature = "test-helpers"))]
 impl Default for ContractUtxoInfo {
     fn default() -> Self {
         Self::V1(Default::default())

--- a/crates/types/src/entities/contract.rs
+++ b/crates/types/src/entities/contract.rs
@@ -14,6 +14,13 @@ pub enum ContractUtxoInfo {
     V1(ContractUtxoInfoV1),
 }
 
+#[cfg(any(test, feature = "test-helpers"))]
+impl Default for ContractUtxoInfo {
+    fn default() -> Self {
+        Self::V1(Default::default())
+    }
+}
+
 impl ContractUtxoInfo {
     /// Get the Contract UTXO's id
     pub fn utxo_id(&self) -> &UtxoId {
@@ -38,6 +45,15 @@ pub struct ContractUtxoInfoV1 {
     pub utxo_id: UtxoId,
     /// the tx pointer to the utxo
     pub tx_pointer: TxPointer,
+}
+
+impl From<(UtxoId, TxPointer)> for ContractUtxoInfoV1 {
+    fn from((utxo_id, tx_pointer): (UtxoId, TxPointer)) -> Self {
+        Self {
+            utxo_id,
+            tx_pointer,
+        }
+    }
 }
 
 /// Versioned type for storing information about a contract. Contract


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-core/issues/1552

This PR remodels the existing `ContractUtxoInfo` type as an enum for the purpose of representing different versions of the data. This PR introduces `ContractUtxoInfoV1` which simply holds the existing data types for `ContractUtxoInfo`. This allows the `ContractsLatestUtxo` table to now use a versioned data type.