### PR TITLE
fix: Use Enum for GQL versions (0.24.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-Description of the upcoming release here.
+### Fixed
+
+- [#1861](https://github.com/FuelLabs/fuel-core/pull/1861): Replaced instances of `Union` with `Enum` for GraphQL definitions of `ConsensusParametersVersion` and related types. This is needed because `Union` does not support multiple `Version`s inside discriminants or empty variants. 
 
 ## [Version 0.24.2]
 

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -190,7 +190,9 @@ type ConsensusParameters {
 	privilegedAddress: Address!
 }
 
-union ConsensusParametersVersion = Version
+enum ConsensusParametersVersion {
+	V1
+}
 
 type Contract {
 	id: ContractId!
@@ -259,7 +261,9 @@ type ContractParameters {
 	maxStorageSlots: U64!
 }
 
-union ContractParametersVersion = Version
+enum ContractParametersVersion {
+	V1
+}
 
 union DependentCost = LightOperation | HeavyOperation
 
@@ -312,7 +316,9 @@ type FeeParameters {
 	gasPerByte: U64!
 }
 
-union FeeParametersVersion = Version
+enum FeeParametersVersion {
+	V1
+}
 
 
 type GasCosts {
@@ -429,7 +435,9 @@ type GasCosts {
 	newStoragePerByte: U64!
 }
 
-union GasCostsVersion = Version
+enum GasCostsVersion {
+	V1
+}
 
 type Genesis {
 	"""
@@ -783,7 +791,9 @@ type PredicateParameters {
 	maxMessageDataLength: U64!
 }
 
-union PredicateParametersVersion = Version
+enum PredicateParametersVersion {
+	V1
+}
 
 type ProgramState {
 	returnType: ReturnType!
@@ -927,7 +937,9 @@ type ScriptParameters {
 	maxScriptDataLength: U64!
 }
 
-union ScriptParametersVersion = Version
+enum ScriptParametersVersion {
+	V1
+}
 
 scalar Signature
 
@@ -1061,7 +1073,9 @@ type TxParameters {
 	maxSize: U64!
 }
 
-union TxParametersVersion = Version
+enum TxParametersVersion {
+	V1
+}
 
 scalar TxPointer
 
@@ -1071,18 +1085,12 @@ scalar U32
 
 scalar U64
 
-scalar U8
-
 scalar UtxoId
 
 type VariableOutput {
 	to: Address!
 	amount: U64!
 	assetId: AssetId!
-}
-
-type Version {
-	value: U8!
 }
 
 schema {

--- a/crates/client/src/client/schema/chain.rs
+++ b/crates/client/src/client/schema/chain.rs
@@ -7,14 +7,7 @@ use crate::client::schema::{
     U16,
     U32,
     U64,
-    U8,
 };
-
-#[derive(cynic::QueryFragment, Clone, Debug)]
-#[cynic(schema_path = "./assets/schema.sdl")]
-pub struct Version {
-    pub value: U8,
-}
 
 #[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
@@ -32,12 +25,10 @@ pub struct ConsensusParameters {
     pub privileged_address: Address,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum ConsensusParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 #[derive(cynic::QueryFragment, Clone, Debug)]
@@ -51,12 +42,10 @@ pub struct TxParameters {
     pub max_size: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum TxParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
@@ -64,7 +53,7 @@ impl TryFrom<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
 
     fn try_from(params: TxParameters) -> Result<Self, Self::Error> {
         match params.version {
-            TxParametersVersion::V1(_) => Ok(
+            TxParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::TxParametersV1 {
                     max_inputs: params.max_inputs.into(),
                     max_outputs: params.max_outputs.into(),
@@ -74,9 +63,6 @@ impl TryFrom<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
                 }
                 .into(),
             ),
-            TxParametersVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("TxParametersVersion"))
-            }
         }
     }
 }
@@ -91,12 +77,10 @@ pub struct PredicateParameters {
     pub max_gas_per_predicate: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum PredicateParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<PredicateParameters> for fuel_core_types::fuel_tx::PredicateParameters {
@@ -104,7 +88,7 @@ impl TryFrom<PredicateParameters> for fuel_core_types::fuel_tx::PredicateParamet
 
     fn try_from(params: PredicateParameters) -> Result<Self, Self::Error> {
         match params.version {
-            PredicateParametersVersion::V1(_) => Ok(
+            PredicateParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::PredicateParametersV1 {
                     max_predicate_length: params.max_predicate_length.into(),
                     max_predicate_data_length: params.max_predicate_data_length.into(),
@@ -113,9 +97,6 @@ impl TryFrom<PredicateParameters> for fuel_core_types::fuel_tx::PredicateParamet
                 }
                 .into(),
             ),
-            PredicateParametersVersion::Unknown => Err(ConversionError::UnknownVariant(
-                "PredicateParametersVersion",
-            )),
         }
     }
 }
@@ -128,12 +109,10 @@ pub struct ScriptParameters {
     pub max_script_data_length: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum ScriptParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<ScriptParameters> for fuel_core_types::fuel_tx::ScriptParameters {
@@ -141,16 +120,13 @@ impl TryFrom<ScriptParameters> for fuel_core_types::fuel_tx::ScriptParameters {
 
     fn try_from(params: ScriptParameters) -> Result<Self, Self::Error> {
         match params.version {
-            ScriptParametersVersion::V1(_) => Ok(
+            ScriptParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::ScriptParametersV1 {
                     max_script_length: params.max_script_length.into(),
                     max_script_data_length: params.max_script_data_length.into(),
                 }
                 .into(),
             ),
-            ScriptParametersVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("ScriptParametersVersion"))
-            }
         }
     }
 }
@@ -163,12 +139,10 @@ pub struct ContractParameters {
     pub max_storage_slots: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum ContractParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<ContractParameters> for fuel_core_types::fuel_tx::ContractParameters {
@@ -176,16 +150,13 @@ impl TryFrom<ContractParameters> for fuel_core_types::fuel_tx::ContractParameter
 
     fn try_from(params: ContractParameters) -> Result<Self, Self::Error> {
         match params.version {
-            ContractParametersVersion::V1(_) => Ok(
+            ContractParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::ContractParametersV1 {
                     contract_max_size: params.contract_max_size.into(),
                     max_storage_slots: params.max_storage_slots.into(),
                 }
                 .into(),
             ),
-            ContractParametersVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("ContractParametersVersion"))
-            }
         }
     }
 }
@@ -198,12 +169,10 @@ pub struct FeeParameters {
     pub gas_per_byte: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum FeeParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<FeeParameters> for fuel_core_types::fuel_tx::FeeParameters {
@@ -211,16 +180,13 @@ impl TryFrom<FeeParameters> for fuel_core_types::fuel_tx::FeeParameters {
 
     fn try_from(params: FeeParameters) -> Result<Self, Self::Error> {
         match params.version {
-            FeeParametersVersion::V1(_) => Ok(
+            FeeParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::FeeParametersV1 {
                     gas_price_factor: params.gas_price_factor.into(),
                     gas_per_byte: params.gas_per_byte.into(),
                 }
                 .into(),
             ),
-            FeeParametersVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("FeeParametersVersion"))
-            }
         }
     }
 }
@@ -344,12 +310,10 @@ pub struct GasCosts {
     pub new_storage_per_byte: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum GasCostsVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<GasCosts> for fuel_core_types::fuel_tx::GasCosts {
@@ -357,7 +321,7 @@ impl TryFrom<GasCosts> for fuel_core_types::fuel_tx::GasCosts {
 
     fn try_from(value: GasCosts) -> Result<Self, Self::Error> {
         match value.version {
-            GasCostsVersion::V1(_) => {
+            GasCostsVersion::V1 => {
                 let values = fuel_core_types::fuel_tx::consensus_parameters::gas::GasCostsValuesV1 {
                     add: value.add.into(),
                     addi: value.addi.into(),
@@ -472,9 +436,6 @@ impl TryFrom<GasCosts> for fuel_core_types::fuel_tx::GasCosts {
                 };
                 Ok(fuel_core_types::fuel_tx::GasCosts::new(values.into()))
             }
-            GasCostsVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("GasCostsVersion"))
-            }
         }
     }
 }
@@ -507,7 +468,7 @@ impl TryFrom<ConsensusParameters> for fuel_core_types::fuel_tx::ConsensusParamet
 
     fn try_from(params: ConsensusParameters) -> Result<Self, Self::Error> {
         match params.version {
-            ConsensusParametersVersion::V1(_) => Ok(
+            ConsensusParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::ConsensusParametersV1 {
                     tx_params: params.tx_params.try_into()?,
                     predicate_params: params.predicate_params.try_into()?,
@@ -522,9 +483,6 @@ impl TryFrom<ConsensusParameters> for fuel_core_types::fuel_tx::ConsensusParamet
                 }
                 .into(),
             ),
-            ConsensusParametersVersion::Unknown => Err(ConversionError::UnknownVariant(
-                "ConsensusParametersVersion",
-            )),
         }
     }
 }

--- a/crates/client/src/client/schema/primitives.rs
+++ b/crates/client/src/client/schema/primitives.rs
@@ -273,7 +273,6 @@ macro_rules! number_scalar {
 number_scalar!(U64, u64);
 number_scalar!(U32, u32);
 number_scalar!(U16, u16);
-number_scalar!(U8, u8);
 
 impl TryFrom<U64> for PanicInstruction {
     type Error = ConversionError;

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -40,19 +40,9 @@ query {
       }
     }
     consensusParameters {
-      version {
-        __typename
-        ... on Version {
-          value
-        }
-      }
+      version
       txParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         maxInputs
         maxOutputs
         maxWitnesses
@@ -60,44 +50,24 @@ query {
         maxSize
       }
       predicateParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         maxPredicateLength
         maxPredicateDataLength
         maxMessageDataLength
         maxGasPerPredicate
       }
       scriptParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         maxScriptLength
         maxScriptDataLength
       }
       contractParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         contractMaxSize
         maxStorageSlots
       }
       feeParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         gasPriceFactor
         gasPerByte
       }
@@ -105,12 +75,7 @@ query {
       blockGasLimit
       chainId
       gasCosts {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         add
         addi
         aloc

--- a/crates/fuel-core/src/schema/chain.rs
+++ b/crates/fuel-core/src/schema/chain.rs
@@ -16,12 +16,12 @@ use crate::{
             U16,
             U32,
             U64,
-            U8,
         },
     },
 };
 use async_graphql::{
     Context,
+    Enum,
     Object,
     Union,
 };
@@ -41,41 +41,39 @@ pub struct FeeParameters(fuel_tx::FeeParameters);
 
 pub struct GasCosts(fuel_tx::GasCosts);
 
-pub struct Version(u8);
-
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum GasCostsVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum FeeParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum ContractParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum ScriptParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum PredicateParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum TxParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum ConsensusParametersVersion {
-    V1(Version),
+    V1,
 }
 
 #[derive(Union)]
@@ -112,19 +110,10 @@ impl From<fuel_tx::DependentCost> for DependentCost {
 }
 
 #[Object]
-impl Version {
-    async fn value(&self) -> U8 {
-        self.0.into()
-    }
-}
-
-#[Object]
 impl ConsensusParameters {
     async fn version(&self) -> ConsensusParametersVersion {
         match self.0 {
-            fuel_tx::ConsensusParameters::V1(_) => {
-                ConsensusParametersVersion::V1(Version(1))
-            }
+            fuel_tx::ConsensusParameters::V1(_) => ConsensusParametersVersion::V1,
         }
     }
 
@@ -216,7 +205,7 @@ impl ConsensusParameters {
 impl TxParameters {
     async fn version(&self) -> TxParametersVersion {
         match self.0 {
-            fuel_tx::TxParameters::V1(_) => TxParametersVersion::V1(Version(1)),
+            fuel_tx::TxParameters::V1(_) => TxParametersVersion::V1,
         }
     }
 
@@ -245,9 +234,7 @@ impl TxParameters {
 impl PredicateParameters {
     async fn version(&self) -> PredicateParametersVersion {
         match self.0 {
-            fuel_tx::PredicateParameters::V1(_) => {
-                PredicateParametersVersion::V1(Version(1))
-            }
+            fuel_tx::PredicateParameters::V1(_) => PredicateParametersVersion::V1,
         }
     }
 
@@ -272,7 +259,7 @@ impl PredicateParameters {
 impl ScriptParameters {
     async fn version(&self) -> ScriptParametersVersion {
         match self.0 {
-            fuel_tx::ScriptParameters::V1(_) => ScriptParametersVersion::V1(Version(1)),
+            fuel_tx::ScriptParameters::V1(_) => ScriptParametersVersion::V1,
         }
     }
 
@@ -289,9 +276,7 @@ impl ScriptParameters {
 impl ContractParameters {
     async fn version(&self) -> ContractParametersVersion {
         match self.0 {
-            fuel_tx::ContractParameters::V1(_) => {
-                ContractParametersVersion::V1(Version(1))
-            }
+            fuel_tx::ContractParameters::V1(_) => ContractParametersVersion::V1,
         }
     }
 
@@ -308,7 +293,7 @@ impl ContractParameters {
 impl FeeParameters {
     async fn version(&self) -> FeeParametersVersion {
         match self.0 {
-            fuel_tx::FeeParameters::V1(_) => FeeParametersVersion::V1(Version(1)),
+            fuel_tx::FeeParameters::V1(_) => FeeParametersVersion::V1,
         }
     }
 
@@ -325,7 +310,7 @@ impl FeeParameters {
 impl GasCosts {
     async fn version(&self) -> GasCostsVersion {
         match self.0.deref() {
-            GasCostsValues::V1(_) => GasCostsVersion::V1(Version(1)),
+            GasCostsValues::V1(_) => GasCostsVersion::V1,
         }
     }
 


### PR DESCRIPTION
This branch is based off of `0.24.2` This PR is a hotfix for GQL version types and applies the change from https://github.com/FuelLabs/fuel-core/pull/1856 on master to this branch. 

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
