### PR TITLE
Remove genesis temp tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- [#1737](https://github.com/FuelLabs/fuel-core/pull/1737): Remove temporary tables for calculating roots during genesis.
 - [#1731](https://github.com/FuelLabs/fuel-core/pull/1731): Expose `schema.sdl` from `fuel-core-client`.
 
 ### Changed

--- a/crates/fuel-core/src/database/genesis_progress.rs
+++ b/crates/fuel-core/src/database/genesis_progress.rs
@@ -1,36 +1,28 @@
-use crate::state::DataSource;
-
 use super::Database;
+use fuel_core_chain_config::GenesisCommitment;
+use fuel_core_executor::refs::ContractRef;
 use fuel_core_storage::{
-    blueprint::{
-        plain::Plain,
-        Blueprint,
-    },
-    codec::{
-        postcard::Postcard,
-        raw::Raw,
-    },
+    blueprint::plain::Plain,
+    codec::postcard::Postcard,
     column::Column,
     structured_storage::TableWithBlueprint,
-    tables::ContractsLatestUtxo,
+    tables::{
+        Coins,
+        ContractsLatestUtxo,
+        Messages,
+    },
+    transactional::Transactional,
     Mappable,
     MerkleRoot,
     Result,
     StorageAsMut,
     StorageInspect,
-    StorageMutate,
 };
 use fuel_core_types::{
-    fuel_merkle::sparse::{
-        in_memory::MerkleTree,
-        MerkleTreeKey,
-    },
+    fuel_merkle::binary::root_calculator::MerkleRootCalculator,
     fuel_types::ContractId,
 };
-use itertools::{
-    process_results,
-    Itertools,
-};
+use itertools::process_results;
 use serde::{
     Deserialize,
     Serialize,
@@ -63,60 +55,6 @@ impl TableWithBlueprint for GenesisMetadata {
     }
 }
 
-// TODO: Remove as part of the https://github.com/FuelLabs/fuel-core/issues/1734
-pub struct GenesisCoinRoots;
-
-impl Mappable for GenesisCoinRoots {
-    type Key = Self::OwnedKey;
-    type OwnedKey = MerkleRoot;
-    type Value = Self::OwnedValue;
-    type OwnedValue = ();
-}
-
-impl TableWithBlueprint for GenesisCoinRoots {
-    type Blueprint = Plain<Raw, Postcard>;
-    type Column = Column;
-    fn column() -> Self::Column {
-        Column::GenesisCoinRoots
-    }
-}
-
-// TODO: Remove as part of the https://github.com/FuelLabs/fuel-core/issues/1734
-pub struct GenesisMessageRoots;
-
-impl Mappable for GenesisMessageRoots {
-    type Key = Self::OwnedKey;
-    type OwnedKey = MerkleRoot;
-    type Value = Self::OwnedValue;
-    type OwnedValue = ();
-}
-
-impl TableWithBlueprint for GenesisMessageRoots {
-    type Blueprint = Plain<Raw, Postcard>;
-    type Column = Column;
-    fn column() -> Self::Column {
-        Column::GenesisMessageRoots
-    }
-}
-
-// TODO: Remove as part of the https://github.com/FuelLabs/fuel-core/issues/1734
-pub struct GenesisContractRoots;
-
-impl Mappable for GenesisContractRoots {
-    type Key = Self::OwnedKey;
-    type OwnedKey = MerkleRoot;
-    type Value = Self::OwnedValue;
-    type OwnedValue = ();
-}
-
-impl TableWithBlueprint for GenesisContractRoots {
-    type Blueprint = Plain<Raw, Postcard>;
-    type Column = Column;
-    fn column() -> Self::Column {
-        Column::GenesisContractRoots
-    }
-}
-
 pub type GenesisImportedContractId = ContractId;
 
 impl Database {
@@ -139,66 +77,49 @@ impl Database {
         Ok(())
     }
 
-    pub fn add_coin_root(&mut self, root: MerkleRoot) -> Result<()> {
-        StorageMutate::<GenesisCoinRoots>::insert(self, &root, &())?;
-        Ok(())
-    }
-
-    pub fn add_message_root(&mut self, root: MerkleRoot) -> Result<()> {
-        StorageMutate::<GenesisMessageRoots>::insert(self, &root, &())?;
-        Ok(())
-    }
-
-    pub fn add_contract_root(&mut self, root: MerkleRoot) -> Result<()> {
-        StorageMutate::<GenesisContractRoots>::insert(self, &root, &())?;
-        Ok(())
-    }
-
-    pub(crate) fn genesis_roots<M>(
-        &self,
-    ) -> Result<impl Iterator<Item = (MerkleTreeKey, [u8; 32])>>
-    where
-        M: Mappable<OwnedKey = [u8; 32]> + TableWithBlueprint<Column = Column>,
-        M::Blueprint: Blueprint<M, DataSource>,
-    {
-        let roots_iter = self.iter_all::<M>(None);
+    pub fn genesis_coin_root(&self) -> Result<MerkleRoot> {
+        let roots_iter = self.iter_all::<Coins>(None);
 
         let roots = process_results(roots_iter, |roots| {
-            roots.map(|(root, _)| root).collect::<Vec<MerkleRoot>>()
+            roots
+                .map(|(_, coin)| coin.root().unwrap())
+                .collect::<Vec<MerkleRoot>>()
         })?
-        .into_iter()
-        .enumerate()
-        .map(|(idx, root)| (MerkleTreeKey::new(idx.to_be_bytes()), root));
+        .into_iter();
 
-        Ok(roots)
-    }
-
-    fn compute_genesis_root<M>(&self) -> Result<MerkleRoot>
-    where
-        M: Mappable<OwnedKey = [u8; 32]> + TableWithBlueprint<Column = Column>,
-        M::Blueprint: Blueprint<M, DataSource>,
-    {
-        let roots = self.genesis_roots::<M>()?;
-        Ok(MerkleTree::root_from_set(roots.into_iter()))
-    }
-
-    pub fn genesis_coin_root(&self) -> Result<MerkleRoot> {
-        self.compute_genesis_root::<GenesisCoinRoots>()
+        Ok(MerkleRootCalculator::new().root_from_iterator(roots))
     }
 
     pub fn genesis_messages_root(&self) -> Result<MerkleRoot> {
-        self.compute_genesis_root::<GenesisMessageRoots>()
+        let roots_iter = self.iter_all::<Messages>(None);
+
+        let roots = process_results(roots_iter, |roots| {
+            roots
+                .map(|(_, message)| message.root().unwrap())
+                .collect::<Vec<MerkleRoot>>()
+        })?
+        .into_iter();
+
+        Ok(MerkleRootCalculator::new().root_from_iterator(roots))
     }
 
     pub fn genesis_contracts_root(&self) -> Result<MerkleRoot> {
-        self.compute_genesis_root::<GenesisContractRoots>()
-    }
+        let mut database_transaction = Transactional::transaction(self);
 
-    pub fn genesis_loaded_contracts(
-        &self,
-    ) -> impl Iterator<Item = Result<GenesisImportedContractId>> + '_ {
-        self.iter_all::<ContractsLatestUtxo>(None)
-            .map_ok(|(contract_id, _)| contract_id)
-            .map(|res| res.map_err(Into::into))
+        let database = database_transaction.as_mut();
+        let contracts_iter = self.iter_all::<ContractsLatestUtxo>(None);
+
+        let roots = process_results(contracts_iter, |contracts| {
+            contracts
+                .map(|(contract_id, _)| {
+                    ContractRef::new(&mut *database, contract_id)
+                        .root()
+                        .unwrap()
+                })
+                .collect::<Vec<MerkleRoot>>()
+        })?
+        .into_iter();
+
+        Ok(MerkleRootCalculator::new().root_from_iterator(roots))
     }
 }

--- a/crates/fuel-core/src/database/storage.rs
+++ b/crates/fuel-core/src/database/storage.rs
@@ -53,12 +53,7 @@ use fuel_core_storage::{
 };
 use std::borrow::Cow;
 
-use super::genesis_progress::{
-    GenesisCoinRoots,
-    GenesisContractRoots,
-    GenesisMessageRoots,
-    GenesisMetadata,
-};
+use super::genesis_progress::GenesisMetadata;
 
 /// The trait allows selectively inheriting the implementation of storage traits from `StructuredStorage`
 /// for the `Database`. Not all default implementations of the `StructuredStorage` are suitable
@@ -106,10 +101,7 @@ use_structured_implementation!(
     FuelBlockIdsToHeights,
     FuelBlockMerkleData,
     FuelBlockMerkleMetadata,
-    GenesisMetadata,
-    GenesisCoinRoots,
-    GenesisMessageRoots,
-    GenesisContractRoots
+    GenesisMetadata
 );
 
 #[cfg(feature = "relayer")]

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -1,12 +1,7 @@
 use self::workers::GenesisWorkers;
 use crate::{
     database::{
-        genesis_progress::{
-            GenesisCoinRoots,
-            GenesisContractRoots,
-            GenesisMessageRoots,
-            GenesisMetadata,
-        },
+        genesis_progress::GenesisMetadata,
         Database,
     },
     service::config::Config,
@@ -31,7 +26,6 @@ use fuel_core_storage::{
         StorageTransaction,
         Transactional,
     },
-    MerkleRoot,
     StorageAsMut,
 };
 use fuel_core_types::{
@@ -130,18 +124,13 @@ async fn import_chain_state(workers: GenesisWorkers) -> anyhow::Result<()> {
         return Err(e);
     }
 
-    workers.compute_contracts_root().await?;
-
     Ok(())
 }
 
 fn cleanup_genesis_progress(database: &mut Database) -> anyhow::Result<()> {
-    database.delete_all(GenesisMetadata::column())?;
-    database.delete_all(GenesisCoinRoots::column())?;
-    database.delete_all(GenesisMessageRoots::column())?;
-    database.delete_all(GenesisContractRoots::column())?;
-
-    Ok(())
+    database
+        .delete_all(GenesisMetadata::column())
+        .map_err(|e| e.into())
 }
 
 pub fn create_genesis_block(config: &Config) -> Block {
@@ -206,7 +195,7 @@ fn init_coin(
     coin: &CoinConfig,
     output_index: u64,
     height: BlockHeight,
-) -> anyhow::Result<MerkleRoot> {
+) -> anyhow::Result<()> {
     // TODO: Store merkle sum tree root over coins with unspecified utxo ids.
     let utxo_id = coin.utxo_id().unwrap_or(generated_utxo_id(output_index));
 
@@ -235,7 +224,7 @@ fn init_coin(
         return Err(anyhow!("Coin should not exist"));
     }
 
-    compressed_coin.root()
+    Ok(())
 }
 
 fn init_contract(
@@ -290,7 +279,7 @@ fn init_contract(
     Ok(())
 }
 
-fn init_da_message(db: &mut Database, msg: MessageConfig) -> anyhow::Result<MerkleRoot> {
+fn init_da_message(db: &mut Database, msg: MessageConfig) -> anyhow::Result<()> {
     let message: Message = msg.into();
 
     if db
@@ -301,7 +290,7 @@ fn init_da_message(db: &mut Database, msg: MessageConfig) -> anyhow::Result<Merk
         return Err(anyhow!("Message should not exist"));
     }
 
-    message.root()
+    Ok(())
 }
 
 #[cfg(test)]
@@ -310,12 +299,7 @@ mod tests {
 
     use crate::{
         combined_database::CombinedDatabase,
-        database::genesis_progress::{
-            GenesisCoinRoots,
-            GenesisContractRoots,
-            GenesisMessageRoots,
-            GenesisResource,
-        },
+        database::genesis_progress::GenesisResource,
         service::{
             config::Config,
             FuelService,
@@ -454,21 +438,6 @@ mod tests {
         for key in GenesisResource::iter() {
             assert!(db.genesis_progress(&key).is_none());
         }
-        assert!(db
-            .genesis_roots::<GenesisCoinRoots>()
-            .unwrap()
-            .next()
-            .is_none());
-        assert!(db
-            .genesis_roots::<GenesisMessageRoots>()
-            .unwrap()
-            .next()
-            .is_none());
-        assert!(db
-            .genesis_roots::<GenesisContractRoots>()
-            .unwrap()
-            .next()
-            .is_none());
     }
 
     #[tokio::test]

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -88,7 +88,7 @@ pub async fn execute_genesis_block(
 
     let genesis = Genesis {
         chain_config_hash: config.chain_config.root()?.into(),
-        coins_root: original_database.genesis_coin_root()?.into(),
+        coins_root: original_database.genesis_coins_root()?.into(),
         messages_root: original_database.genesis_messages_root()?.into(),
         contracts_root: original_database.genesis_contracts_root()?.into(),
     };

--- a/crates/services/executor/src/refs/contract.rs
+++ b/crates/services/executor/src/refs/contract.rs
@@ -117,7 +117,7 @@ pub trait ContractStorageTrait:
     type InnerError: fmt::Debug + fmt::Display + Send + Sync + 'static;
 }
 
-impl<'a, Database> GenesisCommitment for ContractRef<&'a mut Database>
+impl<'a, Database> GenesisCommitment for ContractRef<&'a Database>
 where
     Database: ContractStorageTrait,
     anyhow::Error: From<Database::InnerError>,
@@ -133,12 +133,12 @@ where
             .utxo_id();
 
         let state_root = self
-            .database()
+            .database
             .storage::<ContractsState>()
             .root(&contract_id)?;
 
         let balance_root = self
-            .database()
+            .database
             .storage::<ContractsAssets>()
             .root(&contract_id)?;
 


### PR DESCRIPTION
Closes #1734

Removes the temporary tables for calculating genesis block roots.