### PR TITLE
fix(da_block_costs): remove Arc<Mutex<>> on shared_state and expose channel

### DIFF
--- a/crates/services/gas_price_service/src/v1.rs
+++ b/crates/services/gas_price_service/src/v1.rs
@@ -1,2 +1,2 @@
 pub mod algorithm;
-pub mod da_source_adapter;
+pub mod da_source_service;

--- a/crates/services/gas_price_service/src/v1/da_source_adapter.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_adapter.rs
@@ -55,7 +55,7 @@ mod tests {
             blob_cost_wei: 1,
         };
         let da_block_costs_source = DummyDaBlockCosts::new(Ok(expected_da_cost.clone()));
-        let service = new_service(da_block_costs_source, Some(Duration::from_millis(1)));
+        let service = new_service(da_block_costs_source, Some(Duration::from_millis(8)));
         let mut shared_state = &mut service.shared.subscribe();
 
         // when

--- a/crates/services/gas_price_service/src/v1/da_source_adapter.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_adapter.rs
@@ -1,26 +1,9 @@
-use crate::{
-    common::utils::Result as GasPriceResult,
-    v1::da_source_adapter::service::{
-        new_service,
-        DaBlockCostsService,
-        DaBlockCostsSource,
-    },
-};
-use fuel_core_services::ServiceRunner;
-use std::{
-    sync::Arc,
-    time::Duration,
-};
-use tokio::sync::{
-    mpsc,
-    Mutex,
-};
+use crate::v1::da_source_adapter::service::DaBlockCostsSource;
+use std::time::Duration;
 
 pub mod block_committer_costs;
 pub mod dummy_costs;
 pub mod service;
-
-pub const POLLING_INTERVAL_MS: u64 = 10_000;
 
 #[derive(Debug, Default, Clone, Eq, Hash, PartialEq)]
 pub struct DaBlockCosts {
@@ -29,66 +12,20 @@ pub struct DaBlockCosts {
     pub blob_cost_wei: u128,
 }
 
-pub trait GetDaBlockCosts: Send + Sync {
-    fn get(&self) -> GasPriceResult<Option<DaBlockCosts>>;
-}
-
-#[derive(Clone)]
-pub struct DaBlockCostsSharedState {
-    inner: Arc<Mutex<mpsc::Receiver<DaBlockCosts>>>,
-}
-
-impl DaBlockCostsSharedState {
-    fn new(receiver: mpsc::Receiver<DaBlockCosts>) -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(receiver)),
-        }
-    }
-}
-
-pub struct DaBlockCostsProvider<T: DaBlockCostsSource + 'static> {
-    pub service: ServiceRunner<DaBlockCostsService<T>>,
-    pub shared_state: DaBlockCostsSharedState,
-}
-
-const CHANNEL_BUFFER_SIZE: usize = 10;
-
-impl<T> DaBlockCostsProvider<T>
-where
-    T: DaBlockCostsSource,
-{
-    pub fn new(source: T, polling_interval: Option<Duration>) -> Self {
-        let (sender, receiver) = mpsc::channel(CHANNEL_BUFFER_SIZE);
-        let service = new_service(source, sender, polling_interval);
-        Self {
-            shared_state: DaBlockCostsSharedState::new(receiver),
-            service,
-        }
-    }
-}
-
-impl GetDaBlockCosts for DaBlockCostsSharedState {
-    fn get(&self) -> GasPriceResult<Option<DaBlockCosts>> {
-        if let Ok(mut guard) = self.inner.try_lock() {
-            if let Ok(da_block_costs) = guard.try_recv() {
-                return Ok(Some(da_block_costs));
-            }
-        }
-        Ok(None)
-    }
-}
-
 #[allow(non_snake_case)]
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::v1::da_source_adapter::dummy_costs::DummyDaBlockCosts;
+    use crate::v1::da_source_adapter::{
+        dummy_costs::DummyDaBlockCosts,
+        service::new_service,
+    };
     use fuel_core_services::Service;
     use std::time::Duration;
     use tokio::time::sleep;
 
     #[tokio::test]
