### PR TITLE
Fix collection of tx pool insertion time metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - [2366](https://github.com/FuelLabs/fuel-core/pull/2366): The `importer_gas_price_for_block` metric is properly collected.
+- [2369](https://github.com/FuelLabs/fuel-core/pull/2369): The `transaction_insertion_time_in_thread_pool_milliseconds` metric is properly collected.
 
 ### Added
 - [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the txpool: "The size of transactions in the txpool" (`txpool_tx_size`), "The time spent by a transaction in the txpool in seconds" (`txpool_tx_time_in_txpool_seconds`), The number of transactions in the txpool (`txpool_number_of_transactions`), "The number of transactions pending verification before entering the txpool" (`txpool_number_of_transactions_pending_verification`), "The number of executable transactions in the txpool" (`txpool_number_of_executable_transactions`), "The time it took to select transactions for inclusion in a block in nanoseconds" (`txpool_select_transaction_time_nanoseconds`), The time it took to insert a transaction in the txpool in milliseconds (`txpool_insert_transaction_time_milliseconds`).

--- a/crates/metrics/src/txpool_metrics.rs
+++ b/crates/metrics/src/txpool_metrics.rs
@@ -91,7 +91,9 @@ impl Default for TxPoolMetrics {
         registry.register(
             "txpool_insert_transaction_time_milliseconds",
             "The time it took to insert a transaction in the txpool in milliseconds",
-            metrics.transaction_insertion_time_in_thread_pool_milliseconds.clone(),
+            metrics
+                .transaction_insertion_time_in_thread_pool_milliseconds
+                .clone(),
         );
 
         metrics

--- a/crates/metrics/src/txpool_metrics.rs
+++ b/crates/metrics/src/txpool_metrics.rs
@@ -91,7 +91,7 @@ impl Default for TxPoolMetrics {
         registry.register(
             "txpool_insert_transaction_time_milliseconds",
             "The time it took to insert a transaction in the txpool in milliseconds",
-            metrics.select_transaction_time_nanoseconds.clone(),
+            metrics.transaction_insertion_time_in_thread_pool_milliseconds.clone(),
         );
 
         metrics


### PR DESCRIPTION
## Description
This PR fixes the collection of `transaction_insertion_time_in_thread_pool_milliseconds` metric.

### Before requesting review
- [X] I have reviewed the code myself