### PR TITLE
fix: Rename `e2e-client` test crate to `fuel-core-e2e-client` and rem…

### DIFF
--- a/bin/e2e-test-client/Cargo.toml
+++ b/bin/e2e-test-client/Cargo.toml
@@ -31,9 +31,9 @@ toml = { version = "0.5" }
 
 [dev-dependencies]
 assert_cmd = "2.0"
-e2e_client = { path = ".", features = [
+fuel-core-e2e-client = { path = ".", features = [
   "dev-deps",
-], package = "fuel-core-e2e-client", default-features = false }
+], default-features = false }
 fuel-core-trace = { path = "../../crates/trace" }
 insta = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
Closes #2074 
