### PR TITLE
feat: Add graphql query fields for retreiving information about upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2112](https://github.com/FuelLabs/fuel-core/pull/2112): Alter the way the sealed blocks are fetched with a given height.
 - [2115](https://github.com/FuelLabs/fuel-core/pull/2115): Add test for `SignMode` `is_available` method.
 
+### Added
+- [2119](https://github.com/FuelLabs/fuel-core/pull/2119): GraphQL query fields for retrieving information about upgrades.
 
 ## [Version 0.34.0]
 
@@ -18,7 +20,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2051](https://github.com/FuelLabs/fuel-core/pull/2051): Add support for AWS KMS signing for the PoA consensus module. The new key can be specified with `--consensus-aws-kms AWS_KEY_ARN`.
 - [2092](https://github.com/FuelLabs/fuel-core/pull/2092): Allow iterating by keys in rocksdb, and other storages.
 - [2096](https://github.com/FuelLabs/fuel-core/pull/2096): GraphQL query field to fetch blob byte code by its blob ID.
-- [2119](https://github.com/FuelLabs/fuel-core/pull/2119): GraphQL query fields for retrieving information about upgrades.
 
 ### Changed
 - [2106](https://github.com/FuelLabs/fuel-core/pull/2106): Remove deadline clock in POA and replace with tokio time functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [2051](https://github.com/FuelLabs/fuel-core/pull/2051): Add support for AWS KMS signing for the PoA consensus module. The new key can be specified with `--consensus-aws-kms AWS_KEY_ARN`.
 - [2092](https://github.com/FuelLabs/fuel-core/pull/2092): Allow iterating by keys in rocksdb, and other storages.
-- [2096](https://github.com/FuelLabs/fuel-core/pull/2096): GraphQL endpoint to fetch blob byte code by its blob ID.
+- [2096](https://github.com/FuelLabs/fuel-core/pull/2096): GraphQL query field to fetch blob byte code by its blob ID.
+- [2119](https://github.com/FuelLabs/fuel-core/pull/2119): GraphQL query fields for retreiving information about upgrades.
 
 ### Changed
 - [2106](https://github.com/FuelLabs/fuel-core/pull/2106): Remove deadline clock in POA and replace with tokio time functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2051](https://github.com/FuelLabs/fuel-core/pull/2051): Add support for AWS KMS signing for the PoA consensus module. The new key can be specified with `--consensus-aws-kms AWS_KEY_ARN`.
 - [2092](https://github.com/FuelLabs/fuel-core/pull/2092): Allow iterating by keys in rocksdb, and other storages.
 - [2096](https://github.com/FuelLabs/fuel-core/pull/2096): GraphQL query field to fetch blob byte code by its blob ID.
-- [2119](https://github.com/FuelLabs/fuel-core/pull/2119): GraphQL query fields for retreiving information about upgrades.
+- [2119](https://github.com/FuelLabs/fuel-core/pull/2119): GraphQL query fields for retrieving information about upgrades.
 
 ### Changed
 - [2106](https://github.com/FuelLabs/fuel-core/pull/2106): Remove deadline clock in POA and replace with tokio time functions.

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -1251,8 +1251,17 @@ scalar U64
 union UpgradePurpose = ConsensusParametersPurpose | StateTransitionPurpose
 
 type UploadedBytecode {
+	"""
+	Combined bytecode of all uploaded subsections.
+	"""
 	bytecode: HexString!
-	uploadedSubsectionsNumber: Int!
+	"""
+	Number of uploaded subsections (if incomplete).
+	"""
+	uploadedSubsectionsNumber: Int
+	"""
+	Indicates if the bytecode upload is complete.
+	"""
 	completed: Boolean!
 }
 

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -977,6 +977,9 @@ type Query {
 		"""
 		id: RelayedTransactionId!
 	): RelayedTransactionStatus
+	consensusParameters(version: Int!): ConsensusParameters!
+	stateTransitionBytecodeByVersion(version: Int!): StateTransitionBytecode
+	stateTransitionBytecodeByRoot(root: HexString!): StateTransitionBytecode!
 }
 
 type Receipt {
@@ -1092,6 +1095,11 @@ input SpendQueryElementInput {
 
 type SqueezedOutStatus {
 	reason: String!
+}
+
+type StateTransitionBytecode {
+	root: HexString!
+	bytecode: UploadedBytecode!
 }
 
 type StateTransitionPurpose {
@@ -1241,6 +1249,12 @@ scalar U32
 scalar U64
 
 union UpgradePurpose = ConsensusParametersPurpose | StateTransitionPurpose
+
+type UploadedBytecode {
+	bytecode: HexString!
+	uploadedSubsectionsNumber: Int!
+	completed: Boolean!
+}
 
 scalar UtxoId
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -23,6 +23,7 @@ use crate::client::{
             ContractId,
             UtxoId,
         },
+        upgrades::StateTransitionBytecode,
         RelayedTransactionStatus,
     },
 };
@@ -45,6 +46,7 @@ use fuel_core_types::{
     fuel_tx::{
         BlobId,
         Bytes32,
+        ConsensusParameters,
         Receipt,
         Transaction,
         TxId,
@@ -381,6 +383,57 @@ impl FuelClient {
             let result = r.chain.try_into()?;
             Ok(result)
         })
+    }
+
+    pub async fn consensus_parameters(
+        &self,
+        version: i32,
+    ) -> io::Result<Option<ConsensusParameters>> {
+        let args = schema::upgrades::ConsensusParametersByVersionArgs { version };
+        let query = schema::upgrades::ConsensusParametersByVersionQuery::build(args);
+
+        let result = self
+            .query(query)
+            .await?
+            .consensus_parameters
+            .map(TryInto::try_into)
+            .transpose()?;
+
+        Ok(result)
+    }
+
+    pub async fn state_transition_byte_code_by_version(
+        &self,
+        version: i32,
+    ) -> io::Result<Option<StateTransitionBytecode>> {
+        let args = schema::upgrades::StateTransitionBytecodeByVersionArgs { version };
+        let query = schema::upgrades::StateTransitionBytecodeByVersionQuery::build(args);
+        let result = self
+            .query(query)
+            .await?
+            .state_transition_bytecode_by_version
+            .map(TryInto::try_into)
+            .transpose()?;
+
+        Ok(result)
+    }
+
+    pub async fn state_transition_byte_code_by_root(
+        &self,
+        root: Bytes32,
+    ) -> io::Result<Option<StateTransitionBytecode>> {
+        let args = schema::upgrades::StateTransitionBytecodeByRootArgs {
+            root: HexString(Bytes(root.to_vec())),
+        };
+        let query = schema::upgrades::StateTransitionBytecodeByRootQuery::build(args);
+        let result = self
+            .query(query)
+            .await?
+            .state_transition_bytecode_by_root
+            .map(TryInto::try_into)
+            .transpose()?;
+
+        Ok(result)
     }
 
     /// Default dry run, matching the exact configuration as the node

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -408,6 +408,7 @@ impl FuelClient {
     ) -> io::Result<Option<StateTransitionBytecode>> {
         let args = schema::upgrades::StateTransitionBytecodeByVersionArgs { version };
         let query = schema::upgrades::StateTransitionBytecodeByVersionQuery::build(args);
+
         let result = self
             .query(query)
             .await?
@@ -426,6 +427,7 @@ impl FuelClient {
             root: HexString(Bytes(root.to_vec())),
         };
         let query = schema::upgrades::StateTransitionBytecodeByRootQuery::build(args);
+
         let result = self
             .query(query)
             .await?

--- a/crates/client/src/client/schema.rs
+++ b/crates/client/src/client/schema.rs
@@ -34,6 +34,7 @@ pub mod coins;
 pub mod contract;
 pub mod message;
 pub mod node_info;
+pub mod upgrades;
 
 pub mod gas_price;
 pub mod primitives;

--- a/crates/client/src/client/schema/upgrades.rs
+++ b/crates/client/src/client/schema/upgrades.rs
@@ -1,0 +1,90 @@
+use crate::client::schema::schema;
+
+use crate::client::schema::{
+    chain::ConsensusParameters,
+    primitives::HexString,
+};
+
+use fuel_core_types::fuel_vm::UploadedBytecode as VmUploadedBytecode;
+
+use std::num::TryFromIntError;
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct ConsensusParametersByVersionArgs {
+    pub version: i32,
+}
+
+#[derive(cynic::QueryFragment, Clone, Debug)]
+#[cynic(
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    variables = "ConsensusParametersByVersionArgs"
+)]
+pub struct ConsensusParametersByVersionQuery {
+    #[arguments(version: $version)]
+    pub consensus_parameters: Option<ConsensusParameters>,
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct StateTransitionBytecodeByVersionArgs {
+    pub version: i32,
+}
+
+#[derive(cynic::QueryFragment, Clone, Debug)]
+#[cynic(
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    variables = "StateTransitionBytecodeByVersionArgs"
+)]
+pub struct StateTransitionBytecodeByVersionQuery {
+    #[arguments(version: $version)]
+    pub state_transition_bytecode_by_version: Option<StateTransitionBytecode>,
+}
+
+#[derive(cynic::QueryVariables, Debug)]
+pub struct StateTransitionBytecodeByRootArgs {
+    pub root: HexString,
+}
+
+#[derive(cynic::QueryFragment, Clone, Debug)]
+#[cynic(
+    schema_path = "./assets/schema.sdl",
+    graphql_type = "Query",
+    variables = "StateTransitionBytecodeByRootArgs"
+)]
+pub struct StateTransitionBytecodeByRootQuery {
+    #[arguments(root: $root)]
+    pub state_transition_bytecode_by_root: Option<StateTransitionBytecode>,
+}
+
+#[derive(cynic::QueryFragment, Clone, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct StateTransitionBytecode {
+    pub root: HexString,
+    pub bytecode: UploadedBytecode,
+}
+
+#[derive(cynic::QueryFragment, Clone, Debug)]
+#[cynic(schema_path = "./assets/schema.sdl")]
+pub struct UploadedBytecode {
+    pub bytecode: HexString,
+    pub uploaded_subsections_number: i32,
+    pub completed: bool,
+}
+
+// GrapqhQL translation
+
+impl TryFrom<UploadedBytecode> for VmUploadedBytecode {
+    type Error = TryFromIntError;
+    fn try_from(value: UploadedBytecode) -> Result<Self, Self::Error> {
+        Ok(match value.completed {
+            true => Self::Completed(value.bytecode.into()),
+            false => Self::Uncompleted {
+                bytecode: value.bytecode.into(),
+                uploaded_subsections_number: value
+                    .uploaded_subsections_number
+                    .try_into()?,
+            },
+        })
+    }
+}

--- a/crates/client/src/client/types.rs
+++ b/crates/client/src/client/types.rs
@@ -5,6 +5,7 @@ pub mod chain_info;
 pub mod coins;
 pub mod contract;
 pub mod gas_costs;
+pub mod upgrades;
 
 pub mod gas_price;
 pub mod merkle_proof;

--- a/crates/client/src/client/types/upgrades.rs
+++ b/crates/client/src/client/types/upgrades.rs
@@ -1,0 +1,29 @@
+use crate::client::{
+    schema::{
+        self,
+        ConversionError,
+    },
+    types::primitives::MerkleRoot,
+};
+use fuel_core_types::fuel_vm::UploadedBytecode;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StateTransitionBytecode {
+    pub root: MerkleRoot,
+    pub bytecode: UploadedBytecode,
+}
+
+// GraphQL Translation
+
+impl TryFrom<schema::upgrades::StateTransitionBytecode> for StateTransitionBytecode {
+    type Error = ConversionError;
+
+    fn try_from(
+        value: schema::upgrades::StateTransitionBytecode,
+    ) -> Result<Self, Self::Error> {
+        let root = value.root.0 .0.as_slice().try_into()?;
+        let bytecode = value.bytecode.try_into()?;
+
+        Ok(Self { root, bytecode })
+    }
+}

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -11,6 +11,8 @@ use fuel_core_storage::{
         ContractsAssets,
         ContractsRawCode,
         Messages,
+        StateTransitionBytecodeVersions,
+        UploadedBytecodes,
     },
     Error as StorageError,
     Result as StorageResult,
@@ -21,6 +23,7 @@ use fuel_core_types::{
     blockchain::{
         block::CompressedBlock,
         consensus::Consensus,
+        header::ConsensusParametersVersion,
         primitives::{
             BlockId,
             DaBlockHeight,
@@ -119,6 +122,8 @@ pub trait OnChainDatabase:
     + DatabaseMessages
     + StorageInspect<Coins, Error = StorageError>
     + StorageInspect<BlobData, Error = StorageError>
+    + StorageInspect<StateTransitionBytecodeVersions, Error = StorageError>
+    + StorageInspect<UploadedBytecodes, Error = StorageError>
     + DatabaseContracts
     + DatabaseChain
     + DatabaseMessageProof
@@ -366,4 +371,9 @@ pub mod worker {
 pub trait ConsensusProvider: Send + Sync {
     /// Returns latest consensus parameters.
     fn latest_consensus_params(&self) -> Arc<ConsensusParameters>;
+
+    fn consensus_params_at_version(
+        &self,
+        version: &ConsensusParametersVersion,
+    ) -> anyhow::Result<Arc<ConsensusParameters>>;
 }

--- a/crates/fuel-core/src/query.rs
+++ b/crates/fuel-core/src/query.rs
@@ -7,6 +7,7 @@ mod contract;
 mod message;
 mod subscriptions;
 mod tx;
+mod upgrades;
 
 // TODO: Remove reexporting of everything
 pub use balance::*;
@@ -18,3 +19,4 @@ pub use contract::*;
 pub use message::*;
 pub(crate) use subscriptions::*;
 pub use tx::*;
+pub use upgrades::*;

--- a/crates/fuel-core/src/query/block.rs
+++ b/crates/fuel-core/src/query/block.rs
@@ -1,7 +1,4 @@
-use crate::fuel_core_graphql_api::ports::{
-    DatabaseBlocks,
-    OnChainDatabase,
-};
+use crate::fuel_core_graphql_api::ports::DatabaseBlocks;
 use fuel_core_storage::{
     iter::{
         BoxedIter,
@@ -23,7 +20,7 @@ pub trait SimpleBlockData: Send + Sync {
 
 impl<D> SimpleBlockData for D
 where
-    D: OnChainDatabase + DatabaseBlocks + ?Sized,
+    D: DatabaseBlocks + ?Sized + Send + Sync,
 {
     fn block(&self, id: &BlockHeight) -> StorageResult<CompressedBlock> {
         self.block(id)
@@ -46,7 +43,7 @@ pub trait BlockQueryData: Send + Sync + SimpleBlockData {
 
 impl<D> BlockQueryData for D
 where
-    D: OnChainDatabase + ?Sized,
+    D: DatabaseBlocks + ?Sized + Send + Sync,
 {
     fn latest_block_height(&self) -> StorageResult<BlockHeight> {
         self.latest_height()

--- a/crates/fuel-core/src/query/block.rs
+++ b/crates/fuel-core/src/query/block.rs
@@ -46,7 +46,7 @@ pub trait BlockQueryData: Send + Sync + SimpleBlockData {
 
 impl<D> BlockQueryData for D
 where
-    D: OnChainDatabase + DatabaseBlocks + ?Sized,
+    D: OnChainDatabase + ?Sized,
 {
     fn latest_block_height(&self) -> StorageResult<BlockHeight> {
         self.latest_height()

--- a/crates/fuel-core/src/query/upgrades.rs
+++ b/crates/fuel-core/src/query/upgrades.rs
@@ -1,0 +1,57 @@
+use fuel_core_storage::{
+    not_found,
+    tables::{
+        StateTransitionBytecodeVersions,
+        UploadedBytecodes,
+    },
+    Result as StorageResult,
+    StorageAsRef,
+};
+use fuel_core_types::{
+    blockchain::header::StateTransitionBytecodeVersion,
+    fuel_tx::Bytes32,
+    fuel_vm::UploadedBytecode,
+};
+
+use crate::graphql_api::ports::OnChainDatabase;
+
+pub trait UpgradeQueryData: Send + Sync {
+    fn state_transition_bytecode_root(
+        &self,
+        version: StateTransitionBytecodeVersion,
+    ) -> StorageResult<Bytes32>;
+
+    fn state_transition_bytecode(&self, root: Bytes32)
+        -> StorageResult<UploadedBytecode>;
+}
+
+impl<D> UpgradeQueryData for D
+where
+    D: OnChainDatabase + ?Sized,
+{
+    fn state_transition_bytecode_root(
+        &self,
+        version: StateTransitionBytecodeVersion,
+    ) -> StorageResult<Bytes32> {
+        let merkle_root = self
+            .storage::<StateTransitionBytecodeVersions>()
+            .get(&version)?
+            .ok_or(not_found!(StateTransitionBytecodeVersions))?
+            .into_owned();
+
+        Ok(merkle_root)
+    }
+
+    fn state_transition_bytecode(
+        &self,
+        root: Bytes32,
+    ) -> StorageResult<UploadedBytecode> {
+        let bytecode = self
+            .storage::<UploadedBytecodes>()
+            .get(&root)?
+            .ok_or(not_found!(UploadedBytecodes))?
+            .into_owned();
+
+        Ok(bytecode)
+    }
+}

--- a/crates/fuel-core/src/schema.rs
+++ b/crates/fuel-core/src/schema.rs
@@ -36,6 +36,7 @@ pub mod dap;
 pub mod health;
 pub mod message;
 pub mod node_info;
+pub mod upgrades;
 
 pub mod gas_price;
 pub mod scalars;
@@ -60,6 +61,7 @@ pub struct Query(
     gas_price::EstimateGasPriceQuery,
     message::MessageQuery,
     relayed_tx::RelayedTransactionQuery,
+    upgrades::UpgradeQuery,
 );
 
 #[derive(MergedObject, Default)]

--- a/crates/fuel-core/src/schema/chain.rs
+++ b/crates/fuel-core/src/schema/chain.rs
@@ -36,7 +36,7 @@ use std::{
 };
 
 pub struct ChainInfo;
-pub struct ConsensusParameters(Arc<fuel_tx::ConsensusParameters>);
+pub struct ConsensusParameters(pub Arc<fuel_tx::ConsensusParameters>);
 pub struct TxParameters(fuel_tx::TxParameters);
 pub struct PredicateParameters(fuel_tx::PredicateParameters);
 pub struct ScriptParameters(fuel_tx::ScriptParameters);
@@ -122,78 +122,38 @@ impl ConsensusParameters {
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
-    async fn tx_params(&self, ctx: &Context<'_>) -> async_graphql::Result<TxParameters> {
-        let params = ctx
-            .data_unchecked::<ConsensusProvider>()
-            .latest_consensus_params();
-
-        Ok(TxParameters(params.tx_params().to_owned()))
+    async fn tx_params(&self) -> TxParameters {
+        TxParameters(self.0.tx_params().to_owned())
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
-    async fn predicate_params(
-        &self,
-        ctx: &Context<'_>,
-    ) -> async_graphql::Result<PredicateParameters> {
-        let params = ctx
-            .data_unchecked::<ConsensusProvider>()
-            .latest_consensus_params();
-
-        Ok(PredicateParameters(params.predicate_params().to_owned()))
+    async fn predicate_params(&self) -> PredicateParameters {
+        PredicateParameters(self.0.predicate_params().to_owned())
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
-    async fn script_params(
-        &self,
-        ctx: &Context<'_>,
-    ) -> async_graphql::Result<ScriptParameters> {
-        let params = ctx
-            .data_unchecked::<ConsensusProvider>()
-            .latest_consensus_params();
-
-        Ok(ScriptParameters(params.script_params().to_owned()))
+    async fn script_params(&self) -> ScriptParameters {
+        ScriptParameters(self.0.script_params().to_owned())
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
-    async fn contract_params(
-        &self,
-        ctx: &Context<'_>,
-    ) -> async_graphql::Result<ContractParameters> {
-        let params = ctx
-            .data_unchecked::<ConsensusProvider>()
-            .latest_consensus_params();
-
-        Ok(ContractParameters(params.contract_params().to_owned()))
+    async fn contract_params(&self) -> ContractParameters {
+        ContractParameters(self.0.contract_params().to_owned())
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
-    async fn fee_params(
-        &self,
-        ctx: &Context<'_>,
-    ) -> async_graphql::Result<FeeParameters> {
-        let params = ctx
-            .data_unchecked::<ConsensusProvider>()
-            .latest_consensus_params();
-
-        Ok(FeeParameters(params.fee_params().to_owned()))
+    async fn fee_params(&self) -> FeeParameters {
+        FeeParameters(self.0.fee_params().to_owned())
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read")]
-    async fn base_asset_id(&self, ctx: &Context<'_>) -> async_graphql::Result<AssetId> {
-        let params = ctx
-            .data_unchecked::<ConsensusProvider>()
-            .latest_consensus_params();
-
-        Ok(AssetId(*params.base_asset_id()))
+    async fn base_asset_id(&self) -> AssetId {
+        AssetId(*self.0.base_asset_id())
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read")]
-    async fn block_gas_limit(&self, ctx: &Context<'_>) -> async_graphql::Result<U64> {
-        let params = ctx
-            .data_unchecked::<ConsensusProvider>()
-            .latest_consensus_params();
-
-        Ok(params.block_gas_limit().into())
+    async fn block_gas_limit(&self) -> U64 {
+        self.0.block_gas_limit().into()
     }
 
     async fn chain_id(&self) -> U64 {
@@ -201,12 +161,8 @@ impl ConsensusParameters {
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
-    async fn gas_costs(&self, ctx: &Context<'_>) -> async_graphql::Result<GasCosts> {
-        let params = ctx
-            .data_unchecked::<ConsensusProvider>()
-            .latest_consensus_params();
-
-        Ok(GasCosts(params.gas_costs().clone()))
+    async fn gas_costs(&self) -> async_graphql::Result<GasCosts> {
+        Ok(GasCosts(self.0.gas_costs().clone()))
     }
 
     #[graphql(complexity = "QUERY_COSTS.storage_read")]

--- a/crates/fuel-core/src/schema/upgrades.rs
+++ b/crates/fuel-core/src/schema/upgrades.rs
@@ -43,6 +43,7 @@ impl UpgradeQuery {
         Ok(ConsensusParameters(params))
     }
 
+    #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
     async fn state_transition_bytecode_by_version(
         &self,
         ctx: &Context<'_>,
@@ -54,6 +55,7 @@ impl UpgradeQuery {
             .into_api_result()
     }
 
+    #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
     async fn state_transition_bytecode_by_root(
         &self,
         root: HexString,

--- a/crates/fuel-core/src/schema/upgrades.rs
+++ b/crates/fuel-core/src/schema/upgrades.rs
@@ -103,8 +103,11 @@ impl TryFrom<HexString> for StateTransitionBytecode {
 
 #[derive(SimpleObject)]
 pub struct UploadedBytecode {
+    /// Combined bytecode of all uploaded subsections.
     bytecode: HexString,
-    uploaded_subsections_number: u16,
+    /// Number of uploaded subsections (if incomplete).
+    uploaded_subsections_number: Option<u16>,
+    /// Indicates if the bytecode upload is complete.
     completed: bool,
 }
 
@@ -116,12 +119,12 @@ impl From<StorageUploadedBytecode> for UploadedBytecode {
                 uploaded_subsections_number,
             } => Self {
                 bytecode: HexString(bytecode),
-                uploaded_subsections_number,
+                uploaded_subsections_number: Some(uploaded_subsections_number),
                 completed: false,
             },
             StorageUploadedBytecode::Completed(bytecode) => Self {
                 bytecode: HexString(bytecode),
-                uploaded_subsections_number: 0,
+                uploaded_subsections_number: None,
                 completed: true,
             },
         }

--- a/crates/fuel-core/src/schema/upgrades.rs
+++ b/crates/fuel-core/src/schema/upgrades.rs
@@ -1,0 +1,127 @@
+use crate::{
+    graphql_api::{
+        api_service::ConsensusProvider,
+        IntoApiResult,
+        QUERY_COSTS,
+    },
+    query::UpgradeQueryData,
+    schema::{
+        chain::ConsensusParameters,
+        scalars::HexString,
+        ReadViewProvider,
+    },
+};
+use async_graphql::{
+    Context,
+    Object,
+    SimpleObject,
+};
+use fuel_core_types::{
+    blockchain::header::{
+        ConsensusParametersVersion,
+        StateTransitionBytecodeVersion,
+    },
+    fuel_types,
+    fuel_vm::UploadedBytecode as StorageUploadedBytecode,
+};
+
+#[derive(Default)]
+pub struct UpgradeQuery;
+
+#[Object]
+impl UpgradeQuery {
+    #[graphql(complexity = "QUERY_COSTS.storage_read + child_complexity")]
+    async fn consensus_parameters(
+        &self,
+        ctx: &Context<'_>,
+        version: ConsensusParametersVersion,
+    ) -> async_graphql::Result<ConsensusParameters> {
+        let params = ctx
+            .data_unchecked::<ConsensusProvider>()
+            .consensus_params_at_version(&version)?;
+
+        Ok(ConsensusParameters(params))
+    }
+
+    async fn state_transition_bytecode_by_version(
+        &self,
+        ctx: &Context<'_>,
+        version: StateTransitionBytecodeVersion,
+    ) -> async_graphql::Result<Option<StateTransitionBytecode>> {
+        let query = ctx.read_view()?;
+        query
+            .state_transition_bytecode_root(version)
+            .into_api_result()
+    }
+
+    async fn state_transition_bytecode_by_root(
+        &self,
+        root: HexString,
+    ) -> async_graphql::Result<StateTransitionBytecode> {
+        StateTransitionBytecode::try_from(root)
+    }
+}
+
+pub struct StateTransitionBytecode {
+    root: fuel_types::Bytes32,
+}
+
+#[Object]
+impl StateTransitionBytecode {
+    async fn root(&self) -> HexString {
+        HexString(self.root.to_vec())
+    }
+
+    async fn bytecode(
+        &self,
+        ctx: &Context<'_>,
+    ) -> async_graphql::Result<UploadedBytecode> {
+        let query = ctx.read_view()?;
+        query
+            .state_transition_bytecode(self.root)
+            .map(UploadedBytecode::from)
+            .map_err(async_graphql::Error::from)
+    }
+}
+
+impl From<fuel_types::Bytes32> for StateTransitionBytecode {
+    fn from(root: fuel_types::Bytes32) -> Self {
+        Self { root }
+    }
+}
+
+impl TryFrom<HexString> for StateTransitionBytecode {
+    type Error = async_graphql::Error;
+
+    fn try_from(root: HexString) -> Result<Self, Self::Error> {
+        let root = root.0.as_slice().try_into()?;
+        Ok(Self { root })
+    }
+}
+
+#[derive(SimpleObject)]
+pub struct UploadedBytecode {
+    bytecode: HexString,
+    uploaded_subsections_number: u16,
+    completed: bool,
+}
+
+impl From<StorageUploadedBytecode> for UploadedBytecode {
+    fn from(value: fuel_core_types::fuel_vm::UploadedBytecode) -> Self {
+        match value {
+            StorageUploadedBytecode::Uncompleted {
+                bytecode,
+                uploaded_subsections_number,
+            } => Self {
+                bytecode: HexString(bytecode),
+                uploaded_subsections_number,
+                completed: false,
+            },
+            StorageUploadedBytecode::Completed(bytecode) => Self {
+                bytecode: HexString(bytecode),
+                uploaded_subsections_number: 0,
+                completed: true,
+            },
+        }
+    }
+}

--- a/crates/fuel-core/src/service/adapters/graphql_api.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api.rs
@@ -29,6 +29,7 @@ use fuel_core_txpool::{
     types::TxId,
 };
 use fuel_core_types::{
+    blockchain::header::ConsensusParametersVersion,
     entities::relayer::message::MerkleProof,
     fuel_tx::{
         Bytes32,
@@ -173,6 +174,13 @@ impl GasPriceEstimate for StaticGasPrice {
 impl ConsensusProvider for ConsensusParametersProvider {
     fn latest_consensus_params(&self) -> Arc<ConsensusParameters> {
         self.shared_state.latest_consensus_parameters()
+    }
+
+    fn consensus_params_at_version(
+        &self,
+        version: &ConsensusParametersVersion,
+    ) -> anyhow::Result<Arc<ConsensusParameters>> {
+        Ok(self.shared_state.get_consensus_parameters(version)?)
     }
 }
 


### PR DESCRIPTION
## Linked Issues/PRs
Closes #2071  

## Description
This PR adds the following three new query fields

- consensusParameters(version: Int!): ConsensusParameters!
- stateTransitionBytecodeByVersion(version: Int!): StateTransitionBytecode
- stateTransitionBytecodeByRoot(root: HexString!): StateTransitionBytecode!

which help provide more insights in previous upgrades on the chain.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
