### PR TITLE
refactor: move TxPoolError from fuel-core-types to fuel-core-txpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [2076](https://github.com/FuelLabs/fuel-core/pull/2076): Replace usages of `iter_all` with `iter_all_keys` where necessary.
 
-#### Breaking
+### Breaking
 - [2080](https://github.com/FuelLabs/fuel-core/pull/2080): Reject Upgrade txs with invalid wasm on txpool level.
 - [2082](https://github.com/FuelLabs/fuel-core/pull/2088): Move `TxPoolError` from `fuel-core-types` to `fuel-core-txpool`.
 - [2086](https://github.com/FuelLabs/fuel-core/pull/2086): Added support for PoA key rotation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2079](https://github.com/FuelLabs/fuel-core/pull/2079): Open unknown columns in the RocksDB for forward compatibility.
 
 ### Changed
+- [2076](https://github.com/FuelLabs/fuel-core/pull/2076): Replace usages of `iter_all` with `iter_all_keys` where necessary.
 
 #### Breaking
-
 - [2080](https://github.com/FuelLabs/fuel-core/pull/2080): Reject Upgrade txs with invalid wasm on txpool level.
-- [2076](https://github.com/FuelLabs/fuel-core/pull/2076): Replace usages of `iter_all` with `iter_all_keys` where necessary.
 - [2082](https://github.com/FuelLabs/fuel-core/pull/2088): Move `TxPoolError` from `fuel-core-types` to `fuel-core-txpool`.
 - [2086](https://github.com/FuelLabs/fuel-core/pull/2086): Added support for PoA key rotation.
 - [2086](https://github.com/FuelLabs/fuel-core/pull/2086): Support overriding of the non consensus parameters in the chan config.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2079](https://github.com/FuelLabs/fuel-core/pull/2079): Open unknown columns in the RocksDB for forward compatibility.
 
 ### Changed
-- [2076](https://github.com/FuelLabs/fuel-core/pull/2076): Replace usages of `iter_all` with `iter_all_keys` where necessary.
 
 #### Breaking
 
+- [2080](https://github.com/FuelLabs/fuel-core/pull/2080): Reject Upgrade txs with invalid wasm on txpool level.
+- [2076](https://github.com/FuelLabs/fuel-core/pull/2076): Replace usages of `iter_all` with `iter_all_keys` where necessary.
+- [2082](https://github.com/FuelLabs/fuel-core/pull/2088): Move `TxPoolError` from `fuel-core-types` to `fuel-core-txpool`.
 - [2086](https://github.com/FuelLabs/fuel-core/pull/2086): Added support for PoA key rotation.
 - [2086](https://github.com/FuelLabs/fuel-core/pull/2086): Support overriding of the non consensus parameters in the chan config.
-
-### Breaking
--[2080](https://github.com/FuelLabs/fuel-core/pull/2080): Reject Upgrade txs with invalid wasm on txpool level.
 
 ## [Version 0.32.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [2076](https://github.com/FuelLabs/fuel-core/pull/2076): Replace usages of `iter_all` with `iter_all_keys` where necessary.
 
-### Breaking
+#### Breaking
 - [2080](https://github.com/FuelLabs/fuel-core/pull/2080): Reject Upgrade txs with invalid wasm on txpool level.
 - [2082](https://github.com/FuelLabs/fuel-core/pull/2088): Move `TxPoolError` from `fuel-core-types` to `fuel-core-txpool`.
 - [2086](https://github.com/FuelLabs/fuel-core/pull/2086): Added support for PoA key rotation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,6 +3326,7 @@ version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "derive_more",
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
@@ -3339,7 +3340,6 @@ dependencies = [
  "proptest",
  "rstest",
  "test-strategy",
- "thiserror",
  "tokio",
  "tokio-rayon",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,6 +3339,7 @@ dependencies = [
  "proptest",
  "rstest",
  "test-strategy",
+ "thiserror",
  "tokio",
  "tokio-rayon",
  "tokio-stream",

--- a/crates/fuel-core/src/service/adapters/fuel_gas_price_provider.rs
+++ b/crates/fuel-core/src/service/adapters/fuel_gas_price_provider.rs
@@ -4,14 +4,12 @@ use fuel_core_gas_price_service::{
     SharedGasPriceAlgo,
 };
 use fuel_core_producer::block_producer::gas_price::GasPriceProvider as ProducerGasPriceProvider;
-use fuel_core_txpool::ports::GasPriceProvider as TxPoolGasPriceProvider;
-use fuel_core_types::{
-    fuel_types::BlockHeight,
-    services::txpool::{
-        Error as TxPoolError,
-        Result as TxPoolResult,
-    },
+use fuel_core_txpool::{
+    ports::GasPriceProvider as TxPoolGasPriceProvider,
+    Error as TxPoolError,
+    Result as TxPoolResult,
 };
+use fuel_core_types::fuel_types::BlockHeight;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/crates/fuel-core/src/service/adapters/txpool.rs
+++ b/crates/fuel-core/src/service/adapters/txpool.rs
@@ -21,11 +21,14 @@ use fuel_core_storage::{
     Result as StorageResult,
     StorageAsRef,
 };
-use fuel_core_txpool::ports::{
-    BlockImporter,
-    ConsensusParametersProvider as ConsensusParametersProviderTrait,
-    GasPriceProvider,
-    MemoryPool,
+use fuel_core_txpool::{
+    ports::{
+        BlockImporter,
+        ConsensusParametersProvider as ConsensusParametersProviderTrait,
+        GasPriceProvider,
+        MemoryPool,
+    },
+    Result as TxPoolResult,
 };
 use fuel_core_types::{
     blockchain::header::ConsensusParametersVersion,
@@ -51,7 +54,6 @@ use fuel_core_types::{
             GossipsubMessageInfo,
             TransactionGossipData,
         },
-        txpool::Result as TxPoolResult,
     },
 };
 use std::sync::Arc;

--- a/crates/services/txpool/Cargo.toml
+++ b/crates/services/txpool/Cargo.toml
@@ -13,6 +13,7 @@ description = "Transaction pool"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+derive_more = { workspace = true }
 fuel-core-metrics = { workspace = true }
 fuel-core-services = { workspace = true }
 fuel-core-storage = { workspace = true }
@@ -20,7 +21,6 @@ fuel-core-types = { workspace = true }
 mockall = { workspace = true, optional = true }
 num-rational = { workspace = true }
 parking_lot = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 tokio-rayon = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/services/txpool/Cargo.toml
+++ b/crates/services/txpool/Cargo.toml
@@ -20,6 +20,7 @@ fuel-core-types = { workspace = true }
 mockall = { workspace = true, optional = true }
 num-rational = { workspace = true }
 parking_lot = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 tokio-rayon = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/services/txpool/src/error.rs
+++ b/crates/services/txpool/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     GasPriceNotFound(String),
     #[display(fmt = "Failed to calculate max block bytes: {_0}")]
     MaxBlockBytes(String),
-    #[display(fmt = "TxPool required that transaction contains metadata")]
+    #[display(fmt = "TxPool requires that the transaction contains metadata")]
     NoMetadata,
     #[display(fmt = "TxPool doesn't support this type of transaction.")]
     NotSupportedTransactionType,
@@ -47,15 +47,15 @@ pub enum Error {
     #[display(fmt = "Transaction is not inserted. The gas price is too low.")]
     NotInsertedGasPriceTooLow,
     #[display(
-        fmt = "Transaction is not inserted. More priced tx {_0:#x} already spend this UTXO output: {_1:#x}"
+        fmt = "Transaction is not inserted. Higher priced tx {_0:#x} has already spent this UTXO output: {_1:#x}"
     )]
     NotInsertedCollision(TxId, UtxoId),
     #[display(
-        fmt = "Transaction is not inserted. More priced tx has created contract with ContractId {_0:#x}"
+        fmt = "Transaction is not inserted. Higher priced tx has created contract with ContractId {_0:#x}"
     )]
     NotInsertedCollisionContractId(ContractId),
     #[display(
-        fmt = "Transaction is not inserted. More priced tx has uploaded the blob with BlobId {_0:#x}"
+        fmt = "Transaction is not inserted. Higher priced tx has uploaded the blob with BlobId {_0:#x}"
     )]
     NotInsertedCollisionBlobId(BlobId),
     #[display(
@@ -85,7 +85,7 @@ pub enum Error {
     )]
     NotInsertedContractPricedLower(ContractId),
     #[display(
-        fmt = "Transaction is not inserted. Input coin mismatch the values from database"
+        fmt = "Transaction is not inserted. Input coin does not match the values from database"
     )]
     NotInsertedIoCoinMismatch,
     #[display(
@@ -101,7 +101,7 @@ pub enum Error {
     )]
     NotInsertedIoWrongAssetId,
     #[display(
-        fmt = "Transaction is not inserted. Input message mismatch the values from database"
+        fmt = "Transaction is not inserted. Input message does not match the values from database"
     )]
     NotInsertedIoMessageMismatch,
     #[display(

--- a/crates/services/txpool/src/error.rs
+++ b/crates/services/txpool/src/error.rs
@@ -1,0 +1,128 @@
+use fuel_core_types::{
+    fuel_tx::{
+        Address,
+        BlobId,
+        ContractId,
+        TxId,
+        UtxoId,
+    },
+    fuel_types::Nonce,
+    fuel_vm::checked_transaction::CheckError,
+};
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+#[allow(missing_docs)]
+#[derive(thiserror::Error, Debug, Clone)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("Gas price not found for block height {0}")]
+    GasPriceNotFound(String),
+    #[error("Failed to calculate max block bytes: {0}")]
+    MaxBlockBytes(String),
+    #[error("TxPool required that transaction contains metadata")]
+    NoMetadata,
+    #[error("TxPool doesn't support this type of transaction.")]
+    NotSupportedTransactionType,
+    #[error("Transaction is not inserted. Hash is already known")]
+    NotInsertedTxKnown,
+    #[error("Transaction is not inserted. Pool limit is hit, try to increase gas_price")]
+    NotInsertedLimitHit,
+    #[error("Transaction is not inserted. Attempting to upgrade WASM bytecode when WASM support is not enabled.")]
+    NotInsertedWasmNotEnabled,
+    #[error("Transaction is not inserted. WASM bytecode matching the given root was not found.")]
+    NotInsertedWasmNotFound,
+    #[error("Transaction is not inserted. WASM bytecode contents are not valid.")]
+    NotInsertedInvalidWasm,
+    #[error("Transaction is not inserted. The gas price is too low.")]
+    NotInsertedGasPriceTooLow,
+    #[error(
+        "Transaction is not inserted. More priced tx {0:#x} already spend this UTXO output: {1:#x}"
+    )]
+    NotInsertedCollision(TxId, UtxoId),
+    #[error(
+        "Transaction is not inserted. More priced tx has created contract with ContractId {0:#x}"
+    )]
+    NotInsertedCollisionContractId(ContractId),
+    #[error(
+        "Transaction is not inserted. More priced tx has uploaded the blob with BlobId {0:#x}"
+    )]
+    NotInsertedCollisionBlobId(BlobId),
+    #[error(
+        "Transaction is not inserted. A higher priced tx {0:#x} is already spending this message: {1:#x}"
+    )]
+    NotInsertedCollisionMessageId(TxId, Nonce),
+    #[error("Transaction is not inserted. UTXO input does not exist: {0:#x}")]
+    NotInsertedOutputDoesNotExist(UtxoId),
+    #[error("Transaction is not inserted. UTXO input contract does not exist or was already spent: {0:#x}")]
+    NotInsertedInputContractDoesNotExist(ContractId),
+    #[error("Transaction is not inserted. ContractId is already taken {0:#x}")]
+    NotInsertedContractIdAlreadyTaken(ContractId),
+    #[error("Transaction is not inserted. BlobId is already taken {0:#x}")]
+    NotInsertedBlobIdAlreadyTaken(BlobId),
+    #[error("Transaction is not inserted. UTXO does not exist: {0:#x}")]
+    NotInsertedInputUtxoIdNotDoesNotExist(UtxoId),
+    #[error("Transaction is not inserted. UTXO is spent: {0:#x}")]
+    NotInsertedInputUtxoIdSpent(UtxoId),
+    #[error("Transaction is not inserted. Message id {0:#x} does not match any received message from the DA layer.")]
+    NotInsertedInputMessageUnknown(Nonce),
+    #[error(
+        "Transaction is not inserted. UTXO requires Contract input {0:#x} that is priced lower"
+    )]
+    NotInsertedContractPricedLower(ContractId),
+    #[error("Transaction is not inserted. Input coin mismatch the values from database")]
+    NotInsertedIoCoinMismatch,
+    #[error("Transaction is not inserted. Input output mismatch. Coin owner is different from expected input")]
+    NotInsertedIoWrongOwner,
+    #[error("Transaction is not inserted. Input output mismatch. Coin output does not match expected input")]
+    NotInsertedIoWrongAmount,
+    #[error("Transaction is not inserted. Input output mismatch. Coin output asset_id does not match expected inputs")]
+    NotInsertedIoWrongAssetId,
+    #[error(
+        "Transaction is not inserted. Input message mismatch the values from database"
+    )]
+    NotInsertedIoMessageMismatch,
+    #[error(
+        "Transaction is not inserted. Input output mismatch. Expected coin but output is contract"
+    )]
+    NotInsertedIoContractOutput,
+    #[error("Transaction is not inserted. Maximum depth of dependent transaction chain reached")]
+    NotInsertedMaxDepth,
+    // small todo for now it can pass but in future we should include better messages
+    #[error("Transaction removed.")]
+    Removed,
+    #[error("Transaction expired because it exceeded the configured time to live `tx-pool-ttl`.")]
+    TTLReason,
+    #[error("Transaction squeezed out because {0}")]
+    SqueezedOut(String),
+    #[error("Invalid transaction data: {0:?}")]
+    ConsensusValidity(CheckError),
+    #[error("Mint transactions are disallowed from the txpool")]
+    MintIsDisallowed,
+    #[error("The UTXO `{0}` is blacklisted")]
+    BlacklistedUTXO(UtxoId),
+    #[error("The owner `{0}` is blacklisted")]
+    BlacklistedOwner(Address),
+    #[error("The contract `{0}` is blacklisted")]
+    BlacklistedContract(ContractId),
+    #[error("The message `{0}` is blacklisted")]
+    BlacklistedMessage(Nonce),
+    #[error("Database error: {0}")]
+    Database(String),
+    // TODO: We need it for now until channels are removed from TxPool.
+    #[error("Got some unexpected error: {0}")]
+    Other(String),
+}
+
+#[cfg(feature = "test-helpers")]
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string().eq(&other.to_string())
+    }
+}
+
+impl From<CheckError> for Error {
+    fn from(e: CheckError) -> Self {
+        Error::ConsensusValidity(e)
+    }
+}

