### PR TITLE
Remove SpentMessages table

### DIFF
--- a/crates/fuel-core/src/database/message.rs
+++ b/crates/fuel-core/src/database/message.rs
@@ -14,10 +14,7 @@ use fuel_core_storage::{
         IterDirection,
         IteratorOverTable,
     },
-    tables::{
-        Messages,
-        SpentMessages,
-    },
+    tables::Messages,
     Error as StorageError,
     Result as StorageResult,
 };
@@ -63,22 +60,13 @@ impl Database {
     ) -> impl Iterator<Item = StorageResult<TableEntry<Messages>>> + '_ {
         self.iter_all_by_start::<Messages>(None, None)
             .filter_map(|msg| {
-                // Return only unspent messages
                 if let Ok(msg) = msg {
-                    match self.message_is_spent(msg.1.id()) {
-                        Ok(false) => Some(Ok(msg)),
-                        Ok(true) => None,
-                        Err(e) => Some(Err(e)),
-                    }
+                    Some(Ok(msg))
                 } else {
                     Some(msg.map_err(StorageError::from))
                 }
             })
             .map_ok(|(key, value)| TableEntry { key, value })
-    }
-
-    pub fn message_is_spent(&self, id: &Nonce) -> StorageResult<bool> {
-        fuel_core_storage::StorageAsRef::storage::<SpentMessages>(&self).contains_key(id)
     }
 
     pub fn message_exists(&self, id: &Nonce) -> StorageResult<bool> {

--- a/crates/fuel-core/src/graphql_api/database.rs
+++ b/crates/fuel-core/src/graphql_api/database.rs
@@ -196,10 +196,6 @@ impl DatabaseMessages for ReadView {
         self.on_chain.all_messages(start_message_id, direction)
     }
 
-    fn message_is_spent(&self, nonce: &Nonce) -> StorageResult<bool> {
-        self.on_chain.message_is_spent(nonce)
-    }
-
     fn message_exists(&self, nonce: &Nonce) -> StorageResult<bool> {
         self.on_chain.message_exists(nonce)
     }

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -147,8 +147,6 @@ pub trait DatabaseMessages: StorageInspect<Messages, Error = StorageError> {
         direction: IterDirection,
     ) -> BoxedIter<'_, StorageResult<Message>>;
 
-    fn message_is_spent(&self, nonce: &Nonce) -> StorageResult<bool>;
-
     fn message_exists(&self, nonce: &Nonce) -> StorageResult<bool>;
 }
 

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -285,11 +285,9 @@ pub fn message_status<T: DatabaseMessages + ?Sized>(
     database: &T,
     message_nonce: Nonce,
 ) -> StorageResult<MessageStatus> {
-    if database.message_is_spent(&message_nonce)? {
-        Ok(MessageStatus::spent())
-    } else if database.message_exists(&message_nonce)? {
-        Ok(MessageStatus::unspent())
+    if database.message_exists(&message_nonce)? {
+        Ok(MessageStatus::Unspent)
     } else {
-        Ok(MessageStatus::not_found())
+        Ok(MessageStatus::SpentOrNonExistent)
     }
 }

--- a/crates/fuel-core/src/schema/message.rs
+++ b/crates/fuel-core/src/schema/message.rs
@@ -234,17 +234,17 @@ pub struct MessageStatus(pub(crate) entities::relayer::message::MessageStatus);
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 enum MessageState {
     Unspent,
-    Spent,
-    NotFound,
+    SpentOrNonExistent,
 }
 
 #[Object]
 impl MessageStatus {
     async fn state(&self) -> MessageState {
-        match self.0.state {
-            entities::relayer::message::MessageState::Unspent => MessageState::Unspent,
-            entities::relayer::message::MessageState::Spent => MessageState::Spent,
-            entities::relayer::message::MessageState::NotFound => MessageState::NotFound,
+        match self.0 {
+            entities::relayer::message::MessageStatus::Unspent => MessageState::Unspent,
+            entities::relayer::message::MessageStatus::SpentOrNonExistent => {
+                MessageState::SpentOrNonExistent
+            }
         }
     }
 }

--- a/crates/fuel-core/src/service/adapters/graphql_api/on_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/on_chain.rs
@@ -70,10 +70,6 @@ impl DatabaseMessages for Database {
             .into_boxed()
     }
 
-    fn message_is_spent(&self, nonce: &Nonce) -> StorageResult<bool> {
-        self.message_is_spent(nonce)
-    }
-
     fn message_exists(&self, nonce: &Nonce) -> StorageResult<bool> {
         self.message_exists(nonce)
     }

--- a/crates/fuel-core/src/service/adapters/txpool.rs
+++ b/crates/fuel-core/src/service/adapters/txpool.rs
@@ -13,7 +13,6 @@ use fuel_core_storage::{
         Coins,
         ContractsRawCode,
         Messages,
-        SpentMessages,
     },
     Result as StorageResult,
     StorageAsRef,
@@ -134,10 +133,6 @@ impl fuel_core_txpool::ports::TxPoolDb for Database {
         self.storage::<Messages>()
             .get(id)
             .map(|t| t.map(|t| t.as_ref().clone()))
-    }
-
-    fn is_message_spent(&self, id: &Nonce) -> StorageResult<bool> {
-        self.storage::<SpentMessages>().contains_key(id)
     }
 }
 

--- a/crates/fuel-core/src/service/genesis/importer/on_chain.rs
+++ b/crates/fuel-core/src/service/genesis/importer/on_chain.rs
@@ -18,6 +18,7 @@ use fuel_core_storage::{
         ContractsRawCode,
         ContractsState,
         Messages,
+        ProcessedTransactions,
         Transactions,
     },
     transactional::StorageTransaction,
@@ -143,6 +144,8 @@ impl ImportTable for Handler<Transactions> {
         for transaction in &group {
             tx.storage::<Transactions>()
                 .insert(&transaction.key, &transaction.value)?;
+            tx.storage::<ProcessedTransactions>()
+                .insert(&transaction.key, &())?;
         }
         Ok(())
     }

--- a/crates/fuel-core/src/service/genesis/importer/on_chain.rs
+++ b/crates/fuel-core/src/service/genesis/importer/on_chain.rs
@@ -144,8 +144,6 @@ impl ImportTable for Handler<Transactions> {
         for transaction in &group {
             tx.storage::<Transactions>()
                 .insert(&transaction.key, &transaction.value)?;
-            tx.storage::<ProcessedTransactions>()
-                .insert(&transaction.key, &())?;
         }
         Ok(())
     }

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -18,7 +18,6 @@ use fuel_core_storage::{
         FuelBlocks,
         Messages,
         ProcessedTransactions,
-        SpentMessages,
     },
     transactional::{
         Changes,
@@ -1271,12 +1270,6 @@ where
                 | Input::MessageCoinPredicate(MessageCoinPredicate { nonce, .. })
                 | Input::MessageDataSigned(MessageDataSigned { nonce, .. })
                 | Input::MessageDataPredicate(MessageDataPredicate { nonce, .. }) => {
-                    // Eagerly return already spent if status is known.
-                    if db.storage::<SpentMessages>().contains_key(nonce)? {
-                        return Err(
-                            TransactionValidityError::MessageAlreadySpent(*nonce).into()
-                        );
-                    }
                     if let Some(message) = db.storage::<Messages>().get(nonce)? {
                         if message.da_height() > block_da_height {
                             return Err(TransactionValidityError::MessageSpendTooEarly(
@@ -1360,19 +1353,12 @@ where
                 | Input::MessageCoinPredicate(MessageCoinPredicate { nonce, .. })
                 | Input::MessageDataSigned(MessageDataSigned { nonce, .. })
                 | Input::MessageDataPredicate(MessageDataPredicate { nonce, .. }) => {
-                    // `MessageDataSigned` and `MessageDataPredicate` are spent only if tx is not reverted
-                    // mark message id as spent
-                    let was_already_spent =
-                        db.storage::<SpentMessages>().insert(nonce, &())?;
-                    // ensure message wasn't already marked as spent
-                    if was_already_spent.is_some() {
-                        return Err(ExecutorError::MessageAlreadySpent(*nonce))
-                    }
-                    // cleanup message contents
+                    // ensure message wasn't already marked as spent,
+                    // and cleanup message contents
                     let message = db
                         .storage::<Messages>()
                         .remove(nonce)?
-                        .ok_or(ExecutorError::MessageAlreadySpent(*nonce))?;
+                        .ok_or(ExecutorError::MessageDoesNotExist(*nonce))?;
                     execution_data
                         .events
                         .push(ExecutorEvent::MessageConsumed(message));

--- a/crates/services/txpool/src/containers/dependency.rs
+++ b/crates/services/txpool/src/containers/dependency.rs
@@ -372,13 +372,6 @@ impl Dependency {
                             {
                                 return Err(Error::NotInsertedIoMessageMismatch)
                             }
-                            // return an error if spent block is set
-                            if db
-                                .is_message_spent(nonce)
-                                .map_err(|e| Error::Database(format!("{:?}", e)))?
-                            {
-                                return Err(Error::NotInsertedInputMessageSpent(*nonce))
-                            }
                         } else {
                             return Err(Error::NotInsertedInputMessageUnknown(*nonce))
                         }

--- a/crates/services/txpool/src/mock_db.rs
+++ b/crates/services/txpool/src/mock_db.rs
@@ -84,10 +84,6 @@ impl TxPoolDb for MockDb {
     fn message(&self, id: &Nonce) -> StorageResult<Option<Message>> {
         Ok(self.data.lock().unwrap().messages.get(id).cloned())
     }
-
-    fn is_message_spent(&self, id: &Nonce) -> StorageResult<bool> {
-        Ok(self.data.lock().unwrap().spent_messages.contains(id))
-    }
 }
 
 pub struct MockDBProvider(pub MockDb);

--- a/crates/services/txpool/src/ports.rs
+++ b/crates/services/txpool/src/ports.rs
@@ -58,8 +58,6 @@ pub trait TxPoolDb: Send + Sync {
     fn contract_exist(&self, contract_id: &ContractId) -> StorageResult<bool>;
 
     fn message(&self, message_id: &Nonce) -> StorageResult<Option<Message>>;
-
-    fn is_message_spent(&self, message_id: &Nonce) -> StorageResult<bool>;
 }
 
 /// Trait for getting gas price for the Tx Pool code to look up the gas price for a given block height

--- a/crates/storage/src/structured_storage/messages.rs
+++ b/crates/storage/src/structured_storage/messages.rs
@@ -8,10 +8,7 @@ use crate::{
     },
     column::Column,
     structured_storage::TableWithBlueprint,
-    tables::{
-        Messages,
-        SpentMessages,
-    },
+    tables::Messages,
 };
 
 impl TableWithBlueprint for Messages {
@@ -23,15 +20,6 @@ impl TableWithBlueprint for Messages {
     }
 }
 
-impl TableWithBlueprint for SpentMessages {
-    type Blueprint = Plain<Raw, Postcard>;
-    type Column = Column;
-
-    fn column() -> Column {
-        Column::SpentMessages
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -40,11 +28,5 @@ mod test {
         Messages,
         <Messages as crate::Mappable>::Key::default(),
         <Messages as crate::Mappable>::Value::default()
-    );
-
-    crate::basic_storage_tests!(
-        SpentMessages,
-        <SpentMessages as crate::Mappable>::Key::default(),
-        <SpentMessages as crate::Mappable>::Value::default()
     );
 }

--- a/crates/storage/src/tables.rs
+++ b/crates/storage/src/tables.rs
@@ -92,16 +92,6 @@ impl Mappable for Messages {
     type OwnedValue = Message;
 }
 
-/// The storage table that indicates if the message is spent or not.
-pub struct SpentMessages;
-
-impl Mappable for SpentMessages {
-    type Key = Self::OwnedKey;
-    type OwnedKey = Nonce;
-    type Value = Self::OwnedValue;
-    type OwnedValue = ();
-}
-
 /// The storage table of confirmed transactions.
 pub struct Transactions;
 

--- a/crates/types/src/entities/relayer/message.rs
+++ b/crates/types/src/entities/relayer/message.rs
@@ -273,40 +273,9 @@ impl MessageProof {
 }
 
 /// Represents the status of a message
-pub struct MessageStatus {
-    /// The message state
-    pub state: MessageState,
-}
-
-impl MessageStatus {
-    /// Constructor for `MessageStatus` that fills with `Unspent` state
-    pub fn unspent() -> Self {
-        Self {
-            state: MessageState::Unspent,
-        }
-    }
-
-    /// Constructor for `MessageStatus` that fills with `Spent` state
-    pub fn spent() -> Self {
-        Self {
-            state: MessageState::Spent,
-        }
-    }
-
-    /// Constructor for `MessageStatus` that fills with `Unknown` state
-    pub fn not_found() -> Self {
-        Self {
-            state: MessageState::NotFound,
-        }
-    }
-}
-
-/// The possible states a Message can be in
-pub enum MessageState {
-    /// Message is still unspent
+pub enum MessageStatus {
+    /// The message is unspent
     Unspent,
-    /// Message has already been spent
-    Spent,
-    /// There is no record of this Message
-    NotFound,
+    /// The message is either already spent, or does not exist
+    SpentOrNonExistent,
 }

--- a/crates/types/src/services/executor.rs
+++ b/crates/types/src/services/executor.rs
@@ -387,7 +387,7 @@ pub enum Error {
     #[display(fmt = "No matching utxo for contract id ${_0:#x}")]
     ContractUtxoMissing(ContractId),
     #[display(fmt = "message already spent {_0:#x}")]
-    MessageAlreadySpent(Nonce),
+    MessageDoesNotExist(Nonce),
     #[display(fmt = "Expected input of type {_0}")]
     InputTypeMismatch(String),
     #[display(fmt = "Executing of the genesis block is not allowed")]
@@ -434,13 +434,11 @@ pub enum TransactionValidityError {
     CoinMismatch(UtxoId),
     #[error("The specified coin({0:#x}) doesn't exist")]
     CoinDoesNotExist(UtxoId),
-    #[error("The specified message({0:#x}) was already spent")]
-    MessageAlreadySpent(Nonce),
     #[error(
         "Message({0:#x}) is not yet spendable, as it's DA height is newer than this block allows"
     )]
     MessageSpendTooEarly(Nonce),
-    #[error("The specified message({0:#x}) doesn't exist")]
+    #[error("The specified message({0:#x}) doesn't exist, possibly because it was already spent")]
     MessageDoesNotExist(Nonce),
     #[error("The input message({0:#x}) doesn't match the relayer message")]
     MessageMismatch(Nonce),


### PR DESCRIPTION
Work towards #1790

Depends on #1811

Removes `SpentMessages` table.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### Before merging
- [ ] Retarget to `master`
