### PR TITLE
TransactionSource: specify maximum number of transactions to be fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2158](https://github.com/FuelLabs/fuel-core/pull/2158): Log the public address of the signing key, if it is specified
 - [2188](https://github.com/FuelLabs/fuel-core/pull/2188): Upgraded the `fuel-vm` to `0.57.0`. More information in the [release](https://github.com/FuelLabs/fuel-vm/releases/tag/v0.57.0).
 
-
 ## [Version 0.35.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [2131](https://github.com/FuelLabs/fuel-core/pull/2131): Add flow in TxPool in order to ask to newly connected peers to share their transaction pool
+- [2182](https://github.com/FuelLabs/fuel-core/pull/2151): Limit number of transactions that can be fetched via TxSource::next
 
 ### Changed
 
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2142](https://github.com/FuelLabs/fuel-core/pull/2142): Added benchmarks for varied forms of db lookups to assist in optimizations.
 - [2158](https://github.com/FuelLabs/fuel-core/pull/2158): Log the public address of the signing key, if it is specified
 - [2188](https://github.com/FuelLabs/fuel-core/pull/2188): Upgraded the `fuel-vm` to `0.57.0`. More information in the [release](https://github.com/FuelLabs/fuel-vm/releases/tag/v0.57.0).
+
 
 ## [Version 0.35.0]
 

--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -6,7 +6,10 @@ mod tests {
     use crate as fuel_core;
     use fuel_core::database::Database;
     use fuel_core_executor::{
-        executor::OnceTransactionsSource,
+        executor::{
+            OnceTransactionsSource,
+            MAX_TX_COUNT,
+        },
         ports::{
             MaybeCheckedTransaction,
             RelayerPort,
@@ -2984,14 +2987,14 @@ mod tests {
     }
 
     #[test]
-    fn block_producer_never_includes_more_than_u16_max_transactions() {
+    fn block_producer_never_includes_more_than_max_tx_count_transactions() {
         let block_height = 1u32;
         let block_da_height = 2u64;
 
         let mut consensus_parameters = ConsensusParameters::default();
 
         // Given
-        let transactions_in_tx_source = u16::MAX as usize + 10;
+        let transactions_in_tx_source = (MAX_TX_COUNT as usize) + 10;
         consensus_parameters.set_block_gas_limit(u64::MAX);
         let config = Config {
             consensus_parameters,
@@ -3013,9 +3016,10 @@ mod tests {
             .into();
 
         // Then
-        // u16::MAX -1 transactions have been included from the transaction source, plus the mint transaction
-        // In total we expect to see u16::MAX transactions in the block
-        assert_eq!(result.block.transactions().len(), (u16::MAX) as usize);
+        assert_eq!(
+            result.block.transactions().len(),
+            (MAX_TX_COUNT as usize + 1)
+        );
     }
 
     #[cfg(feature = "relayer")]

--- a/crates/fuel-core/src/service/adapters/executor.rs
+++ b/crates/fuel-core/src/service/adapters/executor.rs
@@ -9,11 +9,15 @@ use fuel_core_types::{
 };
 
 impl fuel_core_executor::ports::TransactionsSource for TransactionsSource {
-    // TODO: Use `tx_count_limit` https://github.com/FuelLabs/fuel-core/issues/2114
     // TODO: Use `size_limit` https://github.com/FuelLabs/fuel-core/issues/2133
-    fn next(&self, gas_limit: u64, _: u16, _: u32) -> Vec<MaybeCheckedTransaction> {
+    fn next(
+        &self,
+        gas_limit: u64,
+        transactions_limit: u16,
+        _: u32,
+    ) -> Vec<MaybeCheckedTransaction> {
         self.txpool
-            .select_transactions(gas_limit)
+            .select_transactions(gas_limit, transactions_limit)
             .into_iter()
             .map(|tx| {
                 MaybeCheckedTransaction::CheckedTransaction(

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -589,6 +589,7 @@ where
         let mut regular_tx_iter = l2_tx_source
             .next(remaining_gas_limit, remaining_tx_count, remaining_size)
             .into_iter()
+            .take(remaining_tx_count as usize)
             .peekable();
         while regular_tx_iter.peek().is_some() {
             for transaction in regular_tx_iter {
@@ -619,6 +620,7 @@ where
             regular_tx_iter = l2_tx_source
                 .next(remaining_gas_limit, remaining_tx_count, remaining_size)
                 .into_iter()
+                .take(remaining_tx_count as usize)
                 .peekable();
         }
 

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -162,6 +162,8 @@ use alloc::{
     vec::Vec,
 };
 
+pub const MAX_TX_COUNT: u16 = u16::MAX.saturating_sub(1);
+
 pub struct OnceTransactionsSource {
     transactions: ParkingMutex<Vec<MaybeCheckedTransaction>>,
 }
@@ -580,8 +582,7 @@ where
         // When processing l2 transactions, we must take into account transactions from the l1
         // that have been included in the block already (stored in `data.tx_count`), as well
         // as the final mint transaction.
-        let max_tx_count = u16::MAX.saturating_sub(1);
-        let mut remaining_tx_count = max_tx_count.saturating_sub(data.tx_count);
+        let mut remaining_tx_count = MAX_TX_COUNT.saturating_sub(data.tx_count);
 
         let mut regular_tx_iter = l2_tx_source
             .next(remaining_gas_limit, remaining_tx_count, remaining_size)
@@ -610,7 +611,7 @@ where
                     }
                 }
                 remaining_gas_limit = block_gas_limit.saturating_sub(data.used_gas);
-                remaining_tx_count = max_tx_count.saturating_sub(data.tx_count);
+                remaining_tx_count = MAX_TX_COUNT.saturating_sub(data.tx_count);
             }
 
             regular_tx_iter = l2_tx_source

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -162,6 +162,8 @@ use alloc::{
     vec::Vec,
 };
 
+/// The maximum amount of transactions that can be included in a block,
+/// excluding the mint transaction.
 pub const MAX_TX_COUNT: u16 = u16::MAX.saturating_sub(1);
 
 pub struct OnceTransactionsSource {
@@ -578,7 +580,7 @@ where
         // TODO: Handle `remaining_size` https://github.com/FuelLabs/fuel-core/issues/2133
         let remaining_size = u32::MAX;
 
-        // We allow at most u64::MAX transactions in a block, including the mint transaction.
+        // We allow at most u16::MAX transactions in a block, including the mint transaction.
         // When processing l2 transactions, we must take into account transactions from the l1
         // that have been included in the block already (stored in `data.tx_count`), as well
         // as the final mint transaction.

--- a/crates/services/executor/src/ports.rs
+++ b/crates/services/executor/src/ports.rs
@@ -116,6 +116,8 @@ impl TransactionExt for MaybeCheckedTransaction {
 
 pub trait TransactionsSource {
     /// Returns the next batch of transactions to satisfy the `gas_limit`.
+    /// The returned batch has at most `tx_count_limit` transactions, none
+    /// of which has a size in bytes greater than `size_limit`.
     fn next(
         &self,
         gas_limit: u64,

--- a/tests/tests/blocks.rs
+++ b/tests/tests/blocks.rs
@@ -473,7 +473,8 @@ mod full_block {
         }
 
         // Then
-        let last_block_height: u32 = client.produce_blocks(2, None).await.unwrap().into();
+        let _last_block_height: u32 =
+            client.produce_blocks(2, None).await.unwrap().into();
         let second_last_block = client
             .block_by_height(BlockHeight::from(1))
             .await


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

Part of #2114 

## Description

- Add a new argument `transactions_limit: u16` to the function `TxSource::next()`. 
- Changes the logic of the block production to never exceed `u16::MAX` transactions (included FTI transactions and mint transactions) when selecting L2 transacitons. The number of transactions can still exceed `u16::MAX` when selecting transactions from L1. This is addressed in #2189.
- Changes the implementation of all TxSource adapters to fetch a number of transactions below or equal to the `transaction_limit`. 
- Introduces a new WASM host function to peek the next transactions size for a number of transactions below a specified limit.

Breaks forward compatibility of the genesis transition function. See https://github.com/FuelLabs/fuel-core/blob/8eeae5d6730d34ae06390b7797478bb98fd07987/version-compatibility/forkless-upgrade/README.md

## TODO:
- [x] Check that requirements are met
- [x] Implementation for the WasmTxSource is missing (only the argument has been added) 
- [ ] Integration Tests

## Checklist
- [ x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
