### PR TITLE
Limited number of connections per IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [1983](https://github.com/FuelLabs/fuel-core/pull/1983): Add adapters for gas price service for accessing database values
+- [2046](https://github.com/FuelLabs/fuel-core/pull/2046): Added limit for the number of connections per same remote IP.
 
 ### Breaking
 - [2025](https://github.com/FuelLabs/fuel-core/pull/2025): Add new V0 algorithm for gas price to services.

--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -90,6 +90,10 @@ pub struct P2PArgs {
     #[clap(long = "max-peers-connected", default_value = "50", env)]
     pub max_peers_connected: u32,
 
+    /// Max number of unique peers connected with the same remote IP address.
+    #[clap(long = "max-peers-per-remote-ip", default_value = "5", env)]
+    pub max_peers_per_remote_ip: usize,
+
     /// Max number of connections per single peer
     /// The total number of connections will be `(max_peers_connected + reserved_nodes.len()) * max_connections_per_peer`
     #[clap(long = "max-connections-per-peer", default_value = "3", env)]
@@ -309,6 +313,7 @@ impl P2PArgs {
             reserved_nodes_only_mode: self.reserved_nodes_only_mode,
             enable_mdns: self.enable_mdns,
             max_peers_connected: self.max_peers_connected,
+            max_peers_per_remote_ip: self.max_peers_per_remote_ip,
             max_connections_per_peer: self.max_connections_per_peer,
             allow_private_addresses: self.allow_private_addresses,
             random_walk,

--- a/crates/services/p2p/src/config.rs
+++ b/crates/services/p2p/src/config.rs
@@ -91,6 +91,8 @@ pub struct Config<State = Initialized> {
     /// This number should be at least number of `mesh_n` from `Gossipsub` configuration.
     /// The total number of connections will be `(max_peers_connected + reserved_nodes.len()) * max_connections_per_peer`
     pub max_peers_connected: u32,
+    /// Max number of unique peers connected with the same remote IP address.
+    pub max_peers_per_remote_ip: usize,
     /// Max number of connections per single peer
     /// The total number of connections will be `(max_peers_connected + reserved_nodes.len()) * max_connections_per_peer`
     pub max_connections_per_peer: u32,
@@ -154,6 +156,7 @@ impl Config<NotInitialized> {
             bootstrap_nodes: self.bootstrap_nodes,
             enable_mdns: self.enable_mdns,
             max_peers_connected: self.max_peers_connected,
+            max_peers_per_remote_ip: self.max_peers_per_remote_ip,
             max_connections_per_peer: self.max_connections_per_peer,
             allow_private_addresses: self.allow_private_addresses,
             random_walk: self.random_walk,
@@ -203,6 +206,7 @@ impl Config<NotInitialized> {
             bootstrap_nodes: vec![],
             enable_mdns: false,
             max_peers_connected: 50,
+            max_peers_per_remote_ip: 50,
             max_connections_per_peer: 3,
             allow_private_addresses: true,
             random_walk: Some(Duration::from_millis(500)),


### PR DESCRIPTION
It is possible to create many connections from the same subnetwork and occupy connection slots. This change should limit the number of connections allowed from the same remote IP.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself