### PR TITLE
Removed `protobuf` from everywhere since `libp2p` uses `quick-protobuf`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
   release:
-    types: [published]
+    types: [ published ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -40,7 +40,7 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
           components: rustfmt
-          
+
       - name: Rustfmt check
         run: cargo +${{ env.NIGHTLY_RUST_VERSION }} fmt --all -- --check
 
@@ -161,10 +161,6 @@ jobs:
         uses: davidB/rust-cargo-make@v1
         with:
           version: "0.36.4"
-      - name: Install Protoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install protobuf-compiler
       - uses: rui314/setup-mold@v1
       - uses: buildjet/cache@v3
         with:
@@ -245,11 +241,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-
-      - name: Install Protoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install protobuf-compiler
 
       - name: Publish crate
         uses: xgreenx/publish-crates@v1
@@ -579,7 +570,7 @@ jobs:
 
   # Deploy Fuel Core Ephemeral Developer Environment
   deploy-eph-env:
-    if:  startsWith(github.head_ref, 'preview/')
+    if: startsWith(github.head_ref, 'preview/')
     needs:
       - publish-docker-image
     runs-on: buildjet-4vcpu-ubuntu-2204

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ Description of the upcoming release here.
 
   Using uniform-sized batches may result in batches containing items from multiple contracts. Optimal performance can presumably be achieved by selecting a batch size that typically encompasses an entire contract's state or balance, allowing for immediate initialization of relevant Merkle trees.
 
+### Removed
+
+- [#1757](https://github.com/FuelLabs/fuel-core/pull/1757): Removed `protobuf` from everywhere since `libp2p` uses `quick-protobuf`.
 
 ## [Version 0.23.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,6 @@ To build Fuel Core you'll need to at least have the following installed:
 -   `git` - version control
 -   [`rustup`](https://rustup.rs/) - Rust installer and toolchain manager
 -   [`clang`](http://releases.llvm.org/download.html) - Used to build system libraries (required for rocksdb).
--   [`protoc`](https://grpc.io/docs/protoc-installation/) - Used to compile Protocol Buffer files (required by libp2p).
 
 See the [README.md](README.md#system-requirements) for platform specific setup steps.
 

--- a/README.md
+++ b/README.md
@@ -24,20 +24,19 @@ There are several system requirements including clang.
 ```bash
 brew update
 brew install cmake
-brew install protobuf
 ```
 
 #### Debian
 
 ```bash
 apt update
-apt install -y cmake pkg-config build-essential git clang libclang-dev protobuf-compiler
+apt install -y cmake pkg-config build-essential git clang libclang-dev
 ```
 
 #### Arch
 
 ```bash
-pacman -Syu --needed --noconfirm cmake gcc pkgconf git clang protobuf-compiler
+pacman -Syu --needed --noconfirm cmake gcc pkgconf git clang
 ```
 
 ### Compiling

--- a/ci/Dockerfile.aarch64-unknown-linux-gnu-clang
+++ b/ci/Dockerfile.aarch64-unknown-linux-gnu-clang
@@ -4,4 +4,4 @@ ENV PKG_CONFIG_ALLOW_CROSS="true"
 
 RUN dpkg --add-architecture arm64 && \
     apt-get update && \
-    apt-get install --assume-yes clang-8 libclang-8-dev binutils-aarch64-linux-gnu protobuf-compiler zlib1g-dev:arm64
+    apt-get install --assume-yes clang-8 libclang-8-dev binutils-aarch64-linux-gnu zlib1g-dev:arm64

--- a/ci/Dockerfile.x86_64-unknown-linux-gnu-clang
+++ b/ci/Dockerfile.x86_64-unknown-linux-gnu-clang
@@ -1,4 +1,4 @@
 FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main@sha256:bf0cd3027befe882feb5a2b4040dc6dbdcb799b25c5338342a03163cea43da1b
 
 RUN apt-get update && \
-    apt-get install --assume-yes clang libclang-dev binutils-aarch64-linux-gnu protobuf-compiler
+    apt-get install --assume-yes clang libclang-dev binutils-aarch64-linux-gnu

--- a/ci/macos-install-packages.sh
+++ b/ci/macos-install-packages.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
 brew install llvm
-brew install protobuf

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
     lld \
     clang \
     libclang-dev \
-    protobuf-compiler \
     && xx-apt-get update  \
     && xx-apt-get install -y libc6-dev g++ binutils \
     && apt-get clean \


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/1755

After updating `libp2p` to the latest version, we don't need to require a `protobuf` shared library to exist in the OS. A new version uses native rust implementation of the protobuf - `quick-protobuf`.