### PR TITLE
chore(gas_price_service): remove dependency on Config from fuel-core

### DIFF
--- a/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
@@ -15,6 +15,7 @@ use fuel_core_gas_price_service::{
     },
     ports::{
         GasPriceData,
+        GasPriceServiceConfig,
         L2Data,
         MetadataStorage,
     },
@@ -37,9 +38,12 @@ use fuel_core_types::{
     fuel_types::BlockHeight,
 };
 
-use crate::database::{
-    database_description::gas_price::GasPriceDatabase,
-    Database,
+use crate::{
+    database::{
+        database_description::gas_price::GasPriceDatabase,
+        Database,
+    },
+    service::Config,
 };
 
 #[cfg(test)]
@@ -93,6 +97,17 @@ impl MetadataStorage for Database<GasPriceDatabase> {
                 source_error: err.into(),
             })?;
         Ok(())
+    }
+}
+
+impl From<Config> for GasPriceServiceConfig {
+    fn from(value: Config) -> Self {
+        GasPriceServiceConfig::new(
+            value.min_gas_price,
+            value.starting_gas_price,
+            value.gas_price_change_percent,
+            value.gas_price_threshold_percent,
+        )
     }
 }
 

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -201,7 +201,7 @@ pub fn init_sub_services(
     let block_stream = importer_adapter.events_shared_result();
 
     let gas_price_init = algorithm_updater::InitializeTask::new(
-        config.clone(),
+        config.clone().into(),
         genesis_block_height,
         settings,
         block_stream,

--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -1,7 +1,4 @@
-use crate::service::{
-    adapters::ConsensusParametersProvider,
-    Config,
-};
+use crate::service::adapters::ConsensusParametersProvider;
 
 use fuel_core_gas_price_service::{
     fuel_gas_price_updater::{
@@ -27,6 +24,7 @@ use fuel_core_gas_price_service::{
     },
     ports::{
         GasPriceData,
+        GasPriceServiceConfig,
         L2Data,
         MetadataStorage,
     },
@@ -60,7 +58,7 @@ type Updater<GasPriceStore> = FuelGasPriceUpdater<
 >;
 
 pub struct InitializeTask<L2DataStoreView, GasPriceStore> {
-    pub config: Config,
+    pub config: GasPriceServiceConfig,
     pub genesis_block_height: BlockHeight,
     pub settings: ConsensusParametersProvider,
     pub gas_price_db: GasPriceStore,
@@ -80,7 +78,7 @@ where
     GasPriceStore: GasPriceData + MetadataStorage,
 {
     pub fn new(
-        config: Config,
+        config: GasPriceServiceConfig,
         genesis_block_height: BlockHeight,
         settings: ConsensusParametersProvider,
         block_stream: BoxStream<SharedImportResult>,
@@ -113,7 +111,10 @@ where
     }
 }
 
-fn get_default_metadata(config: &Config, latest_block_height: u32) -> UpdaterMetadata {
+fn get_default_metadata(
+    config: &GasPriceServiceConfig,
+    latest_block_height: u32,
+) -> UpdaterMetadata {
     UpdaterMetadata::V0(V0Metadata {
         new_exec_price: config.starting_gas_price.max(config.min_gas_price),
         min_exec_gas_price: config.min_gas_price,
@@ -191,7 +192,7 @@ where
 }
 
 pub fn get_synced_gas_price_updater<L2DataStore, L2DataStoreView, GasPriceStore>(
-    config: Config,
+    config: GasPriceServiceConfig,
     genesis_block_height: BlockHeight,
     settings: ConsensusParametersProvider,
     mut gas_price_db: GasPriceStore,

--- a/crates/services/gas_price_service/src/ports.rs
+++ b/crates/services/gas_price_service/src/ports.rs
@@ -26,3 +26,26 @@ pub trait MetadataStorage: Send + Sync {
 pub trait GasPriceData: Send + Sync {
     fn latest_height(&self) -> Option<BlockHeight>;
 }
+
+pub struct GasPriceServiceConfig {
+    pub min_gas_price: u64,
+    pub starting_gas_price: u64,
+    pub gas_price_change_percent: u64,
+    pub gas_price_threshold_percent: u64,
+}
+
+impl GasPriceServiceConfig {
+    pub fn new(
+        min_gas_price: u64,
+        starting_gas_price: u64,
+        gas_price_change_percent: u64,
+        gas_price_threshold_percent: u64,
+    ) -> Self {
+        Self {
+            min_gas_price,
+            starting_gas_price,
+            gas_price_change_percent,
+            gas_price_threshold_percent,
+        }
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> This is PR 3/n in cleaning up the gas price service. 
> Please review https://github.com/FuelLabs/fuel-core/pull/2226  before getting to this one ;) 

## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->
Defines a custom configuration for the `GasPriceService` which is passed in on subservice initialization.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
