### PR TITLE
Don't use historical view during dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Bug Fixes
 - [2059](https://github.com/FuelLabs/fuel-core/pull/2059): Remove unwrap that is breaking backwards compatibility
+- [2063](https://github.com/FuelLabs/fuel-core/pull/2063): Don't use historical view during dry run.
 
 ## [Version 0.32.0]
 

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -484,7 +484,12 @@ where
             gas_price,
         };
 
-        let previous_block_height = block.header_to_produce.height().pred();
+        let previous_block_height = if !dry_run {
+            block.header_to_produce.height().pred()
+        } else {
+            // TODO: https://github.com/FuelLabs/fuel-core/issues/2062
+            None
+        };
 
         let instance_without_input =
             crate::instance::Instance::new(&self.engine).add_source(source)?;
@@ -560,7 +565,12 @@ where
     where
         TxSource: TransactionsSource + Send + Sync + 'static,
     {
-        let previous_block_height = block.header_to_produce.height().pred();
+        let previous_block_height = if !dry_run {
+            block.header_to_produce.height().pred()
+        } else {
+            // TODO: https://github.com/FuelLabs/fuel-core/issues/2062
+            None
+        };
         let relayer = self.relayer_view_provider.latest_view()?;
 
         if let Some(previous_block_height) = previous_block_height {


### PR DESCRIPTION
Due to race conditions dry run may fail with `InMemory` store. I disabled the usage of the historical view for dry run case until the future. https://github.com/FuelLabs/fuel-core/issues/2062

### Before requesting review
- [x] I have reviewed the code myself