-    async fn run__when_da_block_cost_source_gives_value_shared_value_is_updated() {
+    async fn run__when_da_block_cost_source_gives_value_shared_state_is_updated() {
         // given
         let expected_da_cost = DaBlockCosts {
             l2_block_range: 0..10,
@@ -96,21 +33,17 @@ mod tests {
             blob_cost_wei: 2,
         };
         let da_block_costs_source = DummyDaBlockCosts::new(Ok(expected_da_cost.clone()));
-        let provider = DaBlockCostsProvider::new(
-            da_block_costs_source,
-            Some(Duration::from_millis(1)),
-        );
-        let shared_state = provider.shared_state.clone();
+        let service = new_service(da_block_costs_source, Some(Duration::from_millis(1)));
+        let mut shared_state = &mut service.shared.subscribe();
 
         // when
-        provider.service.start_and_await().await.unwrap();
+        service.start_and_await().await.unwrap();
         sleep(Duration::from_millis(10)).await;
-        provider.service.stop_and_await().await.unwrap();
+        service.stop_and_await().await.unwrap();
 
         // then
-        let da_block_costs_opt = shared_state.get().unwrap();
-        assert!(da_block_costs_opt.is_some());
-        assert_eq!(da_block_costs_opt.unwrap(), expected_da_cost);
+        let da_block_costs = shared_state.try_recv().unwrap();
+        assert_eq!(da_block_costs, expected_da_cost);
     }
 
     #[tokio::test]
@@ -122,42 +55,36 @@ mod tests {
             blob_cost_wei: 1,
         };
         let da_block_costs_source = DummyDaBlockCosts::new(Ok(expected_da_cost.clone()));
-        let provider = DaBlockCostsProvider::new(
-            da_block_costs_source,
-            Some(Duration::from_millis(1)),
-        );
-        let shared_state = provider.shared_state.clone();
+        let service = new_service(da_block_costs_source, Some(Duration::from_millis(1)));
+        let mut shared_state = &mut service.shared.subscribe();
 
         // when
-        provider.service.start_and_await().await.unwrap();
+        service.start_and_await().await.unwrap();
         sleep(Duration::from_millis(10)).await;
-        provider.service.stop_and_await().await.unwrap();
-        let da_block_costs_opt = shared_state.get().unwrap();
-        assert!(da_block_costs_opt.is_some());
-        assert_eq!(da_block_costs_opt.unwrap(), expected_da_cost);
+        service.stop_and_await().await.unwrap();
+
+        let initial = shared_state.try_recv().unwrap();
+        assert_eq!(initial, expected_da_cost);
 
         // then
-        let da_block_costs_opt = shared_state.get().unwrap();
-        assert!(da_block_costs_opt.is_none());
+        let da_block_costs_res = shared_state.try_recv();
+        assert!(da_block_costs_res.is_err());
     }
 
     #[tokio::test]
     async fn run__when_da_block_cost_source_errors_shared_value_is_not_updated() {
         // given
         let da_block_costs_source = DummyDaBlockCosts::new(Err(anyhow::anyhow!("boo!")));
-        let provider = DaBlockCostsProvider::new(
-            da_block_costs_source,
-            Some(Duration::from_millis(1)),
-        );
-        let shared_state = provider.shared_state.clone();
+        let service = new_service(da_block_costs_source, Some(Duration::from_millis(1)));
+        let mut shared_state = &mut service.shared.subscribe();
 
         // when
-        provider.service.start_and_await().await.unwrap();
+        service.start_and_await().await.unwrap();
         sleep(Duration::from_millis(10)).await;
-        provider.service.stop_and_await().await.unwrap();
+        service.stop_and_await().await.unwrap();
 
         // then
-        let da_block_costs_opt = shared_state.get().unwrap();
-        assert!(da_block_costs_opt.is_none());
+        let da_block_costs_res = shared_state.try_recv();
+        assert!(da_block_costs_res.is_err());
     }
 }

--- a/crates/services/gas_price_service/src/v1/da_source_adapter/service.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_adapter/service.rs
@@ -40,7 +40,6 @@ where
     poll_interval: Interval,
     source: Source,
     shared_state: DaBlockCostsSharedState,
-    cache: HashSet<DaBlockCosts>,
 }
 
 const DA_BLOCK_COSTS_CHANNEL_SIZE: usize = 10;
@@ -59,7 +58,6 @@ where
                 poll_interval.unwrap_or(Duration::from_millis(POLLING_INTERVAL_MS)),
             ),
             source,
-            cache: Default::default(),
         }
     }
 }
@@ -115,10 +113,7 @@ where
             }
             _ = self.poll_interval.tick() => {
                 let da_block_costs = self.source.request_da_block_cost().await?;
-                if !self.cache.contains(&da_block_costs) {
-                    self.cache.insert(da_block_costs.clone());
-                    self.shared_state.0.send(da_block_costs)?;
-                }
+                self.shared_state.0.send(da_block_costs)?;
                 continue_running = true;
             }
         }

--- a/crates/services/gas_price_service/src/v1/da_source_service.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service.rs
@@ -1,4 +1,4 @@
-use crate::v1::da_source_adapter::service::DaBlockCostsSource;
+use crate::v1::da_source_service::service::DaBlockCostsSource;
 use std::time::Duration;
 
 pub mod block_committer_costs;
