### PR TITLE
fix: Bump executor crate version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Description of the upcoming release here.
 
 ### Fixed
 
+- [#1865](https://github.com/FuelLabs/fuel-core/pull/1865): Bump executor version to 0.25.3. 
 - [#1862](https://github.com/FuelLabs/fuel-core/pull/1862): Replaced instances of `Union` with `Enum` for GraphQL definitions of `ConsensusParametersVersion` and related types. This is needed because `Union` does not support multiple `Version`s inside discriminants or empty variants. 
 
 ## [Version 0.25.2]

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -113,7 +113,7 @@ impl<S, R> Executor<S, R> {
     /// This constant is used along with the `version_check` test.
     /// To avoid automatic bumping during release, the constant uses `-` instead of `.`.
     #[cfg(test)]
-    pub const CRATE_VERSION: &'static str = "0-25-2";
+    pub const CRATE_VERSION: &'static str = "0-25-3";
 
     pub fn new(
         storage_view_provider: S,


### PR DESCRIPTION
The previous release of v0.25.3 had a failing test because of a mismatch in crate version. This PR bumps the executor `CRATE_VERSION` to match the correct crate version. 

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
