### PR TITLE
Disable flaky `test_poa_multiple_producers` test

### DIFF
--- a/crates/services/src/async_processor.rs
+++ b/crates/services/src/async_processor.rs
@@ -270,6 +270,8 @@ mod tests {
         // Then
         while broadcast_receiver.recv().await.is_ok() {}
         assert!(instant.elapsed() >= Duration::from_secs(10));
+        // Wait for the metrics to be updated.
+        tokio::time::sleep(Duration::from_secs(1)).await;
         let duration = Duration::from_nanos(heavy_task_processor.metric.busy.get());
         assert_eq!(duration.as_secs(), 10);
         let duration = Duration::from_nanos(heavy_task_processor.metric.idle.get());
@@ -302,6 +304,8 @@ mod tests {
         // Then
         while broadcast_receiver.recv().await.is_ok() {}
         assert!(instant.elapsed() <= Duration::from_secs(2));
+        // Wait for the metrics to be updated.
+        tokio::time::sleep(Duration::from_secs(1)).await;
         let duration = Duration::from_nanos(heavy_task_processor.metric.busy.get());
         assert_eq!(duration.as_secs(), 10);
         let duration = Duration::from_nanos(heavy_task_processor.metric.idle.get());
@@ -333,8 +337,9 @@ mod tests {
 
         // Then
         while broadcast_receiver.recv().await.is_ok() {}
-        tokio::task::yield_now().await;
         assert!(instant.elapsed() <= Duration::from_secs(2));
+        // Wait for the metrics to be updated.
+        tokio::time::sleep(Duration::from_secs(1)).await;
         let duration = Duration::from_nanos(heavy_task_processor.metric.busy.get());
         assert_eq!(duration.as_secs(), 0);
         let duration = Duration::from_nanos(heavy_task_processor.metric.idle.get());

--- a/crates/services/src/sync_processor.rs
+++ b/crates/services/src/sync_processor.rs
@@ -209,6 +209,8 @@ mod tests {
         // Then
         while broadcast_receiver.recv().await.is_ok() {}
         assert!(instant.elapsed() >= Duration::from_secs(10));
+        // Wait for the metrics to be updated.
+        tokio::time::sleep(Duration::from_secs(1)).await;
         let duration = Duration::from_nanos(heavy_task_processor.metric.busy.get());
         assert_eq!(duration.as_secs(), 10);
     }
@@ -275,6 +277,8 @@ mod tests {
         // Then
         while broadcast_receiver.recv().await.is_ok() {}
         assert!(instant.elapsed() <= Duration::from_secs(2));
+        // Wait for the metrics to be updated.
+        tokio::time::sleep(Duration::from_secs(1)).await;
         let duration = Duration::from_nanos(heavy_task_processor.metric.busy.get());
         assert_eq!(duration.as_secs(), 10);
     }

--- a/tests/tests/poa.rs
+++ b/tests/tests/poa.rs
@@ -259,6 +259,7 @@ mod p2p {
     // Then starts second_producer that uses the first one as a reserved peer.
     // second_producer should not produce blocks while the first one is producing
     // after the first_producer stops, second_producer should start producing blocks
+    #[ignore = "seems to be flaky, issue: https://github.com/FuelLabs/fuel-core/issues/2351"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_poa_multiple_producers() {
         const SYNC_TIMEOUT: u64 = 30;


### PR DESCRIPTION
This PR disables the flaky `test_poa_multiple_producers` test.

Follow-up issue: https://github.com/FuelLabs/fuel-core/issues/2351

### Before requesting review
- [X] I have reviewed the code myself
- [X] I have created follow-up issues caused by this PR and linked them here