### PR TITLE
chore(rocks_db): move ShallowTempDir to benches crate

### DIFF
--- a/benches/benches/vm_set/blockchain.rs
+++ b/benches/benches/vm_set/blockchain.rs
@@ -20,10 +20,7 @@ use fuel_core::{
         GenesisDatabase,
     },
     service::Config,
-    state::{
-        historical_rocksdb::HistoricalRocksDB,
-        rocks_db::ShallowTempDir,
-    },
+    state::historical_rocksdb::HistoricalRocksDB,
 };
 use fuel_core_benches::*;
 use fuel_core_storage::{
@@ -67,12 +64,12 @@ use rand::{
 pub struct BenchDb {
     db: GenesisDatabase,
     /// Used for RAII cleanup. Contents of this directory are deleted on drop.
-    _tmp_dir: ShallowTempDir,
+    _tmp_dir: utils::ShallowTempDir,
 }
 
 impl BenchDb {
     fn new(contract_id: &ContractId) -> anyhow::Result<Self> {
-        let tmp_dir = ShallowTempDir::new();
+        let tmp_dir = utils::ShallowTempDir::new();
 
         let db = HistoricalRocksDB::<OnChain>::default_open(
             tmp_dir.path(),

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -38,6 +38,7 @@ use std::{
 
 pub mod default_gas_costs;
 pub mod import;
+pub mod utils;
 
 pub use fuel_core_storage::vm_storage::VmStorage;
 pub use rand::Rng;

--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -1,0 +1,40 @@
+use rand::RngCore;
+use std::{
+    env,
+    path::PathBuf,
+};
+
+/// Reimplementation of `tempdir::TempDir` that allows creating a new
+/// instance without actually creating a new directory on the filesystem.
+/// This is needed since rocksdb requires empty directory for checkpoints.
+pub struct ShallowTempDir {
+    path: PathBuf,
+}
+
+impl Default for ShallowTempDir {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ShallowTempDir {
+    /// Creates a random directory.
+    pub fn new() -> Self {
+        let mut rng = rand::thread_rng();
+        let mut path = env::temp_dir();
+        path.push(format!("fuel-core-shallow-{}", rng.next_u64()));
+        Self { path }
+    }
+
+    /// Returns the path of the directory.
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}
+
+impl Drop for ShallowTempDir {
+    fn drop(&mut self) {
+        // Ignore errors
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -35,7 +35,6 @@ use fuel_core_storage::{
     Result as StorageResult,
 };
 use itertools::Itertools;
-use rand::RngCore;
 use rocksdb::{
     BlockBasedOptions,
     BoundColumnFamily,
@@ -55,7 +54,6 @@ use rocksdb::{
 use std::{
     cmp,
     collections::BTreeMap,
-    env,
     fmt,
     fmt::Formatter,
     iter,
@@ -68,41 +66,6 @@ use std::{
 use tempfile::TempDir;
 
 type DB = DBWithThreadMode<MultiThreaded>;
-
-/// Reimplementation of `tempdir::TempDir` that allows creating a new
-/// instance without actually creating a new directory on the filesystem.
-/// This is needed since rocksdb requires empty directory for checkpoints.
-pub struct ShallowTempDir {
-    path: PathBuf,
-}
-
-impl Default for ShallowTempDir {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ShallowTempDir {
-    /// Creates a random directory.
-    pub fn new() -> Self {
-        let mut rng = rand::thread_rng();
-        let mut path = env::temp_dir();
-        path.push(format!("fuel-core-shallow-{}", rng.next_u64()));
-        Self { path }
-    }
-
-    /// Returns the path of the directory.
-    pub fn path(&self) -> &PathBuf {
-        &self.path
-    }
-}
-
-impl Drop for ShallowTempDir {
-    fn drop(&mut self) {
-        // Ignore errors
-        let _ = std::fs::remove_dir_all(&self.path);
-    }
-}
 
 type DropFn = Box<dyn FnOnce() + Send + Sync>;
 #[derive(Default)]


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- https://github.com/FuelLabs/fuel-core/pull/2159#discussion_r1744990149

## Description
<!-- List of detailed changes -->

Trying to split up #2159 into smaller PRs, here we move `ShallowTempDir` which was only used in benchmarks to the benches crate, where it is more appropriate.
Additionally a follow up PR will be created to make it conditionally drop databases/directories based on an env var.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] ] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
