### PR TITLE
Use ref instead of owned `Block` in validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 
+- [#1886](https://github.com/FuelLabs/fuel-core/pull/1886): Use ref to `Block` in validation code
 - [#1876](https://github.com/FuelLabs/fuel-core/pull/1876): Updated benchmark to include the worst scenario for `CROO` opcode. Also include consensus parameters in bench output.
 
 ### Changed

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -336,7 +336,7 @@ mod tests {
             ..
         } = producer.produce_and_commit(block.into()).unwrap();
 
-        let validation_result = verifier.validate(block);
+        let validation_result = verifier.validate(&block);
         assert!(validation_result.is_ok());
         assert!(skipped_transactions.is_empty());
     }
@@ -677,7 +677,7 @@ mod tests {
             let producer = create_executor(database.clone(), config.clone());
 
             let ExecutionResult {
-                block: produced_block,
+                block,
                 skipped_transactions,
                 ..
             } = producer
@@ -690,18 +690,15 @@ mod tests {
                 .unwrap()
                 .into_result();
             assert!(skipped_transactions.is_empty());
-            let produced_txs = produced_block.transactions().to_vec();
+            let produced_txs = block.transactions().to_vec();
 
             let mut validator = create_executor(
                 Default::default(),
                 // Use the same config as block producer
                 config,
             );
-            let ExecutionResult {
-                block: validated_block,
-                ..
-            } = validator.validate_and_commit(produced_block).unwrap();
-            assert_eq!(validated_block.transactions(), produced_txs);
+            let _ = validator.validate_and_commit(&block).unwrap();
+            assert_eq!(block.transactions(), produced_txs);
             let ContractBalance {
                 asset_id, amount, ..
             } = validator
@@ -822,7 +819,7 @@ mod tests {
                 },
             );
             let validation_err = validator
-                .validate_and_commit(block)
+                .validate_and_commit(&block)
                 .expect_err("Expected error because coinbase if invalid");
             assert!(matches!(
                 validation_err,
@@ -848,7 +845,7 @@ mod tests {
 
             let mut validator = create_executor(Default::default(), Default::default());
             let validation_err = validator
-                .validate_and_commit(block)
+                .validate_and_commit(&block)
                 .expect_err("Expected error because coinbase if invalid");
             assert!(matches!(
                 validation_err,
@@ -862,7 +859,7 @@ mod tests {
 
             let mut validator = create_executor(Default::default(), Default::default());
             let validation_err = validator
-                .validate_and_commit(block)
+                .validate_and_commit(&block)
                 .expect_err("Expected error because coinbase is missing");
             assert!(matches!(validation_err, ExecutorError::MintMissing));
         }
@@ -884,7 +881,7 @@ mod tests {
 
             let mut validator = create_executor(Default::default(), Default::default());
             let validation_err = validator
-                .validate_and_commit(block)
+                .validate_and_commit(&block)
                 .expect_err("Expected error because coinbase if invalid");
 
             assert!(matches!(
@@ -919,7 +916,7 @@ mod tests {
             };
             let mut validator = create_executor(Default::default(), config);
             let validation_err = validator
-                .validate_and_commit(block)
+                .validate_and_commit(&block)
                 .expect_err("Expected error because coinbase if invalid");
 
             assert!(matches!(
@@ -947,7 +944,7 @@ mod tests {
 
             let mut validator = create_executor(Default::default(), Default::default());
             let validation_err = validator
-                .validate_and_commit(block)
+                .validate_and_commit(&block)
                 .expect_err("Expected error because coinbase if invalid");
             assert!(matches!(
                 validation_err,
@@ -991,7 +988,7 @@ mod tests {
 
         let ExecutionResult {
             skipped_transactions,
-            block,
+            mut block,
             ..
         } = producer
             .produce_without_commit(block)
@@ -1008,15 +1005,15 @@ mod tests {
         ));
 
         // Produced block is valid
-        let ExecutionResult { mut block, .. } = verifier
-            .validate_without_commit(block)
+        let _ = verifier
+            .validate_without_commit(&block)
             .unwrap()
             .into_result();
 
         // Invalidate the block with Insufficient tx
         let len = block.transactions().len();
         block.transactions_mut().insert(len - 1, tx);
-        let verify_result = verifier.validate_without_commit(block);
+        let verify_result = verifier.validate_without_commit(&block);
         assert!(matches!(
             verify_result,
             Err(ExecutorError::InvalidTransaction(
@@ -1043,7 +1040,7 @@ mod tests {
 
         let ExecutionResult {
             skipped_transactions,
-            block,
+            mut block,
             ..
         } = producer
             .produce_without_commit(block)
@@ -1056,8 +1053,8 @@ mod tests {
         ));
 
         // Produced block is valid
-        let ExecutionResult { mut block, .. } = verifier
-            .validate_without_commit(block)
+        let _ = verifier
+            .validate_without_commit(&block)
             .unwrap()
             .into_result();
 
@@ -1066,7 +1063,7 @@ mod tests {
         block
             .transactions_mut()
             .insert(len - 1, Transaction::default_test_tx());
-        let verify_result = verifier.validate_without_commit(block);
+        let verify_result = verifier.validate_without_commit(&block);
         assert!(matches!(
             verify_result,
             Err(ExecutorError::TransactionIdCollision(_))
@@ -1113,7 +1110,7 @@ mod tests {
 
         let ExecutionResult {
             skipped_transactions,
-            block,
+            mut block,
             ..
         } = producer
             .produce_without_commit(block)
@@ -1128,15 +1125,15 @@ mod tests {
         ));
 
         // Produced block is valid
-        let ExecutionResult { mut block, .. } = verifier
-            .validate_without_commit(block)
+        let _ = verifier
+            .validate_without_commit(&block)
             .unwrap()
             .into_result();
 
         // Invalidate block by adding transaction with not existing coin
         let len = block.transactions().len();
         block.transactions_mut().insert(len - 1, tx);
-        let verify_result = verifier.validate_without_commit(block);
+        let verify_result = verifier.validate_without_commit(&block);
         assert!(matches!(
             verify_result,
             Err(ExecutorError::TransactionValidity(
@@ -1181,7 +1178,7 @@ mod tests {
         }
 
         // then
-        let err = verifier.validate_and_commit(block).unwrap_err();
+        let err = verifier.validate_and_commit(&block).unwrap_err();
         assert_eq!(
             err,
             ExecutorError::InvalidTransactionOutcome { transaction_id }
@@ -1216,7 +1213,7 @@ mod tests {
         block.header_mut().set_transaction_root(rng.gen());
         block.header_mut().recalculate_metadata();
 
-        let err = verifier.validate_and_commit(block).unwrap_err();
+        let err = verifier.validate_and_commit(&block).unwrap_err();
 
         assert_eq!(err, ExecutorError::BlockMismatch)
     }
@@ -1869,7 +1866,7 @@ mod tests {
         assert_eq!(tx.inputs()[0].state_root(), state_root);
 
         let _ = executor
-            .validate(block)
+            .validate(&block)
             .expect("Validation of block should be successful");
     }
 
@@ -2058,7 +2055,7 @@ mod tests {
         assert!(skipped_transactions.is_empty());
 
         let verifier = create_executor(db, Default::default());
-        let verify_result = verifier.validate_without_commit(second_block);
+        let verify_result = verifier.validate_without_commit(&second_block);
         assert!(verify_result.is_ok());
     }
 
@@ -2133,7 +2130,7 @@ mod tests {
         }
 
         let verifier = create_executor(db, Default::default());
-        let err = verifier.validate_without_commit(second_block).unwrap_err();
+        let err = verifier.validate_without_commit(&second_block).unwrap_err();
 
         assert_eq!(
             err,
@@ -2283,7 +2280,7 @@ mod tests {
             .expect("block execution failed unexpectedly");
 
         make_executor(&[&message])
-            .validate_and_commit(block)
+            .validate_and_commit(&block)
             .expect("block validation failed unexpectedly");
     }
 
@@ -2402,14 +2399,14 @@ mod tests {
 
         // Produced block is valid
         make_executor(&[]) // No messages in the db
-            .validate_and_commit(block.clone())
+            .validate_and_commit(&block)
             .unwrap();
 
         // Invalidate block by returning back `tx` with not existing message
         let index = block.transactions().len() - 1;
         block.transactions_mut().insert(index, tx);
         let res = make_executor(&[]) // No messages in the db
-            .validate_and_commit(block);
+            .validate_and_commit(&block);
         assert!(matches!(
             res,
             Err(ExecutorError::TransactionValidity(
@@ -2444,13 +2441,13 @@ mod tests {
 
         // Produced block is valid
         make_executor(&[&message])
-            .validate_and_commit(block.clone())
+            .validate_and_commit(&block)
             .unwrap();
 
         // Invalidate block by return back `tx` with not ready message.
         let index = block.transactions().len() - 1;
         block.transactions_mut().insert(index, tx);
-        let res = make_executor(&[&message]).validate_and_commit(block);
+        let res = make_executor(&[&message]).validate_and_commit(&block);
         assert!(matches!(
             res,
             Err(ExecutorError::TransactionValidity(
@@ -2504,7 +2501,7 @@ mod tests {
         let exec = make_executor(&[&message]);
         let ExecutionResult {
             skipped_transactions,
-            block,
+            mut block,
             ..
         } = exec.produce_without_commit(block).unwrap().into_result();
         // One of two transactions is skipped.
@@ -2520,14 +2517,13 @@ mod tests {
 
         // Produced block is valid
         let exec = make_executor(&[&message]);
-        let ExecutionResult { mut block, .. } =
-            exec.validate_without_commit(block).unwrap().into_result();
+        let _ = exec.validate_without_commit(&block).unwrap().into_result();
 
         // Invalidate block by return back `tx2` transaction skipped during production.
         let len = block.transactions().len();
         block.transactions_mut().insert(len - 1, tx2);
         let exec = make_executor(&[&message]);
-        let res = exec.validate_without_commit(block);
+        let res = exec.validate_without_commit(&block);
         assert!(matches!(
             res,
             Err(ExecutorError::TransactionValidity(
@@ -2739,7 +2735,7 @@ mod tests {
         assert!(skipped_transactions.is_empty());
 
         let validator = create_executor(db.clone(), config);
-        let result = validator.validate(block);
+        let result = validator.validate(&block);
         assert!(result.is_ok(), "{result:?}")
     }
 

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -3279,10 +3279,7 @@ mod tests {
             let events = vec![event];
             add_events_to_relayer(&mut verifier_relayer_db, da_height.into(), &events);
             let verifier = create_relayer_executor(verifyer_db, verifier_relayer_db);
-            let (result, _) = verifier
-                .validate_without_commit(&produced_block)
-                .unwrap()
-                .into();
+            let (result, _) = verifier.validate(&produced_block).unwrap().into();
 
             // then
             let txs = produced_block.transactions();
@@ -3437,7 +3434,7 @@ mod tests {
 
             let validator = create_relayer_executor(on_chain_db, relayer_db);
             // When
-            let result = validator.validate_without_commit(&result.block).map(|_| ());
+            let result = validator.validate(&result.block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -1005,15 +1005,12 @@ mod tests {
         ));
 
         // Produced block is valid
-        let _ = verifier
-            .validate_without_commit(&block)
-            .unwrap()
-            .into_result();
+        let _ = verifier.validate(&block).unwrap().into_result();
 
         // Invalidate the block with Insufficient tx
         let len = block.transactions().len();
         block.transactions_mut().insert(len - 1, tx);
-        let verify_result = verifier.validate_without_commit(&block);
+        let verify_result = verifier.validate(&block);
         assert!(matches!(
             verify_result,
             Err(ExecutorError::InvalidTransaction(
@@ -1053,17 +1050,14 @@ mod tests {
         ));
 
         // Produced block is valid
-        let _ = verifier
-            .validate_without_commit(&block)
-            .unwrap()
-            .into_result();
+        let _ = verifier.validate(&block).unwrap().into_result();
 
         // Make the block invalid by adding of the duplicating transaction
         let len = block.transactions().len();
         block
             .transactions_mut()
             .insert(len - 1, Transaction::default_test_tx());
-        let verify_result = verifier.validate_without_commit(&block);
+        let verify_result = verifier.validate(&block);
         assert!(matches!(
             verify_result,
             Err(ExecutorError::TransactionIdCollision(_))
@@ -1125,15 +1119,12 @@ mod tests {
         ));
 
         // Produced block is valid
-        let _ = verifier
-            .validate_without_commit(&block)
-            .unwrap()
-            .into_result();
+        let _ = verifier.validate(&block).unwrap().into_result();
 
         // Invalidate block by adding transaction with not existing coin
         let len = block.transactions().len();
         block.transactions_mut().insert(len - 1, tx);
-        let verify_result = verifier.validate_without_commit(&block);
+        let verify_result = verifier.validate(&block);
         assert!(matches!(
             verify_result,
             Err(ExecutorError::TransactionValidity(
@@ -2055,7 +2046,7 @@ mod tests {
         assert!(skipped_transactions.is_empty());
 
         let verifier = create_executor(db, Default::default());
-        let verify_result = verifier.validate_without_commit(&second_block);
+        let verify_result = verifier.validate(&second_block);
         assert!(verify_result.is_ok());
     }
 
@@ -2130,7 +2121,7 @@ mod tests {
         }
 
         let verifier = create_executor(db, Default::default());
-        let err = verifier.validate_without_commit(&second_block).unwrap_err();
+        let err = verifier.validate(&second_block).unwrap_err();
 
         assert_eq!(
             err,
@@ -2517,13 +2508,13 @@ mod tests {
 
         // Produced block is valid
         let exec = make_executor(&[&message]);
-        let _ = exec.validate_without_commit(&block).unwrap().into_result();
+        let _ = exec.validate(&block).unwrap().into_result();
 
         // Invalidate block by return back `tx2` transaction skipped during production.
         let len = block.transactions().len();
         block.transactions_mut().insert(len - 1, tx2);
         let exec = make_executor(&[&message]);
-        let res = exec.validate_without_commit(&block);
+        let res = exec.validate(&block);
         assert!(matches!(
             res,
             Err(ExecutorError::TransactionValidity(

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -3289,12 +3289,12 @@ mod tests {
             add_events_to_relayer(&mut verifier_relayer_db, da_height.into(), &events);
             let verifier = create_relayer_executor(verifyer_db, verifier_relayer_db);
             let (result, _) = verifier
-                .validate_without_commit(produced_block)
+                .validate_without_commit(&produced_block)
                 .unwrap()
                 .into();
 
             // then
-            let txs = result.block.transactions();
+            let txs = produced_block.transactions();
             assert_eq!(txs.len(), 1);
 
             // and
@@ -3446,7 +3446,7 @@ mod tests {
 
             let validator = create_relayer_executor(on_chain_db, relayer_db);
             // When
-            let result = validator.validate_without_commit(result.block).map(|_| ());
+            let result = validator.validate_without_commit(&result.block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);

--- a/crates/fuel-core/src/service/adapters/block_importer.rs
+++ b/crates/fuel-core/src/service/adapters/block_importer.rs
@@ -44,7 +44,7 @@ use fuel_core_types::{
     },
     services::executor::{
         Result as ExecutorResult,
-        UncommittedResult as UncommittedExecutionResult,
+        UncommittedValidationResult,
     },
 };
 use std::sync::Arc;
@@ -103,8 +103,8 @@ impl ImporterDatabase for Database {
 impl Validator for ExecutorAdapter {
     fn validate(
         &self,
-        block: Block,
-    ) -> ExecutorResult<UncommittedExecutionResult<Changes>> {
+        block: &Block,
+    ) -> ExecutorResult<UncommittedValidationResult<Changes>> {
         self.executor.validate(block)
     }
 }

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -265,7 +265,7 @@ where
         let consensus_params_version = block.header().consensus_parameters_version;
         let (block_executor, storage_tx) =
             self.into_executor(consensus_params_version)?;
-        let execution_data = block_executor.validate_block(&block, storage_tx)?;
+        let execution_data = block_executor.validate_block(block, storage_tx)?;
         Self::uncommitted_validation_result(block, execution_data)
     }
 

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -400,7 +400,6 @@ where
             return Err(Error::ExecuteGenesis)
         }
 
-        // TODO: Pass `block` into `ExecutionBlock::Validation` by ref
         let (
             ValidationResult {
                 skipped_transactions,

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -34,7 +34,7 @@ use fuel_core_types::{
             UncommittedResult,
         },
         executor,
-        executor::ExecutionResult,
+        executor::ValidationResult,
         Uncommitted,
     },
 };
@@ -402,15 +402,14 @@ where
 
         // TODO: Pass `block` into `ExecutionBlock::Validation` by ref
         let (
-            ExecutionResult {
-                block,
+            ValidationResult {
                 skipped_transactions,
                 tx_status,
                 events,
             },
             changes,
         ) = executor
-            .validate(block)
+            .validate(&block)
             .map_err(Error::FailedExecution)?
             .into();
 

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -87,10 +87,6 @@ pub enum Error {
     FailedVerification(anyhow::Error),
     #[display(fmt = "The execution of the block failed: {_0}.")]
     FailedExecution(executor::Error),
-    #[display(
-        fmt = "It is not possible to skip transactions during importing of the block."
-    )]
-    SkippedTransactionsNotEmpty,
     #[display(fmt = "It is not possible to execute the genesis block.")]
     ExecuteGenesis,
     #[display(fmt = "The database already contains the data at the height {_0}.")]
@@ -400,22 +396,10 @@ where
             return Err(Error::ExecuteGenesis)
         }
 
-        let (
-            ValidationResult {
-                skipped_transactions,
-                tx_status,
-                events,
-            },
-            changes,
-        ) = executor
+        let (ValidationResult { tx_status, events }, changes) = executor
             .validate(&block)
             .map_err(Error::FailedExecution)?
             .into();
-
-        // If we skipped transaction, it means that the block is invalid.
-        if !skipped_transactions.is_empty() {
-            return Err(Error::SkippedTransactionsNotEmpty)
-        }
 
         let actual_block_id = block.id();
         if actual_block_id != sealed_block_id {

--- a/crates/services/importer/src/importer/test.rs
+++ b/crates/services/importer/src/importer/test.rs
@@ -460,11 +460,6 @@ fn one_lock_at_the_same_time() {
     "commits block 113"
 )]
 #[test_case(
-    poa_block(113), ok(ex_result(0)), ok(()), 0
-    => Err(Error::BlockIdMismatch(poa_block(113).entity.id(), poa_block(114).entity.id()));
-    "execution result should match block height"
-)]
-#[test_case(
     poa_block(113), execution_failure, ok(()), 0
     => Err(execution_failure_error());
     "commit fails if execution fails"

--- a/crates/services/importer/src/ports.rs
+++ b/crates/services/importer/src/ports.rs
@@ -35,7 +35,7 @@ use fuel_core_types::{
     },
     services::executor::{
         Result as ExecutorResult,
-        UncommittedResult,
+        UncommittedValidationResult,
     },
 };
 
@@ -44,7 +44,10 @@ use fuel_core_types::{
 pub trait Validator: Send + Sync {
     /// Executes the block and returns the result of execution with uncommitted database
     /// transaction.
-    fn validate(&self, block: Block) -> ExecutorResult<UncommittedResult<Changes>>;
+    fn validate(
+        &self,
+        block: &Block,
+    ) -> ExecutorResult<UncommittedValidationResult<Changes>>;
 }
 
 /// The trait indicates that the type supports storage transactions.

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -500,24 +500,7 @@ where
 
         match output {
             fuel_core_wasm_executor::utils::ReturnType::V1(result) => {
-                let (
-                    ExecutionResult {
-                        skipped_transactions,
-                        tx_status,
-                        events,
-                        ..
-                    },
-                    changes,
-                ) = result?.into();
-
-                Ok(Uncommitted::new(
-                    ValidationResult {
-                        skipped_transactions,
-                        tx_status,
-                        events,
-                    },
-                    changes,
-                ))
+                Ok(result?.into_validation_result())
             }
         }
     }

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -54,6 +54,10 @@ use fuel_core_storage::{
 use fuel_core_types::blockchain::block::PartialFuelBlock;
 #[cfg(any(test, feature = "test-helpers"))]
 use fuel_core_types::services::executor::UncommittedResult;
+use fuel_core_types::services::executor::{
+    UncommittedValidationResult,
+    ValidationResult,
+};
 
 #[cfg(feature = "wasm-executor")]
 enum ExecutionStrategy {
@@ -210,10 +214,9 @@ where
     /// Executes the block and commits the result of the execution into the inner `Database`.
     pub fn validate_and_commit(
         &mut self,
-        block: Block,
-    ) -> fuel_core_types::services::executor::Result<ExecutionResult> {
+        block: &Block,
+    ) -> fuel_core_types::services::executor::Result<ValidationResult> {
         let (result, changes) = self.validate_without_commit(block)?.into();
-
         self.storage_view_provider.commit_changes(changes)?;
         Ok(result)
     }
@@ -235,11 +238,13 @@ where
         self.produce_without_commit_with_coinbase(block, Default::default(), 0)
     }
 
+    // TODO: Can we remove this and just use `validate` everywhere?
     /// Executes the block and returns the result of the execution with storage changes.
     pub fn validate_without_commit(
         &self,
-        block: Block,
-    ) -> fuel_core_types::services::executor::Result<UncommittedResult<Changes>> {
+        block: &Block,
+    ) -> fuel_core_types::services::executor::Result<UncommittedValidationResult<Changes>>
+    {
         let options = self.config.as_ref().into();
         self.validate_inner(block, options)
     }
@@ -336,8 +341,8 @@ where
 
     pub fn validate(
         &self,
-        block: Block,
-    ) -> ExecutorResult<Uncommitted<ExecutionResult, Changes>> {
+        block: &Block,
+    ) -> ExecutorResult<Uncommitted<ValidationResult, Changes>> {
         let options = self.config.as_ref().into();
         self.validate_inner(block, options)
     }
@@ -395,9 +400,9 @@ where
     #[cfg(feature = "wasm-executor")]
     fn validate_inner(
         &self,
-        block: Block,
+        block: &Block,
         options: ExecutionOptions,
-    ) -> ExecutorResult<Uncommitted<ExecutionResult, Changes>> {
+    ) -> ExecutorResult<Uncommitted<ValidationResult, Changes>> {
         let block_version = block.header().state_transition_bytecode_version;
         let native_executor_version = self.native_executor_version();
         if block_version == native_executor_version {
@@ -427,9 +432,9 @@ where
     #[cfg(not(feature = "wasm-executor"))]
     fn validate_inner(
         &self,
-        block: Block,
+        block: &Block,
         options: ExecutionOptions,
-    ) -> ExecutorResult<Uncommitted<ExecutionResult, Changes>> {
+    ) -> ExecutorResult<Uncommitted<ValidationResult, Changes>> {
         let block_version = block.header().state_transition_bytecode_version;
         let native_executor_version = self.native_executor_version();
         if block_version == native_executor_version {
@@ -493,9 +498,9 @@ where
     fn wasm_validate_inner(
         &self,
         module: &wasmtime::Module,
-        block: Block,
+        block: &Block,
         options: ExecutionOptions,
-    ) -> ExecutorResult<Uncommitted<ExecutionResult, Changes>> {
+    ) -> ExecutorResult<Uncommitted<ValidationResult, Changes>> {
         let storage = self.storage_view_provider.latest_view();
         let relayer = self.relayer_view_provider.latest_view();
 
@@ -508,7 +513,26 @@ where
         let output = instance.run(module)?;
 
         match output {
-            fuel_core_wasm_executor::utils::ReturnType::V1(result) => result,
+            fuel_core_wasm_executor::utils::ReturnType::V1(result) => {
+                let (
+                    ExecutionResult {
+                        skipped_transactions,
+                        tx_status,
+                        events,
+                        ..
+                    },
+                    changes,
+                ) = result?.into();
+
+                Ok(Uncommitted::new(
+                    ValidationResult {
+                        skipped_transactions,
+                        tx_status,
+                        events,
+                    },
+                    changes,
+                ))
+            }
         }
     }
 
@@ -527,9 +551,9 @@ where
 
     fn native_validate_inner(
         &self,
-        block: Block,
+        block: &Block,
         options: ExecutionOptions,
-    ) -> ExecutorResult<Uncommitted<ExecutionResult, Changes>> {
+    ) -> ExecutorResult<Uncommitted<ValidationResult, Changes>> {
         let instance = self.new_native_executor_instance(options);
         instance.validate_without_commit(block)
     }
@@ -809,7 +833,7 @@ mod test {
             let block = valid_block(Executor::<Storage, DisabledRelayer>::VERSION);
 
             // When
-            let result = executor.validate_without_commit(block).map(|_| ());
+            let result = executor.validate_without_commit(&block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);
@@ -824,7 +848,7 @@ mod test {
             let block = valid_block(Executor::<Storage, DisabledRelayer>::VERSION);
 
             // When
-            let result = executor.validate_without_commit(block).map(|_| ());
+            let result = executor.validate_without_commit(&block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);
@@ -840,7 +864,7 @@ mod test {
             let block = valid_block(wrong_version);
 
             // When
-            let result = executor.validate_without_commit(block).map(|_| ());
+            let result = executor.validate_without_commit(&block).map(|_| ());
 
             // Then
             result.expect_err("The validation should fail because of versions mismatch");
@@ -856,7 +880,7 @@ mod test {
             let block = valid_block(wrong_version);
 
             // When
-            let result = executor.validate_without_commit(block).map(|_| ());
+            let result = executor.validate_without_commit(&block).map(|_| ());
 
             // Then
             result.expect_err("The validation should fail because of versions mismatch");
@@ -895,7 +919,7 @@ mod test {
             let block = valid_block(next_version);
 
             // When
-            let result = executor.validate_without_commit(block).map(|_| ());
+            let result = executor.validate_without_commit(&block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);
@@ -910,7 +934,7 @@ mod test {
             let block = valid_block(next_version);
 
             // When
-            let result = executor.validate_without_commit(block).map(|_| ());
+            let result = executor.validate_without_commit(&block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);
@@ -929,7 +953,7 @@ mod test {
 
             // When
             for _ in 0..1000 {
-                let result = executor.validate_without_commit(block.clone()).map(|_| ());
+                let result = executor.validate_without_commit(&block).map(|_| ());
 
                 // Then
                 assert_eq!(Ok(()), result);
@@ -949,7 +973,7 @@ mod test {
 
             // When
             for _ in 0..1000 {
-                let result = executor.validate_without_commit(block.clone()).map(|_| ());
+                let result = executor.validate_without_commit(&block).map(|_| ());
 
                 // Then
                 assert_eq!(Ok(()), result);

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -819,7 +819,7 @@ mod test {
             let block = valid_block(Executor::<Storage, DisabledRelayer>::VERSION);
 
             // When
-            let result = executor.validate_without_commit(&block).map(|_| ());
+            let result = executor.validate(&block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);
@@ -834,7 +834,7 @@ mod test {
             let block = valid_block(Executor::<Storage, DisabledRelayer>::VERSION);
 
             // When
-            let result = executor.validate_without_commit(&block).map(|_| ());
+            let result = executor.validate(&block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);
@@ -850,7 +850,7 @@ mod test {
             let block = valid_block(wrong_version);
 
             // When
-            let result = executor.validate_without_commit(&block).map(|_| ());
+            let result = executor.validate(&block).map(|_| ());
 
             // Then
             result.expect_err("The validation should fail because of versions mismatch");
@@ -866,7 +866,7 @@ mod test {
             let block = valid_block(wrong_version);
 
             // When
-            let result = executor.validate_without_commit(&block).map(|_| ());
+            let result = executor.validate(&block).map(|_| ());
 
             // Then
             result.expect_err("The validation should fail because of versions mismatch");
@@ -905,7 +905,7 @@ mod test {
             let block = valid_block(next_version);
 
             // When
-            let result = executor.validate_without_commit(&block).map(|_| ());
+            let result = executor.validate(&block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);
@@ -920,7 +920,7 @@ mod test {
             let block = valid_block(next_version);
 
             // When
-            let result = executor.validate_without_commit(&block).map(|_| ());
+            let result = executor.validate(&block).map(|_| ());
 
             // Then
             assert_eq!(Ok(()), result);
@@ -939,7 +939,7 @@ mod test {
 
             // When
             for _ in 0..1000 {
-                let result = executor.validate_without_commit(&block).map(|_| ());
+                let result = executor.validate(&block).map(|_| ());
 
                 // Then
                 assert_eq!(Ok(()), result);
@@ -959,7 +959,7 @@ mod test {
 
             // When
             for _ in 0..1000 {
-                let result = executor.validate_without_commit(&block).map(|_| ());
+                let result = executor.validate(&block).map(|_| ());
 
                 // Then
                 assert_eq!(Ok(()), result);

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -54,10 +54,7 @@ use fuel_core_storage::{
 use fuel_core_types::blockchain::block::PartialFuelBlock;
 #[cfg(any(test, feature = "test-helpers"))]
 use fuel_core_types::services::executor::UncommittedResult;
-use fuel_core_types::services::executor::{
-    UncommittedValidationResult,
-    ValidationResult,
-};
+use fuel_core_types::services::executor::ValidationResult;
 
 #[cfg(feature = "wasm-executor")]
 enum ExecutionStrategy {
@@ -216,7 +213,7 @@ where
         &mut self,
         block: &Block,
     ) -> fuel_core_types::services::executor::Result<ValidationResult> {
-        let (result, changes) = self.validate_without_commit(block)?.into();
+        let (result, changes) = self.validate(block)?.into();
         self.storage_view_provider.commit_changes(changes)?;
         Ok(result)
     }
@@ -236,17 +233,6 @@ where
         block: PartialFuelBlock,
     ) -> fuel_core_types::services::executor::Result<UncommittedResult<Changes>> {
         self.produce_without_commit_with_coinbase(block, Default::default(), 0)
-    }
-
-    // TODO: Can we remove this and just use `validate` everywhere?
-    /// Executes the block and returns the result of the execution with storage changes.
-    pub fn validate_without_commit(
-        &self,
-        block: &Block,
-    ) -> fuel_core_types::services::executor::Result<UncommittedValidationResult<Changes>>
-    {
-        let options = self.config.as_ref().into();
-        self.validate_inner(block, options)
     }
 
     /// The analog of the [`Self::produce_without_commit`] method,

--- a/crates/services/upgradable-executor/src/instance.rs
+++ b/crates/services/upgradable-executor/src/instance.rs
@@ -31,9 +31,9 @@ use fuel_core_types::{
 use fuel_core_wasm_executor::utils::{
     pack_exists_size_result,
     unpack_ptr_and_len,
-    InputType,
+    InputSerializationType,
     ReturnType,
-    WasmExecutionBlockTypes,
+    WasmSerializationBlockTypes,
 };
 use std::{
     collections::HashMap,
@@ -459,8 +459,8 @@ impl Instance<Relayer> {
         components: Components<()>,
         options: ExecutionOptions,
     ) -> ExecutorResult<Instance<InputData>> {
-        let input = InputType::V1 {
-            block: WasmExecutionBlockTypes::Production(components),
+        let input = InputSerializationType::V1 {
+            block: WasmSerializationBlockTypes::Production(components),
             options,
         };
         self.add_input_data(input)
@@ -471,8 +471,8 @@ impl Instance<Relayer> {
         components: Components<()>,
         options: ExecutionOptions,
     ) -> ExecutorResult<Instance<InputData>> {
-        let input = InputType::V1 {
-            block: WasmExecutionBlockTypes::DryRun(components),
+        let input = InputSerializationType::V1 {
+            block: WasmSerializationBlockTypes::DryRun(components),
             options,
         };
         self.add_input_data(input)
@@ -484,16 +484,17 @@ impl Instance<Relayer> {
         block: &Block,
         options: ExecutionOptions,
     ) -> ExecutorResult<Instance<InputData>> {
-        // TODO: Can we avoid cloning the block?
-        let block_owned = block.to_owned();
-        let input = InputType::V1 {
-            block: WasmExecutionBlockTypes::Validation(block_owned),
+        let input = InputSerializationType::V1 {
+            block: WasmSerializationBlockTypes::Validation(block),
             options,
         };
         self.add_input_data(input)
     }
 
-    fn add_input_data(mut self, input: InputType) -> ExecutorResult<Instance<InputData>> {
+    fn add_input_data(
+        mut self,
+        input: InputSerializationType,
+    ) -> ExecutorResult<Instance<InputData>> {
         let encoded_input = postcard::to_allocvec(&input).map_err(|e| {
             ExecutorError::Other(format!(
                 "Failed encoding of the input for `input` function: {}",

--- a/crates/services/upgradable-executor/src/instance.rs
+++ b/crates/services/upgradable-executor/src/instance.rs
@@ -478,13 +478,16 @@ impl Instance<Relayer> {
         self.add_input_data(input)
     }
 
+    //
     pub fn add_validation_input_data(
         self,
-        block: Block,
+        block: &Block,
         options: ExecutionOptions,
     ) -> ExecutorResult<Instance<InputData>> {
+        // TODO: Can we avoid cloning the block?
+        let block_owned = block.to_owned();
         let input = InputType::V1 {
-            block: WasmExecutionBlockTypes::Validation(block),
+            block: WasmExecutionBlockTypes::Validation(block_owned),
             options,
         };
         self.add_input_data(input)

--- a/crates/services/upgradable-executor/wasm-executor/src/ext.rs
+++ b/crates/services/upgradable-executor/wasm-executor/src/ext.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
     unpack_exists_size_result,
-    InputType,
+    InputDeserializationType,
 };
 use core::marker::PhantomData;
 use fuel_core_executor::ports::MaybeCheckedTransaction;
@@ -131,7 +131,7 @@ mod host {
 pub struct ReturnResult(u16);
 
 /// Gets the `InputType` by using the host function. The `size` is the size of the encoded input.
-pub fn input(size: usize) -> anyhow::Result<InputType> {
+pub fn input(size: usize) -> anyhow::Result<InputDeserializationType> {
     let mut encoded_block = vec![0u8; size];
     let size = encoded_block.len();
     unsafe {
@@ -141,7 +141,7 @@ pub fn input(size: usize) -> anyhow::Result<InputType> {
         )
     };
 
-    let input: InputType = postcard::from_bytes(&encoded_block)
+    let input: InputDeserializationType = postcard::from_bytes(&encoded_block)
         .map_err(|e| anyhow::anyhow!("Failed to decode the block: {:?}", e))?;
 
     Ok(input)

--- a/crates/services/upgradable-executor/wasm-executor/src/main.rs
+++ b/crates/services/upgradable-executor/wasm-executor/src/main.rs
@@ -25,6 +25,7 @@ use fuel_core_types::{
             Error as ExecutorError,
             ExecutionResult,
             Result as ExecutorResult,
+            ValidationResult,
         },
         Uncommitted,
     },
@@ -114,15 +115,16 @@ fn execute_validation(
     block: Block,
 ) -> ExecutorResult<Uncommitted<ExecutionResult, Changes>> {
     let (
-        ExecutionResult {
-            block,
+        ValidationResult {
             skipped_transactions,
             tx_status,
             events,
         },
         changes,
-    ) = instance.validate_without_commit(block)?.into();
+    ) = instance.validate_without_commit(&block)?.into();
 
+    // We have to return the same type here because if the input parsing fails it won't know if this
+    // is a validation or production block.
     Ok(Uncommitted::new(
         ExecutionResult {
             block,

--- a/crates/services/upgradable-executor/wasm-executor/src/main.rs
+++ b/crates/services/upgradable-executor/wasm-executor/src/main.rs
@@ -125,8 +125,8 @@ fn execute_validation(
         changes,
     ) = instance.validate_without_commit(&block)?.into();
 
-    // We have to return the same type here because if the input parsing fails it won't know if this
-    // is a validation or production block.
+    // TODO: Modify return type to differentiate between validation and production results
+    // https://github.com/FuelLabs/fuel-core/issues/1887
     Ok(Uncommitted::new(
         ExecutionResult {
             block,

--- a/crates/services/upgradable-executor/wasm-executor/src/main.rs
+++ b/crates/services/upgradable-executor/wasm-executor/src/main.rs
@@ -28,7 +28,6 @@ use fuel_core_types::{
             Error as ExecutorError,
             ExecutionResult,
             Result as ExecutorResult,
-            ValidationResult,
         },
         Uncommitted,
     },
@@ -116,26 +115,13 @@ fn execute_validation(
     instance: ExecutionInstance<WasmRelayer, WasmStorage>,
     block: Block,
 ) -> ExecutorResult<Uncommitted<ExecutionResult, Changes>> {
-    let (
-        ValidationResult {
-            skipped_transactions,
-            tx_status,
-            events,
-        },
-        changes,
-    ) = instance.validate_without_commit(&block)?.into();
+    let result = instance
+        .validate_without_commit(&block)?
+        .into_execution_result(block, vec![]);
 
     // TODO: Modify return type to differentiate between validation and production results
     // https://github.com/FuelLabs/fuel-core/issues/1887
-    Ok(Uncommitted::new(
-        ExecutionResult {
-            block,
-            skipped_transactions,
-            tx_status,
-            events,
-        },
-        changes,
-    ))
+    Ok(result)
 }
 
 fn use_wasm_tx_source(component: Components<()>) -> Components<WasmTxSource> {

--- a/crates/services/upgradable-executor/wasm-executor/src/main.rs
+++ b/crates/services/upgradable-executor/wasm-executor/src/main.rs
@@ -14,7 +14,10 @@
 #![deny(warnings)]
 
 use crate as fuel_core_wasm_executor;
-use crate::utils::WasmExecutionBlockTypes;
+use crate::utils::{
+    InputDeserializationType,
+    WasmDeserializationBlockTypes,
+};
 use fuel_core_executor::executor::ExecutionInstance;
 use fuel_core_storage::transactional::Changes;
 use fuel_core_types::{
@@ -36,7 +39,6 @@ use fuel_core_wasm_executor::{
     tx_source::WasmTxSource,
     utils::{
         pack_ptr_and_len,
-        InputType,
         ReturnType,
     },
 };
@@ -66,16 +68,16 @@ pub fn execute_without_commit(
         .map_err(|e| ExecutorError::Other(e.to_string()))?;
 
     let (block, options) = match input {
-        InputType::V1 { block, options } => {
+        InputDeserializationType::V1 { block, options } => {
             let block = match block {
-                WasmExecutionBlockTypes::DryRun(c) => {
-                    WasmExecutionBlockTypes::DryRun(use_wasm_tx_source(c))
+                WasmDeserializationBlockTypes::DryRun(c) => {
+                    WasmDeserializationBlockTypes::DryRun(use_wasm_tx_source(c))
                 }
-                WasmExecutionBlockTypes::Production(c) => {
-                    WasmExecutionBlockTypes::Production(use_wasm_tx_source(c))
+                WasmDeserializationBlockTypes::Production(c) => {
+                    WasmDeserializationBlockTypes::Production(use_wasm_tx_source(c))
                 }
-                WasmExecutionBlockTypes::Validation(c) => {
-                    WasmExecutionBlockTypes::Validation(c)
+                WasmDeserializationBlockTypes::Validation(c) => {
+                    WasmDeserializationBlockTypes::Validation(c)
                 }
             };
 
@@ -90,9 +92,9 @@ pub fn execute_without_commit(
     };
 
     match block {
-        WasmExecutionBlockTypes::DryRun(c) => execute_dry_run(instance, c),
-        WasmExecutionBlockTypes::Production(c) => execute_production(instance, c),
-        WasmExecutionBlockTypes::Validation(c) => execute_validation(instance, c),
+        WasmDeserializationBlockTypes::DryRun(c) => execute_dry_run(instance, c),
+        WasmDeserializationBlockTypes::Production(c) => execute_production(instance, c),
+        WasmDeserializationBlockTypes::Validation(c) => execute_validation(instance, c),
     }
 }
 

--- a/crates/services/upgradable-executor/wasm-executor/src/utils.rs
+++ b/crates/services/upgradable-executor/wasm-executor/src/utils.rs
@@ -44,16 +44,34 @@ pub fn unpack_exists_size_result(val: u64) -> (bool, u32, u16) {
 
 /// The input type for the WASM executor. Enum allows handling different
 /// versions of the input without introducing new host functions.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub enum InputType {
+#[derive(Debug, serde::Serialize)]
+pub enum InputSerializationType<'a> {
     V1 {
-        block: WasmExecutionBlockTypes<()>,
+        block: WasmSerializationBlockTypes<'a, ()>,
         options: ExecutionOptions,
     },
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub enum WasmExecutionBlockTypes<TxSource> {
+#[derive(Debug, serde::Deserialize)]
+pub enum InputDeserializationType {
+    V1 {
+        block: WasmDeserializationBlockTypes<()>,
+        options: ExecutionOptions,
+    },
+}
+
+#[derive(Debug, serde::Serialize)]
+pub enum WasmSerializationBlockTypes<'a, TxSource> {
+    /// DryRun mode where P is being produced.
+    DryRun(Components<TxSource>),
+    /// Production mode where P is being produced.
+    Production(Components<TxSource>),
+    /// Validation of a produced block.
+    Validation(&'a Block),
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub enum WasmDeserializationBlockTypes<TxSource> {
     /// DryRun mode where P is being produced.
     DryRun(Components<TxSource>),
     /// Production mode where P is being produced.

--- a/crates/types/src/services/executor.rs
+++ b/crates/types/src/services/executor.rs
@@ -63,9 +63,6 @@ pub struct ExecutionResult {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug)]
 pub struct ValidationResult {
-    /// The list of skipped transactions with corresponding errors. Those transactions were
-    /// not included in the block and didn't affect the state of the blockchain.
-    pub skipped_transactions: Vec<(TxId, Error)>,
     /// The status of the transactions execution included into the block.
     pub tx_status: Vec<TransactionExecutionStatus>,
     /// The list of all events generated during the execution of the block.
@@ -77,14 +74,10 @@ impl<DatabaseTransaction> UncommittedValidationResult<DatabaseTransaction> {
     pub fn into_execution_result(
         self,
         block: Block,
+        skipped_transactions: Vec<(TxId, Error)>,
     ) -> UncommittedResult<DatabaseTransaction> {
         let Self {
-            result:
-                ValidationResult {
-                    skipped_transactions,
-                    tx_status,
-                    events,
-                },
+            result: ValidationResult { tx_status, events },
             changes,
         } = self;
         UncommittedResult::new(
@@ -105,23 +98,12 @@ impl<DatabaseTransaction> UncommittedResult<DatabaseTransaction> {
         self,
     ) -> UncommittedValidationResult<DatabaseTransaction> {
         let Self {
-            result:
-                ExecutionResult {
-                    skipped_transactions,
-                    tx_status,
-                    events,
-                    ..
-                },
-            changes,
-        } = self;
-        UncommittedValidationResult::new(
-            ValidationResult {
-                skipped_transactions,
-                tx_status,
-                events,
+            result: ExecutionResult {
+                tx_status, events, ..
             },
             changes,
-        )
+        } = self;
+        UncommittedValidationResult::new(ValidationResult { tx_status, events }, changes)
     }
 }
 

--- a/crates/types/src/services/executor.rs
+++ b/crates/types/src/services/executor.rs
@@ -36,16 +36,33 @@ use crate::{
 
 /// The alias for executor result.
 pub type Result<T> = core::result::Result<T, Error>;
-/// The uncommitted result of the transaction execution.
+/// The uncommitted result of the block production execution.
 pub type UncommittedResult<DatabaseTransaction> =
     Uncommitted<ExecutionResult, DatabaseTransaction>;
 
-/// The result of transactions execution.
+/// The uncommitted result of the block validation.
+pub type UncommittedValidationResult<DatabaseTransaction> =
+    Uncommitted<ValidationResult, DatabaseTransaction>;
+
+/// The result of transactions execution for block production.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug)]
 pub struct ExecutionResult {
     /// Created block during the execution of transactions. It contains only valid transactions.
     pub block: Block,
+    /// The list of skipped transactions with corresponding errors. Those transactions were
+    /// not included in the block and didn't affect the state of the blockchain.
+    pub skipped_transactions: Vec<(TxId, Error)>,
+    /// The status of the transactions execution included into the block.
+    pub tx_status: Vec<TransactionExecutionStatus>,
+    /// The list of all events generated during the execution of the block.
+    pub events: Vec<Event>,
+}
+
+/// The result of the validation of the block.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug)]
+pub struct ValidationResult {
     /// The list of skipped transactions with corresponding errors. Those transactions were
     /// not included in the block and didn't affect the state of the blockchain.
     pub skipped_transactions: Vec<(TxId, Error)>,

--- a/crates/types/src/services/executor.rs
+++ b/crates/types/src/services/executor.rs
@@ -72,6 +72,59 @@ pub struct ValidationResult {
     pub events: Vec<Event>,
 }
 
+impl<DatabaseTransaction> UncommittedValidationResult<DatabaseTransaction> {
+    /// Convert the `UncommittedValidationResult` into the `UncommittedResult`.
+    pub fn into_execution_result(
+        self,
+        block: Block,
+    ) -> UncommittedResult<DatabaseTransaction> {
+        let Self {
+            result:
+                ValidationResult {
+                    skipped_transactions,
+                    tx_status,
+                    events,
+                },
+            changes,
+        } = self;
+        UncommittedResult::new(
+            ExecutionResult {
+                block,
+                skipped_transactions,
+                tx_status,
+                events,
+            },
+            changes,
+        )
+    }
+}
+
+impl<DatabaseTransaction> UncommittedResult<DatabaseTransaction> {
+    /// Convert the `UncommittedResult` into the `UncommittedValidationResult`.
+    pub fn into_validation_result(
+        self,
+    ) -> UncommittedValidationResult<DatabaseTransaction> {
+        let Self {
+            result:
+                ExecutionResult {
+                    skipped_transactions,
+                    tx_status,
+                    events,
+                    ..
+                },
+            changes,
+        } = self;
+        UncommittedValidationResult::new(
+            ValidationResult {
+                skipped_transactions,
+                tx_status,
+                events,
+            },
+            changes,
+        )
+    }
+}
+
 /// The event represents some internal state changes caused by the block execution.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
https://github.com/FuelLabs/fuel-core/issues/1882

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
