### PR TITLE
Remove RUSTSEC-2023-0052 from ignored errors as it's fixed now

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,4 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2023-0052", # https://github.com/FuelLabs/fuel-core/issues/1316
     "RUSTSEC-2024-0336" # https://github.com/FuelLabs/fuel-core/issues/1843
-    ]
+]


### PR DESCRIPTION
Closes #1316, closes #1317 

We no longer depend on `webpki`