### PR TITLE
fix(dummy_da_block_costs): remove dependency on polling_interval and use channel instead

### DIFF
--- a/crates/services/gas_price_service/src/v1/da_source_service/dummy_costs.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service/dummy_costs.rs
@@ -5,14 +5,17 @@ use crate::v1::da_source_service::{
     },
     DaBlockCosts,
 };
+use tokio::sync::mpsc::Sender;
 
 pub struct DummyDaBlockCosts {
     value: DaBlockCostsResult<DaBlockCosts>,
+    // sends true if the request was successful, false otherwise
+    notifier: Sender<bool>,
 }
 
 impl DummyDaBlockCosts {
-    pub fn new(value: DaBlockCostsResult<DaBlockCosts>) -> Self {
-        Self { value }
+    pub fn new(value: DaBlockCostsResult<DaBlockCosts>, notifier: Sender<bool>) -> Self {
+        Self { value, notifier }
     }
 }
 
@@ -20,8 +23,14 @@ impl DummyDaBlockCosts {
 impl DaBlockCostsSource for DummyDaBlockCosts {
     async fn request_da_block_cost(&mut self) -> DaBlockCostsResult<DaBlockCosts> {
         match &self.value {
-            Ok(da_block_costs) => Ok(da_block_costs.clone()),
-            Err(err) => Err(anyhow::anyhow!(err.to_string())),
+            Ok(da_block_costs) => {
+                self.notifier.send(true).await?;
+                Ok(da_block_costs.clone())
+            }
+            Err(err) => {
+                self.notifier.send(false).await?;
+                Err(anyhow::anyhow!(err.to_string()))
+            }
         }
     }
 }


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
fixes https://github.com/FuelLabs/fuel-core/issues/2312

## Description
<!-- List of detailed changes -->
- removes dependency on time in da source service tests.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
