### PR TITLE
chore: Add initial CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for fuel-core
+* @xgreenx @Dentosal @MitchTurner


### PR DESCRIPTION
Simple CODEOWNERS file setting @xgreenx, @Dentosal and @MitchTurner as code owners for this repo. This initially will add them to any PR within the repo, and also allows us to require one approval from either of them to pass a PR.

As the team matures, we should replace the root CODEOWNERS with just the `FuelLabs/Client` team.

Closes #1982 