### PR TITLE
Describe why a message proof couldn't be processed

### DIFF
--- a/crates/fuel-core/src/query/message/test.rs
+++ b/crates/fuel-core/src/query/message/test.rs
@@ -208,14 +208,14 @@ async fn can_build_message_proof() {
 
     let data: Box<dyn MessageProofData> = Box::new(data);
 
-    let proof = message_proof(
+    let Ok(MessageProofEvaluation::Success(proof)) = message_proof(
         data.deref(),
         transaction_id,
         nonce.to_owned(),
         *commit_block.header().height(),
-    )
-    .unwrap()
-    .unwrap();
+    ) else {
+        panic!();
+    };
     assert_eq!(
         proof.message_block_header.message_outbox_root,
         message_block.header().message_outbox_root

--- a/crates/types/src/entities/relayer/message.rs
+++ b/crates/types/src/entities/relayer/message.rs
@@ -272,6 +272,30 @@ impl MessageProof {
     }
 }
 
+/// The result provided by the processing of a message proof.
+pub enum MessageProofEvaluation {
+    /// Successful processing.
+    Success(MessageProof),
+    /// Unavailable message proof.
+    Unavailable(MessageProofUnavailability),
+}
+
+/// Describes the reasons why a message couldn't be processed.
+pub enum MessageProofUnavailability {
+    /// Couldn't look beyond the genesis block.
+    InvalidBlockHeaderHeight,
+    /// It was not possible to assert the presence and integrity of the message data.
+    InvalidMsgData,
+    /// Message ID is not related to any receipts.
+    ReceiptMismatch,
+    /// Block header related to the commit height is not present in the database.
+    UnavailableCommitBlockHeader,
+    /// Block header related to the message is not present in the database.
+    UnavailableMsgBlockHeader,
+    /// Transaction is not ready for processing.
+    UnavailableTx,
+}
+
 /// Represents the status of a message
 pub struct MessageStatus {
     /// The message state


### PR DESCRIPTION
Work towards #1394 without changing the public GraphQL API to avoid further breakage. Feel free to indicate if such thing is desirable.

* Changes the return type of `message_proof` from `StorageResult<Option<MessageProof>>` to `StorageResult<MessageProofEvaluation>`.

cc @xgreenx