### PR TITLE
Use `min-gas-price` as a starting point if `start-gas-price` is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Bug Fixes
+### Fixes
+- [2060](https://github.com/FuelLabs/fuel-core/pull/2060): Use `min-gas-price` as a starting point if `start-gas-price` is zero.
 - [2059](https://github.com/FuelLabs/fuel-core/pull/2059): Remove unwrap that is breaking backwards compatibility
 
 ## [Version 0.32.0]

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -157,7 +157,7 @@ pub fn get_synced_gas_price_updater(
     };
 
     let first_metadata = UpdaterMetadata::V0(V0Metadata {
-        new_exec_price: config.starting_gas_price,
+        new_exec_price: config.starting_gas_price.max(config.min_gas_price),
         min_exec_gas_price: config.min_gas_price,
         exec_gas_price_change_percent: config.gas_price_change_percent,
         l2_block_height: latest_block_height,

--- a/tests/tests/gas_price.rs
+++ b/tests/tests/gas_price.rs
@@ -233,6 +233,25 @@ async fn estimate_gas_price__is_greater_than_actual_price_at_desired_height() {
 }
 
 #[tokio::test]
+async fn estimate_gas_price__returns_min_gas_price_if_starting_gas_price_is_zero() {
+    const MIN_GAS_PRICE: u64 = 1;
+
+    // Given
+    let mut node_config = Config::local_node();
+    node_config.min_gas_price = MIN_GAS_PRICE;
+    node_config.starting_gas_price = 0;
+    let srv = FuelService::new_node(node_config.clone()).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    // When
+    let result = client.estimate_gas_price(10).await.unwrap();
+
+    // Then
+    let actual = result.gas_price.0;
+    assert_eq!(MIN_GAS_PRICE, actual)
+}
+
+#[tokio::test]
 async fn latest_gas_price__if_node_restarts_gets_latest_value() {
     // given
     let args = vec![


### PR DESCRIPTION
Use `min-gas-price` as a starting point if `start-gas-price` is zero to follow the old behavior.

## Checklist
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself
