### PR TITLE
fix: Use Enum for GQL versions (0.25.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-Description of the upcoming release here.
+### Fixed
+
+- [#1862](https://github.com/FuelLabs/fuel-core/pull/1862): Replaced instances of `Union` with `Enum` for GraphQL definitions of `ConsensusParametersVersion` and related types. This is needed because `Union` does not support multiple `Version`s inside discriminants or empty variants. 
 
 ## [Version 0.25.2]
 

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -195,7 +195,9 @@ type ConsensusParametersPurpose {
 	checksum: Bytes32!
 }
 
-union ConsensusParametersVersion = Version
+enum ConsensusParametersVersion {
+	V1
+}
 
 type Contract {
 	id: ContractId!
@@ -264,7 +266,9 @@ type ContractParameters {
 	maxStorageSlots: U64!
 }
 
-union ContractParametersVersion = Version
+enum ContractParametersVersion {
+	V1
+}
 
 union DependentCost = LightOperation | HeavyOperation
 
@@ -323,7 +327,9 @@ type FeeParameters {
 	gasPerByte: U64!
 }
 
-union FeeParametersVersion = Version
+enum FeeParametersVersion {
+	V1
+}
 
 
 type GasCosts {
@@ -440,7 +446,9 @@ type GasCosts {
 	newStoragePerByte: U64!
 }
 
-union GasCostsVersion = Version
+enum GasCostsVersion {
+	V1
+}
 
 type Genesis {
 	"""
@@ -798,7 +806,9 @@ type PredicateParameters {
 	maxMessageDataLength: U64!
 }
 
-union PredicateParametersVersion = Version
+enum PredicateParametersVersion {
+	V1
+}
 
 type ProgramState {
 	returnType: ReturnType!
@@ -952,7 +962,9 @@ type ScriptParameters {
 	maxScriptDataLength: U64!
 }
 
-union ScriptParametersVersion = Version
+enum ScriptParametersVersion {
+	V1
+}
 
 scalar Signature
 
@@ -1100,7 +1112,9 @@ type TxParameters {
 	maxBytecodeSubsections: U16!
 }
 
-union TxParametersVersion = Version
+enum TxParametersVersion {
+	V1
+}
 
 scalar TxPointer
 
@@ -1110,8 +1124,6 @@ scalar U32
 
 scalar U64
 
-scalar U8
-
 union UpgradePurpose = ConsensusParametersPurpose | StateTransitionPurpose
 
 scalar UtxoId
@@ -1120,10 +1132,6 @@ type VariableOutput {
 	to: Address!
 	amount: U64!
 	assetId: AssetId!
-}
-
-type Version {
-	value: U8!
 }
 
 schema {

--- a/crates/client/src/client/schema/chain.rs
+++ b/crates/client/src/client/schema/chain.rs
@@ -7,14 +7,7 @@ use crate::client::schema::{
     U16,
     U32,
     U64,
-    U8,
 };
-
-#[derive(cynic::QueryFragment, Clone, Debug)]
-#[cynic(schema_path = "./assets/schema.sdl")]
-pub struct Version {
-    pub value: U8,
-}
 
 #[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
@@ -32,12 +25,10 @@ pub struct ConsensusParameters {
     pub privileged_address: Address,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum ConsensusParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 #[derive(cynic::QueryFragment, Clone, Debug)]
@@ -52,12 +43,10 @@ pub struct TxParameters {
     pub max_bytecode_subsections: U16,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum TxParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
@@ -65,7 +54,7 @@ impl TryFrom<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
 
     fn try_from(params: TxParameters) -> Result<Self, Self::Error> {
         match params.version {
-            TxParametersVersion::V1(_) => Ok(
+            TxParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::TxParametersV1 {
                     max_inputs: params.max_inputs.into(),
                     max_outputs: params.max_outputs.into(),
@@ -76,9 +65,6 @@ impl TryFrom<TxParameters> for fuel_core_types::fuel_tx::TxParameters {
                 }
                 .into(),
             ),
-            TxParametersVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("TxParametersVersion"))
-            }
         }
     }
 }
@@ -93,12 +79,10 @@ pub struct PredicateParameters {
     pub max_gas_per_predicate: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum PredicateParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<PredicateParameters> for fuel_core_types::fuel_tx::PredicateParameters {
@@ -106,7 +90,7 @@ impl TryFrom<PredicateParameters> for fuel_core_types::fuel_tx::PredicateParamet
 
     fn try_from(params: PredicateParameters) -> Result<Self, Self::Error> {
         match params.version {
-            PredicateParametersVersion::V1(_) => Ok(
+            PredicateParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::PredicateParametersV1 {
                     max_predicate_length: params.max_predicate_length.into(),
                     max_predicate_data_length: params.max_predicate_data_length.into(),
@@ -115,9 +99,6 @@ impl TryFrom<PredicateParameters> for fuel_core_types::fuel_tx::PredicateParamet
                 }
                 .into(),
             ),
-            PredicateParametersVersion::Unknown => Err(ConversionError::UnknownVariant(
-                "PredicateParametersVersion",
-            )),
         }
     }
 }
@@ -130,12 +111,10 @@ pub struct ScriptParameters {
     pub max_script_data_length: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum ScriptParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<ScriptParameters> for fuel_core_types::fuel_tx::ScriptParameters {
@@ -143,16 +122,13 @@ impl TryFrom<ScriptParameters> for fuel_core_types::fuel_tx::ScriptParameters {
 
     fn try_from(params: ScriptParameters) -> Result<Self, Self::Error> {
         match params.version {
-            ScriptParametersVersion::V1(_) => Ok(
+            ScriptParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::ScriptParametersV1 {
                     max_script_length: params.max_script_length.into(),
                     max_script_data_length: params.max_script_data_length.into(),
                 }
                 .into(),
             ),
-            ScriptParametersVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("ScriptParametersVersion"))
-            }
         }
     }
 }
@@ -165,12 +141,10 @@ pub struct ContractParameters {
     pub max_storage_slots: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum ContractParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<ContractParameters> for fuel_core_types::fuel_tx::ContractParameters {
@@ -178,16 +152,13 @@ impl TryFrom<ContractParameters> for fuel_core_types::fuel_tx::ContractParameter
 
     fn try_from(params: ContractParameters) -> Result<Self, Self::Error> {
         match params.version {
-            ContractParametersVersion::V1(_) => Ok(
+            ContractParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::ContractParametersV1 {
                     contract_max_size: params.contract_max_size.into(),
                     max_storage_slots: params.max_storage_slots.into(),
                 }
                 .into(),
             ),
-            ContractParametersVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("ContractParametersVersion"))
-            }
         }
     }
 }
@@ -200,12 +171,10 @@ pub struct FeeParameters {
     pub gas_per_byte: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum FeeParametersVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<FeeParameters> for fuel_core_types::fuel_tx::FeeParameters {
@@ -213,16 +182,13 @@ impl TryFrom<FeeParameters> for fuel_core_types::fuel_tx::FeeParameters {
 
     fn try_from(params: FeeParameters) -> Result<Self, Self::Error> {
         match params.version {
-            FeeParametersVersion::V1(_) => Ok(
+            FeeParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::FeeParametersV1 {
                     gas_price_factor: params.gas_price_factor.into(),
                     gas_per_byte: params.gas_per_byte.into(),
                 }
                 .into(),
             ),
-            FeeParametersVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("FeeParametersVersion"))
-            }
         }
     }
 }
@@ -346,12 +312,10 @@ pub struct GasCosts {
     pub new_storage_per_byte: U64,
 }
 
-#[derive(cynic::InlineFragments, Clone, Debug)]
+#[derive(cynic::Enum, Clone, Debug)]
 #[cynic(schema_path = "./assets/schema.sdl")]
 pub enum GasCostsVersion {
-    V1(Version),
-    #[cynic(fallback)]
-    Unknown,
+    V1,
 }
 
 impl TryFrom<GasCosts> for fuel_core_types::fuel_tx::GasCosts {
@@ -359,7 +323,7 @@ impl TryFrom<GasCosts> for fuel_core_types::fuel_tx::GasCosts {
 
     fn try_from(value: GasCosts) -> Result<Self, Self::Error> {
         match value.version {
-            GasCostsVersion::V1(_) => {
+            GasCostsVersion::V1 => {
                 let values = fuel_core_types::fuel_tx::consensus_parameters::gas::GasCostsValuesV1 {
                     add: value.add.into(),
                     addi: value.addi.into(),
@@ -474,9 +438,6 @@ impl TryFrom<GasCosts> for fuel_core_types::fuel_tx::GasCosts {
                 };
                 Ok(fuel_core_types::fuel_tx::GasCosts::new(values.into()))
             }
-            GasCostsVersion::Unknown => {
-                Err(ConversionError::UnknownVariant("GasCostsVersion"))
-            }
         }
     }
 }
@@ -509,7 +470,7 @@ impl TryFrom<ConsensusParameters> for fuel_core_types::fuel_tx::ConsensusParamet
 
     fn try_from(params: ConsensusParameters) -> Result<Self, Self::Error> {
         match params.version {
-            ConsensusParametersVersion::V1(_) => Ok(
+            ConsensusParametersVersion::V1 => Ok(
                 fuel_core_types::fuel_tx::consensus_parameters::ConsensusParametersV1 {
                     tx_params: params.tx_params.try_into()?,
                     predicate_params: params.predicate_params.try_into()?,
@@ -524,9 +485,6 @@ impl TryFrom<ConsensusParameters> for fuel_core_types::fuel_tx::ConsensusParamet
                 }
                 .into(),
             ),
-            ConsensusParametersVersion::Unknown => Err(ConversionError::UnknownVariant(
-                "ConsensusParametersVersion",
-            )),
         }
     }
 }

--- a/crates/client/src/client/schema/primitives.rs
+++ b/crates/client/src/client/schema/primitives.rs
@@ -274,7 +274,6 @@ macro_rules! number_scalar {
 number_scalar!(U64, u64);
 number_scalar!(U32, u32);
 number_scalar!(U16, u16);
-number_scalar!(U8, u8);
 
 impl TryFrom<U64> for PanicInstruction {
     type Error = ConversionError;

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__chain__tests__chain_gql_query_output.snap
@@ -41,19 +41,9 @@ query {
       }
     }
     consensusParameters {
-      version {
-        __typename
-        ... on Version {
-          value
-        }
-      }
+      version
       txParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         maxInputs
         maxOutputs
         maxWitnesses
@@ -62,44 +52,24 @@ query {
         maxBytecodeSubsections
       }
       predicateParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         maxPredicateLength
         maxPredicateDataLength
         maxMessageDataLength
         maxGasPerPredicate
       }
       scriptParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         maxScriptLength
         maxScriptDataLength
       }
       contractParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         contractMaxSize
         maxStorageSlots
       }
       feeParams {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         gasPriceFactor
         gasPerByte
       }
@@ -107,12 +77,7 @@ query {
       blockGasLimit
       chainId
       gasCosts {
-        version {
-          __typename
-          ... on Version {
-            value
-          }
-        }
+        version
         add
         addi
         aloc

--- a/crates/fuel-core/src/schema/chain.rs
+++ b/crates/fuel-core/src/schema/chain.rs
@@ -16,12 +16,12 @@ use crate::{
             U16,
             U32,
             U64,
-            U8,
         },
     },
 };
 use async_graphql::{
     Context,
+    Enum,
     Object,
     Union,
 };
@@ -44,41 +44,39 @@ pub struct FeeParameters(fuel_tx::FeeParameters);
 
 pub struct GasCosts(fuel_tx::GasCosts);
 
-pub struct Version(u8);
-
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum GasCostsVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum FeeParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum ContractParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum ScriptParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum PredicateParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum TxParametersVersion {
-    V1(Version),
+    V1,
 }
 
-#[derive(Union)]
+#[derive(Clone, Copy, Debug, Enum, Eq, PartialEq)]
 pub enum ConsensusParametersVersion {
-    V1(Version),
+    V1,
 }
 
 #[derive(Union)]
@@ -115,19 +113,10 @@ impl From<fuel_tx::DependentCost> for DependentCost {
 }
 
 #[Object]
-impl Version {
-    async fn value(&self) -> U8 {
-        self.0.into()
-    }
-}
-
-#[Object]
 impl ConsensusParameters {
     async fn version(&self) -> ConsensusParametersVersion {
         match self.0.as_ref() {
-            fuel_tx::ConsensusParameters::V1(_) => {
-                ConsensusParametersVersion::V1(Version(1))
-            }
+            fuel_tx::ConsensusParameters::V1(_) => ConsensusParametersVersion::V1,
         }
     }
 
@@ -227,7 +216,7 @@ impl ConsensusParameters {
 impl TxParameters {
     async fn version(&self) -> TxParametersVersion {
         match self.0 {
-            fuel_tx::TxParameters::V1(_) => TxParametersVersion::V1(Version(1)),
+            fuel_tx::TxParameters::V1(_) => TxParametersVersion::V1,
         }
     }
 
@@ -260,9 +249,7 @@ impl TxParameters {
 impl PredicateParameters {
     async fn version(&self) -> PredicateParametersVersion {
         match self.0 {
-            fuel_tx::PredicateParameters::V1(_) => {
-                PredicateParametersVersion::V1(Version(1))
-            }
+            fuel_tx::PredicateParameters::V1(_) => PredicateParametersVersion::V1,
         }
     }
 
@@ -287,7 +274,7 @@ impl PredicateParameters {
 impl ScriptParameters {
     async fn version(&self) -> ScriptParametersVersion {
         match self.0 {
-            fuel_tx::ScriptParameters::V1(_) => ScriptParametersVersion::V1(Version(1)),
+            fuel_tx::ScriptParameters::V1(_) => ScriptParametersVersion::V1,
         }
     }
 
@@ -304,9 +291,7 @@ impl ScriptParameters {
 impl ContractParameters {
     async fn version(&self) -> ContractParametersVersion {
         match self.0 {
-            fuel_tx::ContractParameters::V1(_) => {
-                ContractParametersVersion::V1(Version(1))
-            }
+            fuel_tx::ContractParameters::V1(_) => ContractParametersVersion::V1,
         }
     }
 
@@ -323,7 +308,7 @@ impl ContractParameters {
 impl FeeParameters {
     async fn version(&self) -> FeeParametersVersion {
         match self.0 {
-            fuel_tx::FeeParameters::V1(_) => FeeParametersVersion::V1(Version(1)),
+            fuel_tx::FeeParameters::V1(_) => FeeParametersVersion::V1,
         }
     }
 
@@ -340,7 +325,7 @@ impl FeeParameters {
 impl GasCosts {
     async fn version(&self) -> GasCostsVersion {
         match self.0.deref() {
-            GasCostsValues::V1(_) => GasCostsVersion::V1(Version(1)),
+            GasCostsValues::V1(_) => GasCostsVersion::V1,
         }
     }
 


### PR DESCRIPTION
This branch is based off of `0.25.2` This PR is a hotfix for GQL version types and applies the change from https://github.com/FuelLabs/fuel-core/pull/1856 on master to this branch. 

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