--- a/crates/services/txpool/src/error.rs
+++ b/crates/services/txpool/src/error.rs
@@ -63,10 +63,6 @@ pub enum Error {
     )]
     NotInsertedCollisionMessageId(TxId, Nonce),
     #[display(fmt = "Transaction is not inserted. UTXO input does not exist: {_0:#x}")]
-    NotInsertedOutputDoesNotExist(UtxoId),
-    #[display(
-        fmt = "Transaction is not inserted. UTXO input contract does not exist or was already spent: {_0:#x}"
-    )]
     NotInsertedInputContractDoesNotExist(ContractId),
     #[display(fmt = "Transaction is not inserted. ContractId is already taken {_0:#x}")]
     NotInsertedContractIdAlreadyTaken(ContractId),

--- a/crates/services/txpool/src/error.rs
+++ b/crates/services/txpool/src/error.rs
@@ -15,106 +15,132 @@ use crate::ports::WasmValidityError;
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[allow(missing_docs)]
-#[derive(thiserror::Error, Debug, Clone)]
+#[derive(Debug, Clone, derive_more::Display)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("Gas price not found for block height {0}")]
+    #[display(fmt = "Gas price not found for block height {_0}")]
     GasPriceNotFound(String),
-    #[error("Failed to calculate max block bytes: {0}")]
+    #[display(fmt = "Failed to calculate max block bytes: {_0}")]
     MaxBlockBytes(String),
