### PR TITLE
change "a the" to “the"

### DIFF
--- a/crates/services/consensus_module/poa/src/service_test/trigger_tests.rs
+++ b/crates/services/consensus_module/poa/src/service_test/trigger_tests.rs
@@ -201,7 +201,7 @@ async fn interval_trigger_produces_blocks_periodically() -> anyhow::Result<()> {
         Err(broadcast::error::TryRecvError::Empty)
     ));
 
-    // Pause time until a the next block is produced
+    // Pause time until the next block is produced
     time::sleep(Duration::new(2, 0)).await;
 
     // Make sure it's produced
@@ -218,7 +218,7 @@ async fn interval_trigger_produces_blocks_periodically() -> anyhow::Result<()> {
         Err(broadcast::error::TryRecvError::Empty)
     ));
 
-    // Pause time until a the next block is produced
+    // Pause time until the next block is produced
     time::sleep(Duration::new(2, 0)).await;
 
     // Make sure only one block is produced

--- a/crates/types/src/blockchain/block.rs
+++ b/crates/types/src/blockchain/block.rs
@@ -152,7 +152,7 @@ impl<T> Block<T> {
 }
 
 impl CompressedBlock {
-    /// Convert from a compressed block back to a the full block.
+    /// Convert from a compressed block back to the full block.
     pub fn uncompress(self, transactions: Vec<Transaction>) -> Block<Transaction> {
         // TODO: should we perform an extra validation step to ensure the provided
         //  txs match the expected ones in the block?


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
change "a the" to "the" to make sentences fluent

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
