### PR TITLE
Return reason of why proof cant be generated (api change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2300](https://github.com/FuelLabs/fuel-core/pull/2300): Added new function to `fuel-core-client` for checking whether a blob exists.
 
 ### Changed
+- [2258](https://github.com/FuelLabs/fuel-core/pull/2258): Updated the `messageProof` GraphQL schema to return a non-nullable `MessageProof` and modified `message_proof()` to return a descriptive error instead of `None` when proof generation fails.
 
 #### Breaking
 - [2299](https://github.com/FuelLabs/fuel-core/pull/2299): Anyone who wants to participate in the transaction broadcasting via p2p must upgrade to support new predicates on the TxPool level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2378](https://github.com/FuelLabs/fuel-core/pull/2378): Use cached hash of the topic instead of calculating it on each publishing gossip message.
 
 #### Breaking
-- [2258](https://github.com/FuelLabs/fuel-core/pull/2258): Updated the `messageProof` GraphQL schema to return a non-nullable `MessageProof`. If proof cannot be generated, error will be returned instead of a null value.
+- [2389](https://github.com/FuelLabs/fuel-core/pull/2258): Updated the `messageProof` GraphQL schema to return a non-nullable `MessageProof`.
 
 ### Added
 - [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the txpool: "The size of transactions in the txpool" (`txpool_tx_size`), "The time spent by a transaction in the txpool in seconds" (`txpool_tx_time_in_txpool_seconds`), The number of transactions in the txpool (`txpool_number_of_transactions`), "The number of transactions pending verification before entering the txpool" (`txpool_number_of_transactions_pending_verification`), "The number of executable transactions in the txpool" (`txpool_number_of_executable_transactions`), "The time it took to select transactions for inclusion in a block in nanoseconds" (`txpool_select_transaction_time_nanoseconds`), The time it took to insert a transaction in the txpool in milliseconds (`txpool_insert_transaction_time_milliseconds`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [2378](https://github.com/FuelLabs/fuel-core/pull/2378): Use cached hash of the topic instead of calculating it on each publishing gossip message.
 
+#### Breaking
+- [2258](https://github.com/FuelLabs/fuel-core/pull/2258): Updated the `messageProof` GraphQL schema to return a non-nullable `MessageProof`. If proof cannot be generated, error will be returned instead of a null value.
+
 ### Added
 - [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the txpool: "The size of transactions in the txpool" (`txpool_tx_size`), "The time spent by a transaction in the txpool in seconds" (`txpool_tx_time_in_txpool_seconds`), The number of transactions in the txpool (`txpool_number_of_transactions`), "The number of transactions pending verification before entering the txpool" (`txpool_number_of_transactions_pending_verification`), "The number of executable transactions in the txpool" (`txpool_number_of_executable_transactions`), "The time it took to select transactions for inclusion in a block in nanoseconds" (`txpool_select_transaction_time_nanoseconds`), The time it took to insert a transaction in the txpool in milliseconds (`txpool_insert_transaction_time_milliseconds`).
 - [2362](https://github.com/FuelLabs/fuel-core/pull/2362): Added a new request_response protocol version `/fuel/req_res/0.0.2`. In comparison with `/fuel/req/0.0.1`, which returns an empty response when a request cannot be fulfilled, this version returns more meaningful error codes. Nodes still support the version `0.0.1` of the protocol to guarantee backward compatibility with fuel-core nodes. Empty responses received from nodes using the old protocol `/fuel/req/0.0.1` are automatically converted into an error `ProtocolV1EmptyResponse` with error code 0, which is also the only error code implemented. More specific error codes will be added in the future.
@@ -100,7 +103,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2300](https://github.com/FuelLabs/fuel-core/pull/2300): Added new function to `fuel-core-client` for checking whether a blob exists.
 
 ### Changed
-- [2258](https://github.com/FuelLabs/fuel-core/pull/2258): Updated the `messageProof` GraphQL schema to return a non-nullable `MessageProof` and modified `message_proof()` to return a descriptive error instead of `None` when proof generation fails.
 
 #### Breaking
 - [2299](https://github.com/FuelLabs/fuel-core/pull/2299): Anyone who wants to participate in the transaction broadcasting via p2p must upgrade to support new predicates on the TxPool level.

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -980,7 +980,7 @@ type Query {
 		"""
 		owner: Address,		first: Int,		after: String,		last: Int,		before: String
 	): MessageConnection!
-	messageProof(transactionId: TransactionId!, nonce: Nonce!, commitBlockId: BlockId, commitBlockHeight: U32): MessageProof
+	messageProof(transactionId: TransactionId!, nonce: Nonce!, commitBlockId: BlockId, commitBlockHeight: U32): MessageProof!
 	messageStatus(nonce: Nonce!): MessageStatus!
 	relayedTransactionStatus(
 		"""

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1141,7 +1141,7 @@ impl FuelClient {
         nonce: &Nonce,
         commit_block_id: Option<&BlockId>,
         commit_block_height: Option<BlockHeight>,
-    ) -> io::Result<Option<types::MessageProof>> {
+    ) -> io::Result<types::MessageProof> {
         let transaction_id: TransactionId = (*transaction_id).into();
         let nonce: schema::Nonce = (*nonce).into();
         let commit_block_id: Option<schema::BlockId> =
@@ -1153,14 +1153,7 @@ impl FuelClient {
             commit_block_id,
             commit_block_height,
         });
-
-        let proof = self
-            .query(query)
-            .await?
-            .message_proof
-            .map(TryInto::try_into)
-            .transpose()?;
-
+        let proof = self.query(query).await?.message_proof.try_into()?;
         Ok(proof)
     }
 

--- a/crates/client/src/client/schema/message.rs
+++ b/crates/client/src/client/schema/message.rs
@@ -114,7 +114,7 @@ pub struct MessageProofQuery {
         commitBlockId: $commit_block_id,
         commitBlockHeight: $commit_block_height
     )]
-    pub message_proof: Option<MessageProof>,
+    pub message_proof: MessageProof,
 }
 
 #[derive(cynic::QueryFragment, Clone, Debug)]

--- a/crates/fuel-core/src/schema/message.rs
+++ b/crates/fuel-core/src/schema/message.rs
@@ -136,7 +136,7 @@ impl MessageQuery {
         nonce: Nonce,
         commit_block_id: Option<BlockId>,
         commit_block_height: Option<U32>,
-    ) -> async_graphql::Result<Option<MessageProof>> {
+    ) -> async_graphql::Result<MessageProof> {
         let query = ctx.read_view()?;
         let height = match (commit_block_id, commit_block_height) {
             (Some(commit_block_id), None) => {
@@ -157,7 +157,7 @@ impl MessageQuery {
             height,
         )?;
 
-        Ok(Some(MessageProof(proof)))
+        Ok(MessageProof(proof))
     }
 
     #[graphql(complexity = "query_costs().storage_read + child_complexity")]

--- a/tests/tests/messages.rs
+++ b/tests/tests/messages.rs
@@ -485,7 +485,6 @@ async fn can_get_message_proof() {
             let result = client
                 .message_proof(&transaction_id, nonce, None, Some(last_height))
                 .await
-                .unwrap()
                 .unwrap();
 
             // 1. Generate the message id (message fields)

--- a/tests/tests/regenesis.rs
+++ b/tests/tests/regenesis.rs
@@ -401,8 +401,7 @@ async fn test_regenesis_message_proofs_are_preserved() -> anyhow::Result<()> {
         .client
         .message_proof(&tx_id, nonce, None, Some((message_block_height + 1).into()))
         .await
-        .expect("Unable to get message proof")
-        .expect("Message proof not found");
+        .expect("Unable to get message proof");
     let prev_root = proof.commit_block_header.prev_root;
     let block_proof_index = proof.block_proof.proof_index;
     let block_proof_set: Vec<_> = proof
@@ -460,8 +459,7 @@ async fn test_regenesis_message_proofs_are_preserved() -> anyhow::Result<()> {
             .client
             .message_proof(&tx_id, nonce, None, Some(block_height.into()))
             .await
-            .expect("Unable to get message proof")
-            .expect("Message proof not found");
+            .expect("Unable to get message proof");
         let prev_root = proof.commit_block_header.prev_root;
         let block_proof_set: Vec<_> = proof
             .block_proof


### PR DESCRIPTION
⚠️ _**This should only be merged into the next, planned breaking release**_ ⚠️ 
⚠️ _**I'll keep it as draft to avoid accidental merge**_ ⚠️ 

## Linked Issues/PRs
Additional changes related to https://github.com/FuelLabs/fuel-core/issues/1394
Closes: https://github.com/FuelLabs/fuel-core/issues/2367

## Description
Initially we [wanted](https://github.com/FuelLabs/fuel-core/pull/2258#pullrequestreview-2342054802) these changes, but eventually [decided](https://github.com/FuelLabs/fuel-core/pull/2258#issuecomment-2404993471) to [revert](https://github.com/FuelLabs/fuel-core/pull/2258#issuecomment-2405160291) them from the original PR, because even though they are [not](https://github.com/FuelLabs/fuel-core/pull/2258#discussion_r1782262098) [considered](https://github.com/FuelLabs/fuel-core/pull/2258#discussion_r1783198432) strictly breaking, they change the API. 



## Checklist
- [X] Breaking changes are clearly marked as such in the PR description and changelog

### Before requesting review
- [X] I have reviewed the code myself