### PR TITLE
Backport GraphQL clone derives for v0.22

### DIFF
--- a/crates/client/src/client/schema.rs
+++ b/crates/client/src/client/schema.rs
@@ -36,13 +36,13 @@ pub mod node_info;
 pub mod primitives;
 pub mod tx;
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Query")]
 pub struct Health {
     pub health: bool,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Mutation")]
 pub struct StartSession {
     pub start_session: cynic::Id,
@@ -53,7 +53,7 @@ pub struct IdArg {
     pub id: cynic::Id,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -64,7 +64,7 @@ pub struct EndSession {
     pub end_session: bool,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -81,7 +81,7 @@ pub struct ExecuteArgs {
     pub op: String,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -98,7 +98,7 @@ pub struct RegisterArgs {
     pub register: U32,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -116,7 +116,7 @@ pub struct MemoryArgs {
     pub size: U32,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -133,7 +133,7 @@ pub struct SetBreakpointArgs {
     pub bp: Breakpoint,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -157,7 +157,7 @@ pub struct SetSingleSteppingArgs {
     pub enable: bool,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -174,7 +174,7 @@ pub struct StartTxArgs {
     pub tx: String,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -190,7 +190,7 @@ pub struct ContinueTxArgs {
     pub id: cynic::Id,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -201,7 +201,7 @@ pub struct ContinueTx {
     pub continue_tx: RunResult,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct RunResult {
     pub breakpoint: Option<OutputBreakpoint>,
@@ -227,7 +227,7 @@ impl fmt::Display for RunResult {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct OutputBreakpoint {
     pub contract: ContractId,
@@ -248,7 +248,7 @@ pub struct ConnectionArgs {
     pub last: Option<i32>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct PageInfo {
     pub end_cursor: Option<String>,

--- a/crates/client/src/client/schema/balance.rs
+++ b/crates/client/src/client/schema/balance.rs
@@ -10,13 +10,13 @@ use crate::client::{
     PaginationRequest,
 };
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct BalanceArgs {
     pub owner: Address,
     pub asset_id: AssetId,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -34,7 +34,7 @@ pub struct BalanceFilterInput {
     pub owner: Address,
 }
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct BalancesConnectionArgs {
     /// Filter coins based on a filter
     filter: BalanceFilterInput,
@@ -70,7 +70,7 @@ impl From<(Address, PaginationRequest<String>)> for BalancesConnectionArgs {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -81,21 +81,21 @@ pub struct BalancesQuery {
     pub balances: BalanceConnection,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct BalanceConnection {
     pub edges: Vec<BalanceEdge>,
     pub page_info: PageInfo,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct BalanceEdge {
     pub cursor: String,
     pub node: Balance,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Balance {
     pub owner: Address,

--- a/crates/client/src/client/schema/block.rs
+++ b/crates/client/src/client/schema/block.rs
@@ -15,12 +15,12 @@ use super::{
     Bytes32,
 };
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct BlockByIdArgs {
     pub id: Option<BlockId>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -31,12 +31,12 @@ pub struct BlockByIdQuery {
     pub block: Option<Block>,
 }
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct BlockByHeightArgs {
     pub height: Option<U32>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -47,7 +47,7 @@ pub struct BlockByHeightQuery {
     pub block: Option<Block>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -58,21 +58,21 @@ pub struct BlocksQuery {
     pub blocks: BlockConnection,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct BlockConnection {
     pub edges: Vec<BlockEdge>,
     pub page_info: PageInfo,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct BlockEdge {
     pub cursor: String,
     pub node: Block,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Block {
     pub id: BlockId,
@@ -81,19 +81,19 @@ pub struct Block {
     pub transactions: Vec<TransactionIdFragment>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Block")]
 pub struct BlockIdFragment {
     pub id: BlockId,
 }
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct ProduceBlockArgs {
     pub start_timestamp: Option<Tai64Timestamp>,
     pub blocks_to_produce: U32,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     variables = "ProduceBlockArgs",
@@ -104,7 +104,7 @@ pub struct BlockMutation {
     pub produce_blocks: U32,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Header {
     pub id: BlockId,
@@ -119,7 +119,7 @@ pub struct Header {
     pub application_hash: Bytes32,
 }
 
-#[derive(cynic::InlineFragments, Debug)]
+#[derive(cynic::InlineFragments, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum Consensus {
     Genesis(Genesis),
@@ -128,7 +128,7 @@ pub enum Consensus {
     Unknown,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Genesis {
     pub chain_config_hash: Bytes32,
@@ -137,7 +137,7 @@ pub struct Genesis {
     pub messages_root: Bytes32,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct PoAConsensus {
     pub signature: Signature,

--- a/crates/client/src/client/schema/chain.rs
+++ b/crates/client/src/client/schema/chain.rs
@@ -7,7 +7,7 @@ use crate::client::schema::{
     U8,
 };
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ConsensusParameters {
     pub tx_params: TxParameters,
@@ -20,7 +20,7 @@ pub struct ConsensusParameters {
     pub gas_costs: GasCosts,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct TxParameters {
     pub max_inputs: U8,
@@ -42,7 +42,7 @@ impl From<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct PredicateParameters {
     pub max_predicate_length: U64,
@@ -62,7 +62,7 @@ impl From<PredicateParameters> for fuel_core_types::fuel_tx::PredicateParameters
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ScriptParameters {
     pub max_script_length: U64,
@@ -78,7 +78,7 @@ impl From<ScriptParameters> for fuel_core_types::fuel_tx::ScriptParameters {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractParameters {
     pub contract_max_size: U64,
@@ -94,7 +94,7 @@ impl From<ContractParameters> for fuel_core_types::fuel_tx::ContractParameters {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct FeeParameters {
     pub gas_price_factor: U64,
@@ -114,7 +114,7 @@ macro_rules! include_from_impls_and_cynic {
     ($(#[$meta:meta])* $vis:vis struct $name:ident {
         $($field_vis:vis $field_name:ident: $field_type:ty,)*
     }) => {
-        #[derive(cynic::QueryFragment, Debug)]
+        #[derive(cynic::QueryFragment, Clone, Debug)]
         #[cynic(schema_path = "./assets/schema.sdl")]
         $vis struct $name {
             $($field_vis $field_name: $field_type,)*
@@ -132,6 +132,7 @@ macro_rules! include_from_impls_and_cynic {
 }
 
 include_from_impls_and_cynic! {
+    #[derive(Copy, Clone, Debug)]
     pub struct GasCosts {
         pub add: U64,
         pub addi: U64,
@@ -249,21 +250,21 @@ include_from_impls_and_cynic! {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct LightOperation {
     pub base: U64,
     pub units_per_gas: U64,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct HeavyOperation {
     pub base: U64,
     pub gas_per_unit: U64,
 }
 
-#[derive(cynic::InlineFragments, Debug)]
+#[derive(cynic::InlineFragments, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum DependentCost {
     LightOperation(LightOperation),
@@ -311,13 +312,13 @@ impl From<ConsensusParameters> for fuel_core_types::fuel_tx::ConsensusParameters
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Query")]
 pub struct ChainQuery {
     pub chain: ChainInfo,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ChainInfo {
     pub da_height: U64,

--- a/crates/client/src/client/schema/coins.rs
+++ b/crates/client/src/client/schema/coins.rs
@@ -13,12 +13,12 @@ use crate::client::{
     PaginationRequest,
 };
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct CoinByIdArgs {
     pub utxo_id: UtxoId,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -38,7 +38,7 @@ pub struct CoinFilterInput {
     pub asset_id: Option<AssetId>,
 }
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct CoinsConnectionArgs {
     /// Filter coins based on a filter
     filter: CoinFilterInput,
@@ -80,7 +80,7 @@ impl From<(Address, AssetId, PaginationRequest<String>)> for CoinsConnectionArgs
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -91,14 +91,14 @@ pub struct CoinsQuery {
     pub coins: CoinConnection,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct CoinConnection {
     pub edges: Vec<CoinEdge>,
     pub page_info: PageInfo,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct CoinEdge {
     pub cursor: String,
@@ -116,7 +116,7 @@ pub struct Coin {
     pub owner: Address,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Coin")]
 pub struct CoinIdFragment {
     pub utxo_id: UtxoId,
@@ -178,7 +178,7 @@ impl CoinType {
     }
 }
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct CoinsToSpendArgs {
     /// The `Address` of the assets' coins owner.
     owner: Address,
@@ -201,7 +201,7 @@ impl From<CoinsToSpendArgsTuple> for CoinsToSpendArgs {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",

--- a/crates/client/src/client/schema/contract.rs
+++ b/crates/client/src/client/schema/contract.rs
@@ -17,7 +17,7 @@ pub struct ContractByIdArgs {
     pub id: ContractId,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -28,7 +28,7 @@ pub struct ContractByIdQuery {
     pub contract: Option<Contract>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractBalance {
     pub contract: ContractId,
@@ -42,7 +42,7 @@ pub struct ContractBalanceQueryArgs {
     pub asset: AssetId,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -53,7 +53,7 @@ pub struct ContractBalanceQuery {
     pub contract_balance: ContractBalance,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Contract {
     pub id: ContractId,
@@ -61,7 +61,7 @@ pub struct Contract {
     pub salt: Salt,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Contract")]
 pub struct ContractIdFragment {
     pub id: ContractId,
@@ -89,21 +89,21 @@ pub struct ContractBalancesConnectionArgs {
     pub last: Option<i32>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractBalanceEdge {
     pub cursor: String,
     pub node: ContractBalance,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractBalanceConnection {
     pub edges: Vec<ContractBalanceEdge>,
     pub page_info: PageInfo,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",

--- a/crates/client/src/client/schema/message.rs
+++ b/crates/client/src/client/schema/message.rs
@@ -20,7 +20,7 @@ use crate::client::{
     },
 };
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Message {
     pub amount: U64,
@@ -31,13 +31,13 @@ pub struct Message {
     pub da_height: U64,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct MessageStatus {
     pub(crate) state: MessageState,
 }
 
-#[derive(cynic::Enum, Debug)]
+#[derive(cynic::Enum, Clone, Copy, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum MessageState {
     Unspent,
@@ -45,7 +45,7 @@ pub enum MessageState {
     NotFound,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -56,14 +56,14 @@ pub struct OwnedMessageQuery {
     pub messages: MessageConnection,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct MessageConnection {
     pub edges: Vec<MessageEdge>,
     pub page_info: PageInfo,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct MessageEdge {
     pub cursor: String,
@@ -85,7 +85,7 @@ pub struct OwnedMessagesConnectionArgs {
     pub last: Option<i32>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -101,7 +101,7 @@ pub struct MessageProofQuery {
     pub message_proof: Option<MessageProof>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct MerkleProof {
     /// The proof set of the message proof.
@@ -110,7 +110,7 @@ pub struct MerkleProof {
     pub proof_index: U64,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct MessageProof {
     /// Proof that message is contained within the provided block header.
@@ -153,7 +153,7 @@ pub struct MessageProofArgs {
     pub commit_block_height: Option<U32>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",

--- a/crates/client/src/client/schema/node_info.rs
+++ b/crates/client/src/client/schema/node_info.rs
@@ -15,7 +15,7 @@ use std::{
     },
 };
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct NodeInfo {
     pub utxo_validation: bool,
@@ -26,7 +26,7 @@ pub struct NodeInfo {
     pub node_version: String,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Query")]
 pub struct QueryNodeInfo {
     pub node_info: NodeInfo,
@@ -35,19 +35,19 @@ pub struct QueryNodeInfo {
 // Use a separate GQL query for showing peer info, as the endpoint is bulky and may return an error
 // if the `p2p` feature is disabled.
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "NodeInfo")]
 pub struct PeersInfo {
     pub peers: Vec<PeerInfo>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Query")]
 pub struct QueryPeersInfo {
     pub node_info: PeersInfo,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct PeerInfo {
     pub id: String,

--- a/crates/client/src/client/schema/tx.rs
+++ b/crates/client/src/client/schema/tx.rs
@@ -32,13 +32,13 @@ use std::convert::{
 pub mod transparent_receipt;
 pub mod transparent_tx;
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct TxIdArgs {
     pub id: TransactionId,
 }
 
 /// Retrieves the transaction in opaque form
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -49,7 +49,7 @@ pub struct TransactionQuery {
     pub transaction: Option<OpaqueTransaction>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -60,7 +60,7 @@ pub struct TransactionsQuery {
     pub transactions: TransactionConnection,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct TransactionConnection {
     pub edges: Vec<TransactionEdge>,
@@ -83,14 +83,14 @@ impl TryFrom<TransactionConnection> for PaginatedResult<TransactionResponse, Str
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct TransactionEdge {
     pub cursor: String,
     pub node: OpaqueTransaction,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(graphql_type = "Transaction", schema_path = "./assets/schema.sdl")]
 pub struct OpaqueTransaction {
     pub raw_payload: HexString,
@@ -109,7 +109,7 @@ impl TryFrom<OpaqueTransaction> for fuel_tx::Transaction {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Transaction")]
 pub struct TransactionIdFragment {
     pub id: TransactionId,
@@ -155,7 +155,7 @@ impl TryFrom<ProgramState> for fuel_vm::ProgramState {
 }
 
 #[allow(clippy::enum_variant_names)]
-#[derive(cynic::InlineFragments, Debug)]
+#[derive(cynic::InlineFragments, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum TransactionStatus {
     SubmittedStatus(SubmittedStatus),
@@ -166,13 +166,13 @@ pub enum TransactionStatus {
     Unknown,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct SubmittedStatus {
     pub time: Tai64Timestamp,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct SuccessStatus {
     pub transaction_id: TransactionId,
@@ -182,7 +182,7 @@ pub struct SuccessStatus {
     pub receipts: Vec<Receipt>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct FailureStatus {
     pub transaction_id: TransactionId,
@@ -193,13 +193,13 @@ pub struct FailureStatus {
     pub receipts: Vec<Receipt>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct SqueezedOutStatus {
     pub reason: String,
 }
 
-#[derive(cynic::QueryVariables, Debug)]
+#[derive(cynic::QueryVariables, Clone, Debug)]
 pub struct TransactionsByOwnerConnectionArgs {
     /// Select transactions based on related `owner`s
     pub owner: Address,
@@ -235,7 +235,7 @@ impl From<(Address, PaginationRequest<String>)> for TransactionsByOwnerConnectio
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -246,7 +246,7 @@ pub struct TransactionsByOwnerQuery {
     pub transactions_by_owner: TransactionConnection,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Subscription",
@@ -264,7 +264,7 @@ pub struct TxArg {
     pub tx: HexString,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -281,7 +281,7 @@ pub struct DryRunArg {
     pub utxo_validation: Option<bool>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -292,7 +292,7 @@ pub struct DryRun {
     pub dry_run: Vec<Receipt>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
@@ -303,7 +303,7 @@ pub struct Submit {
     pub submit: TransactionIdFragment,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Subscription",
@@ -314,7 +314,7 @@ pub struct SubmitAndAwaitSubscription {
     pub submit_and_await: TransactionStatus,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl", graphql_type = "Query")]
 pub struct AllReceipts {
     pub all_receipts: Vec<Receipt>,

--- a/crates/client/src/client/schema/tx/transparent_receipt.rs
+++ b/crates/client/src/client/schema/tx/transparent_receipt.rs
@@ -16,7 +16,7 @@ use fuel_core_types::{
     fuel_tx,
 };
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Receipt {
     pub param1: Option<U64>,

--- a/crates/client/src/client/schema/tx/transparent_tx.rs
+++ b/crates/client/src/client/schema/tx/transparent_tx.rs
@@ -39,7 +39,7 @@ use fuel_core_types::{
 use itertools::Itertools;
 
 /// Retrieves the transaction in opaque form
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -50,7 +50,7 @@ pub struct TransactionQuery {
     pub transaction: Option<Transaction>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Query",
@@ -61,14 +61,14 @@ pub struct TransactionsQuery {
     pub transactions: TransactionConnection,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct TransactionConnection {
     pub edges: Vec<TransactionEdge>,
     pub page_info: PageInfo,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct TransactionEdge {
     pub cursor: String,
@@ -78,7 +78,7 @@ pub struct TransactionEdge {
 /// The `Transaction` schema is a combination of all fields available in
 /// the `fuel_tx::Transaction` from each variant plus some additional
 /// data from helper functions that are often fetched by the user.
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Transaction {
     /// The field of the `Transaction::Script` type.
@@ -295,7 +295,7 @@ impl TryFrom<Transaction> for fuel_tx::Transaction {
     }
 }
 
-#[derive(cynic::InlineFragments, Debug)]
+#[derive(cynic::InlineFragments, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum Input {
     InputCoin(InputCoin),
@@ -305,7 +305,7 @@ pub enum Input {
     Unknown,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct InputCoin {
     pub utxo_id: UtxoId,
@@ -320,7 +320,7 @@ pub struct InputCoin {
     pub predicate_data: HexString,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct InputContract {
     pub utxo_id: UtxoId,
@@ -330,7 +330,7 @@ pub struct InputContract {
     pub contract: ContractIdFragment,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct InputMessage {
     sender: Address,
@@ -421,7 +421,7 @@ impl TryFrom<Input> for fuel_tx::Input {
     }
 }
 
-#[derive(cynic::InlineFragments, Debug)]
+#[derive(cynic::InlineFragments, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum Output {
     CoinOutput(CoinOutput),
@@ -433,7 +433,7 @@ pub enum Output {
     Unknown,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct CoinOutput {
     pub to: Address,
@@ -441,7 +441,7 @@ pub struct CoinOutput {
     pub asset_id: AssetId,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ChangeOutput {
     pub to: Address,
@@ -449,7 +449,7 @@ pub struct ChangeOutput {
     pub asset_id: AssetId,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct VariableOutput {
     pub to: Address,
@@ -457,7 +457,7 @@ pub struct VariableOutput {
     pub asset_id: AssetId,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractOutput {
     pub input_index: i32,
@@ -465,7 +465,7 @@ pub struct ContractOutput {
     pub state_root: Bytes32,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct ContractCreated {
     contract: ContractIdFragment,
@@ -526,7 +526,7 @@ impl TryFrom<ContractOutput> for output::contract::Contract {
     }
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub struct Policies {
     pub gas_price: Option<U64>,


### PR DESCRIPTION
This is needed for https://github.com/FuelLabs/fuel-subgraph/issues/11
The non-Clone response types are extremely annoying to work with.

We also need to relase this. I'm open to doing version bump in this PR or as a separate one.
