### PR TITLE
fix(dnsaddr_resolution): use fqdn separator to prevent suffixing by dns resolvers

### DIFF
--- a/crates/services/p2p/src/dnsaddr_resolution.rs
+++ b/crates/services/p2p/src/dnsaddr_resolution.rs
@@ -94,9 +94,9 @@ mod tests {
         ].iter().map(|s| s.parse().unwrap()).collect();
 
         // when
-        // run a `dig +short txt _dnsaddr.core-test.fuellabs.net` to get the TXT records
+        // run a `dig +short txt _dnsaddr.core-test.fuellabs.net.` to get the TXT records
         let multiaddrs = resolver
-            .lookup_dnsaddr("core-test.fuellabs.net")
+            .lookup_dnsaddr("core-test.fuellabs.net.")
             .await
             .unwrap();
         // then


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- fixes https://github.com/FuelLabs/fuel-core/issues/2221

## Description
<!-- List of detailed changes -->
Some dns resolvers `nslookup` etc, suffix dns lookups with the local domain if they are not fully-qualified. This PR makes the dns lookup FQDN, with a dot at the end.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
