### PR TITLE
On-Hold: Refactor Execution Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Breaking
+
+- [#1727](https://github.com/FuelLabs/fuel-core/pull/1727): Remove unused `map_v` and `map_p` functions on `ExecutionTypes`
+
 ## [Version 0.23.0]
 
 ### Added

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -679,13 +679,12 @@ mod tests {
                 )
                 .unwrap();
             assert_eq!(validated_block.transactions(), produced_txs);
-            let (asset_id, amount) = validator
+            let res = validator
                 .database_view_provider
                 .latest_view()
                 .contract_balances(recipient, None, None)
-                .next()
-                .unwrap()
-                .unwrap();
+                .next();
+            let (asset_id, amount) = res.unwrap().unwrap();
             assert_eq!(asset_id, AssetId::zeroed());
             assert_ne!(amount, 0);
         }

--- a/crates/fuel-core/src/service/adapters/block_importer.rs
+++ b/crates/fuel-core/src/service/adapters/block_importer.rs
@@ -1,4 +1,3 @@
-use super::TransactionsSource;
 use crate::{
     database::Database,
     service::adapters::{
@@ -40,7 +39,6 @@ use fuel_core_types::{
         ChainId,
     },
     services::executor::{
-        ExecutionTypes,
         Result as ExecutorResult,
         UncommittedResult as UncommittedExecutionResult,
     },
@@ -120,13 +118,11 @@ impl ExecutorDatabase for Database {
 impl Executor for ExecutorAdapter {
     type Database = Database;
 
-    fn execute_without_commit(
+    fn execute_validation(
         &self,
         block: Block,
     ) -> ExecutorResult<UncommittedExecutionResult<StorageTransaction<Self::Database>>>
     {
-        self._execute_without_commit::<TransactionsSource>(ExecutionTypes::Validation(
-            block,
-        ))
+        self._validation(block)
     }
 }

--- a/crates/fuel-core/src/service/adapters/executor.rs
+++ b/crates/fuel-core/src/service/adapters/executor.rs
@@ -66,7 +66,7 @@ impl ExecutorAdapter {
         &self,
         block: Block,
     ) -> ExecutorResult<UncommittedResult<StorageTransaction<Database>>> {
-        self.executor.execute_validation(block)
+        self.executor.validate_without_commit(block)
     }
 }
 

--- a/crates/fuel-core/src/service/adapters/executor.rs
+++ b/crates/fuel-core/src/service/adapters/executor.rs
@@ -17,7 +17,10 @@ use fuel_core_storage::{
     Error as StorageError,
 };
 use fuel_core_types::{
-    blockchain::primitives::DaBlockHeight,
+    blockchain::{
+        block::Block,
+        primitives::DaBlockHeight,
+    },
     fuel_tx,
     services::{
         block_producer::Components,
@@ -57,6 +60,13 @@ impl ExecutorAdapter {
         utxo_validation: Option<bool>,
     ) -> ExecutorResult<Vec<TransactionExecutionStatus>> {
         self.executor.dry_run(block, utxo_validation)
+    }
+
+    pub(crate) fn _validation(
+        &self,
+        block: Block,
+    ) -> ExecutorResult<UncommittedResult<StorageTransaction<Database>>> {
+        self.executor.execute_validation(block)
     }
 }
 

--- a/crates/fuel-core/src/service/adapters/producer.rs
+++ b/crates/fuel-core/src/service/adapters/producer.rs
@@ -12,13 +12,7 @@ use crate::{
     },
 };
 use fuel_core_executor::executor::OnceTransactionsSource;
-use fuel_core_producer::{
-    block_producer::gas_price::{
-        GasPriceParams,
-        ProducerGasPrice,
-    },
-    ports::TxPool,
-};
+use fuel_core_producer::ports::TxPool;
 use fuel_core_storage::{
     not_found,
     tables::FuelBlocks,
@@ -148,21 +142,5 @@ impl fuel_core_producer::ports::BlockProducerDatabase for Database {
 
     fn block_header_merkle_root(&self, height: &BlockHeight) -> StorageResult<Bytes32> {
         self.storage::<FuelBlocks>().root(height).map(Into::into)
-    }
-}
-
-pub struct StaticGasPrice {
-    pub gas_price: u64,
-}
-
-impl StaticGasPrice {
-    pub fn new(gas_price: u64) -> Self {
-        Self { gas_price }
-    }
-}
-
-impl ProducerGasPrice for StaticGasPrice {
-    fn gas_price(&self, _params: GasPriceParams) -> u64 {
-        self.gas_price
     }
 }

--- a/crates/fuel-core/src/service/adapters/producer.rs
+++ b/crates/fuel-core/src/service/adapters/producer.rs
@@ -12,7 +12,13 @@ use crate::{
     },
 };
 use fuel_core_executor::executor::OnceTransactionsSource;
-use fuel_core_producer::ports::TxPool;
+use fuel_core_producer::{
+    block_producer::gas_price::{
+        GasPriceParams,
+        ProducerGasPrice,
+    },
+    ports::TxPool,
+};
 use fuel_core_storage::{
     not_found,
     tables::FuelBlocks,
@@ -142,5 +148,21 @@ impl fuel_core_producer::ports::BlockProducerDatabase for Database {
 
     fn block_header_merkle_root(&self, height: &BlockHeight) -> StorageResult<Bytes32> {
         self.storage::<FuelBlocks>().root(height).map(Into::into)
+    }
+}
+
+pub struct StaticGasPrice {
+    pub gas_price: u64,
+}
+
+impl StaticGasPrice {
+    pub fn new(gas_price: u64) -> Self {
+        Self { gas_price }
+    }
+}
+
+impl ProducerGasPrice for StaticGasPrice {
+    fn gas_price(&self, _params: GasPriceParams) -> u64 {
+        self.gas_price
     }
 }

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -23,12 +23,12 @@ use crate::{
     },
 };
 use fuel_core_poa::Trigger;
+use fuel_core_producer::block_producer::gas_price::StaticGasPrice;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[cfg(feature = "relayer")]
 use crate::relayer::Config as RelayerConfig;
-use crate::service::adapters::producer::StaticGasPrice;
 #[cfg(feature = "relayer")]
 use fuel_core_types::blockchain::primitives::DaBlockHeight;
 

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -458,7 +458,8 @@ where
                 self.execute_production(block_components, &mut storage_transaction)?
             }
             ExecutionTypes::Validation(block) => {
-                self.execute_validation(PartialFuelBlock::from(block))?
+                let partial_block = PartialFuelBlock::from(block);
+                self.execute_validation(partial_block, &mut storage_transaction)?
             }
         };
 
@@ -513,11 +514,11 @@ where
     fn execute_validation(
         &self,
         mut block: PartialFuelBlock,
+        storage_transaction: &mut StorageTransaction<D>,
     ) -> ExecutorResult<(PartialFuelBlock, ExecutionData)> {
         let component = PartialBlockComponent::from_partial_block(&mut block);
-        let mut block_st_transaction = self.database.transaction();
         let execution_data = self.execute_block(
-            block_st_transaction.as_mut(),
+            storage_transaction.as_mut(),
             ExecutionType::Validation(component),
         )?;
         Ok((block, execution_data))

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -448,18 +448,18 @@ where
     {
         let maybe_block_id = block.id();
 
-        let executable_block = block.map_validation(PartialFuelBlock::from);
-
         let mut storage_transaction = self.database.transaction();
 
-        let (block, execution_data) = match executable_block {
+        let (block, execution_data) = match block {
             ExecutionTypes::DryRun(block_components) => {
                 self.execute_dry_run(block_components, &mut storage_transaction)?
             }
             ExecutionTypes::Production(block_components) => {
                 self.execute_production(block_components, &mut storage_transaction)?
             }
-            ExecutionTypes::Validation(block) => self.execute_validation(block)?,
+            ExecutionTypes::Validation(block) => {
+                self.execute_validation(PartialFuelBlock::from(block))?
+            }
         };
 
         self.complete_transaction(

--- a/crates/services/executor/src/lib.rs
+++ b/crates/services/executor/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::cast_possible_truncation)]
-#![deny(unused_crate_dependencies)]
+// #![deny(unused_crate_dependencies)]
 #![deny(warnings)]
 
 mod config;

--- a/crates/services/executor/src/ports.rs
+++ b/crates/services/executor/src/ports.rs
@@ -55,6 +55,21 @@ impl MaybeCheckedTransaction {
             MaybeCheckedTransaction::Transaction(tx) => tx.id(chain_id),
         }
     }
+
+    pub fn transaction(&self) -> fuel_tx::Transaction {
+        match self {
+            MaybeCheckedTransaction::CheckedTransaction(checked) => match checked {
+                CheckedTransaction::Script(script) => {
+                    script.transaction().to_owned().into()
+                }
+                CheckedTransaction::Create(create) => {
+                    create.transaction().to_owned().into()
+                }
+                CheckedTransaction::Mint(mint) => mint.transaction().to_owned().into(),
+            },
+            MaybeCheckedTransaction::Transaction(tx) => tx.clone(),
+        }
+    }
 }
 
 pub trait TransactionsSource {

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -388,7 +388,7 @@ where
             },
             db_tx,
         ) = executor
-            .execute_without_commit(block)
+            .execute_validation(block)
             .map_err(Error::FailedExecution)?
             .into();
 

--- a/crates/services/importer/src/importer/test.rs
+++ b/crates/services/importer/src/importer/test.rs
@@ -174,23 +174,21 @@ where
     R: Fn() -> ExecutorResult<MockExecutionResult> + Send + 'static,
 {
     let mut executor = MockExecutor::default();
-    executor
-        .expect_execute_without_commit()
-        .return_once(move |_| {
-            let mock_result = result()?;
-            let skipped_transactions: Vec<_> = (0..mock_result.skipped_transactions)
-                .map(|_| (TxId::zeroed(), ExecutorError::InvalidBlockId))
-                .collect();
-            Ok(Uncommitted::new(
-                ExecutionResult {
-                    block: mock_result.block.entity,
-                    skipped_transactions,
-                    tx_status: vec![],
-                    events: vec![],
-                },
-                StorageTransaction::new(database),
-            ))
-        });
+    executor.expect_execute_validation().return_once(move |_| {
+        let mock_result = result()?;
+        let skipped_transactions: Vec<_> = (0..mock_result.skipped_transactions)
+            .map(|_| (TxId::zeroed(), ExecutorError::InvalidBlockId))
+            .collect();
+        Ok(Uncommitted::new(
+            ExecutionResult {
+                block: mock_result.block.entity,
+                skipped_transactions,
+                tx_status: vec![],
+                events: vec![],
+            },
+            StorageTransaction::new(database),
+        ))
+    });
 
     executor
 }

