### PR TITLE
Allow gas price metadata values to be overridden with config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+-[2064](https://github.com/FuelLabs/fuel-core/pull/2064):  Allow gas price metadata values to be overridden with config
+
 ### Bug Fixes
 - [2059](https://github.com/FuelLabs/fuel-core/pull/2059): Remove unwrap that is breaking backwards compatibility
 - [2063](https://github.com/FuelLabs/fuel-core/pull/2063): Don't use historical view during dry run.

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -200,6 +200,9 @@ pub fn get_synced_gas_price_updater(
             latest_block_height.into(),
             l2_block_source,
             metadata_storage,
+            config.min_gas_price,
+            config.gas_price_change_percent,
+            config.gas_price_threshold_percent,
         )
         .map_err(|e| anyhow::anyhow!("Could not initialize gas price updater: {e:?}"))
     }

--- a/crates/fuel-gas-price-algorithm/src/v0.rs
+++ b/crates/fuel-gas-price-algorithm/src/v0.rs
@@ -80,6 +80,22 @@ pub struct BlockBytes {
 }
 
 impl AlgorithmUpdaterV0 {
+    pub fn new(
+        new_exec_price: u64,
+        min_exec_gas_price: u64,
+        exec_gas_price_change_percent: u64,
+        l2_block_height: u32,
+        l2_block_fullness_threshold_percent: u64,
+    ) -> Self {
+        Self {
+            new_exec_price,
+            min_exec_gas_price,
+            exec_gas_price_change_percent,
+            l2_block_height,
+            l2_block_fullness_threshold_percent,
+        }
+    }
+
     pub fn update_l2_block_data(
         &mut self,
         height: u32,

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -190,14 +190,28 @@ where
         target_block_height: BlockHeight,
         l2_block_source: L2,
         metadata_storage: Metadata,
+        min_exec_gas_price: u64,
+        exec_gas_price_change_percent: u64,
+        l2_block_fullness_threshold_percent: u64,
     ) -> Result<Self> {
-        let inner = metadata_storage
-            .get_metadata(&target_block_height)?
-            .ok_or(Error::CouldNotInitUpdater(anyhow::anyhow!(
+        let old_metadata = metadata_storage.get_metadata(&target_block_height)?.ok_or(
+            Error::CouldNotInitUpdater(anyhow::anyhow!(
                 "No metadata found for block height: {:?}",
                 target_block_height
-            )))?
-            .into();
+            )),
+        )?;
+        let new_metadata = match old_metadata {
+            UpdaterMetadata::V0(old) => {
+                let inner = V0Metadata {
+                    min_exec_gas_price,
+                    exec_gas_price_change_percent,
+                    l2_block_fullness_threshold_percent,
+                    ..old
+                };
+                UpdaterMetadata::V0(inner)
+            }
+        };
+        let inner = new_metadata.into();
         let updater = Self {
             inner,
             l2_block_source,

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -200,18 +200,18 @@ where
                 target_block_height
             )),
         )?;
-        let new_metadata = match old_metadata {
+        let inner = match old_metadata {
             UpdaterMetadata::V0(old) => {
-                let inner = V0Metadata {
+                let v0 = AlgorithmUpdaterV0::new(
+                    old.new_exec_price,
                     min_exec_gas_price,
                     exec_gas_price_change_percent,
+                    old.l2_block_height,
                     l2_block_fullness_threshold_percent,
-                    ..old
-                };
-                UpdaterMetadata::V0(inner)
+                );
+                AlgorithmUpdater::V0(v0)
             }
         };
-        let inner = new_metadata.into();
         let updater = Self {
             inner,
             l2_block_source,

--- a/tests/tests/gas_price.rs
+++ b/tests/tests/gas_price.rs
@@ -19,7 +19,16 @@ use fuel_core_client::client::{
     types::gas_price::LatestGasPrice,
     FuelClient,
 };
+use fuel_core_gas_price_service::fuel_gas_price_updater::{
+    fuel_core_storage_adapter::storage::GasPriceMetadata,
+    UpdaterMetadata,
+    V0Metadata,
+};
 use fuel_core_poa::Trigger;
+use fuel_core_storage::{
+    transactional::AtomicView,
+    StorageAsRef,
+};
 use fuel_core_types::{
     fuel_asm::*,
     fuel_crypto::{
@@ -38,6 +47,7 @@ use fuel_core_types::{
 use rand::Rng;
 use std::{
     iter::repeat,
+    ops::Deref,
     time::Duration,
 };
 use test_helpers::fuel_core_driver::FuelCoreDriver;
@@ -327,4 +337,69 @@ async fn dry_run_opt__zero_gas_price_equal_to_none_gas_price() {
     assert_eq!(total_fee_zero_gas_price, 0);
 
     assert_eq!(total_gas, total_gas_zero_gas_price);
+}
+
+#[tokio::test]
+async fn startup__can_override_gas_price_values_by_changing_config() {
+    // given
+    let args = vec![
+        "--debug",
+        "--poa-instant",
+        "true",
+        "--gas-price-change-percent",
+        "0",
+        "--gas-price-threshold-percent",
+        "0",
+        "--min-gas-price",
+        "0",
+    ];
+    let driver = FuelCoreDriver::spawn(&args).await.unwrap();
+    driver.client.produce_blocks(1, None).await.unwrap();
+    let temp_dir = driver.kill().await;
+
+    // when
+    let new_args = vec![
+        "--debug",
+        "--poa-instant",
+        "true",
+        "--gas-price-change-percent",
+        "11",
+        "--gas-price-threshold-percent",
+        "22",
+        "--min-gas-price",
+        "33",
+    ];
+    let recovered_driver = FuelCoreDriver::spawn_with_directory(temp_dir, &new_args)
+        .await
+        .unwrap();
+
+    // then
+    recovered_driver
+        .client
+        .produce_blocks(1, None)
+        .await
+        .unwrap();
+    let new_height = 2;
+
+    let recovered_database = &recovered_driver.node.shared.database;
+    let recovered_view = recovered_database.gas_price().latest_view().unwrap();
+    let new_metadata = recovered_view
+        .storage::<GasPriceMetadata>()
+        .get(&new_height.into())
+        .unwrap()
+        .unwrap()
+        .deref()
+        .clone();
+
+    let UpdaterMetadata::V0(V0Metadata {
+        min_exec_gas_price,
+        exec_gas_price_change_percent,
+        l2_block_height,
+        l2_block_fullness_threshold_percent,
+        ..
+    }) = new_metadata;
+    assert_eq!(exec_gas_price_change_percent, 11);
+    assert_eq!(l2_block_fullness_threshold_percent, 22);
+    assert_eq!(min_exec_gas_price, 33);
+    assert_eq!(l2_block_height, new_height);
 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/2065

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
