### PR TITLE
Block producer tx limit 1

### DIFF
--- a/crates/services/producer/src/ports.rs
+++ b/crates/services/producer/src/ports.rs
@@ -1,28 +1,17 @@
 use async_trait::async_trait;
-use fuel_core_storage::{
-    transactional::Changes,
-    Result as StorageResult,
-};
+use fuel_core_storage::{transactional::Changes, Result as StorageResult};
 use fuel_core_types::{
     blockchain::{
         block::CompressedBlock,
-        header::{
-            ConsensusParametersVersion,
-            StateTransitionBytecodeVersion,
-        },
+        header::{ConsensusParametersVersion, StateTransitionBytecodeVersion},
         primitives::DaBlockHeight,
     },
-    fuel_tx::{
-        Bytes32,
-        Transaction,
-    },
+    fuel_tx::{Bytes32, Transaction},
     fuel_types::BlockHeight,
     services::{
         block_producer::Components,
         executor::{
-            Result as ExecutorResult,
-            TransactionExecutionStatus,
-            UncommittedResult,
+            Result as ExecutorResult, TransactionExecutionStatus, UncommittedResult,
         },
     },
 };
@@ -72,6 +61,12 @@ pub trait Relayer: Send + Sync {
 
     /// Get the total Forced Transaction gas cost for the block at the given height.
     async fn get_cost_for_block(&self, height: &DaBlockHeight) -> anyhow::Result<u64>;
+
+    /// Get the total number of Forced Transactions for the block at the given height.
+    async fn get_transactions_number_for_block(
+        &self,
+        height: &DaBlockHeight,
+    ) -> anyhow::Result<u64>;
 }
 
 pub trait BlockProducer<TxSource>: Send + Sync {

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -3,46 +3,28 @@ use crate::config::Config;
 use crate::error::UpgradableError;
 
 use fuel_core_executor::{
-    executor::{
-        ExecutionInstance,
-        ExecutionOptions,
-        OnceTransactionsSource,
-    },
-    ports::{
-        RelayerPort,
-        TransactionsSource,
-    },
+    executor::{ExecutionInstance, ExecutionOptions, OnceTransactionsSource},
+    ports::{RelayerPort, TransactionsSource},
 };
 use fuel_core_storage::{
     column::Column,
     kv_store::KeyValueInspect,
-    transactional::{
-        AtomicView,
-        Changes,
-        HistoricalView,
-        Modifiable,
-    },
+    transactional::{AtomicView, Changes, HistoricalView, Modifiable},
 };
 #[cfg(feature = "wasm-executor")]
 use fuel_core_types::fuel_types::Bytes32;
 use fuel_core_types::{
     blockchain::{
         block::Block,
-        header::{
-            StateTransitionBytecodeVersion,
-            LATEST_STATE_TRANSITION_VERSION,
-        },
+        header::{StateTransitionBytecodeVersion, LATEST_STATE_TRANSITION_VERSION},
     },
     fuel_tx::Transaction,
     fuel_types::BlockHeight,
     services::{
         block_producer::Components,
         executor::{
-            Error as ExecutorError,
-            ExecutionResult,
-            Result as ExecutorResult,
-            TransactionExecutionStatus,
-            ValidationResult,
+            Error as ExecutorError, ExecutionResult, Result as ExecutorResult,
+            TransactionExecutionStatus, ValidationResult,
         },
         Uncommitted,
     },
@@ -53,10 +35,7 @@ use std::sync::Arc;
 use fuel_core_storage::{
     not_found,
     structured_storage::StructuredStorage,
-    tables::{
-        StateTransitionBytecodeVersions,
-        UploadedBytecodes,
-    },
+    tables::{StateTransitionBytecodeVersions, UploadedBytecodes},
     StorageAsRef,
 };
 #[cfg(any(test, feature = "test-helpers"))]
@@ -99,10 +78,7 @@ pub struct Executor<S, R> {
 #[cfg(feature = "wasm-executor")]
 mod private {
     use std::sync::OnceLock;
-    use wasmtime::{
-        Engine,
-        Module,
-    };
+    use wasmtime::{Engine, Module};
 
     /// The default engine for the WASM executor. It is used to compile the WASM bytecode.
     pub(crate) static DEFAULT_ENGINE: OnceLock<Engine> = OnceLock::new();
@@ -351,7 +327,7 @@ where
 
         // If one of the transactions fails, return an error.
         if let Some((_, err)) = skipped_transactions.into_iter().next() {
-            return Err(err)
+            return Err(err);
         }
 
         Ok(tx_status)
@@ -644,7 +620,7 @@ where
         let fuel_core_types::fuel_vm::UploadedBytecode::Completed(bytecode) =
             uploaded_bytecode.as_ref()
         else {
-            return Err(UpgradableError::IncompleteUploadedBytecode(bytecode_root))
+            return Err(UpgradableError::IncompleteUploadedBytecode(bytecode_root));
         };
 
         wasmtime::Module::new(&self.engine, bytecode)
@@ -700,42 +676,24 @@ mod test {
 
     use super::*;
     use fuel_core_storage::{
-        kv_store::Value,
-        structured_storage::test::InMemoryStorage,
-        tables::ConsensusParametersVersions,
-        transactional::WriteTransaction,
-        Result as StorageResult,
-        StorageAsMut,
+        kv_store::Value, structured_storage::test::InMemoryStorage,
+        tables::ConsensusParametersVersions, transactional::WriteTransaction,
+        Result as StorageResult, StorageAsMut,
     };
     use fuel_core_types::{
         blockchain::{
-            block::{
-                Block,
-                PartialFuelBlock,
-            },
+            block::{Block, PartialFuelBlock},
             header::{
-                ApplicationHeader,
-                ConsensusHeader,
-                PartialBlockHeader,
+                ApplicationHeader, ConsensusHeader, PartialBlockHeader,
                 StateTransitionBytecodeVersion,
             },
-            primitives::{
-                DaBlockHeight,
-                Empty,
-            },
+            primitives::{DaBlockHeight, Empty},
         },
-        fuel_tx::{
-            AssetId,
-            Bytes32,
-            Transaction,
-        },
+        fuel_tx::{AssetId, Bytes32, Transaction},
         services::relayer::Event,
         tai64::Tai64,
     };
-    use std::collections::{
-        BTreeMap,
-        BTreeSet,
-    };
+    use std::collections::{BTreeMap, BTreeSet};
 
     #[derive(Clone, Debug)]
     struct Storage(InMemoryStorage<Column>);
@@ -940,10 +898,7 @@ mod test {
     #[allow(non_snake_case)]
     mod wasm {
         use super::*;
-        use crate::{
-            executor::Executor,
-            WASM_BYTECODE,
-        };
+        use crate::{executor::Executor, WASM_BYTECODE};
         use fuel_core_storage::tables::UploadedBytecodes;
         use fuel_core_types::fuel_vm::UploadedBytecode;
 


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

Part of #2114

## Description
When producing a block, we want to make sure that we never include more than 65_536 transactions. 
To this end, we select the DA height for including Forced transactions so that no more than 65_535 transactions will ever be included. 

Changes: 

- A new function for the RelayerPort to get the number of forced transactions at a given level
- Refactor the function `select_new_da_height` to return early if more than 65_535 transactions will be included. 
- Test the changes to the `select_new_da_height` function. 
- 
## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
