### PR TITLE
chore: Make snapshot command members pub accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [#1906](https://github.com/FuelLabs/fuel-core/pull/1906): Makes `cli::snapshot::Command` members public such that clients can create and execute snapshot commands programmatically. This enables snapshot execution in external programs, such as the regenesis test suite. 
 - [#1891](https://github.com/FuelLabs/fuel-core/pull/1891): Regenesis now preserves `FuelBlockMerkleData` and `FuelBlockMerkleMetadata` in the off-chain table. These tables are checked when querying message proofs.
 - [#1886](https://github.com/FuelLabs/fuel-core/pull/1886): Use ref to `Block` in validation code
 - [#1876](https://github.com/FuelLabs/fuel-core/pull/1876): Updated benchmark to include the worst scenario for `CROO` opcode. Also include consensus parameters in bench output.

--- a/bin/fuel-core/src/cli/snapshot.rs
+++ b/bin/fuel-core/src/cli/snapshot.rs
@@ -27,11 +27,11 @@ pub struct Command {
         value_parser,
         default_value = default_db_path().into_os_string()
     )]
-    pub(crate) database_path: PathBuf,
+    pub database_path: PathBuf,
 
     /// Where to save the snapshot
     #[arg(name = "OUTPUT_DIR", long = "output-directory")]
-    pub(crate) output_dir: PathBuf,
+    pub output_dir: PathBuf,
 
     /// The maximum database cache size in bytes.
     #[arg(
@@ -43,7 +43,7 @@ pub struct Command {
 
     /// The sub-command of the snapshot operation.
     #[command(subcommand)]
-    pub(crate) subcommand: SubCommands,
+    pub subcommand: SubCommands,
 }
 
 #[derive(Subcommand, Debug, Clone, Copy)]


### PR DESCRIPTION
Related tickets:
- https://github.com/FuelLabs/fuel-core/issues/1571

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
