### PR TITLE
feat(gas_price_service): include trait declaration for block committer data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [2135](https://github.com/FuelLabs/fuel-core/pull/2135): Added metrics logging for number of blocks served over the p2p req/res protocol.
+- [2155](https://github.com/FuelLabs/fuel-core/pull/2155): Added trait declaration for block committer data
 
 
 ## [Version 0.35.0]

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -271,7 +271,7 @@ fn sync_metadata_storage_with_on_chain_storage(
             )?;
         }
         AlgorithmUpdater::V1(_) => {
-            todo!()
+            todo!() // TODO(#2140)
         }
     }
     Ok(())

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -217,7 +217,7 @@ pub fn get_synced_gas_price_updater(
             default_metadata.into(),
             l2_block_source,
             metadata_storage,
-            FuelDaSource::default(),
+            FuelDaSource,
         );
         Ok(updater)
     } else {
@@ -235,7 +235,7 @@ pub fn get_synced_gas_price_updater(
             latest_block_height.into(),
             l2_block_source,
             metadata_storage,
-            FuelDaSource::default(),
+            FuelDaSource,
             config.min_gas_price,
             config.gas_price_change_percent,
             config.gas_price_threshold_percent,

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -20,6 +20,7 @@ use fuel_core_gas_price_service::{
             FuelL2BlockSource,
             GasPriceSettingsProvider,
         },
+        fuel_da_source_adapter::FuelDaSource,
         Algorithm,
         AlgorithmUpdater,
         AlgorithmUpdaterV0,
@@ -57,6 +58,7 @@ use fuel_core_types::{
 type Updater = FuelGasPriceUpdater<
     FuelL2BlockSource<ConsensusParametersProvider>,
     MetadataStorageAdapter,
+    FuelDaSource,
 >;
 
 pub struct InitializeTask {
@@ -77,6 +79,7 @@ type Task = GasPriceService<
     FuelGasPriceUpdater<
         FuelL2BlockSource<ConsensusParametersProvider>,
         MetadataStorageAdapter,
+        FuelDaSource,
     >,
 >;
 
@@ -214,6 +217,7 @@ pub fn get_synced_gas_price_updater(
             default_metadata.into(),
             l2_block_source,
             metadata_storage,
+            FuelDaSource::default(),
         );
         Ok(updater)
     } else {
@@ -231,6 +235,7 @@ pub fn get_synced_gas_price_updater(
             latest_block_height.into(),
             l2_block_source,
             metadata_storage,
+            FuelDaSource::default(),
             config.min_gas_price,
             config.gas_price_change_percent,
             config.gas_price_threshold_percent,
@@ -264,6 +269,9 @@ fn sync_metadata_storage_with_on_chain_storage(
                 updater,
                 metadata_storage,
             )?;
+        }
+        AlgorithmUpdater::V1(_) => {
+            todo!()
         }
     }
     Ok(())

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -21,6 +21,7 @@ pub use fuel_gas_price_algorithm::{
 mod tests;
 
 pub mod fuel_core_storage_adapter;
+pub mod fuel_da_source_adapter;
 
 pub struct FuelGasPriceUpdater<L2, Metadata, DaSource> {
     inner: AlgorithmUpdater,

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -27,6 +27,7 @@ pub struct FuelGasPriceUpdater<L2, Metadata, DaSource> {
     inner: AlgorithmUpdater,
     l2_block_source: L2,
     metadata_storage: Metadata,
+    #[allow(dead_code)]
     da_source: DaSource,
 }
 
@@ -120,9 +121,8 @@ pub struct DaCommitDetails {
     pub partial_block_heights: Option<[u32; 2]>,
 }
 
-#[async_trait::async_trait]
 pub trait DaCommitSource: Send + Sync {
-    async fn get_da_commit_details(&mut self) -> Result<DaCommitDetails>;
+    fn get_da_commit_details(&mut self) -> Result<Option<DaCommitDetails>>;
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
@@ -273,9 +273,8 @@ where
             AlgorithmUpdater::V0(updater) => {
                 updater.update_l2_block_data(height, gas_used, capacity)?;
             }
-            AlgorithmUpdater::V1(updater) => {
-                updater.update_l2_block_data(height, gas_used, capacity, 0, 0)?;
-                let _da_commit_details = self.da_source.get_da_commit_details().await;
+            AlgorithmUpdater::V1(_) => {
+                return Err(anyhow!("V1 of the gas price algo has not been enabled yet"))
                 // TODO: update the DA record data with data received from the source
                 // updater.update_da_record_data(vec![])?;
             }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -194,7 +194,7 @@ impl From<AlgorithmUpdater> for UpdaterMetadata {
                 UpdaterMetadata::V0(metadata)
             }
             AlgorithmUpdater::V1(_v1) => {
-                unimplemented!()
+                unimplemented!() // https://github.com/FuelLabs/fuel-core/issues/2140
             }
         }
     }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -275,7 +275,7 @@ where
             }
             AlgorithmUpdater::V1(_) => {
                 return Err(anyhow!("V1 of the gas price algo has not been enabled yet"))
-                // TODO: update the DA record data with data received from the source
+                // TODO(#2139): update the DA record data with data received from the source
                 // updater.update_da_record_data(vec![])?;
             }
         }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -2,6 +2,8 @@ use crate::{
     GasPriceAlgorithm,
     UpdateAlgorithm,
 };
+use anyhow::anyhow;
+use core::num::NonZeroU64;
 use fuel_core_types::fuel_types::BlockHeight;
 pub use fuel_gas_price_algorithm::{
     v0::{
@@ -14,48 +16,53 @@ pub use fuel_gas_price_algorithm::{
         RecordedBlock,
     },
 };
-use std::num::NonZeroU64;
 
 #[cfg(test)]
 mod tests;
 
 pub mod fuel_core_storage_adapter;
 
-pub struct FuelGasPriceUpdater<L2, Metadata> {
+pub struct FuelGasPriceUpdater<L2, Metadata, DaSource> {
     inner: AlgorithmUpdater,
     l2_block_source: L2,
     metadata_storage: Metadata,
+    da_source: DaSource,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AlgorithmUpdater {
     V0(AlgorithmUpdaterV0),
+    V1(AlgorithmUpdaterV1),
 }
 
 impl AlgorithmUpdater {
     pub fn algorithm(&self) -> Algorithm {
         match self {
             AlgorithmUpdater::V0(v0) => Algorithm::V0(v0.algorithm()),
+            AlgorithmUpdater::V1(v1) => Algorithm::V1(v1.algorithm()),
         }
     }
 
     pub fn l2_block_height(&self) -> BlockHeight {
         match self {
             AlgorithmUpdater::V0(v0) => v0.l2_block_height.into(),
+            AlgorithmUpdater::V1(v1) => v1.l2_block_height.into(),
         }
     }
 }
 
-impl<L2, Metadata> FuelGasPriceUpdater<L2, Metadata> {
+impl<L2, Metadata, DaSource> FuelGasPriceUpdater<L2, Metadata, DaSource> {
     pub fn new(
         inner: AlgorithmUpdater,
         l2_block_source: L2,
         metadata_storage: Metadata,
+        da_source: DaSource,
     ) -> Self {
         Self {
             inner,
             l2_block_source,
             metadata_storage,
+            da_source,
         }
     }
 }
@@ -82,7 +89,7 @@ pub enum Error {
     CouldNotInitUpdater(anyhow::Error),
 }
 
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 // Info required about the l2 block for the gas price algorithm
 #[derive(Debug, Clone, PartialEq)]
@@ -102,6 +109,19 @@ pub enum BlockInfo {
 #[async_trait::async_trait]
 pub trait L2BlockSource: Send + Sync {
     async fn get_l2_block(&mut self, height: BlockHeight) -> Result<BlockInfo>;
+}
+
+#[derive(Debug, Default)]
+pub struct DaCommitDetails {
+    pub l2_block_range: core::ops::Range<u32>,
+    pub blob_bytes: u32,
+    pub blob_cost_wei: u32,
+    pub partial_block_heights: Option<[u32; 2]>,
+}
+
+#[async_trait::async_trait]
+pub trait DaCommitSource: Send + Sync {
+    async fn get_da_commit_details(&mut self) -> Result<DaCommitDetails>;
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
@@ -172,6 +192,9 @@ impl From<AlgorithmUpdater> for UpdaterMetadata {
                 };
                 UpdaterMetadata::V0(metadata)
             }
+            AlgorithmUpdater::V1(_v1) => {
+                unimplemented!()
+            }
         }
     }
 }
@@ -182,14 +205,16 @@ pub trait MetadataStorage: Send + Sync {
     fn set_metadata(&mut self, metadata: UpdaterMetadata) -> Result<()>;
 }
 
-impl<L2, Metadata> FuelGasPriceUpdater<L2, Metadata>
+impl<L2, Metadata, DaSource> FuelGasPriceUpdater<L2, Metadata, DaSource>
 where
     Metadata: MetadataStorage,
+    DaSource: DaCommitSource,
 {
     pub fn init(
         target_block_height: BlockHeight,
         l2_block_source: L2,
         metadata_storage: Metadata,
+        da_source: DaSource,
         min_exec_gas_price: u64,
         exec_gas_price_change_percent: u64,
         l2_block_fullness_threshold_percent: u64,
@@ -216,16 +241,77 @@ where
             inner,
             l2_block_source,
             metadata_storage,
+            da_source,
         };
         Ok(updater)
+    }
+
+    fn validate_block_gas_capacity(
+        &self,
+        block_gas_capacity: u64,
+    ) -> anyhow::Result<NonZeroU64> {
+        NonZeroU64::new(block_gas_capacity)
+            .ok_or_else(|| anyhow!("Block gas capacity must be non-zero"))
+    }
+
+    async fn set_metadata(&mut self) -> anyhow::Result<()> {
+        self.metadata_storage
+            .set_metadata(self.inner.clone().into())
+            .map_err(|err| anyhow!(err))
+    }
+
+    async fn handle_normal_block(
+        &mut self,
+        height: u32,
+        gas_used: u64,
+        block_gas_capacity: u64,
+    ) -> anyhow::Result<()> {
+        let capacity = self.validate_block_gas_capacity(block_gas_capacity)?;
+
+        match &mut self.inner {
+            AlgorithmUpdater::V0(updater) => {
+                updater.update_l2_block_data(height, gas_used, capacity)?;
+            }
+            AlgorithmUpdater::V1(updater) => {
+                updater.update_l2_block_data(height, gas_used, capacity, 0, 0)?;
+                let _da_commit_details = self.da_source.get_da_commit_details().await;
+                // TODO: update the DA record data with data received from the source
+                // updater.update_da_record_data(vec![])?;
+            }
+        }
+
+        self.set_metadata().await?;
+        Ok(())
+    }
+
+    async fn apply_block_info_to_gas_algorithm(
+        &mut self,
+        l2_block: BlockInfo,
+    ) -> anyhow::Result<()> {
+        match l2_block {
+            BlockInfo::GenesisBlock => {
+                self.set_metadata().await?;
+            }
+            BlockInfo::Block {
+                height,
+                gas_used,
+                block_gas_capacity,
+            } => {
+                self.handle_normal_block(height, gas_used, block_gas_capacity)
+                    .await?;
+            }
+        }
+        Ok(())
     }
 }
 
 #[async_trait::async_trait]
-impl<L2, Metadata> UpdateAlgorithm for FuelGasPriceUpdater<L2, Metadata>
+impl<L2, Metadata, DaSource> UpdateAlgorithm
+    for FuelGasPriceUpdater<L2, Metadata, DaSource>
 where
     L2: L2BlockSource,
     Metadata: MetadataStorage + Send + Sync,
+    DaSource: DaCommitSource,
 {
     type Algorithm = Algorithm;
 
@@ -240,25 +326,9 @@ where
             .await;
         tracing::info!("Received L2 block result: {:?}", l2_block_res);
         let l2_block = l2_block_res?;
-        let AlgorithmUpdater::V0(ref mut updater) = &mut self.inner;
-        match l2_block {
-            BlockInfo::GenesisBlock => {
-                self.metadata_storage
-                    .set_metadata(self.inner.clone().into())?;
-            }
-            BlockInfo::Block {
-                height,
-                gas_used,
-                block_gas_capacity,
-            } => {
-                let capacity = NonZeroU64::new(block_gas_capacity).ok_or_else(|| {
-                    anyhow::anyhow!("Block gas capacity must be non-zero")
-                })?;
-                updater.update_l2_block_data(height, gas_used, capacity)?;
-                self.metadata_storage
-                    .set_metadata(self.inner.clone().into())?;
-            }
-        }
+
+        self.apply_block_info_to_gas_algorithm(l2_block).await?;
+
         Ok(self.inner.algorithm())
     }
 }
@@ -266,18 +336,21 @@ where
 #[derive(Debug, Clone, PartialEq)]
 pub enum Algorithm {
     V0(AlgorithmV0),
+    V1(AlgorithmV1),
 }
 
 impl GasPriceAlgorithm for Algorithm {
     fn next_gas_price(&self) -> u64 {
         match self {
             Algorithm::V0(v0) => v0.calculate(),
+            Algorithm::V1(v1) => v1.calculate(0),
         }
     }
 
     fn worst_case_gas_price(&self, height: BlockHeight) -> u64 {
         match self {
             Algorithm::V0(v0) => v0.worst_case(height.into()),
+            Algorithm::V1(v1) => v1.calculate(0),
         }
     }
 }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater.rs
@@ -116,7 +116,7 @@ pub trait L2BlockSource: Send + Sync {
 #[derive(Debug, Default)]
 pub struct DaCommitDetails {
     pub l2_block_range: core::ops::Range<u32>,
-    pub blob_bytes: u32,
+    pub blob_size_bytes: u32,
     pub blob_cost_wei: u32,
     pub partial_block_heights: Option<[u32; 2]>,
 }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_da_source_adapter.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_da_source_adapter.rs
@@ -7,9 +7,10 @@ use crate::fuel_gas_price_updater::{
 #[derive(Default, Clone)]
 pub struct FuelDaSource;
 
-#[async_trait::async_trait]
 impl DaCommitSource for FuelDaSource {
-    async fn get_da_commit_details(&mut self) -> GasPriceUpdaterResult<DaCommitDetails> {
+    fn get_da_commit_details(
+        &mut self,
+    ) -> GasPriceUpdaterResult<Option<DaCommitDetails>> {
         todo!()
     }
 }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_da_source_adapter.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_da_source_adapter.rs
@@ -11,6 +11,6 @@ impl DaCommitSource for FuelDaSource {
     fn get_da_commit_details(
         &mut self,
     ) -> GasPriceUpdaterResult<Option<DaCommitDetails>> {
-        todo!()
+        todo!() // TODO: pending research on how to get the data from the block committer
     }
 }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_da_source_adapter.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_da_source_adapter.rs
@@ -11,6 +11,6 @@ impl DaCommitSource for FuelDaSource {
     fn get_da_commit_details(
         &mut self,
     ) -> GasPriceUpdaterResult<Option<DaCommitDetails>> {
-        todo!() // TODO: pending research on how to get the data from the block committer
+        todo!() // TODO(#2139): pending research on how to get the data from the block committer
     }
 }

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_da_source_adapter.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_da_source_adapter.rs
@@ -1,0 +1,15 @@
+use crate::fuel_gas_price_updater::{
+    DaCommitDetails,
+    DaCommitSource,
+    Result as GasPriceUpdaterResult,
+};
+
+#[derive(Default, Clone)]
+pub struct FuelDaSource;
+
+#[async_trait::async_trait]
+impl DaCommitSource for FuelDaSource {
+    async fn get_da_commit_details(&mut self) -> GasPriceUpdaterResult<DaCommitDetails> {
+        todo!()
+    }
+}

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater/tests.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater/tests.rs
@@ -92,11 +92,10 @@ impl FakeDaSource {
     }
 }
 
-#[async_trait::async_trait]
 impl DaCommitSource for FakeDaSource {
-    async fn get_da_commit_details(&mut self) -> Result<DaCommitDetails> {
+    fn get_da_commit_details(&mut self) -> Result<Option<DaCommitDetails>> {
         *self.called.lock().unwrap() = true;
-        Ok(DaCommitDetails::default())
+        Ok(Some(DaCommitDetails::default()))
     }
 }
 


### PR DESCRIPTION
> [!WARNING]
> 🏗️ This PR is 1/2 of including block committer "da"ta in v1 of the gas price algo. We have a dependency on the api of the block committer, which can be included in a follow up PR when we have more details 🚧

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- https://github.com/FuelLabs/fuel-core/issues/2139

## Description
<!-- List of detailed changes -->
This PR includes the following changes - 
- new trait `DaCommitSource` which specifies `get_da_commit_details` that returns the latest da commit details from the block committer
- removed usages of std lib and replaced with `core::*`
- refactored to make functions shorter and readable


## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
