### PR TITLE
Release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.23.0]
+
 ### Added
 
 - [#1713](https://github.com/FuelLabs/fuel-core/pull/1713): Added automatic `impl` of traits `StorageWrite` and `StorageRead` for `StructuredStorage`. Tables that use a `Blueprint` can be read and written using these interfaces provided by structured storage types.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -869,7 +869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "serde",
 ]
 
@@ -961,10 +961,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -2616,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2699,11 +2700,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.22.1"
+version = "0.23.1"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "clap 4.5.1",
@@ -2729,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2748,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2771,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "clap 4.5.1",
  "fuel-core-client",
@@ -2782,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2794,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2805,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2830,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2844,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2862,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "clap 4.5.1",
@@ -2873,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -2886,7 +2887,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "axum",
  "once_cell",
@@ -2899,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2935,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2953,7 +2954,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2970,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3002,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3016,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3039,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3091,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "ctor",
  "tracing",
@@ -3101,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3127,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.22.1"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "bs58",
@@ -3471,9 +3472,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -3754,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -4063,9 +4064,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.35.1"
+version = "1.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c985c1bef99cf13c58fade470483d81a2bfe846ebde60ed28cc2dddec2df9e2"
+checksum = "0a7c22c4d34ef4788c351e971c52bfdfe7ea2766f8c5466bc175dd46e52ac22e"
 dependencies = [
  "console",
  "lazy_static",
@@ -4154,10 +4155,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "js-sys"
-version = "0.3.68"
+name = "jobserver"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4241,7 +4251,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
 ]
 
 [[package]]