-    #[error("TxPool required that transaction contains metadata")]
+    #[display(fmt = "TxPool required that transaction contains metadata")]
     NoMetadata,
-    #[error("TxPool doesn't support this type of transaction.")]
+    #[display(fmt = "TxPool doesn't support this type of transaction.")]
     NotSupportedTransactionType,
-    #[error("Transaction is not inserted. Hash is already known")]
+    #[display(fmt = "Transaction is not inserted. Hash is already known")]
     NotInsertedTxKnown,
-    #[error("Transaction is not inserted. Pool limit is hit, try to increase gas_price")]
+    #[display(
+        fmt = "Transaction is not inserted. Pool limit is hit, try to increase gas_price"
+    )]
     NotInsertedLimitHit,
-    #[error("Transaction is not inserted. Attempting to upgrade WASM bytecode when WASM support is not enabled.")]
+    #[display(
+        fmt = "Transaction is not inserted. Attempting to upgrade WASM bytecode when WASM support is not enabled."
+    )]
     NotInsertedWasmNotEnabled,
-    #[error("Transaction is not inserted. WASM bytecode matching the given root was not found.")]
+    #[display(
+        fmt = "Transaction is not inserted. WASM bytecode matching the given root was not found."
+    )]
     NotInsertedWasmNotFound,
-    #[error("Transaction is not inserted. WASM bytecode contents are not valid.")]
+    #[display(
+        fmt = "Transaction is not inserted. WASM bytecode contents are not valid."
+    )]
     NotInsertedInvalidWasm,
-    #[error("Transaction is not inserted. The gas price is too low.")]
+    #[display(fmt = "Transaction is not inserted. The gas price is too low.")]
     NotInsertedGasPriceTooLow,
-    #[error(
-        "Transaction is not inserted. More priced tx {0:#x} already spend this UTXO output: {1:#x}"
+    #[display(
+        fmt = "Transaction is not inserted. More priced tx {_0:#x} already spend this UTXO output: {_1:#x}"
     )]
     NotInsertedCollision(TxId, UtxoId),
-    #[error(
-        "Transaction is not inserted. More priced tx has created contract with ContractId {0:#x}"
+    #[display(
+        fmt = "Transaction is not inserted. More priced tx has created contract with ContractId {_0:#x}"
     )]
     NotInsertedCollisionContractId(ContractId),
-    #[error(
-        "Transaction is not inserted. More priced tx has uploaded the blob with BlobId {0:#x}"
+    #[display(
+        fmt = "Transaction is not inserted. More priced tx has uploaded the blob with BlobId {_0:#x}"
     )]
     NotInsertedCollisionBlobId(BlobId),
-    #[error(
-        "Transaction is not inserted. A higher priced tx {0:#x} is already spending this message: {1:#x}"
+    #[display(
+        fmt = "Transaction is not inserted. A higher priced tx {_0:#x} is already spending this message: {_1:#x}"
     )]
     NotInsertedCollisionMessageId(TxId, Nonce),
-    #[error("Transaction is not inserted. UTXO input does not exist: {0:#x}")]
+    #[display(fmt = "Transaction is not inserted. UTXO input does not exist: {_0:#x}")]
     NotInsertedOutputDoesNotExist(UtxoId),
-    #[error("Transaction is not inserted. UTXO input contract does not exist or was already spent: {0:#x}")]
+    #[display(
+        fmt = "Transaction is not inserted. UTXO input contract does not exist or was already spent: {_0:#x}"
+    )]
     NotInsertedInputContractDoesNotExist(ContractId),
-    #[error("Transaction is not inserted. ContractId is already taken {0:#x}")]
+    #[display(fmt = "Transaction is not inserted. ContractId is already taken {_0:#x}")]
     NotInsertedContractIdAlreadyTaken(ContractId),
-    #[error("Transaction is not inserted. BlobId is already taken {0:#x}")]
+    #[display(fmt = "Transaction is not inserted. BlobId is already taken {_0:#x}")]
     NotInsertedBlobIdAlreadyTaken(BlobId),
-    #[error("Transaction is not inserted. UTXO does not exist: {0:#x}")]
+    #[display(fmt = "Transaction is not inserted. UTXO does not exist: {_0:#x}")]
     NotInsertedInputUtxoIdNotDoesNotExist(UtxoId),
-    #[error("Transaction is not inserted. UTXO is spent: {0:#x}")]
+    #[display(fmt = "Transaction is not inserted. UTXO is spent: {_0:#x}")]
     NotInsertedInputUtxoIdSpent(UtxoId),
-    #[error("Transaction is not inserted. Message id {0:#x} does not match any received message from the DA layer.")]
+    #[display(
+        fmt = "Transaction is not inserted. Message id {_0:#x} does not match any received message from the DA layer."
+    )]
     NotInsertedInputMessageUnknown(Nonce),
-    #[error(
-        "Transaction is not inserted. UTXO requires Contract input {0:#x} that is priced lower"
+    #[display(
+        fmt = "Transaction is not inserted. UTXO requires Contract input {_0:#x} that is priced lower"
     )]
     NotInsertedContractPricedLower(ContractId),
-    #[error("Transaction is not inserted. Input coin mismatch the values from database")]
+    #[display(
+        fmt = "Transaction is not inserted. Input coin mismatch the values from database"
+    )]
     NotInsertedIoCoinMismatch,
-    #[error("Transaction is not inserted. Input output mismatch. Coin owner is different from expected input")]
+    #[display(
+        fmt = "Transaction is not inserted. Input output mismatch. Coin owner is different from expected input"
+    )]
     NotInsertedIoWrongOwner,
-    #[error("Transaction is not inserted. Input output mismatch. Coin output does not match expected input")]
+    #[display(
+        fmt = "Transaction is not inserted. Input output mismatch. Coin output does not match expected input"
+    )]
     NotInsertedIoWrongAmount,
-    #[error("Transaction is not inserted. Input output mismatch. Coin output asset_id does not match expected inputs")]
+    #[display(
+        fmt = "Transaction is not inserted. Input output mismatch. Coin output asset_id does not match expected inputs"
+    )]
     NotInsertedIoWrongAssetId,
-    #[error(
-        "Transaction is not inserted. Input message mismatch the values from database"
+    #[display(
+        fmt = "Transaction is not inserted. Input message mismatch the values from database"
     )]
     NotInsertedIoMessageMismatch,
-    #[error(
-        "Transaction is not inserted. Input output mismatch. Expected coin but output is contract"
+    #[display(
+        fmt = "Transaction is not inserted. Input output mismatch. Expected coin but output is contract"
     )]
     NotInsertedIoContractOutput,
-    #[error("Transaction is not inserted. Maximum depth of dependent transaction chain reached")]
+    #[display(
+        fmt = "Transaction is not inserted. Maximum depth of dependent transaction chain reached"
+    )]
     NotInsertedMaxDepth,
     // small todo for now it can pass but in future we should include better messages
-    #[error("Transaction removed.")]
+    #[display(fmt = "Transaction removed.")]
     Removed,
-    #[error("Transaction expired because it exceeded the configured time to live `tx-pool-ttl`.")]
+    #[display(
+        fmt = "Transaction expired because it exceeded the configured time to live `tx-pool-ttl`."
+    )]
     TTLReason,
-    #[error("Transaction squeezed out because {0}")]
+    #[display(fmt = "Transaction squeezed out because {_0}")]
     SqueezedOut(String),
-    #[error("Invalid transaction data: {0:?}")]
+    #[display(fmt = "Invalid transaction data: {_0:?}")]
     ConsensusValidity(CheckError),
-    #[error("Mint transactions are disallowed from the txpool")]
+    #[display(fmt = "Mint transactions are disallowed from the txpool")]
     MintIsDisallowed,
-    #[error("The UTXO `{0}` is blacklisted")]
+    #[display(fmt = "The UTXO `{_0}` is blacklisted")]
     BlacklistedUTXO(UtxoId),
-    #[error("The owner `{0}` is blacklisted")]
+    #[display(fmt = "The owner `{_0}` is blacklisted")]
     BlacklistedOwner(Address),
-    #[error("The contract `{0}` is blacklisted")]
+    #[display(fmt = "The contract `{_0}` is blacklisted")]
     BlacklistedContract(ContractId),
-    #[error("The message `{0}` is blacklisted")]
+    #[display(fmt = "The message `{_0}` is blacklisted")]
     BlacklistedMessage(Nonce),
-    #[error("Database error: {0}")]
+    #[display(fmt = "Database error: {_0}")]
     Database(String),
     // TODO: We need it for now until channels are removed from TxPool.
-    #[error("Got some unexpected error: {0}")]
+    #[display(fmt = "Got some unexpected error: {_0}")]
     Other(String),
 }
