### PR TITLE
Remove ignore RUSTSEC-2024-0336

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,2 @@
 [advisories]
-ignore = [
-    "RUSTSEC-2024-0336" # https://github.com/FuelLabs/fuel-core/issues/1843
-]
+ignore = []


### PR DESCRIPTION
## Linked Issues/PRs
Resolves https://github.com/FuelLabs/fuel-core/issues/1843

## Description
This has been fixed in https://github.com/FuelLabs/fuel-core/pull/1954. Verified it by running cargo audit on my own did had this warning.