### PR TITLE
feat: Impl StorageRead and StorageWrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- [#1713](https://github.com/FuelLabs/fuel-core/pull/1713): Added automatic `impl` of traits `StorageWrite` and `StorageRead` for `StructuredStorage`. Tables that use a `Blueprint` can be read and written using these interfaces provided by structured storage types.
 - [#1671](https://github.com/FuelLabs/fuel-core/pull/1671): Added a new `Merklized` blueprint that maintains the binary Merkle tree over the storage data. It supports only the insertion of the objects without removing them.
 - [#1657](https://github.com/FuelLabs/fuel-core/pull/1657): Moved `ContractsInfo` table from `fuel-vm` to on-chain tables, and created version-able `ContractsInfoType` to act as the table's data type.
 

--- a/crates/storage/src/structured_storage.rs
+++ b/crates/storage/src/structured_storage.rs
@@ -232,7 +232,7 @@ where
             )?
             .map(|prev| prev.to_vec());
         let result = (bytes_written, prev);
-        return Ok(result)
+        Ok(result)
     }
 
     fn take(&mut self, key: &M::Key) -> Result<Option<Vec<u8>>, Self::Error> {
@@ -240,7 +240,7 @@ where
             .storage
             .take(key.as_ref(), <M as TableWithBlueprint>::column())?
             .map(|value| value.to_vec());
-        return Ok(take)
+        Ok(take)
     }
 }
 

--- a/crates/storage/src/structured_storage/contracts.rs
+++ b/crates/storage/src/structured_storage/contracts.rs
@@ -7,20 +7,13 @@ use crate::{
         raw::Raw,
     },
     column::Column,
-    kv_store::KeyValueStore,
-    structured_storage::{
-        StructuredStorage,
-        TableWithBlueprint,
-    },
+    structured_storage::TableWithBlueprint,
     tables::{
         ContractsInfo,
         ContractsLatestUtxo,
         ContractsRawCode,
     },
-    StorageRead,
 };
-use core::ops::Deref;
-use fuel_core_types::fuel_tx::ContractId;
 
 // # Dev-note: The value of the `ContractsRawCode` has a unique implementation of serialization
 // and deserialization and uses `Raw` codec. Because the value is a contract byte code represented
@@ -32,26 +25,6 @@ impl TableWithBlueprint for ContractsRawCode {
 
     fn column() -> Column {
         Column::ContractsRawCode
-    }
-}
-
-impl<S> StorageRead<ContractsRawCode> for StructuredStorage<S>
-where
-    S: KeyValueStore<Column = Column>,
-{
-    fn read(
-        &self,
-        key: &ContractId,
-        buf: &mut [u8],
-    ) -> Result<Option<usize>, Self::Error> {
-        self.storage
-            .read(key.as_ref(), Column::ContractsRawCode, buf)
-    }
-
-    fn read_alloc(&self, key: &ContractId) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.storage
-            .get(key.as_ref(), Column::ContractsRawCode)
-            .map(|value| value.map(|value| value.deref().clone()))
     }
 }
 

--- a/crates/storage/src/structured_storage/contracts.rs
+++ b/crates/storage/src/structured_storage/contracts.rs
@@ -29,17 +29,6 @@ impl TableWithBlueprint for ContractsRawCode {
     }
 }
 
-// # Dev-note: The value of the `ContractsState` table uses raw bytes to
-// represent entries, and uses therefore uses the `Raw` codec.
-impl TableWithBlueprint for ContractsState {
-    type Blueprint = Plain<Raw, Raw>;
-    type Column = Column;
-
-    fn column() -> Column {
-        Column::ContractsState
-    }
-}
-
 impl TableWithBlueprint for ContractsInfo {
     type Blueprint = Plain<Raw, Postcard>;
     type Column = Column;

--- a/crates/storage/src/structured_storage/contracts.rs
+++ b/crates/storage/src/structured_storage/contracts.rs
@@ -14,6 +14,7 @@ use crate::{
         ContractsRawCode,
     },
 };
+use fuel_vm_private::storage::ContractsState;
 
 // # Dev-note: The value of the `ContractsRawCode` has a unique implementation of serialization
 // and deserialization and uses `Raw` codec. Because the value is a contract byte code represented
@@ -25,6 +26,17 @@ impl TableWithBlueprint for ContractsRawCode {
 
     fn column() -> Column {
         Column::ContractsRawCode
+    }
+}
+
+// # Dev-note: The value of the `ContractsState` table uses raw bytes to
+// represent entries, and uses therefore uses the `Raw` codec.
+impl TableWithBlueprint for ContractsState {
+    type Blueprint = Plain<Raw, Raw>;
+    type Column = Column;
+
+    fn column() -> Column {
+        Column::ContractsState
     }
 }
 

--- a/crates/storage/src/structured_storage/contracts.rs
+++ b/crates/storage/src/structured_storage/contracts.rs
@@ -14,7 +14,6 @@ use crate::{
         ContractsRawCode,
     },
 };
-use fuel_vm_private::storage::ContractsState;
 
 // # Dev-note: The value of the `ContractsRawCode` has a unique implementation of serialization
 // and deserialization and uses `Raw` codec. Because the value is a contract byte code represented


### PR DESCRIPTION
Related issues:
- https://github.com/FuelLabs/fuel-vm/issues/655

This PR removes the specific implementation of `StorageRead` for `ContractsRawCode`, and replaces it with a generic implementation over `Blueprint` tables and `StructuredStorage`. This means that other implementations of `TableWithBlueprint` will automatically receive this implementation, including `ContractsStorage`, which uses the `Sparse` Blueprint.