### PR TITLE
Release v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Description of the upcoming release here.
 
+## [Version 0.25.2]
+
 ### Fixed
 
 - [#1844](https://github.com/FuelLabs/fuel-core/pull/1844): Fixed the publishing of the `fuel-core 0.25.1` release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2940,11 +2940,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.25.1"
+version = "0.25.2"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "cynic",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "clap 4.5.4",
  "fuel-core-client",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "axum",
  "once_cell",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3271,7 +3271,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "ctor",
  "tracing",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "bs58",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "fuel-core-executor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,36 +48,36 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.25.1"
+version = "0.25.2"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.25.1", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.25.1", path = "./bin/client" }
-fuel-core-bin = { version = "0.25.1", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.25.1", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.25.1", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.25.1", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.25.1", path = "./crates/client" }
-fuel-core-database = { version = "0.25.1", path = "./crates/database" }
-fuel-core-metrics = { version = "0.25.1", path = "./crates/metrics" }
-fuel-core-services = { version = "0.25.1", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.25.1", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.25.1", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.25.1", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.25.1", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.25.1", path = "./crates/services/importer" }
-fuel-core-p2p = { version = "0.25.1", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.25.1", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.25.1", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.25.1", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.25.1", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.25.1", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.25.1", path = "./crates/trace" }
-fuel-core-types = { version = "0.25.1", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.25.2", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.25.2", path = "./bin/client" }
+fuel-core-bin = { version = "0.25.2", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.25.2", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.25.2", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.25.2", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.25.2", path = "./crates/client" }
+fuel-core-database = { version = "0.25.2", path = "./crates/database" }
+fuel-core-metrics = { version = "0.25.2", path = "./crates/metrics" }
+fuel-core-services = { version = "0.25.2", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.25.2", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.25.2", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.25.2", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.25.2", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.25.2", path = "./crates/services/importer" }
+fuel-core-p2p = { version = "0.25.2", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.25.2", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.25.2", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.25.2", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.25.2", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.25.2", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.25.2", path = "./crates/trace" }
+fuel-core-types = { version = "0.25.2", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.25.1", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.25.1", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.25.2", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.25.2", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 
 # Fuel dependencies

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -113,7 +113,7 @@ impl<S, R> Executor<S, R> {
     /// This constant is used along with the `version_check` test.
     /// To avoid automatic bumping during release, the constant uses `-` instead of `.`.
     #[cfg(test)]
-    pub const CRATE_VERSION: &'static str = "0-25-1";
+    pub const CRATE_VERSION: &'static str = "0-25-2";
 
     pub fn new(
         storage_view_provider: S,

--- a/deployment/charts/Chart.yaml
+++ b/deployment/charts/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ${fuel_core_service_name}
 description: ${fuel_core_service_name} Helm Chart
 type: application
-appVersion: "0.25.1"
+appVersion: "0.25.2"
 version: 0.1.0


### PR DESCRIPTION
## Version v0.25.2

### Fixed

- [#1844](https://github.com/FuelLabs/fuel-core/pull/1844): Fixed the publishing of the `fuel-core 0.25.1` release.
- [1842](https://github.com/FuelLabs/fuel-core/pull/1842): Ignore RUSTSEC-2024-0336: `rustls::ConnectionCommon::complete_io` could fall into an infinite loop based on network

## What's Changed
* Ignore vulnerability `RUSTSEC-2024-0336` by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/1842
* Fixed the publishing of the `fuel-core 0.25.1` by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/1844


**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.25.1...v0.25.2