+
+impl std::error::Error for Error {}
 
 #[cfg(feature = "test-helpers")]
 impl PartialEq for Error {

--- a/crates/services/txpool/src/error.rs
+++ b/crates/services/txpool/src/error.rs
@@ -10,6 +10,8 @@ use fuel_core_types::{
     fuel_vm::checked_transaction::CheckError,
 };
 
+use crate::ports::WasmValidityError;
+
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[allow(missing_docs)]
@@ -124,5 +126,15 @@ impl PartialEq for Error {
 impl From<CheckError> for Error {
     fn from(e: CheckError) -> Self {
         Error::ConsensusValidity(e)
+    }
+}
+
+impl From<WasmValidityError> for Error {
+    fn from(err: WasmValidityError) -> Self {
+        match err {
+            WasmValidityError::NotEnabled => Error::NotInsertedWasmNotEnabled,
+            WasmValidityError::NotFound => Error::NotInsertedWasmNotFound,
+            WasmValidityError::NotValid => Error::NotInsertedInvalidWasm,
+        }
     }
 }

--- a/crates/services/txpool/src/lib.rs
+++ b/crates/services/txpool/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
 
 pub mod config;
 mod containers;
+pub mod error;
 pub mod ports;
 pub mod service;
 mod transaction_selector;
@@ -29,7 +30,10 @@ pub mod mock_db;
 pub use mock_db::MockDb;
 
 pub use config::Config;
-pub use fuel_core_types::services::txpool::Error;
+pub use error::{
+    Error,
+    Result,
+};
 pub use service::{
     new_service,
     Service,

--- a/crates/services/txpool/src/ports.rs
+++ b/crates/services/txpool/src/ports.rs
@@ -1,4 +1,7 @@
-use crate::types::GasPrice;
+use crate::{
+    types::GasPrice,
+    Result as TxPoolResult,
+};
 use fuel_core_services::stream::BoxStream;
 use fuel_core_storage::Result as StorageResult;
 use fuel_core_types::{
@@ -26,7 +29,6 @@ use fuel_core_types::{
             GossipsubMessageInfo,
             NetworkData,
         },
-        txpool::Result as TxPoolResult,
     },
 };
 use std::{

--- a/crates/services/txpool/src/service/test_helpers.rs
+++ b/crates/services/txpool/src/service/test_helpers.rs
@@ -8,6 +8,7 @@ use crate::{
     test_helpers::MockWasmChecker,
     types::GasPrice,
     MockDb,
+    Result as TxPoolResult,
 };
 use fuel_core_services::{
     stream::BoxStream,
@@ -31,7 +32,6 @@ use fuel_core_types::{
     services::{
         block_importer::ImportResult,
         p2p::GossipsubMessageAcceptance,
-        txpool::Result as TxPoolResult,
     },
 };
 use std::cell::RefCell;

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -148,7 +148,7 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
             for remove in removed.iter() {
                 self.remove_tx(&remove.id());
             }
-            return removed;
+            return removed
         }
         Vec::new()
     }
@@ -244,7 +244,7 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
             tokio::time::Instant::now().checked_sub(self.config.transaction_ttl)
         else {
             // TTL is so big that we don't need to prune any transactions
-            return vec![];
+            return vec![]
         };
 
         let mut result = vec![];
@@ -268,10 +268,10 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
                 Input::CoinSigned(CoinSigned { utxo_id, owner, .. })
                 | Input::CoinPredicate(CoinPredicate { utxo_id, owner, .. }) => {
                     if self.config.blacklist.contains_coin(utxo_id) {
-                        return Err(Error::BlacklistedUTXO(*utxo_id));
+                        return Err(Error::BlacklistedUTXO(*utxo_id))
                     }
                     if self.config.blacklist.contains_address(owner) {
-                        return Err(Error::BlacklistedOwner(*owner));
+                        return Err(Error::BlacklistedOwner(*owner))
                     }
                 }
                 Input::Contract(contract) => {
@@ -280,7 +280,7 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
                         .blacklist
                         .contains_contract(&contract.contract_id)
                     {
-                        return Err(Error::BlacklistedContract(contract.contract_id));
+                        return Err(Error::BlacklistedContract(contract.contract_id))
                     }
                 }
                 Input::MessageCoinSigned(MessageCoinSigned {
@@ -308,13 +308,13 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
                     ..
                 }) => {
                     if self.config.blacklist.contains_message(nonce) {
-                        return Err(Error::BlacklistedMessage(*nonce));
+                        return Err(Error::BlacklistedMessage(*nonce))
                     }
                     if self.config.blacklist.contains_address(sender) {
-                        return Err(Error::BlacklistedOwner(*sender));
+                        return Err(Error::BlacklistedOwner(*sender))
                     }
                     if self.config.blacklist.contains_address(recipient) {
-                        return Err(Error::BlacklistedOwner(*recipient));
+                        return Err(Error::BlacklistedOwner(*recipient))
                     }
                 }
             }
@@ -361,11 +361,11 @@ where
         self.check_blacklisting(tx.as_ref())?;
 
         if !tx.is_computed() {
-            return Err(Error::NoMetadata);
+            return Err(Error::NoMetadata)
         }
 
         if self.by_hash.contains_key(&tx.id()) {
-            return Err(Error::NotInsertedTxKnown);
+            return Err(Error::NotInsertedTxKnown)
         }
 
         // If upgrading transition function, at least check that it is valid wasm
@@ -384,7 +384,7 @@ where
             // limit is hit, check if we can push out lowest priced tx
             let lowest_ratio = self.by_ratio_gas_tip.lowest_value().unwrap_or_default();
             if lowest_ratio >= Ratio::new(tx.tip(), tx.max_gas()) {
-                return Err(Error::NotInsertedLimitHit);
+                return Err(Error::NotInsertedLimitHit)
             }
         }
         if self.config.metrics {
@@ -517,7 +517,7 @@ where
     M: Memory + Send + Sync + 'static,
 {
     if tx.is_mint() {
-        return Err(Error::NotSupportedTransactionType);
+        return Err(Error::NotSupportedTransactionType)
     }
 
     let tx: Checked<Transaction> = if utxo_validation {

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -149,7 +149,7 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
             for remove in removed.iter() {
                 self.remove_tx(&remove.id());
             }
-            return removed
+            return removed;
         }
         Vec::new()
     }
@@ -245,7 +245,7 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
             tokio::time::Instant::now().checked_sub(self.config.transaction_ttl)
         else {
             // TTL is so big that we don't need to prune any transactions
-            return vec![]
+            return vec![];
         };
 
         let mut result = vec![];
@@ -256,7 +256,7 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
                 let removed = self.remove_inner(&oldest_tx);
                 result.extend(removed.into_iter());
             } else {
-                break
+                break;
             }
         }
 
