### PR TITLE
Expose the `schema.sdl` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+### Added
+
+- [#1729](https://github.com/FuelLabs/fuel-core/pull/1729): Exposed the `schema.sdl` file from `fuel-core-client`. The user can create his own queries by using this file.
+
 ## [Version 0.22.1]
 
 ### Fixed

--- a/crates/client/src/client/pagination.rs
+++ b/crates/client/src/client/pagination.rs
@@ -16,6 +16,7 @@ pub struct PaginationRequest<T> {
     pub direction: PageDirection,
 }
 
+#[derive(Clone, Debug)]
 pub struct PaginatedResult<T, C> {
     pub cursor: Option<C>,
     pub results: Vec<T>,

--- a/crates/client/src/client/types/balance.rs
+++ b/crates/client/src/client/types/balance.rs
@@ -7,6 +7,7 @@ use crate::client::{
     PaginatedResult,
 };
 
+#[derive(Copy, Clone, Debug)]
 pub struct Balance {
     pub owner: Address,
     pub amount: u64,

--- a/crates/client/src/client/types/block.rs
+++ b/crates/client/src/client/types/block.rs
@@ -12,7 +12,7 @@ use crate::client::{
 };
 use tai64::Tai64;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Block {
     pub id: BlockId,
     pub header: Header,
@@ -27,7 +27,7 @@ impl Block {
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Header {
     pub id: BlockId,
     pub da_height: u64,
@@ -41,14 +41,14 @@ pub struct Header {
     pub application_hash: Hash,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Consensus {
     Genesis(Genesis),
     PoAConsensus(PoAConsensus),
     Unknown,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Genesis {
     pub chain_config_hash: Hash,
     pub coins_root: MerkleRoot,
@@ -56,7 +56,7 @@ pub struct Genesis {
     pub messages_root: MerkleRoot,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct PoAConsensus {
     pub signature: Signature,
 }

--- a/crates/client/src/client/types/chain_info.rs
+++ b/crates/client/src/client/types/chain_info.rs
@@ -7,6 +7,7 @@ use fuel_core_types::{
     fuel_tx::ConsensusParameters,
 };
 
+#[derive(Clone, Debug)]
 pub struct ChainInfo {
     pub da_height: u64,
     pub name: String,

--- a/crates/client/src/client/types/coins.rs
+++ b/crates/client/src/client/types/coins.rs
@@ -9,7 +9,7 @@ use crate::client::{
     PaginatedResult,
 };
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum CoinType {
     Coin(Coin),
     MessageCoin(MessageCoin),
@@ -26,7 +26,7 @@ impl CoinType {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Coin {
     pub amount: u64,
     pub block_created: u32,
@@ -36,7 +36,7 @@ pub struct Coin {
     pub owner: Address,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct MessageCoin {
     pub amount: u64,
     pub sender: Address,

--- a/crates/client/src/client/types/contract.rs
+++ b/crates/client/src/client/types/contract.rs
@@ -9,13 +9,14 @@ use crate::client::{
     PaginatedResult,
 };
 
+#[derive(Clone, Debug)]
 pub struct Contract {
     pub id: ContractId,
     pub bytecode: Bytes,
     pub salt: Salt,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct ContractBalance {
     pub contract: ContractId,
     pub amount: u64,

--- a/crates/client/src/client/types/gas_costs.rs
+++ b/crates/client/src/client/types/gas_costs.rs
@@ -30,7 +30,7 @@ macro_rules! include_from_impls {
 }
 
 include_from_impls! {
-    #[derive(Clone, Debug)]
+    #[derive(Copy, Clone, Debug)]
     pub struct GasCosts {
         pub add: u64,
         pub addi: u64,
@@ -148,7 +148,7 @@ include_from_impls! {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum DependentCost {
     LightOperation { base: u64, units_per_gas: u64 },
     HeavyOperation { base: u64, gas_per_unit: u64 },

--- a/crates/client/src/client/types/merkle_proof.rs
+++ b/crates/client/src/client/types/merkle_proof.rs
@@ -3,7 +3,7 @@ use crate::client::{
     types::primitives::MerkleRoot,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MerkleProof {
     /// The proof set of the message proof.
     pub proof_set: Vec<MerkleRoot>,

--- a/crates/client/src/client/types/message.rs
+++ b/crates/client/src/client/types/message.rs
@@ -12,7 +12,7 @@ use crate::client::{
     PaginatedResult,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Message {
     pub amount: u64,
     pub sender: Address,
@@ -22,7 +22,7 @@ pub struct Message {
     pub da_height: u64,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MessageProof {
     /// Proof that message is contained within the provided block header.
     pub message_proof: MerkleProof,

--- a/crates/client/src/client/types/node_info.rs
+++ b/crates/client/src/client/types/node_info.rs
@@ -1,5 +1,6 @@
 use crate::client::schema;
 
+#[derive(Clone, Debug)]
 pub struct NodeInfo {
     pub utxo_validation: bool,
     pub vm_backtrace: bool,

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -4,3 +4,6 @@
 #![deny(warnings)]
 pub mod client;
 pub mod schema;
+
+/// The GraphQL schema used by the library.
+pub const SCHEMA_SDL: &[u8] = include_bytes!("../assets/schema.sdl");


### PR DESCRIPTION
Exposing of the `schema.sdl` allows create extensions for the `fuel-core-client` like https://github.com/FuelLabs/fuel-core-client-ext