### PR TITLE
Release v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.39.0]
+
 ### Added
 - [2324](https://github.com/FuelLabs/fuel-core/pull/2324): Added metrics for sync, async processor and for all GraphQL queries.
 - [2320](https://github.com/FuelLabs/fuel-core/pull/2320): Added new CLI flag `graphql-max-resolver-recursive-depth` to limit recursion within resolver. The default value it "1".

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3197,7 +3197,7 @@ dependencies = [
  "fuel-core-sync",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3247,7 +3247,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-sync",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "futures",
  "itertools 0.12.1",
  "num_enum",
@@ -3268,11 +3268,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.38.0"
+version = "0.39.0"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3286,7 +3286,7 @@ dependencies = [
  "fuel-core-compression",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3315,7 +3315,7 @@ dependencies = [
  "derivative",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3333,14 +3333,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more",
  "eventsource-client",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "futures",
  "hex",
  "hyper-rustls",
@@ -3357,22 +3357,22 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "clap 4.5.19",
  "fuel-core-client",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "fuel-core-compression",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "paste",
  "postcard",
  "proptest",
@@ -3385,30 +3385,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "derive_more",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3416,7 +3416,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "futures",
  "hex",
  "humantime-serde",
@@ -3433,12 +3433,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "hex",
  "parking_lot",
  "serde",
@@ -3447,14 +3447,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "enum-iterator",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "fuel-gas-price-algorithm",
  "futures",
  "num_enum",
@@ -3471,14 +3471,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "derive_more",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "mockall",
  "parking_lot",
  "rayon",
@@ -3489,18 +3489,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap 4.5.19",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "parking_lot",
  "pin-project-lite",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3536,7 +3536,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3574,7 +3574,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "k256",
  "mockall",
  "rand",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3596,7 +3596,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "mockall",
  "proptest",
  "rand",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3621,7 +3621,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "futures",
  "mockall",
  "once_cell",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3656,13 +3656,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "derive_more",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "fuel-vm 0.58.2",
  "impl-tools",
  "itertools 0.12.1",
@@ -3680,13 +3680,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "futures",
  "mockall",
  "rand",
@@ -3721,7 +3721,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "ctor",
  "tracing",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3766,7 +3766,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "futures",
  "mockall",
  "num-rational",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bs58",
@@ -3814,13 +3814,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "derive_more",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "fuel-core-wasm-executor",
  "ntest",
  "parking_lot",
@@ -3831,13 +3831,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "postcard",
  "proptest",
  "serde",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "proptest",
  "rand",
@@ -8815,7 +8815,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.38.0",
+ "fuel-core-types 0.39.0",
  "futures",
  "itertools 0.12.1",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,40 +51,40 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.38.0", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.38.0", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.38.0", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.38.0", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.38.0", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.38.0", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.38.0", path = "./crates/client" }
-fuel-core-compression = { version = "0.38.0", path = "./crates/compression" }
-fuel-core-database = { version = "0.38.0", path = "./crates/database" }
-fuel-core-metrics = { version = "0.38.0", path = "./crates/metrics" }
-fuel-core-services = { version = "0.38.0", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.38.0", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.38.0", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.38.0", path = "./crates/services/consensus_module/poa" }
-fuel-core-executor = { version = "0.38.0", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.38.0", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.38.0", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.38.0", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.38.0", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.38.0", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.38.0", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.38.0", path = "./crates/services/txpool_v2" }
-fuel-core-storage = { version = "0.38.0", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.38.0", path = "./crates/trace" }
-fuel-core-types = { version = "0.38.0", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.39.0", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.39.0", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.39.0", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.39.0", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.39.0", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.39.0", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.39.0", path = "./crates/client" }
+fuel-core-compression = { version = "0.39.0", path = "./crates/compression" }
+fuel-core-database = { version = "0.39.0", path = "./crates/database" }
+fuel-core-metrics = { version = "0.39.0", path = "./crates/metrics" }
+fuel-core-services = { version = "0.39.0", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.39.0", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.39.0", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.39.0", path = "./crates/services/consensus_module/poa" }
+fuel-core-executor = { version = "0.39.0", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.39.0", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.39.0", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.39.0", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.39.0", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.39.0", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.39.0", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.39.0", path = "./crates/services/txpool_v2" }
+fuel-core-storage = { version = "0.39.0", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.39.0", path = "./crates/trace" }
+fuel-core-types = { version = "0.39.0", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.38.0", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.38.0", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.39.0", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.39.0", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.38.0", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.39.0", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.58.2", package = "fuel-vm", default-features = false }

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -297,7 +297,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 14,
+  "genesis_state_transition_version": 15,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -301,7 +301,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 14,
+  "genesis_state_transition_version": 15,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -153,7 +153,8 @@ impl<S, R> Executor<S, R> {
         ("0-36-0", 11),
         ("0-37-0", 12),
         ("0-37-1", 13),
-        ("0-38-0", LATEST_STATE_TRANSITION_VERSION),
+        ("0-38-0", 14),
+        ("0-39-0", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -166,7 +166,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 14;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 15;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Version v0.39.0

### Added
- [2324](https://github.com/FuelLabs/fuel-core/pull/2324): Added metrics for sync, async processor and for all GraphQL queries.
- [2320](https://github.com/FuelLabs/fuel-core/pull/2320): Added new CLI flag `graphql-max-resolver-recursive-depth` to limit recursion within resolver. The default value it "1".


## Fixed
- [2320](https://github.com/FuelLabs/fuel-core/issues/2320): Prevent `/health` and `/v1/health` from being throttled by the concurrency limiter.
- [2322](https://github.com/FuelLabs/fuel-core/issues/2322): Set the salt of genesis contracts to zero on execution.
- [2324](https://github.com/FuelLabs/fuel-core/pull/2324): Ignore peer if we already are syncing transactions from it.

#### Breaking

- [2320](https://github.com/FuelLabs/fuel-core/pull/2330): Reject queries that are recursive during the resolution of the query.

### Changed

#### Breaking
- [2311](https://github.com/FuelLabs/fuel-core/pull/2311): Changed the text of the error returned by the executor if gas overflows.

## What's Changed
* chore(executor): instrument errors to be more meaningful by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2311
* fix(dummy_da_block_costs): remove dependency on polling_interval and use channel instead by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2314
* fix(txpool): Error in GossipsubMessageAcceptance variant docstrings by @netrome in https://github.com/FuelLabs/fuel-core/pull/2316
* refactor: Eager returns in txpool_v2::service::Task::run by @netrome in https://github.com/FuelLabs/fuel-core/pull/2325
* fix(api_service): exclude health checks from throttling with ConcurrencyLimitLayer by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2320
* Remove the `normalize_rewards_and_costs()` function by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2293
* fix(genesis): set salt of contract on execution of genesis state configuration by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2322
* Fixing the issue with duplicate transaction synchronization processes by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2324
* Reject queries that are recursive during the resolution by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2330


**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.38.0...v0.39.0