### PR TITLE
Allow database migration upon adding new database column family to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-Description of the upcoming release here.
+### Improvements
+- [#1851](https://github.com/FuelLabs/fuel-core/pull/1851/): Provided migration capabilities (enabled addition of new column families) to RocksDB instance  
 
 ## [Version 0.25.2]
 


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/162

Adds migration capabilities (allows adding new column family to existing database) to RocksDB instance. This change makes sure RocksDB open is always requested with the existing set of column families and all new column families are later created once opened.

[x] Breaking changes are clearly marked as such in the PR description and changelog
[x] New behavior is reflected in tests - Tests introduced by https://github.com/FuelLabs/fuel-core/pull/1853

Before requesting review
[x] I have reviewed the code myself