### PR TITLE
Release v0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+## [Version 0.24.2]
+
 ### Changed
 
 #### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -576,7 +576,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
-version = "0.24.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
 dependencies = [
@@ -661,7 +661,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -796,7 +796,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1144,7 +1144,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex 0.7.0",
- "strsim 0.11.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1169,7 +1169,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1759,7 +1759,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1871,7 +1871,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1904,7 +1904,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -2113,7 +2113,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2267,7 +2267,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2287,7 +2287,7 @@ checksum = "03cdc46ec28bd728e67540c528013c6a10eb69a02eb31078a1bda695438cbfb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2442,7 +2442,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.57",
+ "syn 2.0.58",
  "toml 0.8.12",
  "walkdir",
 ]
@@ -2460,7 +2460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2486,7 +2486,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.2",
- "syn 2.0.57",
+ "syn 2.0.58",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3445,7 +3445,7 @@ checksum = "5896603b839f04f27e8bddbae2990dc799fb119f5e62973d6666b2ea1a4b036b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "synstructure 0.13.1",
 ]
 
@@ -3649,7 +3649,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3806,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -4308,7 +4308,7 @@ dependencies = [
  "autocfg",
  "impl-tools-lib",
  "proc-macro-error",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4320,7 +4320,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5021,7 +5021,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5133,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.1"
+version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
@@ -5144,13 +5144,12 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.0.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -5574,9 +5573,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
+checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
 dependencies = [
  "async-io 1.13.0",
  "bytes",
@@ -5766,7 +5765,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6036,9 +6035,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.8"
+version = "2.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -6095,7 +6094,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6133,7 +6132,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6371,7 +6370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6478,7 +6477,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -6581,9 +6580,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca0b7bac0b97248c40bb77288fc52029cf1459c0461ea1b05ee32ccf011de2c"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -6795,12 +6794,12 @@ checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
- "libredox 0.0.1",
+ "libredox 0.1.3",
  "thiserror",
 ]
 
@@ -7432,7 +7431,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7494,7 +7493,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7815,9 +7814,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structmeta"
@@ -7828,7 +7827,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7839,12 +7838,12 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "strum"
-version = "0.24.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
@@ -7892,7 +7891,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7905,7 +7904,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -7970,9 +7969,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8005,7 +8004,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8118,7 +8117,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8129,7 +8128,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "test-case-core",
 ]
 
@@ -8159,7 +8158,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8185,7 +8184,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8340,7 +8339,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8366,7 +8365,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
@@ -8572,7 +8571,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -8918,7 +8917,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -8952,7 +8951,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9165,7 +9164,7 @@ checksum = "4ab8d7566d206c42f8cf1d4ac90c5e40d3582e8eabad9b3b67e9e73c61fc47a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9484,9 +9483,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
 
 [[package]]
 name = "xmltree"
@@ -9568,7 +9567,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -9588,7 +9587,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.57",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attohttpc"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
 dependencies = [
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2933,11 +2933,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.24.1"
+version = "0.24.2"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -2968,7 +2968,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "cynic",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "clap 4.5.4",
  "fuel-core-client",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -3119,7 +3119,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "axum",
  "once_cell",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "ctor",
  "tracing",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "bs58",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -7844,7 +7844,7 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
@@ -8366,7 +8366,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,36 +48,36 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.24.1"
+version = "0.24.2"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.24.1", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.24.1", path = "./bin/client" }
-fuel-core-bin = { version = "0.24.1", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.24.1", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.24.1", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.24.1", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.24.1", path = "./crates/client" }
-fuel-core-database = { version = "0.24.1", path = "./crates/database" }
-fuel-core-metrics = { version = "0.24.1", path = "./crates/metrics" }
-fuel-core-services = { version = "0.24.1", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.24.1", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.24.1", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.24.1", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.24.1", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.24.1", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.24.1", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.24.1", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.24.1", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.24.1", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.24.1", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.24.1", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.24.1", path = "./crates/trace" }
-fuel-core-types = { version = "0.24.1", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.24.2", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.24.2", path = "./bin/client" }
+fuel-core-bin = { version = "0.24.2", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.24.2", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.24.2", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.24.2", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.24.2", path = "./crates/client" }
+fuel-core-database = { version = "0.24.2", path = "./crates/database" }
+fuel-core-metrics = { version = "0.24.2", path = "./crates/metrics" }
+fuel-core-services = { version = "0.24.2", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.24.2", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.24.2", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.24.2", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.24.2", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.24.2", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.24.2", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.24.2", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.24.2", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.24.2", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.24.2", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.24.2", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.24.2", path = "./crates/trace" }
+fuel-core-types = { version = "0.24.2", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.24.1", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.24.1", path = "./crates/services/upgradable-executor/wasm-executor" }
+fuel-core-upgradable-executor = { version = "0.24.2", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.24.2", path = "./crates/services/upgradable-executor/wasm-executor" }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 
 # Fuel dependencies

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.24.1"
+appVersion: "0.24.2"
 version: 0.1.0


### PR DESCRIPTION
## Version v0.24.2

### Changed

#### Breaking
- [#1798](https://github.com/FuelLabs/fuel-core/pull/1798): add nonce to relayed transactions and also hash full messages in the inbox root.

### Fixed

- [#1802](https://github.com/FuelLabs/fuel-core/pull/1802): Fixed a runtime panic that occurred when restarting a node. The panic was caused by an invalid database commit while loading an existing off-chain database. The invalid commit is removed in this PR.
- [#1803](https://github.com/FuelLabs/fuel-core/pull/1803): Produce block when da height haven't changed.
- [#1795](https://github.com/FuelLabs/fuel-core/pull/1795): Fixed the building of the `fuel-core-wasm-executor` to work outside of the `fuel-core` context. The change uses the path to the manifest file of the `fuel-core-upgradable-executor` to build the `fuel-core-wasm-executor` instead of relying on the workspace.

## What's Changed
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/1794
* Improvements for the `fuel-core-upgradable-executor` build script by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1795
* Use full hash for messages in inbox_root and add nonce to relayed transactions by @Voxelot in https://github.com/FuelLabs/fuel-core/pull/1798
* Modify block producer to take into account the total gas used by the L1 transactions by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1785
* Fix: Produce block when da height haven't changed by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1803
* fix: Fix commit error on GraphQL service startup  by @bvrooman in https://github.com/FuelLabs/fuel-core/pull/1802


**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.24.1...v0.24.2