### PR TITLE
Fixed `block` endpoint to return fetch the blocks from both databases after regenesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- [#1871](https://github.com/FuelLabs/fuel-core/pull/1871): Fixed `block` endpoint to return fetch the blocks from both databases after regenesis.
 - [#1856](https://github.com/FuelLabs/fuel-core/pull/1856): Replaced instances of `Union` with `Enum` for GraphQL definitions of `ConsensusParametersVersion` and related types. This is needed because `Union` does not support multiple `Version`s inside discriminants or empty variants. 
 
 ### Added 

--- a/crates/fuel-core/src/coins_query.rs
+++ b/crates/fuel-core/src/coins_query.rs
@@ -952,7 +952,7 @@ mod tests {
         fn service_database(&self) -> ServiceDatabase {
             let on_chain = self.database.on_chain().clone();
             let off_chain = self.database.off_chain().clone();
-            ServiceDatabase::new(on_chain, off_chain)
+            ServiceDatabase::new(0u32.into(), on_chain, off_chain)
         }
     }
 

--- a/crates/fuel-core/src/graphql_api/api_service.rs
+++ b/crates/fuel-core/src/graphql_api/api_service.rs
@@ -171,6 +171,7 @@ impl RunnableTask for Task {
 // Need a seperate Data Object for each Query endpoint, cannot be avoided
 #[allow(clippy::too_many_arguments)]
 pub fn new_service<OnChain, OffChain>(
+    genesis_block_height: BlockHeight,
     config: Config,
     schema: CoreSchemaBuilder,
     on_database: OnChain,
@@ -191,7 +192,8 @@ where
     OffChain::View: OffChainDatabase,
 {
     let network_addr = config.addr;
-    let combined_read_database = ReadDatabase::new(on_database, off_database);
+    let combined_read_database =
+        ReadDatabase::new(genesis_block_height, on_database, off_database);
 
     let schema = schema
         .data(config)

--- a/crates/fuel-core/src/query/block.rs
+++ b/crates/fuel-core/src/query/block.rs
@@ -1,16 +1,13 @@
-use crate::fuel_core_graphql_api::ports::OnChainDatabase;
+use crate::fuel_core_graphql_api::ports::{
+    DatabaseBlocks,
+    OnChainDatabase,
+};
 use fuel_core_storage::{
     iter::{
         BoxedIter,
         IterDirection,
     },
-    not_found,
-    tables::{
-        FuelBlocks,
-        SealedBlockConsensus,
-    },
     Result as StorageResult,
-    StorageAsRef,
 };
 use fuel_core_types::{
     blockchain::{
@@ -24,15 +21,12 @@ pub trait SimpleBlockData: Send + Sync {
     fn block(&self, id: &BlockHeight) -> StorageResult<CompressedBlock>;
 }
 
-impl<D: OnChainDatabase + ?Sized> SimpleBlockData for D {
+impl<D> SimpleBlockData for D
+where
+    D: OnChainDatabase + DatabaseBlocks + ?Sized,
+{
     fn block(&self, id: &BlockHeight) -> StorageResult<CompressedBlock> {
-        let block = self
-            .storage::<FuelBlocks>()
-            .get(id)?
-            .ok_or_else(|| not_found!(FuelBlocks))?
-            .into_owned();
-
-        Ok(block)
+        self.block(id)
     }
 }
 
@@ -50,7 +44,10 @@ pub trait BlockQueryData: Send + Sync + SimpleBlockData {
     fn consensus(&self, id: &BlockHeight) -> StorageResult<Consensus>;
 }
 
-impl<D: OnChainDatabase + ?Sized> BlockQueryData for D {
+impl<D> BlockQueryData for D
+where
+    D: OnChainDatabase + DatabaseBlocks + ?Sized,
+{
     fn latest_block_height(&self) -> StorageResult<BlockHeight> {
         self.latest_height()
     }
@@ -68,9 +65,6 @@ impl<D: OnChainDatabase + ?Sized> BlockQueryData for D {
     }
 
     fn consensus(&self, id: &BlockHeight) -> StorageResult<Consensus> {
-        self.storage::<SealedBlockConsensus>()
-            .get(id)
-            .map(|c| c.map(|c| c.into_owned()))?
-            .ok_or(not_found!(SealedBlockConsensus))
+        self.consensus(id)
     }
 }

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -1,6 +1,7 @@
 use crate::{
     fuel_core_graphql_api::{
         ports::{
+            DatabaseBlocks,
             DatabaseMessageProof,
             DatabaseMessages,
             OffChainDatabase,
@@ -129,7 +130,7 @@ pub trait MessageProofData:
 
 impl<D> MessageProofData for D
 where
-    D: OnChainDatabase + OffChainDatabase + ?Sized,
+    D: OnChainDatabase + DatabaseBlocks + OffChainDatabase + ?Sized,
 {
     fn transaction_status(
         &self,

--- a/crates/fuel-core/src/schema/block.rs
+++ b/crates/fuel-core/src/schema/block.rs
@@ -105,14 +105,7 @@ impl Block {
     async fn consensus(&self, ctx: &Context<'_>) -> async_graphql::Result<Consensus> {
         let query: &ReadView = ctx.data_unchecked();
         let height = self.0.header().height();
-        match query.consensus(height) {
-            Ok(consensus) => Ok(consensus.try_into()?),
-            Err(err) => {
-                // Fallback to pre-regenesis data
-                let consensus = query.old_block_consensus(*height).map_err(|_| err)?;
-                Ok(consensus.try_into()?)
-            }
-        }
+        Ok(query.consensus(height)?.try_into()?)
     }
 
     async fn transactions(

--- a/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
@@ -121,6 +121,16 @@ impl OffChainDatabase for Database<OffChain> {
         Ok(salt)
     }
 
+    fn old_block(&self, height: &BlockHeight) -> StorageResult<CompressedBlock> {
+        let block = self
+            .storage_as_ref::<OldFuelBlocks>()
+            .get(height)?
+            .ok_or(not_found!(OldFuelBlocks))?
+            .into_owned();
+
+        Ok(block)
+    }
+
     fn old_blocks(
         &self,
         height: Option<BlockHeight>,
@@ -131,10 +141,10 @@ impl OffChainDatabase for Database<OffChain> {
             .into_boxed()
     }
 
-    fn old_block_consensus(&self, height: BlockHeight) -> StorageResult<Consensus> {
+    fn old_block_consensus(&self, height: &BlockHeight) -> StorageResult<Consensus> {
         Ok(self
             .storage_as_ref::<OldFuelBlockConsensus>()
-            .get(&height)?
+            .get(height)?
             .ok_or(not_found!(OldFuelBlockConsensus))?
             .into_owned())
     }

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -238,6 +238,7 @@ pub fn init_sub_services(
     };
 
     let graph_ql = fuel_core_graphql_api::api_service::new_service(
+        *genesis_block.header().height(),
         graphql_config,
         schema,
         database.on_chain().clone(),

--- a/tests/tests/regenesis.rs
+++ b/tests/tests/regenesis.rs
@@ -196,6 +196,7 @@ async fn test_regenesis_old_blocks_are_preserved() -> anyhow::Result<()> {
     .await?;
 
     produce_block_with_tx(&mut rng, &core.client).await;
+    // When
     let regenesis_blocks = core
         .client
         .blocks(PaginationRequest {
@@ -207,12 +208,23 @@ async fn test_regenesis_old_blocks_are_preserved() -> anyhow::Result<()> {
         .expect("Failed to get blocks")
         .results;
 
+    // Then
     // We should have generated one new genesis block and one new generated block,
     // but the old ones should be the same.
     assert_eq!(original_blocks.len() + 4, regenesis_blocks.len());
     assert_eq!(original_blocks[0], regenesis_blocks[0]);
     assert_eq!(original_blocks[1], regenesis_blocks[1]);
     assert_eq!(original_blocks[2], regenesis_blocks[2]);
+
+    for block in &regenesis_blocks {
+        // When
+        let result = core.client.block(&block.id).await;
+
+        // Then
+        result
+            .expect("Requested block successfully")
+            .expect("The block and all related data should migrate");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
We forgot to update `block` endpoint to use `OldFuelBlocks` table. This PR adds support for it.

Also, PR optimises fetching the genesis block height.

## Checklist
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself
