### PR TITLE
Txpool metrics update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-- [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the txpool:
+- [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the TxPool:
     - The size of transactions in the txpool (`txpool_tx_size`)
     - The time spent by a transaction in the txpool in seconds (`txpool_tx_time_in_txpool_seconds`)
     - The number of transactions in the txpool (`txpool_number_of_transactions`)
@@ -15,13 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - The number of executable transactions in the txpool (`txpool_number_of_executable_transactions`)
     - The time it took to select transactions for inclusion in a block in microseconds (`txpool_select_transactions_time_microseconds`)
     - The time it took to insert a transaction in the txpool in microseconds (`transaction_insertion_time_in_thread_pool_microseconds`)
+- [2385](https://github.com/FuelLabs/fuel-core/pull/2385): Added new histogram buckets for some of the TxPool metrics, optimize the way they are collected.
 - [2362](https://github.com/FuelLabs/fuel-core/pull/2362): Added a new request_response protocol version `/fuel/req_res/0.0.2`. In comparison with `/fuel/req/0.0.1`, which returns an empty response when a request cannot be fulfilled, this version returns more meaningful error codes. Nodes still support the version `0.0.1` of the protocol to guarantee backward compatibility with fuel-core nodes. Empty responses received from nodes using the old protocol `/fuel/req/0.0.1` are automatically converted into an error `ProtocolV1EmptyResponse` with error code 0, which is also the only error code implemented. More specific error codes will be added in the future.
 
 ### Fixed
 - [2366](https://github.com/FuelLabs/fuel-core/pull/2366): The `importer_gas_price_for_block` metric is properly collected.
 
 ### Changed
-
 - [2378](https://github.com/FuelLabs/fuel-core/pull/2378): Use cached hash of the topic instead of calculating it on each publishing gossip message.
 
 ## [Version 0.40.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the txpool:
+    - The size of transactions in the txpool (`txpool_tx_size`)
+    - The time spent by a transaction in the txpool in seconds (`txpool_tx_time_in_txpool_seconds`)
+    - The number of transactions in the txpool (`txpool_number_of_transactions`)
+    - The number of transactions pending verification before entering the txpool (`txpool_number_of_transactions_pending_verification`)
+    - The number of executable transactions in the txpool (`txpool_number_of_executable_transactions`)
+    - The time it took to select transactions for inclusion in a block in microseconds (`txpool_select_transactions_time_microseconds`)
+    - The time it took to insert a transaction in the txpool in microseconds (`transaction_insertion_time_in_thread_pool_microseconds`)
+
 ### Fixed
 - [2366](https://github.com/FuelLabs/fuel-core/pull/2366): The `importer_gas_price_for_block` metric is properly collected.
-- [2369](https://github.com/FuelLabs/fuel-core/pull/2369): The `transaction_insertion_time_in_thread_pool_milliseconds` metric is properly collected.
-
-### Added
-- [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the txpool: "The size of transactions in the txpool" (`txpool_tx_size`), "The time spent by a transaction in the txpool in seconds" (`txpool_tx_time_in_txpool_seconds`), The number of transactions in the txpool (`txpool_number_of_transactions`), "The number of transactions pending verification before entering the txpool" (`txpool_number_of_transactions_pending_verification`), "The number of executable transactions in the txpool" (`txpool_number_of_executable_transactions`), "The time it took to select transactions for inclusion in a block in nanoseconds" (`txpool_select_transaction_time_nanoseconds`), The time it took to insert a transaction in the txpool in milliseconds (`txpool_insert_transaction_time_milliseconds`).
 
 ## [Version 0.40.0]
 

--- a/crates/metrics/src/buckets.rs
+++ b/crates/metrics/src/buckets.rs
@@ -12,6 +12,7 @@ pub(crate) enum Buckets {
     TransactionSize,
     TransactionInsertionTimeInThreadPool,
     SelectTransactionsTime,
+    TransactionTimeInTxpool,
 }
 static BUCKETS: OnceLock<HashMap<Buckets, Vec<f64>>> = OnceLock::new();
 pub(crate) fn buckets(b: Buckets) -> impl Iterator<Item = f64> {
@@ -85,6 +86,18 @@ fn initialize_buckets() -> HashMap<Buckets, Vec<f64>> {
                    300000.0,
                 1_000_000.0,
                 5_000_000.0,
+            ]
+        ),
+        (
+            Buckets::TransactionTimeInTxpool,
+            vec![
+                      1.0,
+                      2.0,
+                      5.0,
+                     10.0,
+                    100.0,
+                    250.0,
+                    600.0
             ]
         ),
     ]

--- a/crates/metrics/src/buckets.rs
+++ b/crates/metrics/src/buckets.rs
@@ -9,8 +9,9 @@ use strum_macros::EnumIter;
 #[cfg_attr(test, derive(EnumIter))]
 pub(crate) enum Buckets {
     Timing,
-    TimingCoarseGrained,
     TransactionSize,
+    TransactionInsertionTimeInThreadPool,
+    SelectTransactionsTime,
 }
 static BUCKETS: OnceLock<HashMap<Buckets, Vec<f64>>> = OnceLock::new();
 pub(crate) fn buckets(b: Buckets) -> impl Iterator<Item = f64> {
@@ -37,22 +38,6 @@ fn initialize_buckets() -> HashMap<Buckets, Vec<f64>> {
             ],
         ),
         (
-            Buckets::TimingCoarseGrained,
-            vec![
-                5.0,
-                10.0,
-                25.0,
-                50.0,
-                100.0,
-                250.0,
-                500.0,
-                1000.0,
-                2500.0, 
-                5000.0, 
-                10000.0,
-            ],
-        ),
-        (
             // We consider blocks up to 256kb in size and single transaction can take any of this space.
             Buckets::TransactionSize,
             vec![
@@ -74,6 +59,32 @@ fn initialize_buckets() -> HashMap<Buckets, Vec<f64>> {
                 142.0 * 1024.0,
                 191.0 * 1024.0,
                 256.0 * 1024.0,
+            ]
+        ),
+        (
+            Buckets::TransactionInsertionTimeInThreadPool,
+            vec![
+                       50.0,
+                      250.0,
+                     1000.0,
+                    10000.0,
+                   100000.0,
+                   300000.0,
+                1_000_000.0,
+                5_000_000.0,
+            ]
+        ),
+        (
+            Buckets::SelectTransactionsTime,
+            vec![
+                       50.0,
+                      250.0,
+                     1000.0,
+                    10000.0,
+                   100000.0,
+                   300000.0,
+                1_000_000.0,
+                5_000_000.0,
             ]
         ),
     ]

--- a/crates/metrics/src/txpool_metrics.rs
+++ b/crates/metrics/src/txpool_metrics.rs
@@ -31,7 +31,8 @@ pub struct TxPoolMetrics {
 impl Default for TxPoolMetrics {
     fn default() -> Self {
         let tx_size = Histogram::new(buckets(Buckets::TransactionSize));
-        let transaction_time_in_txpool_secs = Histogram::new(buckets(Buckets::Timing));
+        let transaction_time_in_txpool_secs =
+            Histogram::new(buckets(Buckets::TransactionTimeInTxpool));
         let select_transactions_time_microseconds =
             Histogram::new(buckets(Buckets::SelectTransactionsTime));
         let transaction_insertion_time_in_thread_pool_microseconds =

--- a/crates/metrics/src/txpool_metrics.rs
+++ b/crates/metrics/src/txpool_metrics.rs
@@ -33,9 +33,9 @@ impl Default for TxPoolMetrics {
         let tx_size = Histogram::new(buckets(Buckets::TransactionSize));
         let transaction_time_in_txpool_secs = Histogram::new(buckets(Buckets::Timing));
         let select_transactions_time_microseconds =
-            Histogram::new(buckets(Buckets::TimingCoarseGrained));
+            Histogram::new(buckets(Buckets::SelectTransactionsTime));
         let transaction_insertion_time_in_thread_pool_microseconds =
-            Histogram::new(buckets(Buckets::TimingCoarseGrained));
+            Histogram::new(buckets(Buckets::TransactionInsertionTimeInThreadPool));
 
         let number_of_transactions = Gauge::default();
         let number_of_transactions_pending_verification = Gauge::default();

--- a/crates/metrics/src/txpool_metrics.rs
+++ b/crates/metrics/src/txpool_metrics.rs
@@ -25,14 +25,14 @@ pub struct TxPoolMetrics {
     /// Time actively spent by transaction insertion in the thread pool
     pub transaction_insertion_time_in_thread_pool_milliseconds: Histogram,
     /// How long it took for the selection algorithm to select transactions
-    pub select_transaction_time_nanoseconds: Histogram,
+    pub select_transactions_time_nanoseconds: Histogram,
 }
 
 impl Default for TxPoolMetrics {
     fn default() -> Self {
         let tx_size = Histogram::new(buckets(Buckets::TransactionSize));
         let transaction_time_in_txpool_secs = Histogram::new(buckets(Buckets::Timing));
-        let select_transaction_time_nanoseconds =
+        let select_transactions_time_nanoseconds =
             Histogram::new(buckets(Buckets::TimingCoarseGrained));
         let transaction_insertion_time_in_thread_pool_milliseconds =
             Histogram::new(buckets(Buckets::TimingCoarseGrained));
@@ -48,7 +48,7 @@ impl Default for TxPoolMetrics {
             number_of_executable_transactions,
             transaction_time_in_txpool_secs,
             transaction_insertion_time_in_thread_pool_milliseconds,
-            select_transaction_time_nanoseconds,
+            select_transactions_time_nanoseconds,
         };
 
         let mut registry = global_registry().registry.lock();
@@ -83,9 +83,9 @@ impl Default for TxPoolMetrics {
         );
 
         registry.register(
-            "txpool_select_transaction_time_nanoseconds",
+            "txpool_select_transactions_time_nanoseconds",
             "The time it took to select transactions for inclusion in a block in nanoseconds",
-            metrics.select_transaction_time_nanoseconds.clone(),
+            metrics.select_transactions_time_nanoseconds.clone(),
         );
 
         registry.register(

--- a/crates/metrics/src/txpool_metrics.rs
+++ b/crates/metrics/src/txpool_metrics.rs
@@ -23,18 +23,18 @@ pub struct TxPoolMetrics {
     /// Time of transactions in the txpool in seconds
     pub transaction_time_in_txpool_secs: Histogram,
     /// Time actively spent by transaction insertion in the thread pool
-    pub transaction_insertion_time_in_thread_pool_milliseconds: Histogram,
+    pub transaction_insertion_time_in_thread_pool_microseconds: Histogram,
     /// How long it took for the selection algorithm to select transactions
-    pub select_transactions_time_nanoseconds: Histogram,
+    pub select_transactions_time_microseconds: Histogram,
 }
 
 impl Default for TxPoolMetrics {
     fn default() -> Self {
         let tx_size = Histogram::new(buckets(Buckets::TransactionSize));
         let transaction_time_in_txpool_secs = Histogram::new(buckets(Buckets::Timing));
-        let select_transactions_time_nanoseconds =
+        let select_transactions_time_microseconds =
             Histogram::new(buckets(Buckets::TimingCoarseGrained));
-        let transaction_insertion_time_in_thread_pool_milliseconds =
+        let transaction_insertion_time_in_thread_pool_microseconds =
             Histogram::new(buckets(Buckets::TimingCoarseGrained));
 
         let number_of_transactions = Gauge::default();
@@ -47,8 +47,8 @@ impl Default for TxPoolMetrics {
             number_of_transactions_pending_verification,
             number_of_executable_transactions,
             transaction_time_in_txpool_secs,
-            transaction_insertion_time_in_thread_pool_milliseconds,
-            select_transactions_time_nanoseconds,
+            transaction_insertion_time_in_thread_pool_microseconds,
+            select_transactions_time_microseconds,
         };
 
         let mut registry = global_registry().registry.lock();
@@ -83,16 +83,16 @@ impl Default for TxPoolMetrics {
         );
 
         registry.register(
-            "txpool_select_transactions_time_nanoseconds",
-            "The time it took to select transactions for inclusion in a block in nanoseconds",
-            metrics.select_transactions_time_nanoseconds.clone(),
+            "txpool_select_transactions_time_microseconds",
+            "The time it took to select transactions for inclusion in a block in microseconds",
+            metrics.select_transactions_time_microseconds.clone(),
         );
 
         registry.register(
-            "txpool_insert_transaction_time_milliseconds",
-            "The time it took to insert a transaction in the txpool in milliseconds",
+            "txpool_transaction_insertion_time_in_thread_pool_microseconds",
+            "The time it took to insert a transaction in the txpool in microseconds",
             metrics
-                .transaction_insertion_time_in_thread_pool_milliseconds
+                .transaction_insertion_time_in_thread_pool_microseconds
                 .clone(),
         );
 

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -271,19 +271,13 @@ where
         };
 
         if metrics {
-            self.register_tx_removal(best_txs.into_iter().inspect(|storage_data| {
+            best_txs.iter().for_each(|storage_data| {
                 Self::record_transaction_time_in_txpool(storage_data)
-            }))
-        } else {
-            self.register_tx_removal(best_txs.into_iter())
+            });
         }
-    }
 
-    fn register_tx_removal(
-        &mut self,
-        items: impl Iterator<Item = StorageData>,
-    ) -> Vec<ArcPoolTx> {
-        items
+        best_txs
+            .into_iter()
             .map(|storage_entry| {
                 self.update_components_and_caches_on_removal(iter::once(&storage_entry));
                 storage_entry.transaction

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -244,7 +244,7 @@ where
     fn record_select_transaction_time_in_nanoseconds(start: Instant) {
         let elapsed = start.elapsed().as_nanos() as f64;
         fuel_core_metrics::txpool_metrics::txpool_metrics()
-            .select_transaction_time_nanoseconds
+            .select_transactions_time_nanoseconds
             .observe(elapsed);
     }
 

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -89,6 +89,11 @@ impl<S, SI, CM, SA> Pool<S, SI, CM, SA> {
             && self.current_gas == 0
             && self.current_bytes_size == 0
     }
+
+    /// Returns the number of transactions in the pool.
+    pub fn tx_count(&self) -> usize {
+        self.tx_id_to_storage_id.len()
+    }
 }
 
 impl<S: Storage, CM, SA> Pool<S, S::StorageIndex, CM, SA>

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -257,7 +257,7 @@ where
         constraints: Constraints,
     ) -> Vec<ArcPoolTx> {
         let metrics = self.config.metrics;
-        let maybe_start = metrics.then(|| std::time::Instant::now());
+        let maybe_start = metrics.then(std::time::Instant::now);
         let best_txs = self
             .selection_algorithm
             .gather_best_txs(constraints, &mut self.storage);

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -257,10 +257,10 @@ where
         }
     }
 
-    fn record_select_transaction_time_in_nanoseconds(start: Instant) {
-        let elapsed = start.elapsed().as_nanos() as f64;
+    fn record_select_transaction_time(start: Instant) {
+        let elapsed = start.elapsed().as_micros() as f64;
         txpool_metrics()
-            .select_transactions_time_nanoseconds
+            .select_transactions_time_microseconds
             .observe(elapsed);
     }
 
@@ -292,7 +292,7 @@ where
             .selection_algorithm
             .gather_best_txs(constraints, &mut self.storage);
         if let Some(start) = maybe_start {
-            Self::record_select_transaction_time_in_nanoseconds(start)
+            Self::record_select_transaction_time(start)
         };
 
         if metrics {

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -256,13 +256,12 @@ where
         &mut self,
         constraints: Constraints,
     ) -> Vec<ArcPoolTx> {
-        let start = std::time::Instant::now();
         let metrics = self.config.metrics;
+        let maybe_start = metrics.then(|| std::time::Instant::now());
         let best_txs = self
             .selection_algorithm
             .gather_best_txs(constraints, &mut self.storage);
-
-        if metrics {
+        if let Some(start) = maybe_start {
             Self::record_select_transaction_time_in_nanoseconds(start)
         };
 

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -162,6 +162,10 @@ where
         debug_assert!(!self.tx_id_to_storage_id.contains_key(&tx_id));
         self.tx_id_to_storage_id.insert(tx_id, storage_id);
 
+        if self.config.metrics {
+            txpool_metrics().tx_size.observe(bytes_size as f64);
+        };
+
         let tx =
             Storage::get(&self.storage, &storage_id).expect("Transaction is set above");
         self.collision_manager.on_stored_transaction(storage_id, tx);

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -265,16 +265,22 @@ where
             Self::record_select_transaction_time_in_nanoseconds(start)
         };
 
-        best_txs
-            .into_iter()
-            .inspect(|storage_data| {
-                if metrics {
-                    Self::record_transaction_time_in_txpool(storage_data)
-                }
-            })
+        if metrics {
+            self.register_tx_removal(best_txs.into_iter().inspect(|storage_data| {
+                Self::record_transaction_time_in_txpool(storage_data)
+            }))
+        } else {
+            self.register_tx_removal(best_txs.into_iter())
+        }
+    }
+
+    fn register_tx_removal(
+        &mut self,
+        items: impl Iterator<Item = StorageData>,
+    ) -> Vec<ArcPoolTx> {
+        items
             .map(|storage_entry| {
                 self.update_components_and_caches_on_removal(iter::once(&storage_entry));
-
                 storage_entry.transaction
             })
             .collect::<Vec<_>>()

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -247,6 +247,7 @@ where
             .select_transaction_time_nanoseconds
             .observe(elapsed);
     }
+
     // TODO: Use block space also (https://github.com/FuelLabs/fuel-core/issues/2133)
     /// Extract transactions for a block.
     /// Returns a list of transactions that were selected for the block

--- a/crates/services/txpool_v2/src/service.rs
+++ b/crates/services/txpool_v2/src/service.rs
@@ -482,9 +482,9 @@ where
                     .inc();
                 let start_time = tokio::time::Instant::now();
                 insert_transaction_thread_pool_op();
-                let time_for_task_to_complete = start_time.elapsed().as_millis();
+                let time_for_task_to_complete = start_time.elapsed().as_micros();
                 txpool_metrics
-                    .transaction_insertion_time_in_thread_pool_milliseconds
+                    .transaction_insertion_time_in_thread_pool_microseconds
                     .observe(time_for_task_to_complete as f64);
                 txpool_metrics
                     .number_of_transactions_pending_verification

--- a/crates/services/txpool_v2/src/service.rs
+++ b/crates/services/txpool_v2/src/service.rs
@@ -1,6 +1,5 @@
 use crate::{
     self as fuel_core_txpool,
-    selection_algorithms::SelectionAlgorithm,
 };
 
 use fuel_core_metrics::txpool_metrics::txpool_metrics;
@@ -430,21 +429,7 @@ where
                 let result = verification.persistent_storage_provider.latest_view();
 
                 match result {
-                    Ok(view) => {
-                        let insertion_result = pool.insert(tx, &view);
-                        if metrics {
-                            let num_transactions = pool.tx_count();
-                            let executable_txs = pool
-                                .selection_algorithm
-                                .number_of_executable_transactions();
-
-                            record_number_of_transactions_in_txpool(num_transactions);
-                            record_number_of_executable_transactions_in_txpool(
-                                executable_txs,
-                            );
-                        }
-                        insertion_result
-                    }
+                    Ok(view) => pool.insert(tx, &view),
                     Err(err) => Err(Error::Database(format!("{:?}", err))),
                 }
             };
@@ -699,17 +684,6 @@ fn record_tx_size(tx: &PoolTransaction) {
     let size = tx.metered_bytes_size();
     let txpool_metrics = txpool_metrics();
     txpool_metrics.tx_size.observe(size as f64);
-}
-
-fn record_number_of_transactions_in_txpool(num_transactions: usize) {
-    txpool_metrics()
-        .number_of_transactions
-        .set(num_transactions as i64);
-}
-fn record_number_of_executable_transactions_in_txpool(executable_txs: usize) {
-    txpool_metrics()
-        .number_of_executable_transactions
-        .set(executable_txs as i64);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/services/txpool_v2/src/service.rs
+++ b/crates/services/txpool_v2/src/service.rs
@@ -230,7 +230,7 @@ where
         // TODO: move this to the Task struct
         if self.metrics {
             let pool = self.pool.read();
-            let num_transactions = pool.storage.tx_count();
+            let num_transactions = pool.tx_count();
 
             let executable_txs =
                 pool.selection_algorithm.number_of_executable_transactions();

--- a/crates/services/txpool_v2/src/service.rs
+++ b/crates/services/txpool_v2/src/service.rs
@@ -429,11 +429,6 @@ where
                 }
             };
 
-            if metrics {
-                let size = checked_tx.metered_bytes_size();
-                txpool_metrics().tx_size.observe(size as f64);
-            };
-
             let tx = Arc::new(checked_tx);
 
             let result = {

--- a/crates/services/txpool_v2/src/storage/graph.rs
+++ b/crates/services/txpool_v2/src/storage/graph.rs
@@ -619,10 +619,6 @@ impl Storage for GraphStorage {
             self.clear_cache(storage_entry);
         })
     }
-
-    fn tx_count(&self) -> usize {
-        self.graph.node_count()
-    }
 }
 
 impl RatioTipGasSelectionAlgorithmStorage for GraphStorage {

--- a/crates/services/txpool_v2/src/storage/mod.rs
+++ b/crates/services/txpool_v2/src/storage/mod.rs
@@ -102,7 +102,4 @@ pub trait Storage {
 
     /// Remove a transaction from the storage.
     fn remove_transaction(&mut self, index: Self::StorageIndex) -> Option<StorageData>;
-
-    /// Returns the number of transactions in the storage.
-    fn tx_count(&self) -> usize;
 }

--- a/crates/types/src/services/txpool.rs
+++ b/crates/types/src/services/txpool.rs
@@ -32,7 +32,6 @@ use crate::{
     },
     services::executor::TransactionExecutionResult,
 };
-use core::time::Duration;
 use fuel_vm_private::{
     checked_transaction::CheckedTransaction,
     fuel_types::BlockHeight,
@@ -317,18 +316,6 @@ impl From<&PoolTransaction> for CheckedTransaction {
             PoolTransaction::Blob(tx, _) => CheckedTransaction::Blob(tx.clone()),
         }
     }
-}
-
-/// The `removed` field contains the list of removed transactions during the insertion
-/// of the `inserted` transaction.
-#[derive(Debug, PartialEq, Eq)]
-pub struct InsertionResult {
-    /// This was inserted
-    pub inserted: ArcPoolTx,
-    /// The time the transaction was inserted.
-    pub submitted_time: Duration,
-    /// These were removed during the insertion
-    pub removed: Vec<ArcPoolTx>,
 }
 
 /// The status of the transaction during its life from the tx pool until the block.


### PR DESCRIPTION
## Linked Issues/PRs
This PR addresses the outstanding comments to the TxPool metrics PR: https://github.com/FuelLabs/fuel-core/pull/2321

## Description
There are a couple of changes to how and when metrics are registered and some histogram buckets are redefined.

Additionally there is also a small clean-up of the changelog file.

### Before requesting review
- [X] I have reviewed the code myself