### PR TITLE
fix(txpool): Error in GossipsubMessageAcceptance variant docstrings

### DIFF
--- a/crates/types/src/services/p2p.rs
+++ b/crates/types/src/services/p2p.rs
@@ -44,17 +44,14 @@ pub struct GossipsubMessageInfo {
     pub peer_id: PeerId,
 }
 
-// TODO: Maybe we can remove most of types from here directly into P2P
-
-/// Reporting levels on the status of a message received via Gossip
+/// Status of a message received via Gossip
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum GossipsubMessageAcceptance {
-    /// Report whether the gossiped message is valid and safe to rebroadcast
+    /// The gossiped message is valid and safe to rebroadcast.
     Accept,
-    /// Ignore the received message and prevent further gossiping
+    /// The gossiped message is invalid and should be ignored.
     Ignore,
-    /// Punish the gossip sender for providing invalid
-    /// (or malicious) data and prevent further gossiping
+    /// The gossiped message is invalid and anyone relaying it should be penalized.
     Reject,
 }
 

--- a/crates/types/src/services/p2p.rs
+++ b/crates/types/src/services/p2p.rs
@@ -52,10 +52,10 @@ pub enum GossipsubMessageAcceptance {
     /// Report whether the gossiped message is valid and safe to rebroadcast
     Accept,
     /// Ignore the received message and prevent further gossiping
-    Reject,
+    Ignore,
     /// Punish the gossip sender for providing invalid
     /// (or malicious) data and prevent further gossiping
-    Ignore,
+    Reject,
 }
 
 /// A gossipped message from the network containing all relevant data.


### PR DESCRIPTION
## Description
The documentation for the `Ignore` and `Reject` variants has been mixed up. This PR corrects it.