### PR TITLE
Executor: test Tx_count limit with incorrect tx source

### DIFF
--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -4,10 +4,7 @@
 #[cfg(test)]
 mod tests {
 
-    use std::{
-        cell::RefCell,
-        sync::Mutex,
-    };
+    use std::sync::Mutex;
 
     use crate as fuel_core;
     use fuel_core::database::Database;
@@ -194,25 +191,25 @@ mod tests {
     /// that should be returned by [`TransactionsSource::next()`].
     /// It is used only for testing purposes
     pub struct BadTransactionsSource {
-        transactions: Mutex<RefCell<Vec<MaybeCheckedTransaction>>>,
+        transactions: Mutex<Vec<MaybeCheckedTransaction>>,
     }
 
     impl BadTransactionsSource {
         pub fn new(transactions: Vec<Transaction>) -> Self {
             Self {
-                transactions: Mutex::new(RefCell::new(
+                transactions: Mutex::new(
                     transactions
                         .into_iter()
                         .map(MaybeCheckedTransaction::Transaction)
                         .collect(),
-                )),
+                ),
             }
         }
     }
 
     impl TransactionsSource for BadTransactionsSource {
         fn next(&self, _: u64, _: u16, _: u32) -> Vec<MaybeCheckedTransaction> {
-            std::mem::take(&mut *self.transactions.lock().unwrap().borrow_mut())
+            std::mem::take(&mut *self.transactions.lock().unwrap())
         }
     }
 

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -204,35 +204,6 @@ impl TransactionsSource for OnceTransactionsSource {
     }
 }
 
-/// Bad transaction source: ignores the limit of `u16::MAX -1` transactions
-/// that should be returned by [`TransactionsSource::next()`].
-/// It is used only for testing purposes
-#[cfg(feature = "test-helpers")]
-pub struct BadTransactionsSource {
-    transactions: ParkingMutex<Vec<MaybeCheckedTransaction>>,
-}
-
-#[cfg(feature = "test-helpers")]
-impl BadTransactionsSource {
-    pub fn new(transactions: Vec<Transaction>) -> Self {
-        Self {
-            transactions: ParkingMutex::new(
-                transactions
-                    .into_iter()
-                    .map(MaybeCheckedTransaction::Transaction)
-                    .collect(),
-            ),
-        }
-    }
-}
-
-#[cfg(feature = "test-helpers")]
-impl TransactionsSource for BadTransactionsSource {
-    fn next(&self, _: u64, _: u16, _: u32) -> Vec<MaybeCheckedTransaction> {
-        std::mem::take(self.transactions.lock().as_mut())
-    }
-}
-
 /// Data that is generated after executing all transactions.
 #[derive(Default)]
 pub struct ExecutionData {

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -204,6 +204,35 @@ impl TransactionsSource for OnceTransactionsSource {
     }
 }
 
+/// Bad transaction source: ignores the limit of `u16::MAX -1` transactions
+/// that should be returned by [`TransactionsSource::next()`].
+/// It is used only for testing purposes
+#[cfg(feature = "test-helpers")]
+pub struct BadTransactionsSource {
+    transactions: ParkingMutex<Vec<MaybeCheckedTransaction>>,
+}
+
+#[cfg(feature = "test-helpers")]
+impl BadTransactionsSource {
+    pub fn new(transactions: Vec<Transaction>) -> Self {
+        Self {
+            transactions: ParkingMutex::new(
+                transactions
+                    .into_iter()
+                    .map(MaybeCheckedTransaction::Transaction)
+                    .collect(),
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "test-helpers")]
+impl TransactionsSource for BadTransactionsSource {
+    fn next(&self, _: u64, _: u16, _: u32) -> Vec<MaybeCheckedTransaction> {
+        std::mem::take(self.transactions.lock().as_mut())
+    }
+}
+
 /// Data that is generated after executing all transactions.
 #[derive(Default)]
 pub struct ExecutionData {


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

Closes https://github.com/FuelLabs/fuel-core/issues/2225

## Description
<!-- List of detailed changes -->

As per discussion, we should check that the current Executor logic is resilient against transactions source that ignore the limit on MAX_TX_COUNT. 

## Checklist
- [ ] New behavior is reflected in tests


### Before requesting review
- [ ] I have reviewed the code myself