@@ -269,10 +269,10 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
                 Input::CoinSigned(CoinSigned { utxo_id, owner, .. })
                 | Input::CoinPredicate(CoinPredicate { utxo_id, owner, .. }) => {
                     if self.config.blacklist.contains_coin(utxo_id) {
-                        return Err(Error::BlacklistedUTXO(*utxo_id))
+                        return Err(Error::BlacklistedUTXO(*utxo_id));
                     }
                     if self.config.blacklist.contains_address(owner) {
-                        return Err(Error::BlacklistedOwner(*owner))
+                        return Err(Error::BlacklistedOwner(*owner));
                     }
                 }
                 Input::Contract(contract) => {
@@ -281,7 +281,7 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
                         .blacklist
                         .contains_contract(&contract.contract_id)
                     {
-                        return Err(Error::BlacklistedContract(contract.contract_id))
+                        return Err(Error::BlacklistedContract(contract.contract_id));
                     }
                 }
                 Input::MessageCoinSigned(MessageCoinSigned {
@@ -309,13 +309,13 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
                     ..
                 }) => {
                     if self.config.blacklist.contains_message(nonce) {
-                        return Err(Error::BlacklistedMessage(*nonce))
+                        return Err(Error::BlacklistedMessage(*nonce));
                     }
                     if self.config.blacklist.contains_address(sender) {
-                        return Err(Error::BlacklistedOwner(*sender))
+                        return Err(Error::BlacklistedOwner(*sender));
                     }
                     if self.config.blacklist.contains_address(recipient) {
-                        return Err(Error::BlacklistedOwner(*recipient))
+                        return Err(Error::BlacklistedOwner(*recipient));
                     }
                 }
             }
@@ -362,11 +362,11 @@ where
         self.check_blacklisting(tx.as_ref())?;
 
         if !tx.is_computed() {
-            return Err(Error::NoMetadata)
+            return Err(Error::NoMetadata);
         }
 
         if self.by_hash.contains_key(&tx.id()) {
-            return Err(Error::NotInsertedTxKnown)
+            return Err(Error::NotInsertedTxKnown);
         }
 
         // If upgrading transition function, at least check that it is valid wasm
