### PR TITLE
Updated VM initialization benchmark to include many inputs and outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- [#1973](https://github.com/FuelLabs/fuel-core/pull/1973): Updated VM initialization benchmark to include many inputs and outputs.
+
 ## [Version 0.29.0]
 
 ### Added


### PR DESCRIPTION
Covers new behavior from https://github.com/FuelLabs/fuel-vm/pull/770

### Before requesting review
- [x] I have reviewed the code myself