### PR TITLE
chore: update README fuel-core run options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#1879](https://github.com/FuelLabs/fuel-core/pull/1879): Return the old behaviour for the `discovery_works` test.
 - [#1848](https://github.com/FuelLabs/fuel-core/pull/1848): Added `version` field to the `Block` and `BlockHeader` GraphQL entities. Added corresponding `version` field to the `Block` and `BlockHeader` client types in `fuel-core-client`.
 - [#1873](https://github.com/FuelLabs/fuel-core/pull/1873/): Separate dry runs from block production in executor code, remove `ExecutionKind` and `ExecutionType`, remove `thread_block_transaction` concept, remove `PartialBlockComponent` type, refactor away `inner` functions.
+- [#1900](https://github.com/FuelLabs/fuel-core/pull/1900): Update the root README as `fuel-core run` no longer has `--chain` as an option. It has been replaced by `--snapshot`.
 
 ## [Version 0.26.0]
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ USAGE:
     fuel-core run [OPTIONS]
 
 OPTIONS:
-        --chain <CHAIN_CONFIG>
-            Specify either an alias to a built-in configuration or filepath to a JSON file [default:
-            local_testnet]
+        --snapshot <SNAPSHOT>
+          Snapshot from which to do (re)genesis. Defaults to local testnet configuration
+
+          [env: SNAPSHOT=]
         ...
 ```
 


### PR DESCRIPTION
Closes #1899 

`fuel-core run` no longer has `--chain` as an option. It should be replaced by `--snapshot`.

### Before requesting review
- [x] I have reviewed the code myself
