### PR TITLE
Add syncronization for Gas Price Database and On Chain Database on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
         - "gas-price-threshold-percent" - the threshold percent for determining if the gas price will be increase or decreased
     And the following CLI flags are serving a new purpose
         - "min-gas-price" - the minimum gas price that the gas price algorithm will return
+- [2041](https://github.com/FuelLabs/fuel-core/pull/2041): Add code for startup of the gas price algorithm updater so 
+    the gas price db on startup is always in sync with the on chain db
+
 ## [Version 0.31.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,7 +3053,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,6 +3300,7 @@ dependencies = [
  "itertools 0.12.1",
  "pretty_assertions",
  "primitive-types",
+ "proptest",
  "rand",
  "reqwest",
  "rstest",

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -236,7 +236,7 @@ pub trait P2pPort: Send + Sync {
 #[async_trait::async_trait]
 pub trait GasPriceEstimate: Send + Sync {
     /// The worst case scenario for gas price at a given horizon
-    async fn worst_case_gas_price(&self, height: BlockHeight) -> u64;
+    async fn worst_case_gas_price(&self, height: BlockHeight) -> Option<u64>;
 }
 
 /// Trait for getting VM memory.

--- a/crates/fuel-core/src/schema/gas_price.rs
+++ b/crates/fuel-core/src/schema/gas_price.rs
@@ -105,7 +105,10 @@ impl EstimateGasPriceQuery {
         let gas_price_provider = ctx.data_unchecked::<GasPriceProvider>();
         let gas_price = gas_price_provider
             .worst_case_gas_price(target_block.into())
-            .await;
+            .await
+            .ok_or(async_graphql::Error::new(format!(
+                "Failed to estimate gas price for block, algorithm not yet set: {target_block:?}"
+            )))?;
 
         Ok(EstimateGasPrice {
             gas_price: gas_price.into(),

--- a/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests.rs
+++ b/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests.rs
@@ -15,7 +15,7 @@ fn build_provider<A>(algorithm: A) -> FuelGasPriceProvider<A>
 where
     A: Send + Sync,
 {
-    let algorithm = SharedGasPriceAlgo::new(algorithm);
+    let algorithm = SharedGasPriceAlgo::new_with_algorithm(algorithm);
     FuelGasPriceProvider::new(algorithm)
 }
 

--- a/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests/graph_ql_gas_price_estimate_tests.rs
+++ b/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests/graph_ql_gas_price_estimate_tests.rs
@@ -11,7 +11,10 @@ async fn estimate_gas_price__happy_path() {
 
     // when
     let expected_price = algo.worst_case_gas_price(next_height);
-    let actual_price = gas_price_provider.worst_case_gas_price(next_height).await;
+    let actual_price = gas_price_provider
+        .worst_case_gas_price(next_height)
+        .await
+        .unwrap();
 
     // then
     assert_eq!(expected_price, actual_price);

--- a/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests/producer_gas_price_tests.rs
+++ b/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests/producer_gas_price_tests.rs
@@ -13,7 +13,7 @@ async fn gas_price__if_requested_block_height_is_latest_return_gas_price() {
 
     // when
     let expected_price = algo.next_gas_price();
-    let actual_price = gas_price_provider.next_gas_price().await;
+    let actual_price = gas_price_provider.next_gas_price().await.unwrap();
 
     // then
     assert_eq!(expected_price, actual_price);

--- a/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests/tx_pool_gas_price_tests.rs
+++ b/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests/tx_pool_gas_price_tests.rs
@@ -13,7 +13,7 @@ async fn gas_price__if_requested_block_height_is_latest_return_gas_price() {
 
     // when
     let expected_price = algo.next_gas_price();
-    let actual_price = gas_price_provider.next_gas_price().await;
+    let actual_price = gas_price_provider.next_gas_price().await.unwrap();
 
     // then
     assert_eq!(expected_price, actual_price);

--- a/crates/fuel-core/src/service/adapters/graphql_api.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api.rs
@@ -165,8 +165,8 @@ impl worker::TxPool for TxPoolAdapter {
 
 #[async_trait::async_trait]
 impl GasPriceEstimate for StaticGasPrice {
-    async fn worst_case_gas_price(&self, _height: BlockHeight) -> u64 {
-        self.gas_price
+    async fn worst_case_gas_price(&self, _height: BlockHeight) -> Option<u64> {
+        Some(self.gas_price)
     }
 }
 

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::let_unit_value)]
+
 use super::{
     adapters::P2PAdapter,
     genesis::create_genesis_block,
@@ -7,14 +8,7 @@ use super::{
 use crate::relayer::Config as RelayerConfig;
 use crate::{
     combined_database::CombinedDatabase,
-    database::{
-        database_description::{
-            gas_price::GasPriceDatabase,
-            on_chain::OnChain,
-        },
-        Database,
-        RegularStage,
-    },
+    database::Database,
     fuel_core_graphql_api,
     fuel_core_graphql_api::Config as GraphQLConfig,
     schema::build_schema,
@@ -34,6 +28,7 @@ use crate::{
             TxPoolAdapter,
             VerifierAdapter,
         },
+        sub_services::algorithm_updater::get_synced_algorithm_updater,
         Config,
         SharedState,
         SubServices,
@@ -48,34 +43,17 @@ use fuel_core_gas_price_service::fuel_gas_price_updater::{
     UpdaterMetadata,
     V0Metadata,
 };
-use fuel_core_gas_price_service::fuel_gas_price_updater::{
-    fuel_core_storage_adapter::GasPriceSettingsProvider,
-    AlgorithmUpdater,
-    MetadataStorage,
-};
 use fuel_core_poa::Trigger;
-use fuel_core_services::stream::BoxStream;
 use fuel_core_storage::{
-    structured_storage::StructuredStorage,
-    tables::{
-        FuelBlocks,
-        Transactions,
-    },
-    transactional::{
-        AtomicView,
-        HistoricalView,
-    },
-    StorageAsRef,
+    self,
+    transactional::AtomicView,
 };
 #[cfg(feature = "relayer")]
 use fuel_core_types::blockchain::primitives::DaBlockHeight;
-use fuel_core_types::{
-    fuel_tx::field::MintAmount,
-    fuel_types::BlockHeight,
-    services::block_importer::SharedImportResult,
-};
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+mod algorithm_updater;
 
 pub type PoAService =
     fuel_core_poa::Service<TxPoolAdapter, BlockProducerAdapter, BlockImporterAdapter>;
@@ -204,20 +182,10 @@ pub fn init_sub_services(
     #[cfg(not(feature = "p2p"))]
     let p2p_adapter = P2PAdapter::new();
 
-    // let default_metadata = UpdaterMetadata::V0(V0Metadata {
-    //     new_exec_price: config.starting_gas_price,
-    //     min_exec_gas_price: config.min_gas_price,
-    //     exec_gas_price_change_percent: config.gas_price_change_percent,
-    //     l2_block_height: last_height.into(),
-    //     l2_block_fullness_threshold_percent: config.gas_price_threshold_percent,
-    // });
     let genesis_block_height = *genesis_block.header().height();
     let settings = consensus_parameters_provider.clone();
     let block_stream = importer_adapter.events_shared_result();
 
-    // let metadata_storage = StructuredStorage::new(database.gas_price().clone());
-    // let update_algo =
-    //     FuelGasPriceUpdater::init(updater_metadata, l2_block_source, metadata_storage)?;
     let update_algo = get_synced_algorithm_updater(
         config,
         genesis_block_height,
@@ -371,98 +339,4 @@ pub fn init_sub_services(
     services.push(Box::new(graphql_worker));
 
     Ok((services, shared))
-}
-
-fn get_synced_algorithm_updater(
-    config: &Config,
-    genesis_block_height: BlockHeight,
-    settings: ConsensusParametersProvider,
-    block_stream: BoxStream<SharedImportResult>,
-    gas_price_db: Database<GasPriceDatabase, RegularStage<GasPriceDatabase>>,
-    on_chain_db: Database<OnChain, RegularStage<OnChain>>,
-) -> anyhow::Result<
-    FuelGasPriceUpdater<
-        FuelL2BlockSource<ConsensusParametersProvider>,
-        StructuredStorage<Database<GasPriceDatabase, RegularStage<GasPriceDatabase>>>,
-    >,
-> {
-    // if gas price metadata height is behind the latest block height,
-    // we should create an updater and manually update the gas price by adding the missing l2 blocks
-    // from the on_chain database
-    let metadata_height: u32 = gas_price_db
-        .latest_height()?
-        .unwrap_or(genesis_block_height)
-        .into();
-    let latest_block_height: u32 = on_chain_db
-        .latest_height()?
-        .unwrap_or(genesis_block_height)
-        .into();
-    let default_metadata = UpdaterMetadata::V0(V0Metadata {
-        new_exec_price: config.starting_gas_price,
-        min_exec_gas_price: config.min_gas_price,
-        exec_gas_price_change_percent: config.gas_price_change_percent,
-        l2_block_height: genesis_block_height.into(),
-        l2_block_fullness_threshold_percent: config.gas_price_threshold_percent,
-    });
-    if metadata_height < latest_block_height {
-        let mut metadata_storage = StructuredStorage::new(gas_price_db);
-        let metadata = metadata_storage
-            .get_metadata(&metadata_height.into())?
-            .unwrap_or(default_metadata);
-        let mut inner: AlgorithmUpdater = metadata.into();
-        let AlgorithmUpdater::V0(ref mut updater) = &mut inner;
-        for height in (metadata_height + 1)..=latest_block_height {
-            if BlockHeight::from(height) == genesis_block_height {
-                // do nothing
-            } else {
-                let view = on_chain_db.view_at(&height.into())?;
-                let block = view
-                    .storage::<FuelBlocks>()
-                    .get(&height.into())?
-                    .ok_or(anyhow::anyhow!("Expected block to exist"))?;
-                let last_tx_id = block.transactions().last().ok_or(anyhow::anyhow!(
-                    "Expected block to have at least one transaction"
-                ))?;
-                let param_version = block.header().consensus_parameters_version;
-                let params = settings.settings(&param_version)?;
-                let mint = view
-                    .storage::<Transactions>()
-                    .get(&last_tx_id)?
-                    .ok_or(anyhow::anyhow!("Expected tx to exist for id: {last_tx_id}"))?
-                    .as_mint()
-                    .ok_or(anyhow::anyhow!("Expected tx to be a mint"))?
-                    .to_owned();
-                let block_gas_used = mint.mint_amount();
-                let block_gas_capacity = params.block_gas_limit.try_into()?;
-                updater.update_l2_block_data(
-                    height,
-                    *block_gas_used,
-                    block_gas_capacity,
-                )?;
-            }
-        }
-        let l2_block_source =
-            FuelL2BlockSource::new(genesis_block_height, settings, block_stream);
-        metadata_storage.set_metadata(inner.clone().into())?;
-        Ok(FuelGasPriceUpdater::new(
-            inner,
-            l2_block_source,
-            metadata_storage,
-        ))
-    } else if metadata_height > latest_block_height {
-        todo!()
-    } else {
-        let metadata_storage = StructuredStorage::new(gas_price_db);
-        let metadata = metadata_storage
-            .get_metadata(&metadata_height.into())
-            .map_err(|e| anyhow::anyhow!("Expected metadata to exist, got error: {e:?}"))?
-            .unwrap_or(default_metadata);
-        let l2_block_source =
-            FuelL2BlockSource::new(genesis_block_height, settings, block_stream);
-        Ok(FuelGasPriceUpdater::new(
-            metadata.into(),
-            l2_block_source,
-            metadata_storage,
-        ))
-    }
 }

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -28,7 +28,7 @@ use crate::{
             TxPoolAdapter,
             VerifierAdapter,
         },
-        sub_services::algorithm_updater::get_synced_algorithm_updater,
+        sub_services::algorithm_updater::get_synced_gas_price_updater,
         Config,
         SharedState,
         SubServices,
@@ -186,7 +186,7 @@ pub fn init_sub_services(
     let settings = consensus_parameters_provider.clone();
     let block_stream = importer_adapter.events_shared_result();
 
-    let update_algo = get_synced_algorithm_updater(
+    let update_algo = get_synced_gas_price_updater(
         config,
         genesis_block_height,
         settings,

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -189,16 +189,6 @@ pub fn init_sub_services(
     let settings = consensus_parameters_provider.clone();
     let block_stream = importer_adapter.events_shared_result();
 
-    // let update_algo = get_synced_gas_price_updater(
-    //     config,
-    //     genesis_block_height,
-    //     settings,
-    //     block_stream,
-    //     database.gas_price().clone(),
-    //     last_height,
-    // )?;
-    // let gas_price_service =
-    //     fuel_core_gas_price_service::new_service(last_height, update_algo)?;
     let gas_price_init = algorithm_updater::InitializeTask::new(
         config.clone(),
         genesis_block_height,

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -1,0 +1,176 @@
+use crate::{
+    database::{
+        database_description::{
+            gas_price::GasPriceDatabase,
+            on_chain::OnChain,
+        },
+        Database,
+        RegularStage,
+    },
+    service::{
+        adapters::ConsensusParametersProvider,
+        Config,
+    },
+};
+
+use fuel_core_gas_price_service::fuel_gas_price_updater::{
+    fuel_core_storage_adapter::{
+        FuelL2BlockSource,
+        GasPriceSettingsProvider,
+    },
+    AlgorithmUpdater,
+    FuelGasPriceUpdater,
+    MetadataStorage,
+    UpdaterMetadata,
+    V0Metadata,
+};
+use fuel_core_services::stream::BoxStream;
+use fuel_core_storage::{
+    structured_storage::StructuredStorage,
+    tables::{
+        FuelBlocks,
+        Transactions,
+    },
+    transactional::HistoricalView,
+    StorageAsRef,
+};
+use fuel_core_types::{
+    fuel_tx::field::MintAmount,
+    fuel_types::BlockHeight,
+    services::block_importer::SharedImportResult,
+};
+use std::cmp::Ordering;
+
+pub fn get_synced_algorithm_updater(
+    config: &Config,
+    genesis_block_height: BlockHeight,
+    settings: ConsensusParametersProvider,
+    block_stream: BoxStream<SharedImportResult>,
+    gas_price_db: Database<GasPriceDatabase, RegularStage<GasPriceDatabase>>,
+    on_chain_db: Database<OnChain, RegularStage<OnChain>>,
+) -> anyhow::Result<
+    FuelGasPriceUpdater<
+        FuelL2BlockSource<ConsensusParametersProvider>,
+        StructuredStorage<Database<GasPriceDatabase, RegularStage<GasPriceDatabase>>>,
+    >,
+> {
+    let metadata_height: u32 = gas_price_db
+        .latest_height()?
+        .unwrap_or(genesis_block_height)
+        .into();
+    let latest_block_height: u32 = on_chain_db
+        .latest_height()?
+        .unwrap_or(genesis_block_height)
+        .into();
+    let default_metadata = UpdaterMetadata::V0(V0Metadata {
+        new_exec_price: config.starting_gas_price,
+        min_exec_gas_price: config.min_gas_price,
+        exec_gas_price_change_percent: config.gas_price_change_percent,
+        l2_block_height: genesis_block_height.into(),
+        l2_block_fullness_threshold_percent: config.gas_price_threshold_percent,
+    });
+
+    match metadata_height.cmp(&latest_block_height) {
+        Ordering::Less => sync_metadata_storage_with_on_chain_storage(
+            genesis_block_height,
+            settings,
+            block_stream,
+            gas_price_db,
+            on_chain_db,
+            metadata_height,
+            latest_block_height,
+            default_metadata,
+        ),
+        Ordering::Equal => restore_gas_price_updater(
+            genesis_block_height,
+            settings,
+            block_stream,
+            gas_price_db,
+            metadata_height,
+            default_metadata,
+        ),
+        Ordering::Greater => {
+            todo!()
+        }
+    }
+}
+
+fn sync_metadata_storage_with_on_chain_storage(
+    genesis_block_height: BlockHeight,
+    settings: ConsensusParametersProvider,
+    block_stream: BoxStream<SharedImportResult>,
+    gas_price_db: Database<GasPriceDatabase, RegularStage<GasPriceDatabase>>,
+    on_chain_db: Database<OnChain, RegularStage<OnChain>>,
+    metadata_height: u32,
+    latest_block_height: u32,
+    default_metadata: UpdaterMetadata,
+) -> anyhow::Result<
+    FuelGasPriceUpdater<
+        FuelL2BlockSource<ConsensusParametersProvider>,
+        StructuredStorage<Database<GasPriceDatabase, RegularStage<GasPriceDatabase>>>,
+    >,
+> {
+    let mut metadata_storage = StructuredStorage::new(gas_price_db);
+    let metadata = metadata_storage
+        .get_metadata(&metadata_height.into())?
+        .unwrap_or(default_metadata);
+    let mut inner: AlgorithmUpdater = metadata.into();
+    let AlgorithmUpdater::V0(ref mut updater) = &mut inner;
+    for height in (metadata_height + 1)..=latest_block_height {
+        let view = on_chain_db.view_at(&height.into())?;
+        let block = view
+            .storage::<FuelBlocks>()
+            .get(&height.into())?
+            .ok_or(anyhow::anyhow!("Expected block to exist"))?;
+        let last_tx_id = block.transactions().last().ok_or(anyhow::anyhow!(
+            "Expected block to have at least one transaction"
+        ))?;
+        let param_version = block.header().consensus_parameters_version;
+        let params = settings.settings(&param_version)?;
+        let mint = view
+            .storage::<Transactions>()
+            .get(&last_tx_id)?
+            .ok_or(anyhow::anyhow!("Expected tx to exist for id: {last_tx_id}"))?
+            .as_mint()
+            .ok_or(anyhow::anyhow!("Expected tx to be a mint"))?
+            .to_owned();
+        let block_gas_used = mint.mint_amount();
+        let block_gas_capacity = params.block_gas_limit.try_into()?;
+        updater.update_l2_block_data(height, *block_gas_used, block_gas_capacity)?;
+    }
+    let l2_block_source =
+        FuelL2BlockSource::new(genesis_block_height, settings, block_stream);
+    metadata_storage.set_metadata(inner.clone().into())?;
+    Ok(FuelGasPriceUpdater::new(
+        inner,
+        l2_block_source,
+        metadata_storage,
+    ))
+}
+
+fn restore_gas_price_updater(
+    genesis_block_height: BlockHeight,
+    settings: ConsensusParametersProvider,
+    block_stream: BoxStream<SharedImportResult>,
+    gas_price_db: Database<GasPriceDatabase, RegularStage<GasPriceDatabase>>,
+    metadata_height: u32,
+    default_metadata: UpdaterMetadata,
+) -> anyhow::Result<
+    FuelGasPriceUpdater<
+        FuelL2BlockSource<ConsensusParametersProvider>,
+        StructuredStorage<Database<GasPriceDatabase, RegularStage<GasPriceDatabase>>>,
+    >,
+> {
+    let metadata_storage = StructuredStorage::new(gas_price_db);
+    let metadata = metadata_storage
+        .get_metadata(&metadata_height.into())
+        .map_err(|e| anyhow::anyhow!("Expected metadata to exist, got error: {e:?}"))?
+        .unwrap_or(default_metadata);
+    let l2_block_source =
+        FuelL2BlockSource::new(genesis_block_height, settings, block_stream);
+    Ok(FuelGasPriceUpdater::new(
+        metadata.into(),
+        l2_block_source,
+        metadata_storage,
+    ))
+}

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -72,6 +72,7 @@ pub fn get_synced_gas_price_updater(
         l2_block_fullness_threshold_percent: config.gas_price_threshold_percent,
     });
     if BlockHeight::from(latest_block_height) == genesis_block_height {
+        revert_gas_price_db_to_height(&mut gas_price_db, latest_block_height.into())?;
         let metadata_storage = StructuredStorage::new(gas_price_db);
         let l2_block_source =
             FuelL2BlockSource::new(genesis_block_height, settings, block_stream);
@@ -126,11 +127,11 @@ fn sync_metadata_storage_with_on_chain_storage(
     on_chain_db: Database<OnChain, RegularStage<OnChain>>,
     metadata_height: u32,
     latest_block_height: u32,
-    default_metadata: UpdaterMetadata,
+    genesis_metadata: UpdaterMetadata,
     genesis_block_height: u32,
 ) -> anyhow::Result<()> {
     let metadata = if metadata_height == genesis_block_height {
-        default_metadata
+        genesis_metadata
     } else {
         metadata_storage
             .get_metadata(&metadata_height.into())?

--- a/crates/services/gas_price_service/Cargo.toml
+++ b/crates/services/gas_price_service/Cargo.toml
@@ -30,4 +30,3 @@ tracing = { workspace = true }
 fuel-core-services = { workspace = true, features = ["test-helpers"] }
 fuel-core-storage = { workspace = true, features = ["test-helpers"] }
 fuel-core-types = { path = "./../../types", features = ["test-helpers"] }
-tracing-subscriber = { workspace = true }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -186,23 +186,25 @@ impl<L2, Metadata> FuelGasPriceUpdater<L2, Metadata>
 where
     Metadata: MetadataStorage,
 {
-    // pub fn init(
-    //     init_metadata: UpdaterMetadata,
-    //     l2_block_source: L2,
-    //     metadata_storage: Metadata,
-    // ) -> Result<Self> {
-    //     let target_block_height = init_metadata.l2_block_height();
-    //     let inner = metadata_storage
-    //         .get_metadata(&target_block_height)?
-    //         .unwrap_or(init_metadata)
-    //         .into();
-    //     let updater = Self {
-    //         inner,
-    //         l2_block_source,
-    //         metadata_storage,
-    //     };
-    //     Ok(updater)
-    // }
+    pub fn init(
+        target_block_height: BlockHeight,
+        l2_block_source: L2,
+        metadata_storage: Metadata,
+    ) -> Result<Self> {
+        let inner = metadata_storage
+            .get_metadata(&target_block_height)?
+            .ok_or(Error::CouldNotInitUpdater(anyhow::anyhow!(
+                "No metadata found for block height: {:?}",
+                target_block_height
+            )))?
+            .into();
+        let updater = Self {
+            inner,
+            l2_block_source,
+            metadata_storage,
+        };
+        Ok(updater)
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -151,7 +151,7 @@ pub struct V0Metadata {
     /// The Percentage the execution gas price will change in a single block, either increase or decrease
     /// based on the fullness of the last L2 block
     pub exec_gas_price_change_percent: u64,
-    /// The height of the next L2 block
+    /// The height for which the `new_exec_price` is calculated, which should be the _next_ block
     pub l2_block_height: u32,
     /// The threshold of gas usage above and below which the gas price will increase or decrease
     /// This is a percentage of the total capacity of the L2 block
@@ -186,23 +186,23 @@ impl<L2, Metadata> FuelGasPriceUpdater<L2, Metadata>
 where
     Metadata: MetadataStorage,
 {
-    pub fn init(
-        init_metadata: UpdaterMetadata,
-        l2_block_source: L2,
-        metadata_storage: Metadata,
-    ) -> Result<Self> {
-        let target_block_height = init_metadata.l2_block_height();
-        let inner = metadata_storage
-            .get_metadata(&target_block_height)?
-            .unwrap_or(init_metadata)
-            .into();
-        let updater = Self {
-            inner,
-            l2_block_source,
-            metadata_storage,
-        };
-        Ok(updater)
-    }
+    // pub fn init(
+    //     init_metadata: UpdaterMetadata,
+    //     l2_block_source: L2,
+    //     metadata_storage: Metadata,
+    // ) -> Result<Self> {
+    //     let target_block_height = init_metadata.l2_block_height();
+    //     let inner = metadata_storage
+    //         .get_metadata(&target_block_height)?
+    //         .unwrap_or(init_metadata)
+    //         .into();
+    //     let updater = Self {
+    //         inner,
+    //         l2_block_source,
+    //         metadata_storage,
+    //     };
+    //     Ok(updater)
+    // }
 }
 
 #[async_trait::async_trait]

--- a/crates/services/gas_price_service/src/lib.rs
+++ b/crates/services/gas_price_service/src/lib.rs
@@ -90,7 +90,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct SharedGasPriceAlgo<A>(Arc<RwLock<Option<A>>>);
 
 impl<A> Clone for SharedGasPriceAlgo<A> {

--- a/crates/services/gas_price_service/src/lib.rs
+++ b/crates/services/gas_price_service/src/lib.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use fuel_core_services::{
     RunnableService,
     RunnableTask,
-    ServiceRunner,
     StateWatcher,
 };
 use fuel_core_types::fuel_types::BlockHeight;
@@ -19,17 +18,18 @@ pub mod static_updater;
 
 pub mod fuel_gas_price_updater;
 
-pub fn new_service<A, U>(
-    current_fuel_block_height: BlockHeight,
-    update_algo: U,
-) -> anyhow::Result<ServiceRunner<GasPriceService<A, U>>>
-where
-    U: UpdateAlgorithm<Algorithm = A> + Send + Sync,
-    A: Send + Sync,
-{
-    let service = GasPriceService::new(current_fuel_block_height, update_algo);
-    Ok(ServiceRunner::new(service))
-}
+// pub fn new_service<A, U>(
+//     current_fuel_block_height: BlockHeight,
+//     update_algo: U,
+// ) -> anyhow::Result<ServiceRunner<GasPriceService<A, U>>>
+// where
+//     U: UpdateAlgorithm<Algorithm = A> + Send + Sync,
+//     A: Send + Sync,
+// {
+//     let shared_algo
+//     let service = GasPriceService::new(current_fuel_block_height, update_algo, SharedGasPriceAlgo::new(update_algo.start(current_fuel_block_height));
+//     Ok(ServiceRunner::new(service))
+// }
 
 /// The service that updates the gas price algorithm.
 pub struct GasPriceService<A, U> {
@@ -44,11 +44,15 @@ where
     U: UpdateAlgorithm<Algorithm = A>,
     A: Send + Sync,
 {
-    pub fn new(starting_block_height: BlockHeight, update_algorithm: U) -> Self {
+    pub async fn new(
+        starting_block_height: BlockHeight,
+        update_algorithm: U,
+        mut shared_algo: SharedGasPriceAlgo<A>,
+    ) -> Self {
         let algorithm = update_algorithm.start(starting_block_height);
-        let next_block_algorithm = SharedGasPriceAlgo::new(algorithm);
+        shared_algo.update(algorithm).await;
         Self {
-            next_block_algorithm,
+            next_block_algorithm: shared_algo,
             update_algorithm,
         }
     }
@@ -87,7 +91,7 @@ where
 }
 
 #[derive(Debug)]
-pub struct SharedGasPriceAlgo<A>(Arc<RwLock<A>>);
+pub struct SharedGasPriceAlgo<A>(Arc<RwLock<Option<A>>>);
 
 impl<A> Clone for SharedGasPriceAlgo<A> {
     fn clone(&self) -> Self {
@@ -99,12 +103,17 @@ impl<A> SharedGasPriceAlgo<A>
 where
     A: Send + Sync,
 {
-    pub fn new(algo: A) -> Self {
-        Self(Arc::new(RwLock::new(algo)))
+    pub fn new() -> Self {
+        Self(Arc::new(RwLock::new(None)))
     }
+
+    pub fn new_with_algorithm(algorithm: A) -> Self {
+        Self(Arc::new(RwLock::new(Some(algorithm))))
+    }
+
     pub async fn update(&mut self, new_algo: A) {
         let mut write_lock = self.0.write().await;
-        *write_lock = new_algo;
+        *write_lock = Some(new_algo);
     }
 }
 
@@ -112,12 +121,16 @@ impl<A> SharedGasPriceAlgo<A>
 where
     A: GasPriceAlgorithm + Send + Sync,
 {
-    pub async fn next_gas_price(&self) -> u64 {
-        self.0.read().await.next_gas_price()
+    pub async fn next_gas_price(&self) -> Option<u64> {
+        self.0.read().await.as_ref().map(|a| a.next_gas_price())
     }
 
-    pub async fn worst_case_gas_price(&self, block_height: BlockHeight) -> u64 {
-        self.0.read().await.worst_case_gas_price(block_height)
+    pub async fn worst_case_gas_price(&self, block_height: BlockHeight) -> Option<u64> {
+        self.0
+            .read()
+            .await
+            .as_ref()
+            .map(|a| a.worst_case_gas_price(block_height))
     }
 }
 
@@ -181,6 +194,7 @@ mod tests {
     use crate::{
         GasPriceAlgorithm,
         GasPriceService,
+        SharedGasPriceAlgo,
         UpdateAlgorithm,
     };
     use fuel_core_services::{
@@ -233,7 +247,8 @@ mod tests {
             start: TestAlgorithm { price: 0 },
             price_source: price_receiver,
         };
-        let service = GasPriceService::new(0.into(), updater);
+        let shared_algo = SharedGasPriceAlgo::new();
+        let service = GasPriceService::new(0.into(), updater, shared_algo).await;
         let watcher = StateWatcher::started();
         let read_algo = service.next_block_algorithm();
         let task = service.into_task(&watcher, ()).await.unwrap();
@@ -246,7 +261,7 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
         // then
-        let actual_price = read_algo.next_gas_price().await;
+        let actual_price = read_algo.next_gas_price().await.unwrap();
         assert_eq!(expected_price, actual_price);
     }
 }

--- a/crates/services/gas_price_service/src/lib.rs
+++ b/crates/services/gas_price_service/src/lib.rs
@@ -227,8 +227,6 @@ mod tests {
     }
     #[tokio::test]
     async fn run__updates_gas_price() {
-        let _ = tracing_subscriber::fmt::try_init();
-
         // given
         let (price_sender, price_receiver) = mpsc::channel(1);
         let updater = TestAlgorithmUpdater {

--- a/crates/services/gas_price_service/src/lib.rs
+++ b/crates/services/gas_price_service/src/lib.rs
@@ -18,19 +18,6 @@ pub mod static_updater;
 
 pub mod fuel_gas_price_updater;
 
-// pub fn new_service<A, U>(
-//     current_fuel_block_height: BlockHeight,
-//     update_algo: U,
-// ) -> anyhow::Result<ServiceRunner<GasPriceService<A, U>>>
-// where
-//     U: UpdateAlgorithm<Algorithm = A> + Send + Sync,
-//     A: Send + Sync,
-// {
-//     let shared_algo
-//     let service = GasPriceService::new(current_fuel_block_height, update_algo, SharedGasPriceAlgo::new(update_algo.start(current_fuel_block_height));
-//     Ok(ServiceRunner::new(service))
-// }
-
 /// The service that updates the gas price algorithm.
 pub struct GasPriceService<A, U> {
     /// The algorithm that can be used in the next block

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -65,8 +65,8 @@ tokio = { workspace = true, features = [
 
 [dev-dependencies]
 pretty_assertions = "1.4"
-tracing = { workspace = true }
 proptest = { workspace = true }
+tracing = { workspace = true }
 
 [features]
 default = ["fuel-core/default", "relayer"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -66,6 +66,7 @@ tokio = { workspace = true, features = [
 [dev-dependencies]
 pretty_assertions = "1.4"
 tracing = { workspace = true }
+proptest = { workspace = true }
 
 [features]
 default = ["fuel-core/default", "relayer"]

--- a/tests/proptest-regressions/recovery.txt
+++ b/tests/proptest-regressions/recovery.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc e7597718e91e4f2fcb6b3a24943f5a0cd2286c709e4c5fb4c49f58ef59e0f38d # shrinks to heights = 0
+cc 7c4e472cb1f611f337e2b9e029d79cad58b6e80786135c0cea9e37808467f109 # shrinks to (height, lower_height) = (53, 0)

--- a/tests/proptest-regressions/recovery.txt
+++ b/tests/proptest-regressions/recovery.txt
@@ -4,5 +4,4 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-cc e7597718e91e4f2fcb6b3a24943f5a0cd2286c709e4c5fb4c49f58ef59e0f38d # shrinks to heights = 0
 cc 7c4e472cb1f611f337e2b9e029d79cad58b6e80786135c0cea9e37808467f109 # shrinks to (height, lower_height) = (53, 0)

--- a/tests/tests/recovery.rs
+++ b/tests/tests/recovery.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use fuel_core_types::fuel_types::BlockHeight;
 use test_helpers::fuel_core_driver::FuelCoreDriver;
 
@@ -47,6 +48,59 @@ async fn off_chain_worker_can_recover_on_start_up_when_is_behind() -> anyhow::Re
     );
     assert_eq!(
         recovered_database.off_chain().latest_height()?,
+        Some(BlockHeight::new(HEIGHTS))
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gas_price_updater__can_recover_on_startup_when_is_behind() -> anyhow::Result<()>
+{
+    const HEIGHTS: u32 = 100;
+    let driver = FuelCoreDriver::spawn(&[
+        "--debug",
+        "--poa-instant",
+        "true",
+        "--state-rewind-duration",
+        "7d",
+    ])
+    .await?;
+
+    // Given
+    driver.client.produce_blocks(HEIGHTS, None).await?;
+    let database = &driver.node.shared.database;
+    assert_eq!(
+        database.on_chain().latest_height()?,
+        Some(BlockHeight::new(HEIGHTS))
+    );
+    for _ in 0..HEIGHTS {
+        let _ = database.gas_price().rollback_last_block();
+    }
+    assert!(database.on_chain().latest_height()? > database.gas_price().latest_height()?);
+    let temp_dir = driver.kill().await;
+
+    // When
+    let recovered_driver = FuelCoreDriver::spawn_with_directory(
+        temp_dir,
+        &[
+            "--debug",
+            "--poa-instant",
+            "true",
+            "--state-rewind-duration",
+            "7d",
+        ],
+    )
+    .await?;
+
+    // Then
+    let recovered_database = &recovered_driver.node.shared.database;
+    assert_eq!(
+        recovered_database.on_chain().latest_height()?,
+        Some(BlockHeight::new(HEIGHTS))
+    );
+    assert_eq!(
+        recovered_database.gas_price().latest_height()?,
         Some(BlockHeight::new(HEIGHTS))
     );
 

--- a/tests/tests/recovery.rs
+++ b/tests/tests/recovery.rs
@@ -31,7 +31,7 @@ async fn off_chain_worker_can_recover_on_start_up_when_is_behind() -> anyhow::Re
         Some(BlockHeight::new(HEIGHTS))
     );
     for _ in 0..HEIGHTS {
-        let _ = database.off_chain().rollback_last_block();
+        database.off_chain().rollback_last_block()?;
     }
     assert!(database.on_chain().latest_height()? > database.off_chain().latest_height()?);
     let temp_dir = driver.kill().await;
@@ -91,8 +91,8 @@ async fn _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_ahead(
     );
     let diff = height - lower_height;
     for _ in 0..diff {
-        let _ = database.on_chain().rollback_last_block()?;
-        let _ = database.off_chain().rollback_last_block()?;
+        database.on_chain().rollback_last_block()?;
+        database.off_chain().rollback_last_block()?;
     }
     assert!(database.on_chain().latest_height()? < database.gas_price().latest_height()?);
     let temp_dir = driver.kill().await;

--- a/tests/tests/recovery.rs
+++ b/tests/tests/recovery.rs
@@ -128,7 +128,7 @@ async fn _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_ahead(
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(1))]
+    #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
     fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_ahead((height, lower_height) in height_and_lower_height()) {
         let rt = multithreaded_runtime();
@@ -137,7 +137,6 @@ proptest! {
         ).unwrap()
     }
 }
-
 async fn _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(
     height: u32,
     lower_height: u32,

--- a/tests/tests/recovery.rs
+++ b/tests/tests/recovery.rs
@@ -55,8 +55,8 @@ async fn off_chain_worker_can_recover_on_start_up_when_is_behind() -> anyhow::Re
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn gas_price_updater__can_recover_on_startup_when_is_behind() -> anyhow::Result<()>
-{
+async fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(
+) -> anyhow::Result<()> {
     const HEIGHTS: u32 = 100;
     let driver = FuelCoreDriver::spawn(&[
         "--debug",
@@ -102,6 +102,61 @@ async fn gas_price_updater__can_recover_on_startup_when_is_behind() -> anyhow::R
     assert_eq!(
         recovered_database.gas_price().latest_height()?,
         Some(BlockHeight::new(HEIGHTS))
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_ahead(
+) -> anyhow::Result<()> {
+    const HEIGHTS: u32 = 100;
+    const REVERT: u32 = HEIGHTS / 2;
+    let driver = FuelCoreDriver::spawn(&[
+        "--debug",
+        "--poa-instant",
+        "true",
+        "--state-rewind-duration",
+        "7d",
+    ])
+    .await?;
+
+    // Given
+    driver.client.produce_blocks(HEIGHTS, None).await?;
+    let database = &driver.node.shared.database;
+    assert_eq!(
+        database.on_chain().latest_height()?,
+        Some(BlockHeight::new(HEIGHTS))
+    );
+    for _ in 0..REVERT {
+        let _ = database.on_chain().rollback_last_block();
+        let _ = database.off_chain().rollback_last_block();
+    }
+    assert!(database.on_chain().latest_height()? < database.gas_price().latest_height()?);
+    let temp_dir = driver.kill().await;
+
+    // When
+    let recovered_driver = FuelCoreDriver::spawn_with_directory(
+        temp_dir,
+        &[
+            "--debug",
+            "--poa-instant",
+            "true",
+            "--state-rewind-duration",
+            "7d",
+        ],
+    )
+    .await?;
+
+    // Then
+    let recovered_database = &recovered_driver.node.shared.database;
+    assert_eq!(
+        recovered_database.on_chain().latest_height()?,
+        Some(BlockHeight::new(HEIGHTS - REVERT))
+    );
+    assert_eq!(
+        recovered_database.gas_price().latest_height()?,
+        Some(BlockHeight::new(HEIGHTS - REVERT))
     );
 
     Ok(())

--- a/tests/tests/recovery.rs
+++ b/tests/tests/recovery.rs
@@ -1,5 +1,14 @@
 #![allow(non_snake_case)]
+
 use fuel_core_types::fuel_types::BlockHeight;
+use proptest::{
+    prelude::{
+        Just,
+        ProptestConfig,
+    },
+    prop_compose,
+    proptest,
+};
 use test_helpers::fuel_core_driver::FuelCoreDriver;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -54,10 +63,16 @@ async fn off_chain_worker_can_recover_on_start_up_when_is_behind() -> anyhow::Re
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(
+prop_compose! {
+    fn height_and_lower_height()(height in 1..100u32)(height in Just(height), lower_height in 0..height) -> (u32, u32) {
+        (height, lower_height)
+    }
+}
+
+async fn _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_ahead(
+    height: u32,
+    lower_height: u32,
 ) -> anyhow::Result<()> {
-    const HEIGHTS: u32 = 100;
     let driver = FuelCoreDriver::spawn(&[
         "--debug",
         "--poa-instant",
@@ -68,13 +83,84 @@ async fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(
     .await?;
 
     // Given
-    driver.client.produce_blocks(HEIGHTS, None).await?;
+    driver.client.produce_blocks(height, None).await?;
     let database = &driver.node.shared.database;
     assert_eq!(
         database.on_chain().latest_height()?,
-        Some(BlockHeight::new(HEIGHTS))
+        Some(BlockHeight::new(height))
     );
-    for _ in 0..HEIGHTS {
+    let diff = height - lower_height;
+    for _ in 0..diff {
+        let _ = database.on_chain().rollback_last_block()?;
+        let _ = database.off_chain().rollback_last_block()?;
+    }
+    assert!(database.on_chain().latest_height()? < database.gas_price().latest_height()?);
+    let temp_dir = driver.kill().await;
+
+    // When
+    let recovered_driver = FuelCoreDriver::spawn_with_directory(
+        temp_dir,
+        &[
+            "--debug",
+            "--poa-instant",
+            "true",
+            "--state-rewind-duration",
+            "7d",
+        ],
+    )
+    .await?;
+
+    // Then
+    let recovered_database = &recovered_driver.node.shared.database;
+    let actual_onchain_height = recovered_database.on_chain().latest_height()?.unwrap();
+    let expected_onchain_height = BlockHeight::new(lower_height);
+
+    let actual_gas_price_height = recovered_database
+        .gas_price()
+        .latest_height()?
+        .unwrap_or(0.into()); // Gas price metadata never gets written for block 0
+    let expected_gas_price_height = BlockHeight::new(lower_height);
+
+    assert_eq!(actual_onchain_height, expected_onchain_height);
+    assert_eq!(actual_gas_price_height, expected_gas_price_height);
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1))]
+    #[test]
+    fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_ahead((height, lower_height) in height_and_lower_height()) {
+        let rt = multithreaded_runtime();
+        rt.block_on(
+            _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_ahead(height, lower_height)
+        ).unwrap()
+    }
+}
+
+async fn _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(
+    height: u32,
+    lower_height: u32,
+) -> anyhow::Result<()> {
+    let driver = FuelCoreDriver::spawn(&[
+        "--debug",
+        "--poa-instant",
+        "true",
+        "--state-rewind-duration",
+        "7d",
+    ])
+    .await?;
+
+    // Given
+    driver.client.produce_blocks(height, None).await?;
+    let database = &driver.node.shared.database;
+    assert_eq!(
+        database.on_chain().latest_height()?,
+        Some(BlockHeight::new(height))
+    );
+
+    let diff = height - lower_height;
+    for _ in 0..diff {
         let _ = database.gas_price().rollback_last_block();
     }
     assert!(database.on_chain().latest_height()? > database.gas_price().latest_height()?);
@@ -97,67 +183,30 @@ async fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(
     let recovered_database = &recovered_driver.node.shared.database;
     assert_eq!(
         recovered_database.on_chain().latest_height()?,
-        Some(BlockHeight::new(HEIGHTS))
+        Some(BlockHeight::new(height))
     );
     assert_eq!(
         recovered_database.gas_price().latest_height()?,
-        Some(BlockHeight::new(HEIGHTS))
+        Some(BlockHeight::new(height))
     );
 
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_ahead(
-) -> anyhow::Result<()> {
-    const HEIGHTS: u32 = 100;
-    const REVERT: u32 = HEIGHTS / 2;
-    let driver = FuelCoreDriver::spawn(&[
-        "--debug",
-        "--poa-instant",
-        "true",
-        "--state-rewind-duration",
-        "7d",
-    ])
-    .await?;
-
-    // Given
-    driver.client.produce_blocks(HEIGHTS, None).await?;
-    let database = &driver.node.shared.database;
-    assert_eq!(
-        database.on_chain().latest_height()?,
-        Some(BlockHeight::new(HEIGHTS))
-    );
-    for _ in 0..REVERT {
-        let _ = database.on_chain().rollback_last_block();
-        let _ = database.off_chain().rollback_last_block();
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+    #[test]
+    fn gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind((height, lower_height) in height_and_lower_height()) {
+        let rt = multithreaded_runtime();
+        rt.block_on(
+            _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(height, lower_height)
+        ).unwrap()
     }
-    assert!(database.on_chain().latest_height()? < database.gas_price().latest_height()?);
-    let temp_dir = driver.kill().await;
+}
 
-    // When
-    let recovered_driver = FuelCoreDriver::spawn_with_directory(
-        temp_dir,
-        &[
-            "--debug",
-            "--poa-instant",
-            "true",
-            "--state-rewind-duration",
-            "7d",
-        ],
-    )
-    .await?;
-
-    // Then
-    let recovered_database = &recovered_driver.node.shared.database;
-    assert_eq!(
-        recovered_database.on_chain().latest_height()?,
-        Some(BlockHeight::new(HEIGHTS - REVERT))
-    );
-    assert_eq!(
-        recovered_database.gas_price().latest_height()?,
-        Some(BlockHeight::new(HEIGHTS - REVERT))
-    );
-
-    Ok(())
+fn multithreaded_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/2030

In the unlikely situation that the metadata db is behind the on chain database, we should apply the values from each block to the algorithm updater to produce reasonable values.

For now, we should be able to use the updater deterministically, but this might become more difficult as we include the DA values in the updater.

We also define the behavior for when the gas price db is beyond the on-chain db. For now, we are assuming that the blocks produced with the gas prices in the db were either reverted or not properly committed to the on_chain db, and we just revert the gas price db to the height of the on chain db. i.e. **the on chain db is the source of truth.**

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
