### PR TITLE
Release v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - Reading operations on the pool is now asynchronous and it’s the less prioritized operation on the Pool, API has been updated accordingly.
     - GasPrice is no more using async to allow the transactions verifications to not use async anymore 
 
-We also added a lot of new configuration cli parameters to fine-tune TxPool configuration.
-This PR also changes the way we are making the heavy work processor and a sync and asynchronous version is available in services folder (usable by anyone)
-P2P now use separate heavy work processor for DB and TxPool interactions.
+    We also added a lot of new configuration cli parameters to fine-tune TxPool configuration.
+    This PR also changes the way we are making the heavy work processor and a sync and asynchronous version is available in services folder (usable by anyone)
+    P2P now use separate heavy work processor for DB and TxPool interactions.
 
 ### Removed
 - [2306](https://github.com/FuelLabs/fuel-core/pull/2306): Removed hack for genesis asset contract from the code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2309](https://github.com/FuelLabs/fuel-core/pull/2309): Limit number of concurrent queries to the graphql service.
 - [2216](https://github.com/FuelLabs/fuel-core/pull/2216): Add more function to the state and task of TxPoolV2 to handle the future interactions with others modules (PoA, BlockProducer, BlockImporter and P2P).
 - [2263](https://github.com/FuelLabs/fuel-core/pull/2263): Transaction pool is now included in all modules of the code it has requires modifications on different modules : 
-- The PoA is now notify only when there is new transaction and not using the `tx_update_sender` anymore.
-- The Pool transaction source for the executor is now locking the pool until the block production is finished.
-- Reading operations on the pool is now asynchronous and it’s the less prioritized operation on the Pool, API has been updated accordingly.
-- GasPrice is no more using async to allow the transactions verifications to not use async anymore 
+    - The PoA is now notify only when there is new transaction and not using the `tx_update_sender` anymore.
+    - The Pool transaction source for the executor is now locking the pool until the block production is finished.
+    - Reading operations on the pool is now asynchronous and it’s the less prioritized operation on the Pool, API has been updated accordingly.
+    - GasPrice is no more using async to allow the transactions verifications to not use async anymore 
+
 We also added a lot of new configuration cli parameters to fine-tune TxPool configuration.
 This PR also changes the way we are making the heavy work processor and a sync and asynchronous version is available in services folder (usable by anyone)
 P2P now use separate heavy work processor for DB and TxPool interactions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.38.0]
+
 ### Added
 - [2309](https://github.com/FuelLabs/fuel-core/pull/2309): Limit number of concurrent queries to the graphql service.
-- [2216](https://github.com/FuelLabs/fuel-core/pull/2216): Add more function to the state and task of TxPoolV2 to handle the future interactions with others modules (PoA, BlockProducer, BlockImporter and P2P)
-- [2263](https://github.com/FuelLabs/fuel-core/pull/2263): Use the Txpool v2 in the whole codebase
+- [2216](https://github.com/FuelLabs/fuel-core/pull/2216): Add more function to the state and task of TxPoolV2 to handle the future interactions with others modules (PoA, BlockProducer, BlockImporter and P2P).
+- [2263](https://github.com/FuelLabs/fuel-core/pull/2263): Use the Txpool v2 in the whole codebase.
 
 ### Removed
 - [2306](https://github.com/FuelLabs/fuel-core/pull/2306): Removed hack for genesis asset contract from the code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [2309](https://github.com/FuelLabs/fuel-core/pull/2309): Limit number of concurrent queries to the graphql service.
 - [2216](https://github.com/FuelLabs/fuel-core/pull/2216): Add more function to the state and task of TxPoolV2 to handle the future interactions with others modules (PoA, BlockProducer, BlockImporter and P2P).
-- [2263](https://github.com/FuelLabs/fuel-core/pull/2263): Use the Txpool v2 in the whole codebase.
+- [2263](https://github.com/FuelLabs/fuel-core/pull/2263): Transaction pool is now included in all modules of the code it has requires modifications on different modules : 
+- The PoA is now notify only when there is new transaction and not using the `tx_update_sender` anymore.
+- The Pool transaction source for the executor is now locking the pool until the block production is finished.
+- Reading operations on the pool is now asynchronous and it’s the less prioritized operation on the Pool, API has been updated accordingly.
+- GasPrice is no more using async to allow the transactions verifications to not use async anymore 
+We also added a lot of new configuration cli parameters to fine-tune TxPool configuration.
+This PR also changes the way we are making the heavy work processor and a sync and asynchronous version is available in services folder (usable by anyone)
+P2P now use separate heavy work processor for DB and TxPool interactions.
 
 ### Removed
 - [2306](https://github.com/FuelLabs/fuel-core/pull/2306): Removed hack for genesis asset contract from the code.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,30 +3145,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "477a7cf80fc358292cee05f6b16bdd794b4b6dad2d9751cebbd05d2bab93604b"
+checksum = "5f325971bf9047ec70004f80a989e03456316bc19cbef3ff3a39a38b192ab56e"
 dependencies = [
  "bitflags 2.6.0",
- "fuel-types 0.58.1",
+ "fuel-types 0.58.2",
  "serde",
  "strum 0.24.1",
 ]
 
 [[package]]
 name = "fuel-compression"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0273f9a0f448af1f969a04f9ff37393f86c08eeda62a2bbf907a869f040b736"
+checksum = "24e42841f56f76ed759b3f516e5188d5c42de47015bee951651660c13b6dfa6c"
 dependencies = [
- "fuel-derive 0.58.1",
- "fuel-types 0.58.1",
+ "fuel-derive 0.58.2",
+ "fuel-types 0.58.2",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3196,7 +3196,7 @@ dependencies = [
  "fuel-core-sync",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3246,7 +3246,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-sync",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "futures",
  "itertools 0.12.1",
  "num_enum",
@@ -3267,11 +3267,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.37.1"
+version = "0.38.0"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3285,7 +3285,7 @@ dependencies = [
  "fuel-core-compression",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3314,7 +3314,7 @@ dependencies = [
  "derivative",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3332,14 +3332,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more",
  "eventsource-client",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "futures",
  "hex",
  "hyper-rustls",
@@ -3356,22 +3356,22 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "clap 4.5.19",
  "fuel-core-client",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "fuel-core-compression",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "paste",
  "postcard",
  "proptest",
@@ -3384,30 +3384,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "derive_more",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3415,7 +3415,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "futures",
  "hex",
  "humantime-serde",
@@ -3432,12 +3432,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "hex",
  "parking_lot",
  "serde",
@@ -3446,14 +3446,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "enum-iterator",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "fuel-gas-price-algorithm",
  "futures",
  "num_enum",
@@ -3470,14 +3470,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "derive_more",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "mockall",
  "parking_lot",
  "rayon",
@@ -3488,18 +3488,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "parking_lot",
  "pin-project-lite",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3535,7 +3535,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3573,7 +3573,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "k256",
  "mockall",
  "rand",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3595,7 +3595,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "mockall",
  "proptest",
  "rand",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3620,7 +3620,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "futures",
  "mockall",
  "once_cell",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3655,14 +3655,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "derive_more",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.37.1",
- "fuel-vm 0.58.1",
+ "fuel-core-types 0.38.0",
+ "fuel-vm 0.58.2",
  "impl-tools",
  "itertools 0.12.1",
  "mockall",
@@ -3679,13 +3679,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "futures",
  "mockall",
  "rand",
@@ -3720,7 +3720,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "ctor",
  "tracing",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3765,7 +3765,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "futures",
  "mockall",
  "num-rational",
@@ -3797,13 +3797,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bs58",
  "derivative",
  "derive_more",
- "fuel-vm 0.58.1",
+ "fuel-vm 0.58.2",
  "rand",
  "secrecy",
  "serde",
@@ -3813,13 +3813,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "derive_more",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "fuel-core-wasm-executor",
  "ntest",
  "parking_lot",
@@ -3830,13 +3830,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "postcard",
  "proptest",
  "serde",
@@ -3861,15 +3861,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45b64fe44eca9d98a80ca2ec23daffe3634fa83eb3baf086a86e014d0d5e3c1"
+checksum = "65e318850ca64890ff123a99b6b866954ef49da94ab9bc6827cf6ee045568585"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
  "ecdsa",
  "ed25519-dalek",
- "fuel-types 0.58.1",
+ "fuel-types 0.58.2",
  "k256",
  "lazy_static",
  "p256",
@@ -3894,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a913d0f7b3b762ec2739599bf6d3d4dcff92418fc7ce304e9d580a9bd9402a21"
+checksum = "ab0bc46a3552964bae5169e79b383761a54bd115ea66951a1a7a229edcefa55a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "proptest",
  "rand",
@@ -3931,13 +3931,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6a85bba0d7820456cea7f36b37187d28b3967d20269d684dd94f6191edbe3"
+checksum = "c79eca6a452311c70978a5df796c0f99f27e474b69719e0db4c1d82e68800d07"
 dependencies = [
  "derive_more",
  "digest 0.10.7",
- "fuel-storage 0.58.1",
+ "fuel-storage 0.58.2",
  "hashbrown 0.13.2",
  "hex",
  "serde",
@@ -3952,9 +3952,9 @@ checksum = "4c1b711f28553ddc5f3546711bd220e144ce4c1af7d9e9a1f70b2f20d9f5b791"
 
 [[package]]
 name = "fuel-storage"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0a92684129b1ada2e2ef3dbe193411974a6cfd901b01b5f93948c2e44f3ce"
+checksum = "2d0c46b5d76b3e11197bd31e036cd8b1cb46c4d822cacc48836638080c6d2b76"
 
 [[package]]
 name = "fuel-tx"
@@ -3980,18 +3980,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b305ae5f29bc390ba7b6de78838faad40b6133c2c5ca4de97a8c29f389c7c1c9"
+checksum = "6723bb8710ba2b70516ac94d34459593225870c937670fb3afaf82e0354667ac"
 dependencies = [
  "bitflags 2.6.0",
  "derivative",
  "derive_more",
- "fuel-asm 0.58.1",
+ "fuel-asm 0.58.2",
  "fuel-compression",
- "fuel-crypto 0.58.1",
- "fuel-merkle 0.58.1",
- "fuel-types 0.58.1",
+ "fuel-crypto 0.58.2",
+ "fuel-merkle 0.58.2",
+ "fuel-types 0.58.2",
  "hashbrown 0.14.5",
  "itertools 0.10.5",
  "postcard",
@@ -4014,11 +4014,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e6b1e598531fedb8b8c4e7e4d5e19b6e6a60383ff882f0677262daf7f45722"
+checksum = "982265415a99b5bd6277bc24194a233bb2e18764df11c937b3dbb11a02c9e545"
 dependencies = [
- "fuel-derive 0.58.1",
+ "fuel-derive 0.58.2",
  "hex",
  "rand",
  "serde",
@@ -4057,9 +4057,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.58.1"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a51ddd85fd89d8699178400da43540351ebc3e3ab8d2fc9a845081b558a4a8"
+checksum = "54b5362d7d072c72eec20581f67fc5400090c356a7f3ae77c79880b3b177b667"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4068,13 +4068,13 @@ dependencies = [
  "derivative",
  "derive_more",
  "ethnum",
- "fuel-asm 0.58.1",
+ "fuel-asm 0.58.2",
  "fuel-compression",
- "fuel-crypto 0.58.1",
- "fuel-merkle 0.58.1",
- "fuel-storage 0.58.1",
- "fuel-tx 0.58.1",
- "fuel-types 0.58.1",
+ "fuel-crypto 0.58.2",
+ "fuel-merkle 0.58.2",
+ "fuel-storage 0.58.2",
+ "fuel-tx 0.58.2",
+ "fuel-types 0.58.2",
  "hashbrown 0.14.5",
  "itertools 0.10.5",
  "libm",
@@ -4445,6 +4445,8 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -5907,11 +5909,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -7111,9 +7113,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -8812,7 +8814,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.37.1",
+ "fuel-core-types 0.38.0",
  "futures",
  "itertools 0.12.1",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,43 +51,43 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.37.1"
+version = "0.38.0"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.37.1", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.37.1", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.37.1", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.37.1", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.37.1", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.37.1", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.37.1", path = "./crates/client" }
-fuel-core-compression = { version = "0.37.1", path = "./crates/compression" }
-fuel-core-database = { version = "0.37.1", path = "./crates/database" }
-fuel-core-metrics = { version = "0.37.1", path = "./crates/metrics" }
-fuel-core-services = { version = "0.37.1", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.37.1", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.37.1", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.37.1", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.37.1", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.37.1", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.37.1", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.37.1", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.37.1", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.37.1", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.37.1", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.37.1", path = "./crates/services/txpool_v2" }
-fuel-core-storage = { version = "0.37.1", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.37.1", path = "./crates/trace" }
-fuel-core-types = { version = "0.37.1", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.38.0", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.38.0", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.38.0", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.38.0", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.38.0", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.38.0", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.38.0", path = "./crates/client" }
+fuel-core-compression = { version = "0.38.0", path = "./crates/compression" }
+fuel-core-database = { version = "0.38.0", path = "./crates/database" }
+fuel-core-metrics = { version = "0.38.0", path = "./crates/metrics" }
+fuel-core-services = { version = "0.38.0", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.38.0", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.38.0", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.38.0", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.38.0", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.38.0", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.38.0", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.38.0", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.38.0", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.38.0", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.38.0", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.38.0", path = "./crates/services/txpool_v2" }
+fuel-core-storage = { version = "0.38.0", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.38.0", path = "./crates/trace" }
+fuel-core-types = { version = "0.38.0", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.37.1", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.37.1", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.38.0", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.38.0", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.37.1", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.38.0", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.58.1", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.58.2", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -297,7 +297,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 13,
+  "genesis_state_transition_version": 14,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -301,7 +301,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 13,
+  "genesis_state_transition_version": 14,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -152,7 +152,8 @@ impl<S, R> Executor<S, R> {
         ("0-35-0", 10),
         ("0-36-0", 11),
         ("0-37-0", 12),
-        ("0-37-1", LATEST_STATE_TRANSITION_VERSION),
+        ("0-37-1", 13),
+        ("0-38-0", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -166,7 +166,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 13;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 14;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Version v0.38.0

### Added
- [2309](https://github.com/FuelLabs/fuel-core/pull/2309): Limit number of concurrent queries to the graphql service.
- [2216](https://github.com/FuelLabs/fuel-core/pull/2216): Add more function to the state and task of TxPoolV2 to handle the future interactions with others modules (PoA, BlockProducer, BlockImporter and P2P).
- [2263](https://github.com/FuelLabs/fuel-core/pull/2263): Use the Txpool v2 in the whole codebase.

### Removed
- [2306](https://github.com/FuelLabs/fuel-core/pull/2306): Removed hack for genesis asset contract from the code.

## What's Changed
* Updates to price algorithm by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2292
* Removed hack from the code by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2306
* fix(p2p): useless dials to reserved nodes which dont have a location multiaddress by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2308
* Txpool v2 features for futures connections with other modules by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2216
* Limit number of concurrent queries to the graphql service by @netrome in https://github.com/FuelLabs/fuel-core/pull/2309
* Linking TxPoolV2 in place of V1 by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2263


**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.37.1...v0.38.0