### PR TITLE
Added API functions to open a RocksDB in different modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#1924](https://github.com/FuelLabs/fuel-core/pull/1924): `dry_run_opt` has new `gas_price: Option<u64>` argument
 
 ### Added
+- [#1939](https://github.com/FuelLabs/fuel-core/pull/1939): Added API functions to open a RocksDB in different modes.
 - [#1929](https://github.com/FuelLabs/fuel-core/pull/1929): Added support of customization of the state transition version in the `ChainConfig`.
 
 ### Removed


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/1892

The PR adds API to access [Read only and Secondary instances](https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances) of the RocksDB. It allows connect to the database in read-only mode while it is modified by the main process.

## Checklist
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself

