### PR TITLE
Acquire `da_finalization_period` from the command line

### DIFF
--- a/crates/fuel-gas-price-algorithm/gas-price-analysis/src/charts.rs
+++ b/crates/fuel-gas-price-algorithm/gas-price-analysis/src/charts.rs
@@ -8,7 +8,7 @@ pub fn draw_chart(
     results: SimulationResults,
     p_comp: i64,
     d_comp: i64,
-    update_period: usize,
+    da_finalization_period: usize,
     file_path: &str,
 ) -> anyhow::Result<()> {
     let SimulationResults {
@@ -52,10 +52,10 @@ pub fn draw_chart(
         &projected_profit,
         &pessimistic_costs,
         &format!(
-            "Profit p_comp: {}, d_comp: {}, update_period: {}",
+            "Profit p_comp: {}, d_comp: {}, da_finalization_period: {}",
             prettify_number(p_comp),
             prettify_number(d_comp),
-            prettify_number(update_period)
+            prettify_number(da_finalization_period)
         ),
     )?;
     draw_gas_prices(

--- a/crates/fuel-gas-price-algorithm/gas-price-analysis/src/charts.rs
+++ b/crates/fuel-gas-price-algorithm/gas-price-analysis/src/charts.rs
@@ -8,6 +8,7 @@ pub fn draw_chart(
     results: SimulationResults,
     p_comp: i64,
     d_comp: i64,
+    update_period: usize,
     file_path: &str,
 ) -> anyhow::Result<()> {
     let SimulationResults {
@@ -51,9 +52,10 @@ pub fn draw_chart(
         &projected_profit,
         &pessimistic_costs,
         &format!(
-            "Profit p_comp: {}, d_comp: {}",
+            "Profit p_comp: {}, d_comp: {}, update_period: {}",
             prettify_number(p_comp),
-            prettify_number(d_comp)
+            prettify_number(d_comp),
+            prettify_number(update_period)
         ),
     )?;
     draw_gas_prices(

--- a/crates/fuel-gas-price-algorithm/gas-price-analysis/src/main.rs
+++ b/crates/fuel-gas-price-algorithm/gas-price-analysis/src/main.rs
@@ -38,7 +38,7 @@ struct Arg {
     #[arg(short, long)]
     file_path: Option<String>,
     #[arg(short, long)]
-    /// DA finalization period in blocks
+    /// DA finalization period in L2 blocks
     da_finalization_period: usize,
 }
 

--- a/crates/fuel-gas-price-algorithm/gas-price-analysis/src/main.rs
+++ b/crates/fuel-gas-price-algorithm/gas-price-analysis/src/main.rs
@@ -98,7 +98,8 @@ async fn main() -> anyhow::Result<()> {
                 prettify_number(da_finalization_period)
             );
             let simulator = Simulator::new(da_cost_per_byte);
-            let result = simulator.run_simulation(p, d, da_finalization_period);
+            let result =
+                simulator.run_simulation(p, d, UPDATE_PERIOD, da_finalization_period);
             (result, (p, d))
         }
         Mode::Optimization { iterations, source } => {
@@ -112,11 +113,12 @@ async fn main() -> anyhow::Result<()> {
             let (results, (p, d)) = naive_optimisation(
                 &simulator,
                 iterations as usize,
+                UPDATE_PERIOD,
                 da_finalization_period,
             )
             .await;
             println!(
-                "Optimization results: P: {}, D: {}, update_period: {}",
+                "Optimization results: P: {}, D: {}, da_finalization_period: {}",
                 prettify_number(p),
                 prettify_number(d),
                 prettify_number(da_finalization_period)

--- a/crates/fuel-gas-price-algorithm/gas-price-analysis/src/main.rs
+++ b/crates/fuel-gas-price-algorithm/gas-price-analysis/src/main.rs
@@ -38,6 +38,7 @@ struct Arg {
     #[arg(short, long)]
     file_path: Option<String>,
     #[arg(short, long)]
+    /// DA update period in blocks
     update_period: usize,
 }
 

--- a/crates/fuel-gas-price-algorithm/gas-price-analysis/src/optimisation.rs
+++ b/crates/fuel-gas-price-algorithm/gas-price-analysis/src/optimisation.rs
@@ -15,6 +15,7 @@ fn da_pid_factors(size: usize) -> Vec<(i64, i64)> {
 pub async fn naive_optimisation(
     simulator: &Simulator,
     iterations: usize,
+    update_period: usize,
     da_recording_rate: usize,
 ) -> (SimulationResults, (i64, i64)) {
     let tasks = da_pid_factors(iterations)
@@ -23,7 +24,7 @@ pub async fn naive_optimisation(
             let new_simulator = simulator.clone();
             let f = move || {
                 (
-                    new_simulator.run_simulation(p, d, da_recording_rate),
+                    new_simulator.run_simulation(p, d, update_period, da_recording_rate),
                     (p, d),
                 )
             };

--- a/crates/fuel-gas-price-algorithm/gas-price-analysis/src/simulation.rs
+++ b/crates/fuel-gas-price-algorithm/gas-price-analysis/src/simulation.rs
@@ -33,7 +33,8 @@ impl Simulator {
         &self,
         da_p_component: i64,
         da_d_component: i64,
-        da_recording_rate: usize,
+        update_period: usize,
+        da_finalization_rate: usize,
     ) -> SimulationResults {
         let capacity = 30_000_000;
         let gas_per_byte = 63;
@@ -42,8 +43,11 @@ impl Simulator {
         let fullness_and_bytes = fullness_and_bytes_per_block(size, capacity);
 
         let l2_blocks = fullness_and_bytes.clone().into_iter();
-        let da_blocks =
-            self.zip_l2_blocks_with_da_blocks(da_recording_rate, &fullness_and_bytes);
+        let da_blocks = self.calculate_da_blocks(
+            update_period,
+            da_finalization_rate,
+            &fullness_and_bytes,
+        );
 
         let blocks = l2_blocks.zip(da_blocks.iter()).enumerate();
 
@@ -177,11 +181,13 @@ impl Simulator {
         }
     }
 
-    fn zip_l2_blocks_with_da_blocks(
+    fn calculate_da_blocks(
         &self,
         da_recording_rate: usize,
+        da_finalization_rate: usize,
         fullness_and_bytes: &Vec<(u64, u64)>,
     ) -> Vec<Option<Vec<RecordedBlock>>> {
+        let nones = std::iter::repeat(None).take(da_finalization_rate);
         let (_, da_blocks) = fullness_and_bytes
             .iter()
             .zip(self.da_cost_per_byte.iter())
@@ -207,7 +213,7 @@ impl Simulator {
                     }
                 },
             );
-        da_blocks
+        nones.chain(da_blocks).collect()
     }
 }
 

--- a/crates/fuel-gas-price-algorithm/gas-price-analysis/src/simulation.rs
+++ b/crates/fuel-gas-price-algorithm/gas-price-analysis/src/simulation.rs
@@ -187,7 +187,8 @@ impl Simulator {
         da_finalization_rate: usize,
         fullness_and_bytes: &Vec<(u64, u64)>,
     ) -> Vec<Option<Vec<RecordedBlock>>> {
-        let nones = std::iter::repeat(None).take(da_finalization_rate);
+        let l2_blocks_with_no_da_blocks =
+            std::iter::repeat(None).take(da_finalization_rate);
         let (_, da_blocks) = fullness_and_bytes
             .iter()
             .zip(self.da_cost_per_byte.iter())
@@ -213,7 +214,7 @@ impl Simulator {
                     }
                 },
             );
-        nones.chain(da_blocks).collect()
+        l2_blocks_with_no_da_blocks.chain(da_blocks).collect()
     }
 }
 

--- a/crates/fuel-gas-price-algorithm/src/v1.rs
+++ b/crates/fuel-gas-price-algorithm/src/v1.rs
@@ -239,6 +239,12 @@ impl AlgorithmUpdaterV1 {
             // gas prices
             self.update_exec_gas_price(used, capacity);
             self.update_da_gas_price();
+
+            // metadata
+            self.unrecorded_blocks.push(BlockBytes {
+                height,
+                block_bytes,
+            });
             Ok(())
         }
     }

--- a/crates/fuel-gas-price-algorithm/src/v1/tests/update_l2_block_data_tests.rs
+++ b/crates/fuel-gas-price-algorithm/src/v1/tests/update_l2_block_data_tests.rs
@@ -1,5 +1,6 @@
 use crate::v1::{
     tests::UpdaterBuilder,
+    BlockBytes,
     Error,
 };
 
@@ -530,4 +531,72 @@ fn update_l2_block_data__negative_profit_increase_gas_price() {
         new_gas_price,
         old_gas_price
     );
+}
+
+#[test]
+fn update_l2_block_data__adds_l2_block_to_unrecorded_blocks() {
+    // given
+    let starting_block = 0;
+
+    let mut updater = UpdaterBuilder::new()
+        .with_l2_block_height(starting_block)
+        .build();
+
+    let height = 1;
+    let used = 50;
+    let capacity = 100.try_into().unwrap();
+    let block_bytes = 1000;
+    let new_gas_price = 100;
+
+    // when
+    updater
+        .update_l2_block_data(height, used, capacity, block_bytes, new_gas_price)
+        .unwrap();
+
+    //  then
+    let block_bytes = BlockBytes {
+        height,
+        block_bytes,
+    };
+    let contains_block_bytes = updater.unrecorded_blocks.contains(&block_bytes);
+    assert!(contains_block_bytes);
+}
+
+#[test]
+fn update_l2_block_data__retains_existing_blocks_and_adds_l2_block_to_unrecorded_blocks()
+{
+    // given
+    let starting_block = 0;
+    let preexisting_block = BlockBytes {
+        height: 0,
+        block_bytes: 1000,
+    };
+
+    let mut updater = UpdaterBuilder::new()
+        .with_l2_block_height(starting_block)
+        .with_unrecorded_blocks(vec![preexisting_block.clone()])
+        .build();
+
+    let height = 1;
+    let used = 50;
+    let capacity = 100.try_into().unwrap();
+    let block_bytes = 1000;
+    let new_gas_price = 100;
+
+    // when
+    updater
+        .update_l2_block_data(height, used, capacity, block_bytes, new_gas_price)
+        .unwrap();
+
+    //  then
+    let block_bytes = BlockBytes {
+        height,
+        block_bytes,
+    };
+    let contains_block_bytes = updater.unrecorded_blocks.contains(&block_bytes);
+    assert!(contains_block_bytes);
+
+    let contains_preexisting_block_bytes =
+        updater.unrecorded_blocks.contains(&preexisting_block);
+    assert!(contains_preexisting_block_bytes);
 }


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FuelLabs/fuel-core/issues/2218

## Description
This PR extends the set of accepted command line parameters. The user is now able to provide the DA update time via the new `--da-finalization-period` argument.

It also fixes the issue with `unrecorded_blocks` collection which was not saturated with blocks.

## Checklist
- [X] New behavior is reflected in tests

### Before requesting review
- [X] I have reviewed the code myself
