### PR TITLE
test(time): remove start_paused annotation from some tests

### DIFF
--- a/tests/tests/trigger_integration/interval.rs
+++ b/tests/tests/trigger_integration/interval.rs
@@ -29,7 +29,7 @@ use rand::{
 };
 use std::time::Duration;
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn poa_interval_produces_empty_blocks_at_correct_rate() {
     let rounds = 64;
     let round_time_seconds = 2;
@@ -92,7 +92,7 @@ async fn poa_interval_produces_empty_blocks_at_correct_rate() {
     );
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn poa_interval_produces_nonempty_blocks_at_correct_rate() {
     let rounds = 64;
     let round_time_seconds = 2;


### PR DESCRIPTION
>[!WARNING]
> don't merge

## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
