### PR TITLE
deps(client): update eventsource-client to fix CVE(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,15 +1701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct 0.6.1",
-]
-
-[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,16 +2666,17 @@ dependencies = [
 
 [[package]]
 name = "eventsource-client"
-version = "0.10.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9146112ee3ce031aa5aebe3e049e10b1d353b9c7630cc6be488c2c62cc5d9c42"
+checksum = "4c80c6714d1a380314fcb11a22eeff022e1e1c9642f0bb54e15dc9cb29f37b29"
 dependencies = [
  "futures",
  "hyper",
- "hyper-rustls 0.22.1",
+ "hyper-rustls",
  "hyper-timeout",
  "log",
  "pin-project",
+ "rand",
  "tokio",
 ]
 
@@ -2989,7 +2981,7 @@ dependencies = [
  "fuel-core-types",
  "futures",
  "hex",
- "hyper-rustls 0.24.2",
+ "hyper-rustls",
  "insta",
  "itertools 0.12.1",
  "reqwest",
@@ -4131,23 +4123,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
- "rustls 0.19.1",
- "rustls-native-certs 0.5.0",
- "tokio",
- "tokio-rustls 0.22.0",
- "webpki",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
@@ -4157,9 +4132,9 @@ dependencies = [
  "hyper",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "webpki-roots",
 ]
 
@@ -6960,7 +6935,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.24.2",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -6976,7 +6951,7 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7189,19 +7164,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.1",
- "log",
- "ring 0.16.20",
- "sct 0.6.1",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
@@ -7209,7 +7171,7 @@ dependencies = [
  "log",
  "ring 0.17.8",
  "rustls-webpki 0.101.7",
- "sct 0.7.1",
+ "sct",
 ]
 
 [[package]]
@@ -7224,18 +7186,6 @@ dependencies = [
  "rustls-webpki 0.102.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls 0.19.1",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -7414,16 +7364,6 @@ dependencies = [
  "pbkdf2 0.11.0",
  "salsa20",
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -8460,17 +8400,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -8501,7 +8430,7 @@ dependencies = [
  "log",
  "rustls 0.21.12",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots",
 ]
@@ -9291,16 +9220,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -14,7 +14,7 @@ description = "Tx client and schema specification."
 anyhow = { workspace = true }
 cynic = { workspace = true }
 derive_more = { workspace = true }
-eventsource-client = { version = "0.10.2", optional = true }
+eventsource-client = { version = "0.12.2", optional = true }
 fuel-core-types = { workspace = true, features = ["serde"] }
 futures = { workspace = true, optional = true }
 hex = "0.4"


### PR DESCRIPTION
This PR updates `eventsource-client` dependency of `fuel-core-client` from `0.10.2` to `0.12.2`.
Rationale: there are multiple security advisories for `hyper-rustls`/`rustls` indirect dependencies ([RUSTSEC-2024-0336](https://rustsec.org/advisories/RUSTSEC-2024-0336), [RUSTSEC-2023-0052](https://rustsec.org/advisories/RUSTSEC-2023-0052), [CVE-2022-31394](https://github.com/advisories/GHSA-x477-xp89-wc9r)).
Found out about these by running https://github.com/EmbarkStudios/cargo-deny on `fuels-rs`.
No breaking changes.

References:
<details>
<summary>Output of `cargo-deny`</summary>

```
error[vulnerability]: `rustls::ConnectionCommon::complete_io` could fall into an infinite loop based on network input
    ┌─ /Users/brightone/dev/github.com/FuelLabs/fuels-rs/Cargo.lock:298:1
    │
298 │ rustls 0.19.1 registry+https://github.com/rust-lang/crates.io-index
    │ ------------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2024-0336
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0336
    = If a `close_notify` alert is received during a handshake, `complete_io`
      does not terminate.

      Callers which do not call `complete_io` are not affected.

      `rustls-tokio` and `rustls-ffi` do not call `complete_io`
      and are not affected.

      `rustls::Stream` and `rustls::StreamOwned` types use
      `complete_io` and are affected.
    = Announcement: https://github.com/rustls/rustls/security/advisories/GHSA-6g7w-8wpp-frhj
    = Solution: Upgrade to >=0.23.5 OR >=0.22.4, <0.23.0 OR >=0.21.11, <0.22.0 (try `cargo update -p rustls`)
    = rustls v0.19.1
      ├── hyper-rustls v0.22.1
      │   └── eventsource-client v0.10.2
      │       └── fuel-core-client v0.28.0
      │           ├── fuels v0.63.1
      │           │   ├── (dev) e2e v0.63.1
      │           │   ├── (dev) fuels-example-codec v0.63.1
      │           │   ├── (dev) fuels-example-contracts v0.63.1
      │           │   ├── (dev) fuels-example-cookbook v0.63.1
      │           │   ├── (dev) fuels-example-debugging v0.63.1
      │           │   ├── (dev) fuels-example-macros v0.63.1
      │           │   ├── (dev) fuels-example-predicates v0.63.1
      │           │   ├── (dev) fuels-example-providers v0.63.1
      │           │   ├── (dev) fuels-example-rust-bindings v0.63.1
      │           │   ├── (dev) fuels-example-types v0.63.1
      │           │   ├── (dev) fuels-example-wallets v0.63.1
      │           │   └── (dev) wasm-tests v0.63.1
      │           ├── fuels-accounts v0.63.1
      │           │   ├── (build) e2e v0.63.1 (*)
      │           │   ├── fuel-core-version v0.63.1
      │           │   ├── fuels v0.63.1 (*)
      │           │   ├── fuels-programs v0.63.1
      │           │   │   └── fuels v0.63.1 (*)
      │           │   └── fuels-test-helpers v0.63.1
      │           │       └── fuels v0.63.1 (*)
      │           ├── fuels-core v0.63.1
      │           │   ├── fuels v0.63.1 (*)
      │           │   ├── fuels-accounts v0.63.1 (*)
      │           │   ├── fuels-programs v0.63.1 (*)
      │           │   ├── fuels-test-helpers v0.63.1 (*)
      │           │   └── (dev) wasm-tests v0.63.1 (*)
      │           └── fuels-test-helpers v0.63.1 (*)
      ├── rustls-native-certs v0.5.0
      │   └── hyper-rustls v0.22.1 (*)
      └── tokio-rustls v0.22.0
          └── hyper-rustls v0.22.1 (*)

error[vulnerability]: webpki: CPU denial of service in certificate path building
    ┌─ /Users/brightone/dev/github.com/FuelLabs/fuels-rs/Cargo.lock:426:1
    │
426 │ webpki 0.21.4 registry+https://github.com/rust-lang/crates.io-index
    │ ------------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2023-0052
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2023-0052
    = When this crate is given a pathological certificate chain to validate, it will
      spend CPU time exponential with the number of candidate certificates at each
      step of path building.

      Both TLS clients and TLS servers that accept client certificate are affected.

      This was previously reported in
      <https://github.com/briansmith/webpki/issues/69> and re-reported recently
      by Luke Malinowski.

      webpki 0.22.1 included a partial fix and webpki 0.22.2 added further fixes.
    = Solution: Upgrade to >=0.22.2 (try `cargo update -p webpki`)
    = webpki v0.21.4
      ├── hyper-rustls v0.22.1
      │   └── eventsource-client v0.10.2
      │       └── fuel-core-client v0.28.0
      │           ├── fuels v0.63.1
      │           │   ├── (dev) e2e v0.63.1
      │           │   ├── (dev) fuels-example-codec v0.63.1
      │           │   ├── (dev) fuels-example-contracts v0.63.1
      │           │   ├── (dev) fuels-example-cookbook v0.63.1
      │           │   ├── (dev) fuels-example-debugging v0.63.1
      │           │   ├── (dev) fuels-example-macros v0.63.1
      │           │   ├── (dev) fuels-example-predicates v0.63.1
      │           │   ├── (dev) fuels-example-providers v0.63.1
      │           │   ├── (dev) fuels-example-rust-bindings v0.63.1
      │           │   ├── (dev) fuels-example-types v0.63.1
      │           │   ├── (dev) fuels-example-wallets v0.63.1
      │           │   └── (dev) wasm-tests v0.63.1
      │           ├── fuels-accounts v0.63.1
      │           │   ├── (build) e2e v0.63.1 (*)
      │           │   ├── fuel-core-version v0.63.1
      │           │   ├── fuels v0.63.1 (*)
      │           │   ├── fuels-programs v0.63.1
      │           │   │   └── fuels v0.63.1 (*)
      │           │   └── fuels-test-helpers v0.63.1
      │           │       └── fuels v0.63.1 (*)
      │           ├── fuels-core v0.63.1
      │           │   ├── fuels v0.63.1 (*)
      │           │   ├── fuels-accounts v0.63.1 (*)
      │           │   ├── fuels-programs v0.63.1 (*)
      │           │   ├── fuels-test-helpers v0.63.1 (*)
      │           │   └── (dev) wasm-tests v0.63.1 (*)
      │           └── fuels-test-helpers v0.63.1 (*)
      ├── rustls v0.19.1
      │   ├── hyper-rustls v0.22.1 (*)
      │   ├── rustls-native-certs v0.5.0
      │   │   └── hyper-rustls v0.22.1 (*)
      │   └── tokio-rustls v0.22.0
      │       └── hyper-rustls v0.22.1 (*)
      └── tokio-rustls v0.22.0 (*)

 advisories FAILED: 2 errors, 0 warnings, 0 notes
```

</details>

- [release notes](https://github.com/launchdarkly/rust-eventsource-client/releases/tag/0.12.2) for `eventsource-client v0.12.2`

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here