@@ -16,7 +16,7 @@ pub struct DaBlockCosts {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::v1::da_source_adapter::{
+    use crate::v1::da_source_service::{
         dummy_costs::DummyDaBlockCosts,
         service::new_service,
     };

--- a/crates/services/gas_price_service/src/v1/da_source_service/block_committer_costs.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service/block_committer_costs.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 
-use crate::v1::da_source_adapter::{
+use crate::v1::da_source_service::{
     service::{
         DaBlockCostsSource,
         Result as DaBlockCostsResult,

--- a/crates/services/gas_price_service/src/v1/da_source_service/dummy_costs.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service/dummy_costs.rs
@@ -1,4 +1,4 @@
-use crate::v1::da_source_adapter::{
+use crate::v1::da_source_service::{
     service::{
         DaBlockCostsSource,
         Result as DaBlockCostsResult,

--- a/crates/services/gas_price_service/src/v1/da_source_service/service.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service/service.rs
@@ -4,10 +4,7 @@ use fuel_core_services::{
     ServiceRunner,
     StateWatcher,
 };
-use std::{
-    collections::HashSet,
-    time::Duration,
-};
+use std::time::Duration;
 use tokio::{
     sync::broadcast::Sender,
     time::{
@@ -16,13 +13,13 @@ use tokio::{
     },
 };
 
-use crate::v1::da_source_adapter::DaBlockCosts;
+use crate::v1::da_source_service::DaBlockCosts;
 pub use anyhow::Result;
 
 #[derive(Clone)]
-pub struct DaBlockCostsSharedState(Sender<DaBlockCosts>);
+pub struct SharedState(Sender<DaBlockCosts>);
 
-impl DaBlockCostsSharedState {
+impl SharedState {
     fn new(sender: Sender<DaBlockCosts>) -> Self {
         Self(sender)
     }
@@ -33,19 +30,19 @@ impl DaBlockCostsSharedState {
 
 /// This struct houses the shared_state, polling interval
 /// and a source, which does the actual fetching of the data
-pub struct DaBlockCostsService<Source>
+pub struct DaSourceService<Source>
 where
     Source: DaBlockCostsSource,
 {
     poll_interval: Interval,
     source: Source,
-    shared_state: DaBlockCostsSharedState,
+    shared_state: SharedState,
 }
 
 const DA_BLOCK_COSTS_CHANNEL_SIZE: usize = 10;
 const POLLING_INTERVAL_MS: u64 = 10_000;
 
-impl<Source> DaBlockCostsService<Source>
+impl<Source> DaSourceService<Source>
 where
     Source: DaBlockCostsSource,
 {
@@ -53,7 +50,7 @@ where
         let (sender, _) = tokio::sync::broadcast::channel(DA_BLOCK_COSTS_CHANNEL_SIZE);
         #[allow(clippy::arithmetic_side_effects)]
         Self {
-            shared_state: DaBlockCostsSharedState::new(sender),
+            shared_state: SharedState::new(sender),
             poll_interval: interval(
                 poll_interval.unwrap_or(Duration::from_millis(POLLING_INTERVAL_MS)),
             ),
@@ -70,13 +67,13 @@ pub trait DaBlockCostsSource: Send + Sync {
 }
 
 #[async_trait::async_trait]
-impl<Source> RunnableService for DaBlockCostsService<Source>
+impl<Source> RunnableService for DaSourceService<Source>
 where
     Source: DaBlockCostsSource,
 {
-    const NAME: &'static str = "DaBlockCostsService";
+    const NAME: &'static str = "DaSourceService";
 
-    type SharedData = DaBlockCostsSharedState;
+    type SharedData = SharedState;
 
     type Task = Self;
 
@@ -97,7 +94,7 @@ where
 }
 
 #[async_trait::async_trait]
-impl<Source> RunnableTask for DaBlockCostsService<Source>
+impl<Source> RunnableTask for DaSourceService<Source>
 where
     Source: DaBlockCostsSource,
 {
@@ -130,6 +127,6 @@ where
 pub fn new_service<S: DaBlockCostsSource>(
     da_source: S,
     poll_interval: Option<Duration>,
-) -> ServiceRunner<DaBlockCostsService<S>> {
-    ServiceRunner::new(DaBlockCostsService::new(da_source, poll_interval))
+) -> ServiceRunner<DaSourceService<S>> {
+    ServiceRunner::new(DaSourceService::new(da_source, poll_interval))
 }


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- follows up https://github.com/FuelLabs/fuel-core/pull/2192  with some changes to clean up the da block costs source.

## Description
<!-- List of detailed changes -->
- Exposed a `broadcast::Sender` as the shared_state of the DaBlockCostsSource, which is to be subscribed to when a service needs this dependency.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
