### PR TITLE
Fixed the publishing of the `fuel-core 0.25.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+### Fixed
+
+- [#1844](https://github.com/FuelLabs/fuel-core/pull/1844): Fixed the publishing of the `fuel-core 0.25.1` release.
+
 ## [Version 0.25.1]
 
 ### Fixed

--- a/crates/services/upgradable-executor/build.rs
+++ b/crates/services/upgradable-executor/build.rs
@@ -65,6 +65,7 @@ fn build_wasm() {
             // We can use the offline mode because it was already downloaded
             // by the `build.rs` dependencies requirements.
             "--offline".to_string(),
+            "fuel-core-wasm-executor".to_string(),
         ]);
     }
 


### PR DESCRIPTION
Fixed the publishing of the `fuel-core 0.25.1` by including the the name of the crate to install=)

### Before requesting review
- [x] I have reviewed the code myself
