### PR TITLE
Change tip sorting to ratio between tip and max gas sorting in txpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - [#1942](https://github.com/FuelLabs/fuel-core/pull/1942): Sequential relayer's commits.
+- [#1952](https://github.com/FuelLabs/fuel-core/pull/1952): Change tip sorting to ratio between tip and max gas sorting in txpool
 
 ### Fixed
 - [#1950](https://github.com/FuelLabs/fuel-core/pull/1950): Fix cursor `BlockHeight` encoding in `SortedTXCursor`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,7 +3353,7 @@ dependencies = [
  "fuel-core-types",
  "itertools 0.12.1",
  "mockall",
- "num",
+ "num-rational",
  "parking_lot",
  "proptest",
  "rstest",
@@ -5728,7 +5728,6 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,6 +3353,7 @@ dependencies = [
  "fuel-core-types",
  "itertools 0.12.1",
  "mockall",
+ "num",
  "parking_lot",
  "proptest",
  "rstest",
@@ -5727,6 +5728,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -5785,6 +5787,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ derivative = { version = "2" }
 derive_more = { version = "0.99" }
 enum-iterator = "1.2"
 hyper = { version = "0.14.26" }
+num = "0.4.3"
 primitive-types = { version = "0.12", default-features = false }
 rand = "0.8"
 parking_lot = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ derivative = { version = "2" }
 derive_more = { version = "0.99" }
 enum-iterator = "1.2"
 hyper = { version = "0.14.26" }
-num = "0.4.3"
+num-rational = "0.4.2"
 primitive-types = { version = "0.12", default-features = false }
 rand = "0.8"
 parking_lot = "0.12"

--- a/crates/services/txpool/Cargo.toml
+++ b/crates/services/txpool/Cargo.toml
@@ -18,6 +18,7 @@ fuel-core-services = { workspace = true }
 fuel-core-storage = { workspace = true }
 fuel-core-types = { workspace = true }
 mockall = { workspace = true, optional = true }
+num = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 tokio-rayon = { workspace = true }

--- a/crates/services/txpool/Cargo.toml
+++ b/crates/services/txpool/Cargo.toml
@@ -18,7 +18,7 @@ fuel-core-services = { workspace = true }
 fuel-core-storage = { workspace = true }
 fuel-core-types = { workspace = true }
 mockall = { workspace = true, optional = true }
-num = { workspace = true }
+num-rational = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 tokio-rayon = { workspace = true }

--- a/crates/services/txpool/src/containers.rs
+++ b/crates/services/txpool/src/containers.rs
@@ -1,4 +1,4 @@
 pub mod dependency;
-pub mod price_sort;
 pub mod sort;
 pub mod time_sort;
+pub mod tip_per_gas_sort;

--- a/crates/services/txpool/src/containers/tip_per_gas_sort.rs
+++ b/crates/services/txpool/src/containers/tip_per_gas_sort.rs
@@ -53,7 +53,7 @@ impl PartialOrd for RatioGasTipSortKey {
 
 impl Ord for RatioGasTipSortKey {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        let cmp = other.tip_per_gas.cmp(&self.tip_per_gas);
+        let cmp = self.tip_per_gas.cmp(&other.tip_per_gas);
         if cmp == cmp::Ordering::Equal {
             return self.tx_id.cmp(&other.tx_id);
         }

--- a/crates/services/txpool/src/containers/tip_per_gas_sort.rs
+++ b/crates/services/txpool/src/containers/tip_per_gas_sort.rs
@@ -1,3 +1,5 @@
+use num::rational::Ratio;
+
 use crate::{
     containers::sort::{
         Sort,
@@ -9,48 +11,51 @@ use crate::{
 use std::cmp;
 
 /// all transactions sorted by min/max price
-pub type TipSort = Sort<TipSortKey>;
+pub type RatioGasTipSort = Sort<RatioGasTipSortKey>;
+
+/// A ratio between gas and tip
+pub type RatioGasTip = Ratio<Word>;
 
 #[derive(Clone, Debug)]
-pub struct TipSortKey {
-    tip: Word,
+pub struct RatioGasTipSortKey {
+    tip_per_gas: RatioGasTip,
     tx_id: TxId,
 }
 
-impl SortableKey for TipSortKey {
-    type Value = GasPrice;
+impl SortableKey for RatioGasTipSortKey {
+    type Value = RatioGasTip;
 
     fn new(info: &TxInfo) -> Self {
         Self {
-            tip: info.tx().tip(),
+            tip_per_gas: Ratio::new(info.tx().max_gas(), info.tx().tip()),
             tx_id: info.tx().id(),
         }
     }
 
     fn value(&self) -> &Self::Value {
-        &self.tip
+        &self.tip_per_gas
     }
 }
 
-impl PartialEq for TipSortKey {
+impl PartialEq for RatioGasTipSortKey {
     fn eq(&self, other: &Self) -> bool {
         self.tx_id == other.tx_id
     }
 }
 
-impl Eq for TipSortKey {}
+impl Eq for RatioGasTipSortKey {}
 
-impl PartialOrd for TipSortKey {
+impl PartialOrd for RatioGasTipSortKey {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for TipSortKey {
+impl Ord for RatioGasTipSortKey {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
-        let cmp = self.tip.cmp(&other.tip);
+        let cmp = other.tip_per_gas.cmp(&self.tip_per_gas);
         if cmp == cmp::Ordering::Equal {
-            return self.tx_id.cmp(&other.tx_id)
+            return self.tx_id.cmp(&other.tx_id);
         }
         cmp
     }

--- a/crates/services/txpool/src/containers/tip_per_gas_sort.rs
+++ b/crates/services/txpool/src/containers/tip_per_gas_sort.rs
@@ -1,4 +1,4 @@
-use num::rational::Ratio;
+use num_rational::Ratio;
 
 use crate::{
     containers::sort::{

--- a/crates/services/txpool/src/containers/tip_per_gas_sort.rs
+++ b/crates/services/txpool/src/containers/tip_per_gas_sort.rs
@@ -27,7 +27,7 @@ impl SortableKey for RatioGasTipSortKey {
 
     fn new(info: &TxInfo) -> Self {
         Self {
-            tip_per_gas: Ratio::new(info.tx().max_gas(), info.tx().tip()),
+            tip_per_gas: Ratio::new(info.tx().tip(), info.tx().max_gas()),
             tx_id: info.tx().id(),
         }
     }

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -1,8 +1,8 @@
 use crate::{
     containers::{
         dependency::Dependency,
-        price_sort::TipSort,
         time_sort::TimeSort,
+        tip_per_gas_sort::RatioGasTipSort,
     },
     ports::TxPoolDb,
     service::TxStatusChange,
@@ -27,6 +27,7 @@ use fuel_core_types::{
     },
     tai64::Tai64,
 };
+use num::rational::Ratio;
 
 use crate::ports::{
     GasPriceProvider,
@@ -72,7 +73,7 @@ mod tests;
 #[derive(Debug, Clone)]
 pub struct TxPool<ViewProvider> {
     by_hash: HashMap<TxId, TxInfo>,
-    by_tip: TipSort,
+    by_ratio_gas_tip: RatioGasTipSort,
     by_time: TimeSort,
     by_dependency: Dependency,
     config: Config,
@@ -85,7 +86,7 @@ impl<ViewProvider> TxPool<ViewProvider> {
 
         Self {
             by_hash: HashMap::new(),
-            by_tip: TipSort::default(),
+            by_ratio_gas_tip: RatioGasTipSort::default(),
             by_time: TimeSort::default(),
             by_dependency: Dependency::new(max_depth, config.utxo_validation),
             config,
@@ -113,7 +114,11 @@ impl<ViewProvider> TxPool<ViewProvider> {
 
     /// Return all sorted transactions that are includable in next block.
     pub fn sorted_includable(&self) -> impl Iterator<Item = ArcPoolTx> + '_ {
-        self.by_tip.sort.iter().rev().map(|(_, tx)| tx.clone())
+        self.by_ratio_gas_tip
+            .sort
+            .iter()
+            .rev()
+            .map(|(_, tx)| tx.clone())
     }
 
     pub fn remove_inner(&mut self, tx: &ArcPoolTx) -> Vec<ArcPoolTx> {
@@ -139,7 +144,7 @@ impl<ViewProvider> TxPool<ViewProvider> {
         let info = self.by_hash.remove(tx_id);
         if let Some(info) = &info {
             self.by_time.remove(info);
-            self.by_tip.remove(info);
+            self.by_ratio_gas_tip.remove(info);
         }
 
         info
@@ -373,8 +378,8 @@ where
         if self.by_hash.len() >= self.config.max_tx {
             max_limit_hit = true;
             // limit is hit, check if we can push out lowest priced tx
-            let lowest_tip = self.by_tip.lowest_value().unwrap_or_default();
-            if lowest_tip >= tx.tip() {
+            let lowest_ratio = self.by_ratio_gas_tip.lowest_value().unwrap_or_default();
+            if lowest_ratio >= Ratio::new(tx.max_gas(), tx.tip()) {
                 return Err(Error::NotInsertedLimitHit)
             }
         }
@@ -387,7 +392,7 @@ where
         let rem = self.by_dependency.insert(&self.by_hash, view, &tx)?;
         let info = TxInfo::new(tx.clone());
         let submitted_time = info.submitted_time();
-        self.by_tip.insert(&info);
+        self.by_ratio_gas_tip.insert(&info);
         self.by_time.insert(&info);
         self.by_hash.insert(tx.id(), info);
 
@@ -395,7 +400,7 @@ where
         let removed = if rem.is_empty() {
             if max_limit_hit {
                 // remove last tx from sort
-                let rem_tx = self.by_tip.lowest_tx().unwrap(); // safe to unwrap limit is hit
+                let rem_tx = self.by_ratio_gas_tip.lowest_tx().unwrap(); // safe to unwrap limit is hit
                 self.remove_inner(&rem_tx);
                 vec![rem_tx]
             } else {

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -27,7 +27,7 @@ use fuel_core_types::{
     },
     tai64::Tai64,
 };
-use num::rational::Ratio;
+use num_rational::Ratio;
 
 use crate::ports::{
     GasPriceProvider,

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -379,7 +379,7 @@ where
             max_limit_hit = true;
             // limit is hit, check if we can push out lowest priced tx
             let lowest_ratio = self.by_ratio_gas_tip.lowest_value().unwrap_or_default();
-            if lowest_ratio >= Ratio::new(tx.max_gas(), tx.tip()) {
+            if lowest_ratio >= Ratio::new(tx.tip(), tx.max_gas()) {
                 return Err(Error::NotInsertedLimitHit)
             }
         }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/1909

Change tip sorting to ratio between tip and max gas sorting in txpool

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
