### PR TITLE
Do not require build of docker images to pass CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,6 @@ jobs:
     needs:
       - cargo-verifications
       - publish-crates-check
-      - build-docker-images
       - cargo-test-kms
     runs-on: ubuntu-latest
     steps:
@@ -342,8 +341,8 @@ jobs:
       matrix:
         arch: [
           # build on native runners instead of using emulation
-          {platform: linux/amd64, runner: buildjet-8vcpu-ubuntu-2204},
-          {platform: linux/arm64, runner: buildjet-16vcpu-ubuntu-2204-arm}
+          { platform: linux/amd64, runner: buildjet-8vcpu-ubuntu-2204 },
+          { platform: linux/arm64, runner: buildjet-16vcpu-ubuntu-2204-arm }
         ]
     runs-on: ${{ matrix.arch.runner }}
     permissions:


### PR DESCRIPTION
Do not require the build of docker images to pass CI. It seems we have some problems with the cache, and right now, CI doesn't use the cache for the docker build process. Until @mchristopher fixes that, I disable it as a requirement to pass CI.