@@ -392,7 +392,7 @@ where
             // limit is hit, check if we can push out lowest priced tx
             let lowest_ratio = self.by_ratio_gas_tip.lowest_value().unwrap_or_default();
             if lowest_ratio >= Ratio::new(tx.tip(), tx.max_gas()) {
-                return Err(Error::NotInsertedLimitHit)
+                return Err(Error::NotInsertedLimitHit);
             }
         }
         if self.config.metrics {
@@ -525,7 +525,7 @@ where
     M: Memory + Send + Sync + 'static,
 {
     if tx.is_mint() {
-        return Err(Error::NotSupportedTransactionType)
+        return Err(Error::NotSupportedTransactionType);
     }
 
     let tx: Checked<Transaction> = if utxo_validation {

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -1,42 +1,76 @@
 use crate::{
     containers::{
-        dependency::Dependency, time_sort::TimeSort, tip_per_gas_sort::RatioGasTipSort,
+        dependency::Dependency,
+        time_sort::TimeSort,
+        tip_per_gas_sort::RatioGasTipSort,
     },
-    ports::{TxPoolDb, WasmChecker as WasmCheckerConstraint},
+    ports::{
+        TxPoolDb,
+        WasmChecker as WasmCheckerConstraint,
+    },
     service::TxStatusChange,
     types::*,
-    Config, Error, TxInfo,
+    Config,
+    Error,
+    TxInfo,
 };
 use fuel_core_types::{
-    fuel_tx::{field::UpgradePurpose as _, Transaction, UpgradePurpose},
+    fuel_tx::{
+        field::UpgradePurpose as _,
+        Transaction,
+        UpgradePurpose,
+    },
     fuel_types::BlockHeight,
     fuel_vm::checked_transaction::{
-        CheckPredicates, Checked, CheckedTransaction, Checks, IntoChecked,
+        CheckPredicates,
+        Checked,
+        CheckedTransaction,
+        Checks,
+        IntoChecked,
     },
-    services::txpool::{ArcPoolTx, InsertionResult},
+    services::txpool::{
+        ArcPoolTx,
+        InsertionResult,
+    },
     tai64::Tai64,
 };
 use num_rational::Ratio;
 
-use crate::ports::{GasPriceProvider, MemoryPool};
+use crate::ports::{
+    GasPriceProvider,
+    MemoryPool,
+};
 use fuel_core_metrics::txpool_metrics::txpool_metrics;
 use fuel_core_storage::transactional::AtomicView;
 use fuel_core_types::{
     blockchain::header::ConsensusParametersVersion,
     fuel_tx::{
         input::{
-            coin::{CoinPredicate, CoinSigned},
+            coin::{
+                CoinPredicate,
+                CoinSigned,
+            },
             message::{
-                MessageCoinPredicate, MessageCoinSigned, MessageDataPredicate,
+                MessageCoinPredicate,
+                MessageCoinSigned,
+                MessageDataPredicate,
                 MessageDataSigned,
             },
         },
-        ConsensusParameters, Input,
+        ConsensusParameters,
+        Input,
     },
-    fuel_vm::{checked_transaction::CheckPredicateParams, interpreter::Memory},
+    fuel_vm::{
+        checked_transaction::CheckPredicateParams,
+        interpreter::Memory,
+    },
     services::executor::TransactionExecutionStatus,
 };
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{
+    collections::HashMap,
+    ops::Deref,
+    sync::Arc,
+};
 
 #[cfg(test)]
 mod test_helpers;

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -1,77 +1,42 @@
 use crate::{
     containers::{
-        dependency::Dependency,
-        time_sort::TimeSort,
-        tip_per_gas_sort::RatioGasTipSort,
+        dependency::Dependency, time_sort::TimeSort, tip_per_gas_sort::RatioGasTipSort,
     },
-    ports::{
-        TxPoolDb,
-        WasmChecker as WasmCheckerConstraint,
-        WasmValidityError,
-    },
+    ports::{TxPoolDb, WasmChecker as WasmCheckerConstraint},
     service::TxStatusChange,
     types::*,
-    Config,
-    Error,
-    TxInfo,
+    Config, Error, TxInfo,
 };
 use fuel_core_types::{
-    fuel_tx::{
-        field::UpgradePurpose as _,
-        Transaction,
-        UpgradePurpose,
-    },
+    fuel_tx::{field::UpgradePurpose as _, Transaction, UpgradePurpose},
     fuel_types::BlockHeight,
     fuel_vm::checked_transaction::{
-        CheckPredicates,
-        Checked,
-        CheckedTransaction,
-        Checks,
-        IntoChecked,
+        CheckPredicates, Checked, CheckedTransaction, Checks, IntoChecked,
     },
-    services::txpool::{
-        ArcPoolTx,
-        InsertionResult,
-    },
+    services::txpool::{ArcPoolTx, InsertionResult},
     tai64::Tai64,
 };
 use num_rational::Ratio;
 
-use crate::ports::{
-    GasPriceProvider,
-    MemoryPool,
-};
+use crate::ports::{GasPriceProvider, MemoryPool};
 use fuel_core_metrics::txpool_metrics::txpool_metrics;
 use fuel_core_storage::transactional::AtomicView;
 use fuel_core_types::{
     blockchain::header::ConsensusParametersVersion,
     fuel_tx::{
         input::{
-            coin::{
-                CoinPredicate,
-                CoinSigned,
-            },
+            coin::{CoinPredicate, CoinSigned},
             message::{
-                MessageCoinPredicate,
-                MessageCoinSigned,
-                MessageDataPredicate,
+                MessageCoinPredicate, MessageCoinSigned, MessageDataPredicate,
                 MessageDataSigned,
             },
         },
-        ConsensusParameters,
-        Input,
+        ConsensusParameters, Input,
     },
-    fuel_vm::{
-        checked_transaction::CheckPredicateParams,
-        interpreter::Memory,
-    },
+    fuel_vm::{checked_transaction::CheckPredicateParams, interpreter::Memory},
     services::executor::TransactionExecutionStatus,
 };
-use std::{
-    collections::HashMap,
-    ops::Deref,
-    sync::Arc,
-};
+use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 #[cfg(test)]
 mod test_helpers;
@@ -374,14 +339,7 @@ where
             if let UpgradePurpose::StateTransition { root } =
                 upgrade.transaction().upgrade_purpose()
             {
-                if let Err(err) = self.wasm_checker.validate_uploaded_wasm(root) {
-                    // TODO: should be a From<_> impl, see https://github.com/FuelLabs/fuel-core/issues/2082
-                    return Err(match err {
-                        WasmValidityError::NotEnabled => Error::NotInsertedWasmNotEnabled,
-                        WasmValidityError::NotFound => Error::NotInsertedWasmNotFound,
-                        WasmValidityError::NotValid => Error::NotInsertedInvalidWasm,
-                    });
-                }
+                self.wasm_checker.validate_uploaded_wasm(root)?;
             }
         }
 

--- a/crates/services/txpool/src/txpool.rs
+++ b/crates/services/txpool/src/txpool.rs
@@ -255,7 +255,7 @@ impl<ViewProvider, WasmChecker> TxPool<ViewProvider, WasmChecker> {
                 let removed = self.remove_inner(&oldest_tx);
                 result.extend(removed.into_iter());
             } else {
-                break;
+                break
             }
         }
 

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -1,59 +1,20 @@
 //! Types for interoperability with the txpool service
 
 use crate::{
-    blockchain::{
-        block::Block,
-        header::ConsensusParametersVersion,
-    },
+    blockchain::{block::Block, header::ConsensusParametersVersion},
     fuel_asm::Word,
     fuel_tx::{
-        field::{
-            Inputs,
-            Outputs,
-            ScriptGasLimit,
-            Tip,
-        },
-        Blob,
-        Cacheable,
-        Chargeable,
-        Create,
-        Input,
-        Output,
-        Receipt,
-        Script,
-        Transaction,
-        TxId,
-        Upgrade,
-        Upload,
-        UtxoId,
+        field::{Inputs, Outputs, ScriptGasLimit, Tip},
+        Blob, Cacheable, Chargeable, Create, Input, Output, Receipt, Script, Transaction,
+        TxId, Upgrade, Upload,
     },
-    fuel_types::{
-        Address,
-        ContractId,
-        Nonce,
-    },
-    fuel_vm::{
-        checked_transaction::Checked,
-        ProgramState,
-    },
+    fuel_vm::{checked_transaction::Checked, ProgramState},
     services::executor::TransactionExecutionResult,
 };
-use fuel_vm_private::{
-    checked_transaction::{
-        CheckError,
-        CheckedTransaction,
-    },
-    fuel_tx::BlobId,
-    fuel_types::BlockHeight,
-};
-use std::{
-    sync::Arc,
-    time::Duration,
-};
+use fuel_vm_private::{checked_transaction::CheckedTransaction, fuel_types::BlockHeight};
+use std::{sync::Arc, time::Duration};
 use tai64::Tai64;
 
-/// The alias for transaction pool result.
-pub type Result<T> = core::result::Result<T, Error>;
 /// Pool transaction wrapped in an Arc for thread-safe sharing
 pub type ArcPoolTx = Arc<PoolTransaction>;
 
@@ -298,120 +259,5 @@ pub fn from_executor_to_status(
             total_gas,
             total_fee,
         },
-    }
-}
-
-#[allow(missing_docs)]
-#[derive(thiserror::Error, Debug, Clone)]
-#[non_exhaustive]
-pub enum Error {
-    #[error("Gas price not found for block height {0}")]
-    GasPriceNotFound(String),
-    #[error("Failed to calculate max block bytes: {0}")]
-    MaxBlockBytes(String),
-    #[error("TxPool required that transaction contains metadata")]
-    NoMetadata,
-    #[error("TxPool doesn't support this type of transaction.")]
-    NotSupportedTransactionType,
-    #[error("Transaction is not inserted. Hash is already known")]
-    NotInsertedTxKnown,
-    #[error("Transaction is not inserted. Pool limit is hit, try to increase gas_price")]
-    NotInsertedLimitHit,
-    #[error("Transaction is not inserted. Attempting to upgrade WAMS bytecode when WASM support is not enabled.")]
-    NotInsertedWasmNotEnabled,
-    #[error("Transaction is not inserted. WASM bytecode matching the given root was not found.")]
-    NotInsertedWasmNotFound,
-    #[error("Transaction is not inserted. WASM bytecode contents are not valid.")]
-    NotInsertedInvalidWasm,
-    #[error("Transaction is not inserted. The gas price is too low.")]
-    NotInsertedGasPriceTooLow,
-    #[error(
-        "Transaction is not inserted. More priced tx {0:#x} already spend this UTXO output: {1:#x}"
-    )]
-    NotInsertedCollision(TxId, UtxoId),
-    #[error(
-        "Transaction is not inserted. More priced tx has created contract with ContractId {0:#x}"
-    )]
-    NotInsertedCollisionContractId(ContractId),
-    #[error(
-        "Transaction is not inserted. More priced tx has uploaded the blob with BlobId {0:#x}"
-    )]
-    NotInsertedCollisionBlobId(BlobId),
-    #[error(
-        "Transaction is not inserted. A higher priced tx {0:#x} is already spending this message: {1:#x}"
-    )]
-    NotInsertedCollisionMessageId(TxId, Nonce),
-    #[error("Transaction is not inserted. UTXO input does not exist: {0:#x}")]
-    NotInsertedOutputDoesNotExist(UtxoId),
-    #[error("Transaction is not inserted. UTXO input contract does not exist or was already spent: {0:#x}")]
-    NotInsertedInputContractDoesNotExist(ContractId),
-    #[error("Transaction is not inserted. ContractId is already taken {0:#x}")]
-    NotInsertedContractIdAlreadyTaken(ContractId),
-    #[error("Transaction is not inserted. BlobId is already taken {0:#x}")]
-    NotInsertedBlobIdAlreadyTaken(BlobId),
-    #[error("Transaction is not inserted. UTXO does not exist: {0:#x}")]
-    NotInsertedInputUtxoIdNotDoesNotExist(UtxoId),
-    #[error("Transaction is not inserted. UTXO is spent: {0:#x}")]
-    NotInsertedInputUtxoIdSpent(UtxoId),
-    #[error("Transaction is not inserted. Message id {0:#x} does not match any received message from the DA layer.")]
-    NotInsertedInputMessageUnknown(Nonce),
-    #[error(
-        "Transaction is not inserted. UTXO requires Contract input {0:#x} that is priced lower"
-    )]
-    NotInsertedContractPricedLower(ContractId),
-    #[error("Transaction is not inserted. Input coin mismatch the values from database")]
-    NotInsertedIoCoinMismatch,
-    #[error("Transaction is not inserted. Input output mismatch. Coin owner is different from expected input")]
-    NotInsertedIoWrongOwner,
-    #[error("Transaction is not inserted. Input output mismatch. Coin output does not match expected input")]
-    NotInsertedIoWrongAmount,
-    #[error("Transaction is not inserted. Input output mismatch. Coin output asset_id does not match expected inputs")]
-    NotInsertedIoWrongAssetId,
-    #[error(
-        "Transaction is not inserted. Input message mismatch the values from database"
-    )]
-    NotInsertedIoMessageMismatch,
-    #[error(
-        "Transaction is not inserted. Input output mismatch. Expected coin but output is contract"
-    )]
-    NotInsertedIoContractOutput,
-    #[error("Transaction is not inserted. Maximum depth of dependent transaction chain reached")]
-    NotInsertedMaxDepth,
-    // small todo for now it can pass but in future we should include better messages
-    #[error("Transaction removed.")]
-    Removed,
-    #[error("Transaction expired because it exceeded the configured time to live `tx-pool-ttl`.")]
-    TTLReason,
-    #[error("Transaction squeezed out because {0}")]
-    SqueezedOut(String),
-    #[error("Invalid transaction data: {0:?}")]
-    ConsensusValidity(CheckError),
-    #[error("Mint transactions are disallowed from the txpool")]
-    MintIsDisallowed,
-    #[error("The UTXO `{0}` is blacklisted")]
-    BlacklistedUTXO(UtxoId),
-    #[error("The owner `{0}` is blacklisted")]
-    BlacklistedOwner(Address),
-    #[error("The contract `{0}` is blacklisted")]
-    BlacklistedContract(ContractId),
-    #[error("The message `{0}` is blacklisted")]
-    BlacklistedMessage(Nonce),
-    #[error("Database error: {0}")]
-    Database(String),
-    // TODO: We need it for now until channels are removed from TxPool.
-    #[error("Got some unexpected error: {0}")]
-    Other(String),
-}
-
-#[cfg(feature = "test-helpers")]
-impl PartialEq for Error {
-    fn eq(&self, other: &Self) -> bool {
-        self.to_string().eq(&other.to_string())
-    }
-}
-
-impl From<CheckError> for Error {
-    fn from(e: CheckError) -> Self {
-        Error::ConsensusValidity(e)
     }
 }

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -1,18 +1,45 @@
 //! Types for interoperability with the txpool service
 
 use crate::{
-    blockchain::{block::Block, header::ConsensusParametersVersion},
+    blockchain::{
+        block::Block,
+        header::ConsensusParametersVersion,
+    },
     fuel_asm::Word,
     fuel_tx::{
-        field::{Inputs, Outputs, ScriptGasLimit, Tip},
-        Blob, Cacheable, Chargeable, Create, Input, Output, Receipt, Script, Transaction,
-        TxId, Upgrade, Upload,
+        field::{
+            Inputs,
+            Outputs,
+            ScriptGasLimit,
+            Tip,
+        },
+        Blob,
+        Cacheable,
+        Chargeable,
+        Create,
+        Input,
+        Output,
+        Receipt,
+        Script,
+        Transaction,
+        TxId,
+        Upgrade,
+        Upload,
     },
-    fuel_vm::{checked_transaction::Checked, ProgramState},
+    fuel_vm::{
+        checked_transaction::Checked,
+        ProgramState,
+    },
     services::executor::TransactionExecutionResult,
 };
-use fuel_vm_private::{checked_transaction::CheckedTransaction, fuel_types::BlockHeight};
-use std::{sync::Arc, time::Duration};
+use fuel_vm_private::{
+    checked_transaction::CheckedTransaction,
+    fuel_types::BlockHeight,
+};
+use std::{
+    sync::Arc,
+    time::Duration,
+};
 use tai64::Tai64;
 
 /// Pool transaction wrapped in an Arc for thread-safe sharing


### PR DESCRIPTION
## Linked Issues/PRs
- Closes #2082 

## Description
This PR does three things:

1. The `Error` type defined in `crates/types/src/services/txpool.rs` is moved to `crates/services/txpool/src/error.rs`.
2. This error type now also implements `From<WasmValidityError>`.
3. Refactor to use `derive_more` instead of `thiserror` for the error type.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here