### PR TITLE
Ignore the message receipt if transaction is reverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
         - "gas-price-threshold-percent" - the threshold percent for determining if the gas price will be increase or decreased
     And the following CLI flags are serving a new purpose
         - "min-gas-price" - the minimum gas price that the gas price algorithm will return
+
+### Fixed
+
+#### Breaking
+- [](): Include withdrawal message only if transaction is executed successfully.
+
 ## [Version 0.31.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 #### Breaking
-- [](): Include withdrawal message only if transaction is executed successfully.
+- [2045](https://github.com/FuelLabs/fuel-core/pull/2045): Include withdrawal message only if transaction is executed successfully.
 
 ## [Version 0.31.0]
 

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -2573,7 +2573,7 @@ mod tests {
             nonce,
             data,
             ..
-        }) = result.tx_status[0].result.receipts().get(0).cloned()
+        }) = result.tx_status[0].result.receipts().first().cloned()
         else {
             panic!("Expected a MessageOut receipt");
         };

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -54,7 +54,10 @@ mod tests {
             RegId,
         },
         fuel_crypto::SecretKey,
-        fuel_merkle::sparse,
+        fuel_merkle::{
+            common::empty_sum_sha256,
+            sparse,
+        },
         fuel_tx::{
             consensus_parameters::gas::GasCostsValuesV1,
             field::{
@@ -2526,6 +2529,84 @@ mod tests {
                 TransactionValidityError::MessageDoesNotExist(_)
             ))
         ));
+    }
+
+    #[test]
+    fn withdrawal_message_included_in_header_for_successfully_executed_transaction() {
+        // Given
+        let amount_from_random_input = 1000;
+        let smo_tx = TransactionBuilder::script(
+            vec![
+                // The amount to send in coins.
+                op::movi(0x13, amount_from_random_input),
+                // Send the message output.
+                op::smo(0x0, 0x0, 0x0, 0x13),
+                op::ret(RegId::ONE),
+            ]
+            .into_iter()
+            .collect(),
+            vec![],
+        )
+        .add_random_fee_input()
+        .script_gas_limit(1000000)
+        .finalize_as_transaction();
+
+        let block = PartialFuelBlock {
+            header: Default::default(),
+            transactions: vec![smo_tx],
+        };
+
+        // When
+        let ExecutionResult { block, .. } =
+            create_executor(Default::default(), Default::default())
+                .produce_and_commit(block)
+                .expect("block execution failed unexpectedly");
+        create_executor(Default::default(), Default::default())
+            .validate_and_commit(&block)
+            .expect("block validation failed unexpectedly");
+
+        // Then
+        let empty_root = empty_sum_sha256();
+        assert_ne!(block.header().message_outbox_root.as_ref(), empty_root)
+    }
+
+    #[test]
+    fn withdrawal_message_not_included_in_header_for_failed_transaction() {
+        // Given
+        let amount_from_random_input = 1000;
+        let smo_tx = TransactionBuilder::script(
+            vec![
+                // The amount to send in coins.
+                op::movi(0x13, amount_from_random_input),
+                // Send the message output.
+                op::smo(0x0, 0x0, 0x0, 0x13),
+                op::rvrt(0x0),
+            ]
+            .into_iter()
+            .collect(),
+            vec![],
+        )
+        .add_random_fee_input()
+        .script_gas_limit(1000000)
+        .finalize_as_transaction();
+
+        let block = PartialFuelBlock {
+            header: Default::default(),
+            transactions: vec![smo_tx],
+        };
+
+        // When
+        let ExecutionResult { block, .. } =
+            create_executor(Default::default(), Default::default())
+                .produce_and_commit(block)
+                .expect("block execution failed unexpectedly");
+        create_executor(Default::default(), Default::default())
+            .validate_and_commit(&block)
+            .expect("block validation failed unexpectedly");
+
+        // Then
+        let empty_root = empty_sum_sha256();
+        assert_eq!(block.header().message_outbox_root.as_ref(), empty_root)
     }
 
     #[test]

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -1365,9 +1365,13 @@ where
             .used_gas
             .checked_add(used_gas)
             .ok_or(ExecutorError::GasOverflow)?;
-        execution_data
-            .message_ids
-            .extend(receipts.iter().filter_map(|r| r.message_id()));
+
+        if !reverted {
+            execution_data
+                .message_ids
+                .extend(receipts.iter().filter_map(|r| r.message_id()));
+        }
+
         let status = if reverted {
             TransactionExecutionResult::Failed {
                 result: Some(state),


### PR DESCRIPTION
Include withdrawal message only if transaction is executed successfully, otherwise it is possible to use same assets to create many withdrawals with failed transactions.

The network is patched already with a private fix.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself
