### PR TITLE
Add `creation_instant` as second sort key in tx pool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#1942](https://github.com/FuelLabs/fuel-core/pull/1942): Sequential relayer's commits.
 - [#1952](https://github.com/FuelLabs/fuel-core/pull/1952): Change tip sorting to ratio between tip and max gas sorting in txpool
 - [#1960](https://github.com/FuelLabs/fuel-core/pull/1960): Update fuel-vm to v0.53.0.
+- [#1964](https://github.com/FuelLabs/fuel-core/pull/1964): Add `creation_instant` as second sort key in tx pool
 
 ### Fixed
 - [#1950](https://github.com/FuelLabs/fuel-core/pull/1950): Fix cursor `BlockHeight` encoding in `SortedTXCursor`

--- a/crates/services/txpool/src/containers/tip_per_gas_sort.rs
+++ b/crates/services/txpool/src/containers/tip_per_gas_sort.rs
@@ -58,7 +58,7 @@ impl Ord for RatioGasTipSortKey {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         let cmp = self.tip_per_gas.cmp(&other.tip_per_gas);
         if cmp == cmp::Ordering::Equal {
-            let instant_cmp = self.creation_instant.cmp(&other.creation_instant);
+            let instant_cmp = other.creation_instant.cmp(&self.creation_instant);
             if instant_cmp == cmp::Ordering::Equal {
                 self.tx_id.cmp(&other.tx_id)
             } else {

--- a/crates/services/txpool/src/containers/tip_per_gas_sort.rs
+++ b/crates/services/txpool/src/containers/tip_per_gas_sort.rs
@@ -1,4 +1,5 @@
 use num_rational::Ratio;
+use tokio::time::Instant;
 
 use crate::{
     containers::sort::{
@@ -19,6 +20,7 @@ pub type RatioGasTip = Ratio<Word>;
 #[derive(Clone, Debug)]
 pub struct RatioGasTipSortKey {
     tip_per_gas: RatioGasTip,
+    creation_instant: Instant,
     tx_id: TxId,
 }
 
@@ -28,6 +30,7 @@ impl SortableKey for RatioGasTipSortKey {
     fn new(info: &TxInfo) -> Self {
         Self {
             tip_per_gas: Ratio::new(info.tx().tip(), info.tx().max_gas()),
+            creation_instant: info.created(),
             tx_id: info.tx().id(),
         }
     }
@@ -55,8 +58,14 @@ impl Ord for RatioGasTipSortKey {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         let cmp = self.tip_per_gas.cmp(&other.tip_per_gas);
         if cmp == cmp::Ordering::Equal {
-            return self.tx_id.cmp(&other.tx_id);
+            let instant_cmp = self.creation_instant.cmp(&other.creation_instant);
+            if instant_cmp == cmp::Ordering::Equal {
+                self.tx_id.cmp(&other.tx_id)
+            } else {
+                instant_cmp
+            }
+        } else {
+            cmp
         }
-        cmp
     }
 }

--- a/crates/services/txpool/src/txpool/tests.rs
+++ b/crates/services/txpool/src/txpool/tests.rs
@@ -956,6 +956,79 @@ async fn sorted_out_tx_profitable_ratios() {
 }
 
 #[tokio::test]
+async fn sorted_out_tx_by_creation_instant() {
+    let mut context = TextContext::default();
+
+    let (_, gas_coin) = context.setup_coin();
+    let tx1 = TransactionBuilder::script(vec![], vec![])
+        .tip(4)
+        .max_fee_limit(4)
+        .script_gas_limit(GAS_LIMIT)
+        .add_input(gas_coin)
+        .finalize_as_transaction();
+
+    let (_, gas_coin) = context.setup_coin();
+    let tx2 = TransactionBuilder::script(vec![], vec![])
+        .tip(4)
+        .max_fee_limit(4)
+        .script_gas_limit(GAS_LIMIT)
+        .add_input(gas_coin)
+        .finalize_as_transaction();
+
+    let (_, gas_coin) = context.setup_coin();
+    let tx3 = TransactionBuilder::script(vec![], vec![])
+        .tip(4)
+        .max_fee_limit(4)
+        .script_gas_limit(GAS_LIMIT)
+        .add_input(gas_coin)
+        .finalize_as_transaction();
+    
+    let (_, gas_coin) = context.setup_coin();
+    let tx4 = TransactionBuilder::script(vec![], vec![])
+        .tip(4)
+        .max_fee_limit(4)
+        .script_gas_limit(GAS_LIMIT)
+        .add_input(gas_coin)
+        .finalize_as_transaction();
+
+    let tx1_id = tx1.id(&ChainId::default());
+    let tx2_id = tx2.id(&ChainId::default());
+    let tx3_id = tx3.id(&ChainId::default());
+    let tx4_id = tx4.id(&ChainId::default());
+
+    let mut txpool = context.build();
+    let tx1 = check_unwrap_tx(tx1, &txpool.config).await;
+    let tx2 = check_unwrap_tx(tx2, &txpool.config).await;
+    let tx3 = check_unwrap_tx(tx3, &txpool.config).await;
+    let tx4 = check_unwrap_tx(tx4, &txpool.config).await;
+
+    txpool
+        .insert_single(tx1)
+        .expect("Tx1 should be Ok, got Err");
+    txpool
+        .insert_single(tx2)
+        .expect("Tx2 should be Ok, got Err");
+    txpool
+        .insert_single(tx3)
+        .expect("Tx4 should be Ok, got Err");
+    txpool
+        .insert_single(tx4)
+        .expect("Tx4 should be Ok, got Err");
+
+    let txs = txpool.sorted_includable().collect::<Vec<_>>();
+
+    // This order doesn't match the lexicographical order of the tx ids
+    // and so it verifies that the txs are sorted by creation instant
+    // The newest tx should be first
+    assert_eq!(txs.len(), 4, "Should have 3 txs");
+    assert_eq!(txs[0].id(), tx4_id, "First should be tx4");
+    assert_eq!(txs[1].id(), tx3_id, "Second should be tx3");
+    assert_eq!(txs[2].id(), tx2_id, "Third should be tx2");
+    assert_eq!(txs[3].id(), tx1_id, "Fourth should be tx1");
+
+}
+
+#[tokio::test]
 async fn find_dependent_tx1_tx2() {
     let mut context = TextContext::default();
 

--- a/crates/services/txpool/src/txpool/tests.rs
+++ b/crates/services/txpool/src/txpool/tests.rs
@@ -982,7 +982,7 @@ async fn sorted_out_tx_by_creation_instant() {
         .script_gas_limit(GAS_LIMIT)
         .add_input(gas_coin)
         .finalize_as_transaction();
-    
+
     let (_, gas_coin) = context.setup_coin();
     let tx4 = TransactionBuilder::script(vec![], vec![])
         .tip(4)
@@ -1025,7 +1025,6 @@ async fn sorted_out_tx_by_creation_instant() {
     assert_eq!(txs[1].id(), tx3_id, "Second should be tx3");
     assert_eq!(txs[2].id(), tx2_id, "Third should be tx2");
     assert_eq!(txs[3].id(), tx1_id, "Fourth should be tx1");
-
 }
 
 #[tokio::test]

--- a/crates/services/txpool/src/txpool/tests.rs
+++ b/crates/services/txpool/src/txpool/tests.rs
@@ -1020,11 +1020,11 @@ async fn sorted_out_tx_by_creation_instant() {
     // This order doesn't match the lexicographical order of the tx ids
     // and so it verifies that the txs are sorted by creation instant
     // The newest tx should be first
-    assert_eq!(txs.len(), 4, "Should have 3 txs");
-    assert_eq!(txs[0].id(), tx4_id, "First should be tx4");
-    assert_eq!(txs[1].id(), tx3_id, "Second should be tx3");
-    assert_eq!(txs[2].id(), tx2_id, "Third should be tx2");
-    assert_eq!(txs[3].id(), tx1_id, "Fourth should be tx1");
+    assert_eq!(txs.len(), 4, "Should have 4 txs");
+    assert_eq!(txs[0].id(), tx1_id, "First should be tx1");
+    assert_eq!(txs[1].id(), tx2_id, "Second should be tx2");
+    assert_eq!(txs[2].id(), tx3_id, "Third should be tx3");
+    assert_eq!(txs[3].id(), tx4_id, "Fourth should be tx4");
 }
 
 #[tokio::test]


### PR DESCRIPTION
https://github.com/FuelLabs/fuel-core/issues/1739

Add creation instant as second sort key in tx pool.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
