### PR TITLE
Update fuel-vm to v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [#1942](https://github.com/FuelLabs/fuel-core/pull/1942): Sequential relayer's commits.
 - [#1952](https://github.com/FuelLabs/fuel-core/pull/1952): Change tip sorting to ratio between tip and max gas sorting in txpool
+- [#1960](https://github.com/FuelLabs/fuel-core/pull/1960): Update fuel-vm to v0.53.0.
 
 ### Fixed
 - [#1950](https://github.com/FuelLabs/fuel-core/pull/1950): Fix cursor `BlockHeight` encoding in `SortedTXCursor`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ fuel-core-wasm-executor = { version = "0.28.0", path = "./crates/services/upgrad
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.52.0", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.53.0", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"


### PR DESCRIPTION
Updates fuel-vm to 0.53.0

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
