### PR TITLE
chore(benches): conditional dropping of databases in benchmarks

### DIFF
--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -32,19 +32,85 @@ impl ShallowTempDir {
     }
 }
 
+const DB_CLEAN_UP_ENV_VAR: &str = "DB_CLEAN_UP";
+
 impl Drop for ShallowTempDir {
     fn drop(&mut self) {
         let default_db_clean_up = true;
         // Check if DB_CLEAN_UP is set and correctly parsed to a boolean, defaulting to true
-        let should_clean_up = env::var("DB_CLEAN_UP").map_or(default_db_clean_up, |v| {
-            v.parse::<bool>().unwrap_or(default_db_clean_up)
-        });
+        let should_clean_up = env::var(DB_CLEAN_UP_ENV_VAR)
+            .map_or(default_db_clean_up, |v| {
+                v.parse::<bool>().unwrap_or(default_db_clean_up)
+            });
 
         if should_clean_up {
-            // Ignore errors during cleanup
-            if let Err(e) = std::fs::remove_dir_all(&self.path) {
-                eprintln!("Failed to remove directory {:?}: {}", self.path, e);
-            }
+            // Ignore errors when removing the directory
+            let _ = std::fs::remove_dir_all(&self.path);
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use super::*;
+
+    fn shallow_temp_dir__drops_if_env_var_is_set() {
+        // given
+        env::set_var(DB_CLEAN_UP_ENV_VAR, "true");
+        let path;
+        {
+            let dir = ShallowTempDir::new();
+            path = dir.path().clone();
+            std::fs::create_dir_all(&path).expect("Failed to create temp directory");
+        }
+        // when: out of scope, dropped
+
+        // then
+        assert!(!path.exists());
+
+        // clean up
+        env::remove_var(DB_CLEAN_UP_ENV_VAR);
+    }
+
+    fn shallow_temp_dir__does_not_drop_if_env_var_is_set() {
+        // given
+        env::set_var(DB_CLEAN_UP_ENV_VAR, "false");
+        let path;
+        {
+            let dir = ShallowTempDir::new();
+            path = dir.path().clone();
+            std::fs::create_dir_all(&path).expect("Failed to create temp directory");
+        }
+
+        // when: out of scope, not dropped
+
+        // then
+        assert!(path.exists());
+        // clean up manually
+        std::fs::remove_dir_all(path).unwrap();
+        env::remove_var(DB_CLEAN_UP_ENV_VAR);
+    }
+
+    fn shallow_temp_dir__drops_if_env_var_is_not_set() {
+        // given
+        let path;
+        {
+            let dir = ShallowTempDir::new();
+            path = dir.path().clone();
+            std::fs::create_dir_all(&path).expect("Failed to create temp directory");
+        }
+        // when: out of scope, dropped
+
+        // then
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_shallow_temp_dir_behaviour() {
+        // run tests sequentially to avoid conflicts due to env var usage
+        shallow_temp_dir__drops_if_env_var_is_set();
+        shallow_temp_dir__does_not_drop_if_env_var_is_set();
+        shallow_temp_dir__drops_if_env_var_is_not_set();
     }
 }

--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -44,8 +44,9 @@ impl Drop for ShallowTempDir {
             });
 
         if should_clean_up {
-            // Ignore errors when removing the directory
-            let _ = std::fs::remove_dir_all(&self.path);
+            if let Err(e) = std::fs::remove_dir_all(&self.path) {
+                eprintln!("Failed to remove temp directory: {:?}", e);
+            }
         }
     }
 }

--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -106,11 +106,30 @@ mod tests {
         assert!(!path.exists());
     }
 
+    fn shalow_temp_dir__drops_if_env_var_malformed() {
+        // given
+        env::set_var(DB_CLEAN_UP_ENV_VAR, "bing_bong");
+        let path;
+        {
+            let dir = ShallowTempDir::new();
+            path = dir.path().clone();
+            std::fs::create_dir_all(&path).expect("Failed to create temp directory");
+        }
+        // when: out of scope, dropped
+
+        // then
+        assert!(!path.exists());
+
+        // clean up
+        env::remove_var(DB_CLEAN_UP_ENV_VAR);
+    }
+
     #[test]
     fn test_shallow_temp_dir_behaviour() {
         // run tests sequentially to avoid conflicts due to env var usage
         shallow_temp_dir__drops_if_env_var_is_set();
         shallow_temp_dir__does_not_drop_if_env_var_is_set();
         shallow_temp_dir__drops_if_env_var_is_not_set();
+        shalow_temp_dir__drops_if_env_var_malformed();
     }
 }

--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -34,7 +34,17 @@ impl ShallowTempDir {
 
 impl Drop for ShallowTempDir {
     fn drop(&mut self) {
-        // Ignore errors
-        let _ = std::fs::remove_dir_all(&self.path);
+        let default_db_clean_up = true;
+        // Check if DB_CLEAN_UP is set and correctly parsed to a boolean, defaulting to true
+        let should_clean_up = env::var("DB_CLEAN_UP").map_or(default_db_clean_up, |v| {
+            v.parse::<bool>().unwrap_or(default_db_clean_up)
+        });
+
+        if should_clean_up {
+            // Ignore errors during cleanup
+            if let Err(e) = std::fs::remove_dir_all(&self.path) {
+                eprintln!("Failed to remove directory {:?}: {}", self.path, e);
+            }
+        }
     }
 }

--- a/benches/src/utils.rs
+++ b/benches/src/utils.rs
@@ -107,7 +107,7 @@ mod tests {
         assert!(!path.exists());
     }
 
-    fn shalow_temp_dir__drops_if_env_var_malformed() {
+    fn shallow_temp_dir__drops_if_env_var_malformed() {
         // given
         env::set_var(DB_CLEAN_UP_ENV_VAR, "bing_bong");
         let path;
@@ -131,6 +131,6 @@ mod tests {
         shallow_temp_dir__drops_if_env_var_is_set();
         shallow_temp_dir__does_not_drop_if_env_var_is_set();
         shallow_temp_dir__drops_if_env_var_is_not_set();
-        shalow_temp_dir__drops_if_env_var_malformed();
+        shallow_temp_dir__drops_if_env_var_malformed();
     }
 }


### PR DESCRIPTION
>[!NOTE]
> This PR is 2/2 on the `ShallowTempDir` refactor

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- follow up to: https://github.com/FuelLabs/fuel-core/pull/2168

## Description
<!-- List of detailed changes -->
conditionally drops the benchmark databases if `DB_CLEAN_UP` is set to `false`.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
