### PR TITLE
Log executor metrics only if enabled in config

### DIFF
--- a/crates/fuel-core/src/executor.rs
+++ b/crates/fuel-core/src/executor.rs
@@ -161,6 +161,8 @@ mod tests {
         pub consensus_parameters: ConsensusParameters,
         /// Print execution backtraces if transaction execution reverts.
         pub backtrace: bool,
+        /// Enables prometheus metrics for execution.
+        pub metrics: bool,
         /// Default mode for utxo_validation
         pub utxo_validation_default: bool,
     }
@@ -231,6 +233,7 @@ mod tests {
     ) -> Executor<Database, DisabledRelayer> {
         let executor_config = fuel_core_upgradable_executor::config::Config {
             backtrace: config.backtrace,
+            metrics: config.metrics,
             utxo_validation_default: config.utxo_validation_default,
             native_executor_version: None,
         };

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -100,6 +100,7 @@ pub fn init_sub_services(
         database.relayer().clone(),
         fuel_core_upgradable_executor::config::Config {
             backtrace: config.vm.backtrace,
+            metrics: config.block_producer.metrics,
             utxo_validation_default: config.utxo_validation,
             native_executor_version: config.native_executor_version,
         },

--- a/crates/services/upgradable-executor/src/config.rs
+++ b/crates/services/upgradable-executor/src/config.rs
@@ -5,6 +5,8 @@ use fuel_core_types::blockchain::header::StateTransitionBytecodeVersion;
 pub struct Config {
     /// Print execution backtraces if transaction execution reverts.
     pub backtrace: bool,
+    /// Enables prometheus metrics for execution.
+    pub metrics: bool,
     /// Default mode for utxo_validation
     pub utxo_validation_default: bool,
     /// The version of the native executor to determine usage of native vs WASM executor.
@@ -20,6 +22,7 @@ impl From<&Config> for ExecutionOptions {
         Self {
             extra_tx_checks: value.utxo_validation_default,
             backtrace: value.backtrace,
+            metrics: value.metrics,
         }
     }
 }

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -339,6 +339,7 @@ where
         let options = ExecutionOptions {
             extra_tx_checks: utxo_validation,
             backtrace: self.config.backtrace,
+            metrics: self.config.metrics,
         };
 
         let component = Components {


### PR DESCRIPTION
Draft attempt to use "metrics" config param in the executor.

Not sure if this is the way to go because it adds [metrics](https://github.com/FuelLabs/fuel-core/compare/807_add_more_metrics...807_use_metrics_config_param?expand=1#diff-e95b4e1265412154a4e0238710d201a8cc36af50df083a6055a1730e20d1c4d2R251) field to `ExecutionOptions`, which in turn is a member of the **versioned** `InputSerializationType` and `InputDeserializationType`. This could mean a breaking change.

---
Alternative approach would be to log the metrics in higher layer, ie.: modify the `fn produce_inner<TxSource>()` to get additional `metrics` parameter (we have access to `Config` in all call-sites). Then after either of `native_produce_inner()` or `wasm_produce_inner()` finishes, the metric values could be calculated from the `ExecutionResult`.