### PR TITLE
chore(gas_price_service): use port for GasPriceSettings instead of concrete type

### DIFF
--- a/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
+++ b/crates/fuel-core/src/service/sub_services/algorithm_updater.rs
@@ -278,7 +278,7 @@ fn sync_gas_price_db_with_on_chain_storage<
 where
     L2DataStore: L2Data,
     L2DataStoreView: AtomicView<LatestView = L2DataStore>,
-    GasPriceStore: GasPriceData + Modifiable + KeyValueInspect<Column = GasPriceColumn>,,
+    GasPriceStore: GasPriceData + Modifiable + KeyValueInspect<Column = GasPriceColumn>,
     SettingsProvider: GasPriceSettingsProvider,
 {
     let metadata = metadata_storage
@@ -316,7 +316,7 @@ fn sync_v0_metadata<L2DataStore, L2DataStoreView, GasPriceStore, SettingsProvide
 where
     L2DataStore: L2Data,
     L2DataStoreView: AtomicView<LatestView = L2DataStore>,
-    GasPriceStore: GasPriceData + Modifiable + KeyValueInspect<Column = GasPriceColumn>,,
+    GasPriceStore: GasPriceData + Modifiable + KeyValueInspect<Column = GasPriceColumn>,
     SettingsProvider: GasPriceSettingsProvider,
 {
     let first = metadata_height.saturating_add(1);

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_core_storage_adapter.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_core_storage_adapter.rs
@@ -113,7 +113,7 @@ pub struct GasPriceSettings {
     pub gas_price_factor: u64,
     pub block_gas_limit: u64,
 }
-pub trait GasPriceSettingsProvider {
+pub trait GasPriceSettingsProvider: Send + Sync + Clone {
     fn settings(
         &self,
         param_version: &ConsensusParametersVersion,

--- a/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_core_storage_adapter/l2_source_tests.rs
+++ b/crates/services/gas_price_service/src/fuel_gas_price_updater/fuel_core_storage_adapter/l2_source_tests.rs
@@ -34,6 +34,7 @@ use std::{
 };
 use tokio_stream::wrappers::ReceiverStream;
 
+#[derive(Clone)]
 struct FakeSettings {
     gas_price_factor: u64,
     block_gas_limit: u64,


### PR DESCRIPTION
> [!NOTE]
> This is PR 4/n in cleaning up the gas price service.
> Please review https://github.com/FuelLabs/fuel-core/pull/2230 before getting to this one ;)

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- https://github.com/FuelLabs/fuel-core/pull/2230

## Description
<!-- List of detailed changes -->
Used the existing port for `GasPriceSettingsProvider` and made the algorithm updater generic over it. the `algorithm_updater` can be moved to the `fuel-core-gas-price-service` crate after this.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
