### PR TITLE
docs: fix minor typo in fee_calculations.md

### DIFF
--- a/docs/fee_calculations.md
+++ b/docs/fee_calculations.md
@@ -9,7 +9,7 @@ to include an additional cost to op codes that write new data to storage or to
 transactions that add new contracts to the chain.
 
 There are a number of ways we might calculate this value; we have decided to go 
-with a simple calculatoin based on our target storage growth and working
+with a simple calculation based on our target storage growth and working
 backward from there.
 
 #### Pessimistic Estimate


### PR DESCRIPTION
## Description
- fix typo "calculatoin" -> "calculation" in the document

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here


