### PR TITLE
Version 0.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.32.1]
+
 ### Added
 - [2061](https://github.com/FuelLabs/fuel-core/pull/2061): Allow querying filled transaction body from the status.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2874,11 +2874,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.32.0"
+version = "0.32.1"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "cynic",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "clap 4.5.13",
  "fuel-core-client",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-database"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "clap 4.5.13",
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "parking_lot",
  "pin-project-lite",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "ctor",
  "tracing",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "bs58",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "proptest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,39 +50,39 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.32.0"
+version = "0.32.1"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.32.0", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.32.0", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.32.0", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.32.0", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.32.0", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.32.0", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.32.0", path = "./crates/client" }
-fuel-core-database = { version = "0.32.0", path = "./crates/database" }
-fuel-core-metrics = { version = "0.32.0", path = "./crates/metrics" }
-fuel-core-services = { version = "0.32.0", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.32.0", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.32.0", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.32.0", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.32.0", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.32.0", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.32.0", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.32.0", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.32.0", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.32.0", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.32.0", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.32.0", path = "./crates/services/txpool" }
-fuel-core-storage = { version = "0.32.0", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.32.0", path = "./crates/trace" }
-fuel-core-types = { version = "0.32.0", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.32.1", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.32.1", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.32.1", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.32.1", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.32.1", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.32.1", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.32.1", path = "./crates/client" }
+fuel-core-database = { version = "0.32.1", path = "./crates/database" }
+fuel-core-metrics = { version = "0.32.1", path = "./crates/metrics" }
+fuel-core-services = { version = "0.32.1", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.32.1", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.32.1", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.32.1", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.32.1", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.32.1", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.32.1", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.32.1", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.32.1", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.32.1", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.32.1", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.32.1", path = "./crates/services/txpool" }
+fuel-core-storage = { version = "0.32.1", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.32.1", path = "./crates/trace" }
+fuel-core-types = { version = "0.32.1", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.32.0", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.32.0", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.32.1", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.32.1", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.32.0", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.32.1", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.56.0", package = "fuel-vm", default-features = false }

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -296,7 +296,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 6,
+  "genesis_state_transition_version": 7,
   "consensus": {
     "PoA": {
       "signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d"

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -300,7 +300,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 6,
+  "genesis_state_transition_version": 7,
   "consensus": {
     "PoA": {
       "signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb"

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -137,7 +137,8 @@ impl<S, R> Executor<S, R> {
         ("0-29-0", 3),
         ("0-30-0", 4),
         ("0-31-0", 5),
-        ("0-32-0", LATEST_STATE_TRANSITION_VERSION),
+        ("0-32-0", 6),
+        ("0-32-1", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -166,7 +166,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 6;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 7;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
### Added
- [2061](https://github.com/FuelLabs/fuel-core/pull/2061): Allow querying filled transaction body from the status.

### Changed
- [2067](https://github.com/FuelLabs/fuel-core/pull/2067): Return error from TxPool level if the `BlobId` is known.
- [2064](https://github.com/FuelLabs/fuel-core/pull/2064): Allow gas price metadata values to be overridden with config

### Fixes
- [2060](https://github.com/FuelLabs/fuel-core/pull/2060): Use `min-gas-price` as a starting point if `start-gas-price` is zero.
- [2059](https://github.com/FuelLabs/fuel-core/pull/2059): Remove unwrap that is breaking backwards compatibility
- [2063](https://github.com/FuelLabs/fuel-core/pull/2063): Don't use historical view during dry run.

## What's Changed
* Bugfix: Remove unwrap in Consensus Param conversion by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2059
* Don't use historical view during dry run by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2063
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/2050
* Allow gas price metadata values to be overridden with config by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2064
* Use `min-gas-price` as a starting point if `start-gas-price` is zero by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2060
* Allow querying transaction from the status by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2061
* Return error from TxPool level if the `BlobId` is known by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2067


**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.32.0...v0.32.1

