### PR TITLE
chore(gas_price_service): define port for L2 data

### DIFF
--- a/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
@@ -24,14 +24,10 @@ use fuel_core_storage::{
 };
 use fuel_core_types::{
     blockchain::{
-        block::{
-            Block,
-        },
+        block::Block,
         header::ConsensusParametersVersion,
     },
-    fuel_tx::{
-        Transaction,
-    },
+    fuel_tx::Transaction,
     fuel_types::BlockHeight,
 };
 

--- a/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
@@ -13,15 +13,7 @@ use fuel_core_gas_price_service::{
     },
     ports::L2Data,
 };
-use fuel_core_storage::{
-    not_found,
-    tables::{
-        FuelBlocks,
-        Transactions,
-    },
-    Result as StorageResult,
-    StorageAsRef,
-};
+use fuel_core_storage::Result as StorageResult;
 use fuel_core_types::{
     blockchain::{
         block::Block,
@@ -39,23 +31,11 @@ impl L2Data for OnChainIterableKeyValueView {
         self.latest_height()
     }
 
-    fn get_block(&self, height: &BlockHeight) -> StorageResult<Block<Transaction>> {
-        let block = self
-            .storage::<FuelBlocks>()
-            .get(height)
-            .map(|block| block.map(|block| block.as_ref().clone()))?
-            .ok_or(not_found!("FuelBlock"))?;
-
-        let mut transactions = vec![];
-        for tx_id in block.transactions() {
-            let tx = self
-                .storage::<Transactions>()
-                .get(tx_id)
-                .map(|tx| tx.map(|tx| tx.as_ref().clone()))?
-                .ok_or(not_found!("Transaction"))?;
-            transactions.push(tx);
-        }
-        Ok(block.uncompress(transactions))
+    fn get_block(
+        &self,
+        height: &BlockHeight,
+    ) -> StorageResult<Option<Block<Transaction>>> {
+        self.get_full_block(height)
     }
 }
 

--- a/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
@@ -1,16 +1,57 @@
 use crate::service::adapters::ConsensusParametersProvider;
-use fuel_core_gas_price_service::fuel_gas_price_updater::{
-    fuel_core_storage_adapter::{
-        GasPriceSettings,
-        GasPriceSettingsProvider,
+use fuel_core_gas_price_service::{
+    fuel_gas_price_updater::{
+        fuel_core_storage_adapter::{
+            GasPriceSettings,
+            GasPriceSettingsProvider,
+        },
+        Error as GasPriceError,
+        Result as GasPriceResult,
     },
-    Error as GasPriceError,
-    Result as GasPriceResult,
+    ports::L2Data,
 };
-use fuel_core_types::blockchain::header::ConsensusParametersVersion;
+use fuel_core_storage::{
+    tables::{
+        FuelBlocks,
+        Transactions,
+    },
+    Result as StorageResult,
+    StorageAsRef,
+};
+use fuel_core_types::{
+    blockchain::{
+        block::CompressedBlock,
+        header::ConsensusParametersVersion,
+    },
+    fuel_tx::{
+        Transaction,
+        TxId,
+    },
+    fuel_types::BlockHeight,
+};
+
+use crate::database::OnChainIterableKeyValueView;
 
 #[cfg(test)]
 mod tests;
+
+impl L2Data for OnChainIterableKeyValueView {
+    fn latest_height(&self) -> StorageResult<BlockHeight> {
+        self.latest_height()
+    }
+
+    fn get_block(&self, height: &BlockHeight) -> StorageResult<Option<CompressedBlock>> {
+        self.storage::<FuelBlocks>()
+            .get(height)
+            .map(|block| block.map(|block| block.as_ref().clone()))
+    }
+
+    fn get_transaction(&self, tx_id: &TxId) -> StorageResult<Option<Transaction>> {
+        self.storage::<Transactions>()
+            .get(tx_id)
+            .map(|tx| tx.map(|tx| tx.as_ref().clone()))
+    }
+}
 
 impl GasPriceSettingsProvider for ConsensusParametersProvider {
     fn settings(

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -44,6 +44,7 @@ use fuel_core_services::{
     StateWatcher,
 };
 use fuel_core_storage::{
+    not_found,
     structured_storage::StructuredStorage,
     transactional::{
         AtomicView,
@@ -317,7 +318,9 @@ where
     let first = metadata_height.saturating_add(1);
     let view = on_chain_db.latest_view()?;
     for height in first..=latest_block_height {
-        let block = view.get_block(&height.into())?;
+        let block = view
+            .get_block(&height.into())?
+            .ok_or(not_found!("FullBlock"))?;
         let param_version = block.header().consensus_parameters_version;
 
         let GasPriceSettings {

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_core_storage_adapter.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_core_storage_adapter.rs
@@ -118,7 +118,7 @@ pub trait GasPriceSettingsProvider {
     ) -> Result<GasPriceSettings>;
 }
 
-fn get_block_info(
+pub fn get_block_info(
     block: &Block<Transaction>,
     gas_price_factor: u64,
     block_gas_limit: u64,

--- a/crates/services/gas_price_service/src/lib.rs
+++ b/crates/services/gas_price_service/src/lib.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 pub mod static_updater;
 
 pub mod fuel_gas_price_updater;
+pub mod ports;
 
 /// The service that updates the gas price algorithm.
 pub struct GasPriceService<A, U> {

--- a/crates/services/gas_price_service/src/ports.rs
+++ b/crates/services/gas_price_service/src/ports.rs
@@ -7,5 +7,8 @@ use fuel_core_types::{
 
 pub trait L2Data: Send + Sync {
     fn latest_height(&self) -> StorageResult<BlockHeight>;
-    fn get_block(&self, height: &BlockHeight) -> StorageResult<Block<Transaction>>;
+    fn get_block(
+        &self,
+        height: &BlockHeight,
+    ) -> StorageResult<Option<Block<Transaction>>>;
 }

--- a/crates/services/gas_price_service/src/ports.rs
+++ b/crates/services/gas_price_service/src/ports.rs
@@ -1,0 +1,15 @@
+use fuel_core_storage::Result as StorageResult;
+use fuel_core_types::{
+    blockchain::block::CompressedBlock,
+    fuel_tx::{
+        Transaction,
+        TxId,
+    },
+    fuel_types::BlockHeight,
+};
+
+pub trait L2Data: Send + Sync {
+    fn latest_height(&self) -> StorageResult<BlockHeight>;
+    fn get_block(&self, height: &BlockHeight) -> StorageResult<Option<CompressedBlock>>;
+    fn get_transaction(&self, tx_id: &TxId) -> StorageResult<Option<Transaction>>;
+}

--- a/crates/services/gas_price_service/src/ports.rs
+++ b/crates/services/gas_price_service/src/ports.rs
@@ -1,15 +1,11 @@
 use fuel_core_storage::Result as StorageResult;
 use fuel_core_types::{
-    blockchain::block::CompressedBlock,
-    fuel_tx::{
-        Transaction,
-        TxId,
-    },
+    blockchain::block::Block,
+    fuel_tx::Transaction,
     fuel_types::BlockHeight,
 };
 
 pub trait L2Data: Send + Sync {
     fn latest_height(&self) -> StorageResult<BlockHeight>;
-    fn get_block(&self, height: &BlockHeight) -> StorageResult<Option<CompressedBlock>>;
-    fn get_transaction(&self, tx_id: &TxId) -> StorageResult<Option<Transaction>>;
+    fn get_block(&self, height: &BlockHeight) -> StorageResult<Block<Transaction>>;
 }


### PR DESCRIPTION
> [!NOTE]
> This is PR 1/n in cleaning up the gas price service. This PR is first of few that moves the `algorithm_updater` from the `sub_services` module of `fuel-core` to `fuel-core-gas-price-service`.
>
> To do so, we have to cut dependencies on `fuel-core`, which means we have to remove the direct dependency on `Database`, `ConsensusParametersProvider` etc.

## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->
We define a new port in the `fuel-core-gas-price-service` crate that is meant to cut the dependency of `algorithm_updater` from `fuel-core`.


## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests (existing tests already work)
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
