### PR TITLE
Fixed the publishing of the `fuel-core 0.25.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,7 +498,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-          target: ${{ matrix.job.target }}
+          target: ${{ matrix.job.target }},wasm32-unknown-unknown
 
       - name: Install cross
         uses: baptiste0928/cargo-install@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+### Fixed
+
+- [#1840](https://github.com/FuelLabs/fuel-core/pull/1840): Fixed the publishing of the `fuel-core 0.25.0` release.
+
 ## [Version 0.25.0]
 
 ### Fixed

--- a/crates/services/upgradable-executor/build.rs
+++ b/crates/services/upgradable-executor/build.rs
@@ -34,26 +34,39 @@ fn build_wasm() {
     cache_dir.push("fuel-core-upgradable-executor-cache");
     let target_dir = format!("--target-dir={}", cache_dir.to_string_lossy());
 
-    let manifest_dir =
-        env::var_os("CARGO_MANIFEST_DIR").expect("The manifest directory is not set");
-    let manifest_path = Path::new(&manifest_dir);
-    let wasm_executor_path = manifest_path
-        .join("wasm-executor")
-        .to_string_lossy()
-        .to_string();
-
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
 
-    let args = vec![
+    let mut args = vec![
         "install".to_owned(),
-        "--path".to_owned(),
-        wasm_executor_path,
         "--target=wasm32-unknown-unknown".to_owned(),
         "--no-default-features".to_owned(),
         "--locked".to_owned(),
         target_dir,
         bin_dir,
     ];
+
+    let manifest_dir =
+        env::var_os("CARGO_MANIFEST_DIR").expect("The manifest directory is not set");
+    let manifest_path = Path::new(&manifest_dir);
+    let wasm_executor_path = manifest_path.join("wasm-executor");
+
+    // If the `wasm-executor` source code is available, then use it as a source for the
+    // `wasm-executor` binary. Otherwise, use the version from the crates.io.
+    if wasm_executor_path.exists() {
+        args.extend([
+            "--path".to_owned(),
+            wasm_executor_path.to_string_lossy().to_string(),
+        ]);
+    } else {
+        let crate_version = env!("CARGO_PKG_VERSION");
+        args.extend([
+            "--version".to_owned(),
+            crate_version.to_owned(),
+            // We can use the offline mode because it was already downloaded
+            // by the `build.rs` dependencies requirements.
+            "--offline".to_string(),
+        ]);
+    }
 
     let mut cargo = Command::new(cargo);
     cargo.env("CARGO_PROFILE_RELEASE_LTO", "true");


### PR DESCRIPTION
Fixed the publishing of the `fuel-core 0.25.0` by including the `wasm32-unknown-unknown` target and adapting the `build.rs` script to work with the published WASM executor.

### Before requesting review
- [x] I have reviewed the code myself