@@ -5810,9 +5820,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -6350,7 +6360,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -6365,9 +6375,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8338,9 +8348,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8348,9 +8358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -8363,9 +8373,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8375,9 +8385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8385,9 +8395,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8398,15 +8408,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,33 +46,33 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.22.1"
+version = "0.23.1"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.22.1", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.22.1", path = "./bin/client" }
-fuel-core-bin = { version = "0.22.1", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.22.1", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.22.1", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.22.1", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.22.1", path = "./crates/client" }
-fuel-core-database = { version = "0.22.1", path = "./crates/database" }
-fuel-core-metrics = { version = "0.22.1", path = "./crates/metrics" }
-fuel-core-services = { version = "0.22.1", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.22.1", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.22.1", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.22.1", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.22.1", path = "./crates/services/executor" }
-fuel-core-importer = { version = "0.22.1", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.22.1", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.22.1", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.22.1", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.22.1", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.22.1", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.22.1", path = "./crates/storage" }
-fuel-core-trace = { version = "0.22.1", path = "./crates/trace" }
-fuel-core-types = { version = "0.22.1", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.23.1", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.23.1", path = "./bin/client" }
+fuel-core-bin = { version = "0.23.1", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.23.1", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.23.1", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.23.1", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.23.1", path = "./crates/client" }
+fuel-core-database = { version = "0.23.1", path = "./crates/database" }
+fuel-core-metrics = { version = "0.23.1", path = "./crates/metrics" }
+fuel-core-services = { version = "0.23.1", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.23.1", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.23.1", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.23.1", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.23.1", path = "./crates/services/executor" }
+fuel-core-importer = { version = "0.23.1", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.23.1", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.23.1", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.23.1", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.23.1", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.23.1", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.23.1", path = "./crates/storage" }
+fuel-core-trace = { version = "0.23.1", path = "./crates/trace" }
+fuel-core-types = { version = "0.23.1", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.22.1"
+appVersion: "0.23.1"
 version: 0.1.0


### PR DESCRIPTION
## Version v0.23.0

### Added

- [#1713](https://github.com/FuelLabs/fuel-core/pull/1713): Added automatic `impl` of traits `StorageWrite` and `StorageRead` for `StructuredStorage`. Tables that use a `Blueprint` can be read and written using these interfaces provided by structured storage types.
- [#1671](https://github.com/FuelLabs/fuel-core/pull/1671): Added a new `Merklized` blueprint that maintains the binary Merkle tree over the storage data. It supports only the insertion of the objects without removing them.
- [#1657](https://github.com/FuelLabs/fuel-core/pull/1657): Moved `ContractsInfo` table from `fuel-vm` to on-chain tables, and created version-able `ContractsInfoType` to act as the table's data type.

### Changed

- [#1723](https://github.com/FuelLabs/fuel-core/pull/1723): Notify about imported blocks from the off-chain worker.
- [#1717](https://github.com/FuelLabs/fuel-core/pull/1717): The fix for the [#1657](https://github.com/FuelLabs/fuel-core/pull/1657) to include the contract into `ContractsInfo` table.
- [#1657](https://github.com/FuelLabs/fuel-core/pull/1657): Upgrade to `fuel-vm` 0.46.0.
- [#1671](https://github.com/FuelLabs/fuel-core/pull/1671): The logic related to the `FuelBlockIdsToHeights` is moved to the off-chain worker.
- [#1663](https://github.com/FuelLabs/fuel-core/pull/1663): Reduce the punishment criteria for mempool gossipping.
- [#1658](https://github.com/FuelLabs/fuel-core/pull/1658): Removed `Receipts` table. Instead, receipts are part of the `TransactionStatuses` table.
- [#1640](https://github.com/FuelLabs/fuel-core/pull/1640): Upgrade to fuel-vm 0.45.0.
- [#1635](https://github.com/FuelLabs/fuel-core/pull/1635): Move updating of the owned messages and coins to off-chain worker.
- [#1650](https://github.com/FuelLabs/fuel-core/pull/1650): Add api endpoint for getting estimates for future gas prices
- [#1649](https://github.com/FuelLabs/fuel-core/pull/1649): Add api endpoint for getting latest gas price
- [#1600](https://github.com/FuelLabs/fuel-core/pull/1640): Upgrade to fuel-vm 0.45.0
- [#1633](https://github.com/FuelLabs/fuel-core/pull/1633): Notify services about importing of the genesis block.
- [#1625](https://github.com/FuelLabs/fuel-core/pull/1625): Making relayer independent from the executor and preparation for the force transaction inclusion.
- [#1613](https://github.com/FuelLabs/fuel-core/pull/1613): Add api endpoint to retrieve a message by its nonce.
- [#1612](https://github.com/FuelLabs/fuel-core/pull/1612): Use `AtomicView` in all services for consistent results.
- [#1597](https://github.com/FuelLabs/fuel-core/pull/1597): Unify namespacing for `libp2p` modules
- [#1591](https://github.com/FuelLabs/fuel-core/pull/1591): Simplify libp2p dependencies and not depend on all sub modules directly.
- [#1590](https://github.com/FuelLabs/fuel-core/pull/1590): Use `AtomicView` in the `TxPool` to read the state of the database during insertion of the transactions.
- [#1587](https://github.com/FuelLabs/fuel-core/pull/1587): Use `BlockHeight` as a primary key for the `FuelsBlock` table.
- [#1585](https://github.com/FuelLabs/fuel-core/pull/1585): Let `NetworkBehaviour` macro generate `FuelBehaviorEvent` in p2p
- [#1579](https://github.com/FuelLabs/fuel-core/pull/1579): The change extracts the off-chain-related logic from the executor and moves it to the GraphQL off-chain worker. It creates two new concepts - Off-chain and On-chain databases where the GraphQL worker has exclusive ownership of the database and may modify it without intersecting with the On-chain database.
- [#1577](https://github.com/FuelLabs/fuel-core/pull/1577): Moved insertion of sealed blocks into the `BlockImporter` instead of the executor.
- [#1574](https://github.com/FuelLabs/fuel-core/pull/1574): Penalizes peers for sending invalid responses or for not replying at all.
- [#1601](https://github.com/FuelLabs/fuel-core/pull/1601): Fix formatting in docs and check that `cargo doc` passes in the CI.
- [#1636](https://github.com/FuelLabs/fuel-core/pull/1636): Add more docs to GraphQL DAP API.

#### Breaking

- [#1725](https://github.com/FuelLabs/fuel-core/pull/1725): All API endpoints now are prefixed with `/v1` version. New usage looks like: `/v1/playground`, `/v1/graphql`, `/v1/graphql-sub`, `/v1/metrics`, `/v1/health`.
- [#1722](https://github.com/FuelLabs/fuel-core/pull/1722): Bugfix: Zero `predicate_gas_used` field during validation of the produced block.
- [#1714](https://github.com/FuelLabs/fuel-core/pull/1714): The change bumps the `fuel-vm` to `0.47.1`. It breaks several breaking changes into the protocol:
  - All malleable fields are zero during the execution and unavailable through the GTF getters. Accessing them via the memory directly is still possible, but they are zero.
  - The `Transaction` doesn't define the gas price anymore. The gas price is defined by the block producer and recorded in the `Mint` transaction at the end of the block. A price of future blocks can be fetched through a [new API nedopoint](https://github.com/FuelLabs/fuel-core/issues/1641) and the price of the last block can be fetch or via the block or another [API endpoint](https://github.com/FuelLabs/fuel-core/issues/1647).
  - The `GasPrice` policy is replaced with the `Tip` policy. The user may specify in the native tokens how much he wants to pay the block producer to include his transaction in the block. It is the prioritization mechanism to incentivize the block producer to include users transactions earlier.
  - The `MaxFee` policy is mandatory to set. Without it, the transaction pool will reject the transaction. Since the block producer defines the gas price, the only way to control how much user agreed to pay can be done only through this policy.
  - The `maturity` field is removed from the `Input::Coin`. The same affect can be achieve with the `Maturity` policy on the transaction and predicate. This changes breaks how input coin is created and removes the passing of this argument.
  - The metadata of the `Checked<Tx>` doesn't contain `max_fee` and `min_fee` anymore. Only `max_gas` and `min_gas`. The `max_fee` is controlled by the user via the `MaxFee` policy.
  - Added automatic `impl` of traits `StorageWrite` and `StorageRead` for `StructuredStorage`. Tables that use a `Blueprint` can be read and written using these interfaces provided by structured storage types.

- [#1712](https://github.com/FuelLabs/fuel-core/pull/1712): Make `ContractUtxoInfo` type a version-able enum for use in the `ContractsLatestUtxo`table.
- [#1657](https://github.com/FuelLabs/fuel-core/pull/1657): Changed `CROO` gas price type from `Word` to `DependentGasPrice`. The dependent gas price values are dummy values while awaiting updated benchmarks.
- [#1671](https://github.com/FuelLabs/fuel-core/pull/1671): The GraphQL API uses block height instead of the block id where it is possible. The transaction status contains `block_height` instead of the `block_id`.
- [#1675](https://github.com/FuelLabs/fuel-core/pull/1675): Simplify GQL schema by disabling contract resolvers in most cases, and just return a ContractId scalar instead.
- [#1658](https://github.com/FuelLabs/fuel-core/pull/1658): Receipts are part of the transaction status. 
    Removed `reason` from the `TransactionExecutionResult::Failed`. It can be calculated based on the program state and receipts.
    Also, it is not possible to fetch `receipts` from the `Transaction` directly anymore. Instead, you need to fetch `status` and its receipts.
- [#1646](https://github.com/FuelLabs/fuel-core/pull/1646): Remove redundant receipts from queries.
- [#1639](https://github.com/FuelLabs/fuel-core/pull/1639): Make Merkle metadata, i.e. `SparseMerkleMetadata` and `DenseMerkleMetadata` type version-able enums
- [#1632](https://github.com/FuelLabs/fuel-core/pull/1632): Make `Message` type a version-able enum
- [#1631](https://github.com/FuelLabs/fuel-core/pull/1631): Modify api endpoint to dry run multiple transactions.
- [#1629](https://github.com/FuelLabs/fuel-core/pull/1629): Use a separate database for each data domain. Each database has its own folder where data is stored.
- [#1628](https://github.com/FuelLabs/fuel-core/pull/1628): Make `CompressedCoin` type a version-able enum
- [#1616](https://github.com/FuelLabs/fuel-core/pull/1616): Make `BlockHeader` type a version-able enum
- [#1614](https://github.com/FuelLabs/fuel-core/pull/1614): Use the default consensus key regardless of trigger mode. The change is breaking because it removes the `--dev-keys` argument. If the `debug` flag is set, the default consensus key will be used, regardless of the trigger mode.
- [#1596](https://github.com/FuelLabs/fuel-core/pull/1596): Make `Consensus` type a version-able enum
- [#1593](https://github.com/FuelLabs/fuel-core/pull/1593): Make `Block` type a version-able enum
- [#1576](https://github.com/FuelLabs/fuel-core/pull/1576): The change moves the implementation of the storage traits for required tables from `fuel-core` to `fuel-core-storage` crate. The change also adds a more flexible configuration of the encoding/decoding per the table and allows the implementation of specific behaviors for the table in a much easier way. It unifies the encoding between database, SMTs, and iteration, preventing mismatching bytes representation on the Rust type system level. Plus, it increases the re-usage of the code by applying the same blueprint to other tables.
    
    It is a breaking PR because it changes database encoding/decoding for some tables.
    
    ### StructuredStorage
    
    The change adds a new type `StructuredStorage`. It is a wrapper around the key-value storage that implements the storage traits(`StorageInspect`, `StorageMutate`, `StorageRead`, etc) for the tables with blueprint. This blueprint works in tandem with the `TableWithBlueprint` trait. The table may implement `TableWithBlueprint` specifying the blueprint, as an example:
    
    ```rust
    impl TableWithBlueprint for ContractsRawCode {
        type Blueprint = Plain<Raw, Raw>;
    
        fn column() -> Column {
            Column::ContractsRawCode
        }
    }
    ```
    
    It is a definition of the blueprint for the `ContractsRawCode` table. It has a plain blueprint meaning it simply encodes/decodes bytes and stores/loads them into/from the storage. As a key codec and value codec, it uses a `Raw` encoding/decoding that simplifies writing bytes and loads them back into the memory without applying any serialization or deserialization algorithm.
    
    If the table implements `TableWithBlueprint` and the selected codec satisfies all blueprint requirements, the corresponding storage traits for that table are implemented on the `StructuredStorage` type.
    
    ### Codecs
    
    Each blueprint allows customizing the key and value codecs. It allows the use of different codecs for different tables, taking into account the complexity and weight of the data and providing a way of more optimal implementation.
    
    That property may be very useful to perform migration in a more easier way. Plus, it also can be a `no_std` migration potentially allowing its fraud proving.
    
    An example of migration:
    
    ```rust
    /// Define the table for V1 value encoding/decoding.
    impl TableWithBlueprint for ContractsRawCodeV1 {
        type Blueprint = Plain<Raw, Raw>;
    
        fn column() -> Column {
            Column::ContractsRawCode
        }
    }
    
    /// Define the table for V2 value encoding/decoding.
    /// It uses `Postcard` codec for the value instead of `Raw` codec.
    ///
    /// # Dev-note: The columns is the same.
    impl TableWithBlueprint for ContractsRawCodeV2 {
        type Blueprint = Plain<Raw, Postcard>;
    
        fn column() -> Column {
            Column::ContractsRawCode
        }
    }
    
    fn migration(storage: &mut Database) {
        let mut iter = storage.iter_all::<ContractsRawCodeV1>(None);
        while let Ok((key, value)) = iter.next() {
            // Insert into the same table but with another codec.
            storage.storage::<ContractsRawCodeV2>().insert(key, value);
        }
    }
    ```
    
    ### Structures
    
    The blueprint of the table defines its behavior. As an example, a `Plain` blueprint simply encodes/decodes bytes and stores/loads them into/from the storage. The `SMT` blueprint builds a sparse merkle tree on top of the key-value pairs.
    
    Implementing a blueprint one time, we can apply it to any table satisfying the requirements of this blueprint. It increases the re-usage of the code and minimizes duplication.
    
    It can be useful if we decide to create global roots for all required tables that are used in fraud proving.
    
    ```rust
    impl TableWithBlueprint for SpentMessages {
        type Blueprint = Plain<Raw, Postcard>;
    
        fn column() -> Column {
            Column::SpentMessages
        }
    }
                     |
                     |
                    \|/
    
    impl TableWithBlueprint for SpentMessages {
        type Blueprint =
            Sparse<Raw, Postcard, SpentMessagesMerkleMetadata, SpentMessagesMerkleNodes>;
    
        fn column() -> Column {
            Column::SpentMessages
        }
    }
    ```
    
    ### Side changes
    
    #### `iter_all`
    The `iter_all` functionality now accepts the table instead of `K` and `V` generics. It is done to use the correct codec during deserialization. Also, the table definition provides the column.
    
    #### Duplicated unit tests
    
    The `fuel-core-storage` crate provides macros that generate unit tests. Almost all tables had the same test like `get`, `insert`, `remove`, `exist`. All duplicated tests were moved to macros. The unique one still stays at the same place where it was before.
    
    #### `StorageBatchMutate`
    
    Added a new `StorageBatchMutate` trait that we can move to `fuel-storage` crate later. It allows batch operations on the storage. It may be more performant in some cases.

- [#1573](https://github.com/FuelLabs/fuel-core/pull/1573): Remove nested p2p request/response encoding. Only breaks p2p networking compatibility with older fuel-core versions, but is otherwise fully internal.

## What's Changed
* Fix the example tx in README.md by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/1543
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1557
* Update LICENSE by @Voxelot in https://github.com/FuelLabs/fuel-core/pull/1558
* Remove duplicating logic in the `KeyValueStore` trait by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1559
* Move `KeyValueStore` to the `fuel-core-storage` crate by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1566
* Update `libp2p` from `0.50.0` to `0.53.1` by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1379
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1575
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1578
* Moved insertion of the blocks into the `BlockImporter` instead of the executor by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1577
* Let `NetworkBehaviour` macro generate `FuelBehaviorEvent` in p2p by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1585
* Remove RustSec Ignore for RUSTSEC-2022-0093 by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1586
* Simplify p2p request/response message serialization by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/1573
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1588
* Depend on libp2p directly instead of submodules by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1591
* Make `Block` versionable by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1593
* Switch katyo/publish-crates@v2 to xgreenx/publish-crates@v1 for the CI by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/1603
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1599
* Fix cargo doc, check for cargo doc in the CI by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/1601
* Move storage traits implementation to the `fuel-core-storage` crate by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1576
* Extract off chain logic from the executor by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1579
* Applying comments from the PR for the storage crate by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1610
* Use `BlockHeight` as a primary key for the `FuelsBlock` table by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1587
* Use `AtomicView` in the `TxPool` by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1590
* Unify namespacing in P2P codebase by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1597
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1611
* Make `Consensus` version-able by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1596
* feat: add api endpoint to retrieve messages by nonce by @matt-user in https://github.com/FuelLabs/fuel-core/pull/1613
* Update Docker tags for Flux integration by @liviudm in https://github.com/FuelLabs/fuel-core/pull/1617
* Remove dev consensus key by @MujkicA in https://github.com/FuelLabs/fuel-core/pull/1614
* Make `BlockHeader` a versionable enum by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1616
* feat: Versionable CompressedCoin by @bvrooman in https://github.com/FuelLabs/fuel-core/pull/1628
* Use `AtomicView` in all services by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1612
* Notify services about importing of the genesis block by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1633
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1634
* feat: Versionable `Message` by @bvrooman in https://github.com/FuelLabs/fuel-core/pull/1632
* Making relayer independent from the executor by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1625
* Upgrade to the fuel-vm 0.44.0 by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/1600
* Upgrade to fuel-vm 0.45.0 by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1640
* feat: Versionable Merkle metadata by @bvrooman in https://github.com/FuelLabs/fuel-core/pull/1639
* Add docs for GraphQL DAP endpoints by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/1636
* Use a separate database for each data domain by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1629
* feat: dry run multiple transactions by @matt-user in https://github.com/FuelLabs/fuel-core/pull/1631
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1644
* Decrease peer reputation on request timeouts and decode errors  by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/1574
* refactor: remove redudant receipts queries by @matt-user in https://github.com/FuelLabs/fuel-core/pull/1646
* Latest gas price endpoint by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1649
* Estimate gas price API Endpoint by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1650
* Fix for the race condition with tx status and receipts by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1658
* Bump up rust to 1.75 by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1656
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1655
* Duplication of the `0.22.1` release by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1665
* Move updating of the owned messages and coins to off-chain worker by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1635
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1682
* Remove nested contract resolvers in GQL schema by @Voxelot in https://github.com/FuelLabs/fuel-core/pull/1675
* Soften txpool p2p reputation requirements by @Voxelot in https://github.com/FuelLabs/fuel-core/pull/1663
* Remove failing deployment job by @Voxelot in https://github.com/FuelLabs/fuel-core/pull/1692
* chore: format cargo tomls and add ci check by @segfault-magnet in https://github.com/FuelLabs/fuel-core/pull/1691
* Extraction of the `FuelBlockSecondaryKeyBlockHeights` table to an off-chain worker by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1671
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1707
* Increase liveness probe timeout to 5 minutes by @rfuelsh in https://github.com/FuelLabs/fuel-core/pull/1709
* feat: Add `ContractInfo` table and versionable `ContractInfoType` to on-chain storage by @bvrooman in https://github.com/FuelLabs/fuel-core/pull/1657
* feat: Versionable `ContractUtxoInfo` for the `ContractsLatestUtxo` table by @bvrooman in https://github.com/FuelLabs/fuel-core/pull/1712
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1719
* Bump `fuel-vm` dep to 0.47.1 by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1714
* Bugfix: Calling of the contract with enabled `utxo_validation` fails by @bvrooman in https://github.com/FuelLabs/fuel-core/pull/1717
* Bugfix: Zero `predicate_gas_used` field during validation of the produced block by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1722
* Notify about imported blocks from the off-chain worker by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1723
* Added versioning suffix to the GraphQL endpoint by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1725

## New Contributors
* @liviudm made their first contribution in https://github.com/FuelLabs/fuel-core/pull/1617

**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.22.0...v0.23.0