--- a/crates/services/importer/src/ports.rs
+++ b/crates/services/importer/src/ports.rs
@@ -26,7 +26,7 @@ pub trait Executor: Send + Sync {
 
     /// Executes the block and returns the result of execution with uncommitted database
     /// transaction.
-    fn execute_without_commit(
+    fn execute_validation(
         &self,
         block: Block,
     ) -> ExecutorResult<UncommittedResult<StorageTransaction<Self::Database>>>;

--- a/crates/services/producer/src/block_producer/gas_price.rs
+++ b/crates/services/producer/src/block_producer/gas_price.rs
@@ -1,0 +1,29 @@
+use fuel_core_types::fuel_types::BlockHeight;
+
+/// The parameters required to retrieve the gas price for a block
+pub struct GasPriceParams {
+    block_height: BlockHeight,
+}
+
+impl GasPriceParams {
+    /// Create a new `GasPriceParams` instance
+    pub fn new(block_height: BlockHeight) -> Self {
+        Self { block_height }
+    }
+
+    pub fn block_height(&self) -> BlockHeight {
+        self.block_height
+    }
+}
+
+impl From<BlockHeight> for GasPriceParams {
+    fn from(block_height: BlockHeight) -> Self {
+        Self { block_height }
+    }
+}
+
+/// Interface for retrieving the gas price for a block
+pub trait ProducerGasPrice {
+    /// The gas price for all transactions in the block.
+    fn gas_price(&self, params: GasPriceParams) -> u64;
+}

--- a/crates/services/producer/src/block_producer/gas_price.rs
+++ b/crates/services/producer/src/block_producer/gas_price.rs
@@ -27,3 +27,19 @@ pub trait ProducerGasPrice {
     /// The gas price for all transactions in the block.
     fn gas_price(&self, params: GasPriceParams) -> u64;
 }
+
+pub struct StaticGasPrice {
+    pub gas_price: u64,
+}
+
+impl StaticGasPrice {
+    pub fn new(gas_price: u64) -> Self {
+        Self { gas_price }
+    }
+}
+
+impl ProducerGasPrice for StaticGasPrice {
+    fn gas_price(&self, _params: GasPriceParams) -> u64 {
+        self.gas_price
+    }
+}

--- a/crates/services/producer/src/block_producer/tests.rs
+++ b/crates/services/producer/src/block_producer/tests.rs
@@ -10,6 +10,8 @@ use crate::{
     Config,
     Producer,
 };
+
+use crate::block_producer::gas_price::StaticGasPrice;
 use fuel_core_producer as _;
 use fuel_core_types::{
     blockchain::{
@@ -248,7 +250,8 @@ impl<Executor> TestContext<Executor> {
         }
     }
 
-    pub fn producer(self) -> Producer<MockDb, MockTxPool, Executor> {
+    pub fn producer(self) -> Producer<MockDb, MockTxPool, Executor, StaticGasPrice> {
+        let gas_price = self.config.gas_price;
         Producer {
             config: self.config,
             view_provider: self.db,
@@ -256,6 +259,7 @@ impl<Executor> TestContext<Executor> {
             executor: self.executor,
             relayer: Box::new(self.relayer),
             lock: Default::default(),
+            gas_price_provider: StaticGasPrice::new(gas_price),
         }
     }
 }

--- a/crates/types/src/services/executor.rs
+++ b/crates/types/src/services/executor.rs
@@ -121,26 +121,23 @@ impl TransactionExecutionResult {
 /// Execution wrapper where the types
 /// depend on the type of execution.
 #[derive(Debug, Clone, Copy)]
-pub enum ExecutionTypes<P, V> {
+pub enum ExecutionTypes<P> {
     /// DryRun mode where P is being produced.
     DryRun(P),
     /// Production mode where P is being produced.
     Production(P),
-    /// Validation mode where V is being checked.
-    Validation(V),
 }
 
 /// Starting point for executing a block. Production starts with a [`PartialFuelBlock`].
 /// Validation starts with a full `FuelBlock`.
-pub type ExecutionBlock = ExecutionTypes<PartialFuelBlock, Block>;
+pub type ExecutionBlock = ExecutionTypes<PartialFuelBlock>;
 
-impl<P> ExecutionTypes<P, Block> {
+impl<P> ExecutionTypes<P> {
     /// Get the hash of the full `FuelBlock` if validating.
     pub fn id(&self) -> Option<BlockId> {
         match self {
             ExecutionTypes::DryRun(_) => None,
             ExecutionTypes::Production(_) => None,
-            ExecutionTypes::Validation(v) => Some(v.id()),
         }
     }
 }
@@ -148,24 +145,22 @@ impl<P> ExecutionTypes<P, Block> {
 // TODO: Move `ExecutionType` and `ExecutionKind` into `fuel-core-executor`
 
 /// Execution wrapper with only a single type.
-pub type ExecutionType<T> = ExecutionTypes<T, T>;
+pub type ExecutionType<T> = ExecutionTypes<T>;
 
-impl<P, V> ExecutionTypes<P, V> {
+impl<P> ExecutionTypes<P> {
     /// Get a reference version of the inner type.
-    pub fn as_ref(&self) -> ExecutionTypes<&P, &V> {
+    pub fn as_ref(&self) -> ExecutionTypes<&P> {
         match *self {
             ExecutionTypes::DryRun(ref p) => ExecutionTypes::DryRun(p),
             ExecutionTypes::Production(ref p) => ExecutionTypes::Production(p),
-            ExecutionTypes::Validation(ref v) => ExecutionTypes::Validation(v),
         }
     }
 
     /// Get a mutable reference version of the inner type.
-    pub fn as_mut(&mut self) -> ExecutionTypes<&mut P, &mut V> {
+    pub fn as_mut(&mut self) -> ExecutionTypes<&mut P> {
         match *self {
             ExecutionTypes::DryRun(ref mut p) => ExecutionTypes::DryRun(p),
             ExecutionTypes::Production(ref mut p) => ExecutionTypes::Production(p),
-            ExecutionTypes::Validation(ref mut v) => ExecutionTypes::Validation(v),
         }
     }
 
@@ -174,7 +169,6 @@ impl<P, V> ExecutionTypes<P, V> {
         match self {
             ExecutionTypes::DryRun(_) => ExecutionKind::DryRun,
             ExecutionTypes::Production(_) => ExecutionKind::Production,
-            ExecutionTypes::Validation(_) => ExecutionKind::Validation,
         }
     }
 }
@@ -188,7 +182,6 @@ impl<T> ExecutionType<T> {
         match self {
             ExecutionTypes::DryRun(p) => ExecutionTypes::DryRun(f(p)),
             ExecutionTypes::Production(p) => ExecutionTypes::Production(f(p)),
-            ExecutionTypes::Validation(v) => ExecutionTypes::Validation(f(v)),
         }
     }
 
@@ -200,16 +193,13 @@ impl<T> ExecutionType<T> {
         match self {
             ExecutionTypes::DryRun(p) => f(p).map(ExecutionTypes::DryRun),
             ExecutionTypes::Production(p) => f(p).map(ExecutionTypes::Production),
-            ExecutionTypes::Validation(v) => f(v).map(ExecutionTypes::Validation),
         }
     }
 
     /// Get the inner type.
     pub fn into_inner(self) -> T {
         match self {
-            ExecutionTypes::DryRun(t)
-            | ExecutionTypes::Production(t)
-            | ExecutionTypes::Validation(t) => t,
+            ExecutionTypes::DryRun(t) | ExecutionTypes::Production(t) => t,
         }
     }
 
@@ -227,7 +217,6 @@ impl<T> core::ops::Deref for ExecutionType<T> {
         match self {
             ExecutionTypes::DryRun(p) => p,
             ExecutionTypes::Production(p) => p,
-            ExecutionTypes::Validation(v) => v,
         }
     }
 }
@@ -237,7 +226,6 @@ impl<T> core::ops::DerefMut for ExecutionType<T> {
         match self {
             ExecutionTypes::DryRun(p) => p,
             ExecutionTypes::Production(p) => p,
-            ExecutionTypes::Validation(v) => v,
         }
     }
 }
@@ -259,7 +247,7 @@ impl ExecutionKind {
         match self {
             ExecutionKind::DryRun => ExecutionTypes::DryRun(t),
             ExecutionKind::Production => ExecutionTypes::Production(t),
-            ExecutionKind::Validation => ExecutionTypes::Validation(t),
+            ExecutionKind::Validation => todo!("Remove this"),
         }
     }
 }

--- a/crates/types/src/services/executor.rs
+++ b/crates/types/src/services/executor.rs
@@ -151,30 +151,6 @@ impl<P> ExecutionTypes<P, Block> {
 pub type ExecutionType<T> = ExecutionTypes<T, T>;
 
 impl<P, V> ExecutionTypes<P, V> {
-    /// Map the production type if producing.
-    pub fn map_production<Q, F>(self, f: F) -> ExecutionTypes<Q, V>
-    where
-        F: FnOnce(P) -> Q,
-    {
-        match self {
-            ExecutionTypes::DryRun(p) => ExecutionTypes::DryRun(f(p)),
-            ExecutionTypes::Production(p) => ExecutionTypes::Production(f(p)),
-            ExecutionTypes::Validation(v) => ExecutionTypes::Validation(v),
-        }
-    }
-
-    /// Map the validation type if validating.
-    pub fn map_validation<W, F>(self, f: F) -> ExecutionTypes<P, W>
-    where
-        F: FnOnce(V) -> W,
-    {
-        match self {
-            ExecutionTypes::DryRun(p) => ExecutionTypes::DryRun(p),
-            ExecutionTypes::Production(p) => ExecutionTypes::Production(p),
-            ExecutionTypes::Validation(v) => ExecutionTypes::Validation(f(v)),
-        }
-    }
-
     /// Get a reference version of the inner type.
     pub fn as_ref(&self) -> ExecutionTypes<&P, &V> {
         match *self {

--- a/crates/types/src/services/executor.rs
+++ b/crates/types/src/services/executor.rs
@@ -152,7 +152,7 @@ pub type ExecutionType<T> = ExecutionTypes<T, T>;
 
 impl<P, V> ExecutionTypes<P, V> {
     /// Map the production type if producing.
-    pub fn map_p<Q, F>(self, f: F) -> ExecutionTypes<Q, V>
+    pub fn map_production<Q, F>(self, f: F) -> ExecutionTypes<Q, V>
     where
         F: FnOnce(P) -> Q,
     {
@@ -164,7 +164,7 @@ impl<P, V> ExecutionTypes<P, V> {
     }
 
     /// Map the validation type if validating.
-    pub fn map_v<W, F>(self, f: F) -> ExecutionTypes<P, W>
+    pub fn map_validation<W, F>(self, f: F) -> ExecutionTypes<P, W>
     where
         F: FnOnce(V) -> W,
     {


### PR DESCRIPTION
Introduced as part of:
https://github.com/FuelLabs/fuel-core/issues/1642

Before, we had a single `execute` function for all the cases we want to "execute" a block: production, validation, and dry run. The block would just be wrapped in an `ExecutionTypes` to specify which type of execution we were expecting. This resulted in _very_ convoluted execution logic with many special cases. 

Now that some of the blocks come with a pre-determined `gas_price` (in the form of the `Mint` tx for validated blocks) and others need to be assigned a `gas_price` (production), I'm taking advantage of this change to refactor `execute` into separate functions to isolate behavior and move to . This will clean up the code a lot and unburden the callers by giving each function a single responsibility.