### PR TITLE
Bug/fix gas price metadata sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,6 +3285,7 @@ dependencies = [
  "fuel-core-bin",
  "fuel-core-client",
  "fuel-core-executor",
+ "fuel-core-gas-price-service",
  "fuel-core-p2p",
  "fuel-core-poa",
  "fuel-core-relayer",

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -160,7 +160,7 @@ pub fn get_synced_gas_price_updater(
         new_exec_price: config.starting_gas_price,
         min_exec_gas_price: config.min_gas_price,
         exec_gas_price_change_percent: config.gas_price_change_percent,
-        l2_block_height: latest_block_height.into(),
+        l2_block_height: latest_block_height,
         l2_block_fullness_threshold_percent: config.gas_price_threshold_percent,
     });
 

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -247,8 +247,8 @@ fn sync_v0_metadata(
     >,
 ) -> anyhow::Result<()> {
     let first = metadata_height.saturating_add(1);
+    let view = on_chain_db.view_at(&latest_block_height.into())?;
     for height in first..=latest_block_height {
-        let view = on_chain_db.view_at(&height.into())?;
         let block = view
             .storage::<FuelBlocks>()
             .get(&height.into())?

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -38,6 +38,7 @@ fuel-core-poa = { path = "../crates/services/consensus_module/poa" }
 fuel-core-relayer = { path = "../crates/services/relayer", features = [
   "test-helpers",
 ], optional = true }
+fuel-core-gas-price-service = { path = "../crates/services/gas_price_service" }
 fuel-core-storage = { path = "../crates/storage", features = ["test-helpers"] }
 fuel-core-trace = { path = "../crates/trace" }
 fuel-core-txpool = { path = "../crates/services/txpool", features = [

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,6 +31,7 @@ fuel-core-benches = { path = "../benches" }
 fuel-core-bin = { path = "../bin/fuel-core", features = ["parquet", "p2p"] }
 fuel-core-client = { path = "../crates/client", features = ["test-helpers"] }
 fuel-core-executor = { workspace = true }
+fuel-core-gas-price-service = { path = "../crates/services/gas_price_service" }
 fuel-core-p2p = { path = "../crates/services/p2p", features = [
   "test-helpers",
 ], optional = true }
@@ -38,7 +39,6 @@ fuel-core-poa = { path = "../crates/services/consensus_module/poa" }
 fuel-core-relayer = { path = "../crates/services/relayer", features = [
   "test-helpers",
 ], optional = true }
-fuel-core-gas-price-service = { path = "../crates/services/gas_price_service" }
 fuel-core-storage = { path = "../crates/storage", features = ["test-helpers"] }
 fuel-core-trace = { path = "../crates/trace" }
 fuel-core-txpool = { path = "../crates/services/txpool", features = [

--- a/tests/tests/recovery.rs
+++ b/tests/tests/recovery.rs
@@ -71,7 +71,7 @@ async fn off_chain_worker_can_recover_on_start_up_when_is_behind() -> anyhow::Re
 }
 
 prop_compose! {
-    fn height_and_lower_height()(height in 1..100u32)(height in Just(height), lower_height in 0..height) -> (u32, u32) {
+    fn height_and_lower_height()(height in 2..100u32)(height in Just(height), lower_height in 1..height) -> (u32, u32) {
         (height, lower_height)
     }
 }
@@ -253,7 +253,7 @@ async fn gas_price_updater__if_no_metadata_history_start_from_current_block(
     .await?;
 
     // Then
-    // advance the block height to the next block
+    // advance the block height to the next block to add the metadata to db
     recovered_driver.client.produce_blocks(1, None).await?;
     let recovered_database = &recovered_driver.node.shared.database;
     let next_height = height + 1;
@@ -265,11 +265,10 @@ async fn gas_price_updater__if_no_metadata_history_start_from_current_block(
         recovered_database.gas_price().latest_height()?,
         Some(BlockHeight::new(next_height))
     );
-    let prev_height = height - 1;
     let view = recovered_database.gas_price().latest_view().unwrap();
     let previous_metadata = view
         .storage::<GasPriceMetadata>()
-        .get(&prev_height.into())
+        .get(&height.into())
         .unwrap()
         .clone();
     assert!(previous_metadata.is_none());

--- a/tests/tests/recovery.rs
+++ b/tests/tests/recovery.rs
@@ -1,5 +1,12 @@
 #![allow(non_snake_case)]
 
+use fuel_core_gas_price_service::fuel_gas_price_updater::{
+    fuel_core_storage_adapter::storage::GasPriceMetadata,
+};
+use fuel_core_storage::{
+    transactional::AtomicView,
+    StorageAsRef,
+};
 use fuel_core_types::fuel_types::BlockHeight;
 use proptest::{
     prelude::{
@@ -201,6 +208,73 @@ proptest! {
             _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(height, lower_height)
         ).unwrap()
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gas_price_updater__if_no_metadata_history_start_from_current_block(
+) -> anyhow::Result<()> {
+    let driver = FuelCoreDriver::spawn(&[
+        "--debug",
+        "--poa-instant",
+        "true",
+        "--state-rewind-duration",
+        "7d",
+    ])
+    .await?;
+
+    // Given
+    let height = 100;
+    let lower_height = 0;
+    driver.client.produce_blocks(height, None).await?;
+    let database = &driver.node.shared.database;
+    assert_eq!(
+        database.on_chain().latest_height()?,
+        Some(BlockHeight::new(height))
+    );
+
+    let diff = height - lower_height;
+    for _ in 0..diff {
+        let _ = database.gas_price().rollback_last_block();
+    }
+    assert!(database.on_chain().latest_height()? > database.gas_price().latest_height()?);
+    let temp_dir = driver.kill().await;
+
+    // When
+    let recovered_driver = FuelCoreDriver::spawn_with_directory(
+        temp_dir,
+        &[
+            "--debug",
+            "--poa-instant",
+            "true",
+            "--state-rewind-duration",
+            "7d",
+        ],
+    )
+    .await?;
+
+    // Then
+    // advance the block height to the next block
+    recovered_driver.client.produce_blocks(1, None).await?;
+    let recovered_database = &recovered_driver.node.shared.database;
+    let next_height = height + 1;
+    assert_eq!(
+        recovered_database.on_chain().latest_height()?,
+        Some(BlockHeight::new(next_height))
+    );
+    assert_eq!(
+        recovered_database.gas_price().latest_height()?,
+        Some(BlockHeight::new(next_height))
+    );
+    let prev_height = height - 1;
+    let view = recovered_database.gas_price().latest_view().unwrap();
+    let previous_metadata = view
+        .storage::<GasPriceMetadata>()
+        .get(&prev_height.into())
+        .unwrap()
+        .clone();
+    assert!(previous_metadata.is_none());
+
+    Ok(())
 }
 
 fn multithreaded_runtime() -> tokio::runtime::Runtime {


### PR DESCRIPTION
- [x] Have gas price metadata start from latest block if there is no record
- [x] Fix bug in view lookups that creates a new view for every historical lookup :P


## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
https://github.com/FuelLabs/fuel-core/issues/2057

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
