### PR TITLE
chore(readme):Update Link to Latest GitHub Personal Access Token Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ act release -s GITHUB_TOKEN=<YOUR_GITHUB_TOKEN> -j publish-crates-check --contai
 ```
 
 It requires GitHubToken to do request to the GitHub. You can create it 
-with [this](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) instruction.
+with [this](https://docs.github.com/en/enterprise-server@3.13/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) instruction.
 
 #### Outdated database
 


### PR DESCRIPTION
This PR closes #1904.

This PR updates the link to the GitHub Personal Access Token documentation in README to point to the latest version available for GitHub Enterprise Server 3.13.

**Changes**:

Updated the link from:
(https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)

to:
(https://docs.github.com/en/enterprise-server@3.13/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)

**Reason for Change**:
The previous link pointed to an outdated version of the documentation. Updating to the latest version ensures that contributors have the most current instructions for creating a GitHub Personal Access Token.

## Checklist
- [X] Breaking changes are clearly marked as such in the PR description and changelog

### Before requesting review
- [X] I have reviewed the code myself

