### PR TITLE
Follow-up PR to simplify the logic around parallel snapshot creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
-## [Version 0.24.2]
+### Added
+
+- [#1799](https://github.com/FuelLabs/fuel-core/pull/1799) Snapshot creation is now concurrent.
 
 ### Changed
 
 - [#1812](https://github.com/FuelLabs/fuel-core/pull/1812): Follow-up PR to simplify the logic around parallel snapshot creation.
 
+## [Version 0.24.2]
+
+### Changed
+
 #### Breaking
-- [#1798](https://github.com/FuelLabs/fuel-core/pull/1798): add nonce to relayed transactions and also hash full messages in the inbox root.
+- [#1798](https://github.com/FuelLabs/fuel-core/pull/1798): Add nonce to relayed transactions and also hash full messages in the inbox root.
 
 ### Fixed
 
@@ -27,7 +33,6 @@ Description of the upcoming release here.
 
 ### Added
 
-- [#1799](https://github.com/FuelLabs/fuel-core/pull/1799) Snapshot creation is now concurrent.
 - [#1786](https://github.com/FuelLabs/fuel-core/pull/1786): Regenesis now includes off-chain tables.
 - [#1716](https://github.com/FuelLabs/fuel-core/pull/1716): Added support of WASM state transition along with upgradable execution that works with native(std) and WASM(non-std) executors. The `fuel-core` now requires a `wasm32-unknown-unknown` target to build.
 - [#1770](https://github.com/FuelLabs/fuel-core/pull/1770): Add the new L1 event type for forced transactions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Description of the upcoming release here.
 
 ### Changed
 
+- [#1812](https://github.com/FuelLabs/fuel-core/pull/1812): Follow-up PR to simplify the logic around parallel snapshot creation.
+
 #### Breaking
 - [#1798](https://github.com/FuelLabs/fuel-core/pull/1798): add nonce to relayed transactions and also hash full messages in the inbox root.
 

--- a/bin/fuel-core/src/cli/snapshot.rs
+++ b/bin/fuel-core/src/cli/snapshot.rs
@@ -306,12 +306,9 @@ mod tests {
             builder.add(self.common.contract_balance);
 
             let height = self.common.block.value.header().height();
-            builder.set_block_height(*height);
-
             let da_height = self.common.block.value.header().application().da_height;
-            builder.set_da_block_height(da_height);
 
-            builder.build().unwrap()
+            builder.build(*height, da_height).unwrap()
         }
 
         fn read_from_snapshot(snapshot: SnapshotMetadata) -> Self {

--- a/bin/fuel-core/src/main.rs
+++ b/bin/fuel-core/src/main.rs
@@ -15,15 +15,3 @@ mod cli;
 async fn main() -> anyhow::Result<()> {
     cli::run_cli().await
 }
-
-#[cfg(test)]
-mod tests {
-    // No other way to explain that the following deps are used in tests only when snapshots are activated
-    // (that is when rocksdb or rocksdb-production is available).
-    use fuel_core_storage as _;
-    use itertools as _;
-    use pretty_assertions as _;
-    use rand as _;
-    use serde as _;
-    use tempfile as _;
-}

--- a/crates/fuel-core/src/combined_database.rs
+++ b/crates/fuel-core/src/combined_database.rs
@@ -175,10 +175,8 @@ impl CombinedDatabase {
         );
 
         let block = self.on_chain().latest_block()?;
-        builder.set_block_height(*block.header().height());
-        builder.set_da_block_height(block.header().da_height);
-
-        let state_config = builder.build()?;
+        let state_config =
+            builder.build(*block.header().height(), block.header().da_height)?;
 
         Ok(state_config)
     }

--- a/crates/fuel-core/src/database/contracts.rs
+++ b/crates/fuel-core/src/database/contracts.rs
@@ -92,14 +92,6 @@ impl Database {
         )
         .map_ok(|(key, value)| TableEntry { key, value })
     }
-
-    pub fn filter_contract_states(
-        &self,
-        contract_id: ContractId,
-    ) -> impl Iterator<Item = StorageResult<TableEntry<ContractsState>>> + '_ {
-        self.iter_all_by_prefix::<ContractsState, _>(Some(contract_id))
-            .map_ok(|(key, value)| TableEntry { key, value })
-    }
 }
 
 #[cfg(test)]

--- a/tests/tests/deployment.rs
+++ b/tests/tests/deployment.rs
@@ -26,9 +26,8 @@ fn test_deployment_chainconfig(path: impl AsRef<Path>) -> anyhow::Result<()> {
         .set_gas_costs(benchmark_gas_costs);
 
     let temp_dir = tempfile::tempdir()?;
-    let mut writer = SnapshotWriter::json(temp_dir.path());
-    writer.write_chain_config(&chain_config);
-    let generated_snapshot = writer.write_state_config(state_config)?;
+    let writer = SnapshotWriter::json(temp_dir.path());
+    let generated_snapshot = writer.write_state_config(state_config, &chain_config)?;
 
     let chain_config = std::fs::read_to_string(generated_snapshot.chain_config)?
         .trim()


### PR DESCRIPTION
Follow-up PR to simplify the logic around parallel snapshot creation https://github.com/FuelLabs/fuel-core/pull/1799.

The change removes `Option<BlockHeight>`, `Option<DaBlockHeight>` and `Option<ChainConfig>` from snapshot fragments to not allow overriding of them on type system level.

### Before requesting review
- [x] I have reviewed the code myself