### PR TITLE
fix(api_service): exclude health checks from throttling with ConcurrencyLimitLayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ## Fixed
-- [2320](https://github.com/FuelLabs/fuel-core/issues/2320): Prevent `/health` from being throttled by the concurrency limiter.
+- [2320](https://github.com/FuelLabs/fuel-core/issues/2320): Prevent `/health` and `/v1/health` from being throttled by the concurrency limiter.
 
 ## [Version 0.38.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Fixed
+- [2320](https://github.com/FuelLabs/fuel-core/issues/2320): Prevent `/health` from being throttled by the concurrency limiter.
+
 ## [Version 0.38.0]
 
 ### Added

--- a/crates/fuel-core/src/graphql_api/api_service.rs
+++ b/crates/fuel-core/src/graphql_api/api_service.rs
@@ -222,12 +222,10 @@ where
         .finish();
 
     let unthrottled_routes = Router::new()
-        // we shouldn't throttle these requests
         .route("/v1/health", get(health))
         .route("/health", get(health));
 
     let throttled_routes =
-        // we should throttle these requests
         Router::new()
             .route("/v1/playground", get(graphql_playground))
             .route("/v1/graphql", post(graphql_handler).options(ok))

--- a/crates/fuel-core/src/graphql_api/api_service.rs
+++ b/crates/fuel-core/src/graphql_api/api_service.rs
@@ -225,16 +225,15 @@ where
         .route("/v1/health", get(health))
         .route("/health", get(health));
 
-    let throttled_routes =
-        Router::new()
-            .route("/v1/playground", get(graphql_playground))
-            .route("/v1/graphql", post(graphql_handler).options(ok))
-            .route(
-                "/v1/graphql-sub",
-                post(graphql_subscription_handler).options(ok),
-            )
-            .route("/v1/metrics", get(metrics))
-            .layer(ConcurrencyLimitLayer::new(concurrency_limit));
+    let throttled_routes = Router::new()
+        .route("/v1/playground", get(graphql_playground))
+        .route("/v1/graphql", post(graphql_handler).options(ok))
+        .route(
+            "/v1/graphql-sub",
+            post(graphql_subscription_handler).options(ok),
+        )
+        .route("/v1/metrics", get(metrics))
+        .layer(ConcurrencyLimitLayer::new(concurrency_limit));
 
     let router = Router::new()
         .merge(unthrottled_routes)


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
closes #2319

## Description
<!-- List of detailed changes -->
Uses axum's `merge` chaining operator to add the `ConcurrencyLimit Layer` only on subsets of the routes we serve, and exclude `/health` from it.

We retain `/metrics` to be throttled, because it acquires a lock on the `GLOBAL_REGISTER`, which may prevent Prometheus from reading metrics. This is a double-edged sword though i think.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
