### PR TITLE
perf: Add support for multi get operation for database queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - [2378](https://github.com/FuelLabs/fuel-core/pull/2378): Use cached hash of the topic instead of calculating it on each publishing gossip message.
 
+#### Breaking
+- [2396](https://github.com/FuelLabs/fuel-core/pull/2396): Return `StorageResult<Transaction>` in `OffChainDatabase::old_transaction`.
+
 ### Added
 - [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the txpool: "The size of transactions in the txpool" (`txpool_tx_size`), "The time spent by a transaction in the txpool in seconds" (`txpool_tx_time_in_txpool_seconds`), The number of transactions in the txpool (`txpool_number_of_transactions`), "The number of transactions pending verification before entering the txpool" (`txpool_number_of_transactions_pending_verification`), "The number of executable transactions in the txpool" (`txpool_number_of_executable_transactions`), "The time it took to select transactions for inclusion in a block in nanoseconds" (`txpool_select_transaction_time_nanoseconds`), The time it took to insert a transaction in the txpool in milliseconds (`txpool_insert_transaction_time_milliseconds`).
 - [2347](https://github.com/FuelLabs/fuel-core/pull/2364): Add activity concept in order to protect against infinitely increasing DA gas price scenarios
 - [2362](https://github.com/FuelLabs/fuel-core/pull/2362): Added a new request_response protocol version `/fuel/req_res/0.0.2`. In comparison with `/fuel/req/0.0.1`, which returns an empty response when a request cannot be fulfilled, this version returns more meaningful error codes. Nodes still support the version `0.0.1` of the protocol to guarantee backward compatibility with fuel-core nodes. Empty responses received from nodes using the old protocol `/fuel/req/0.0.1` are automatically converted into an error `ProtocolV1EmptyResponse` with error code 0, which is also the only error code implemented. More specific error codes will be added in the future.
 - [2386](https://github.com/FuelLabs/fuel-core/pull/2386): Add a flag to define the maximum number of file descriptors that RocksDB can use. By default it's half of the OS limit.
+- [2396](https://github.com/FuelLabs/fuel-core/pull/2396): Add support for multi get operation for database queries.
 
 ## [Version 0.40.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,6 +3166,8 @@ dependencies = [
 [[package]]
 name = "fuel-asm"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f325971bf9047ec70004f80a989e03456316bc19cbef3ff3a39a38b192ab56e"
 dependencies = [
  "bitflags 2.6.0",
  "fuel-types 0.58.2",
@@ -3176,6 +3178,8 @@ dependencies = [
 [[package]]
 name = "fuel-compression"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e42841f56f76ed759b3f516e5188d5c42de47015bee951651660c13b6dfa6c"
 dependencies = [
  "fuel-derive 0.58.2",
  "fuel-types 0.58.2",
@@ -3889,6 +3893,8 @@ dependencies = [
 [[package]]
 name = "fuel-crypto"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e318850ca64890ff123a99b6b866954ef49da94ab9bc6827cf6ee045568585"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -3920,6 +3926,8 @@ dependencies = [
 [[package]]
 name = "fuel-derive"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0bc46a3552964bae5169e79b383761a54bd115ea66951a1a7a229edcefa55a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3955,6 +3963,8 @@ dependencies = [
 [[package]]
 name = "fuel-merkle"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79eca6a452311c70978a5df796c0f99f27e474b69719e0db4c1d82e68800d07"
 dependencies = [
  "derive_more 0.99.18",
  "digest 0.10.7",
@@ -3974,6 +3984,8 @@ checksum = "4c1b711f28553ddc5f3546711bd220e144ce4c1af7d9e9a1f70b2f20d9f5b791"
 [[package]]
 name = "fuel-storage"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0c46b5d76b3e11197bd31e036cd8b1cb46c4d822cacc48836638080c6d2b76"
 
 [[package]]
 name = "fuel-tx"
@@ -4000,6 +4012,8 @@ dependencies = [
 [[package]]
 name = "fuel-tx"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6723bb8710ba2b70516ac94d34459593225870c937670fb3afaf82e0354667ac"
 dependencies = [
  "bitflags 2.6.0",
  "derivative",
@@ -4032,6 +4046,8 @@ dependencies = [
 [[package]]
 name = "fuel-types"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "982265415a99b5bd6277bc24194a233bb2e18764df11c937b3dbb11a02c9e545"
 dependencies = [
  "fuel-derive 0.58.2",
  "hex",
@@ -4073,6 +4089,8 @@ dependencies = [
 [[package]]
 name = "fuel-vm"
 version = "0.58.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b5362d7d072c72eec20581f67fc5400090c356a7f3ae77c79880b3b177b667"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,8 +3166,6 @@ dependencies = [
 [[package]]
 name = "fuel-asm"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f325971bf9047ec70004f80a989e03456316bc19cbef3ff3a39a38b192ab56e"
 dependencies = [
  "bitflags 2.6.0",
  "fuel-types 0.58.2",
@@ -3178,8 +3176,6 @@ dependencies = [
 [[package]]
 name = "fuel-compression"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e42841f56f76ed759b3f516e5188d5c42de47015bee951651660c13b6dfa6c"
 dependencies = [
  "fuel-derive 0.58.2",
  "fuel-types 0.58.2",
@@ -3893,8 +3889,6 @@ dependencies = [
 [[package]]
 name = "fuel-crypto"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e318850ca64890ff123a99b6b866954ef49da94ab9bc6827cf6ee045568585"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -3926,8 +3920,6 @@ dependencies = [
 [[package]]
 name = "fuel-derive"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0bc46a3552964bae5169e79b383761a54bd115ea66951a1a7a229edcefa55a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3963,8 +3955,6 @@ dependencies = [
 [[package]]
 name = "fuel-merkle"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79eca6a452311c70978a5df796c0f99f27e474b69719e0db4c1d82e68800d07"
 dependencies = [
  "derive_more 0.99.18",
  "digest 0.10.7",
@@ -3984,8 +3974,6 @@ checksum = "4c1b711f28553ddc5f3546711bd220e144ce4c1af7d9e9a1f70b2f20d9f5b791"
 [[package]]
 name = "fuel-storage"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0c46b5d76b3e11197bd31e036cd8b1cb46c4d822cacc48836638080c6d2b76"
 
 [[package]]
 name = "fuel-tx"
@@ -4012,8 +4000,6 @@ dependencies = [
 [[package]]
 name = "fuel-tx"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6723bb8710ba2b70516ac94d34459593225870c937670fb3afaf82e0354667ac"
 dependencies = [
  "bitflags 2.6.0",
  "derivative",
@@ -4046,8 +4032,6 @@ dependencies = [
 [[package]]
 name = "fuel-types"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982265415a99b5bd6277bc24194a233bb2e18764df11c937b3dbb11a02c9e545"
 dependencies = [
  "fuel-derive 0.58.2",
  "hex",
@@ -4089,8 +4073,6 @@ dependencies = [
 [[package]]
 name = "fuel-vm"
 version = "0.58.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b5362d7d072c72eec20581f67fc5400090c356a7f3ae77c79880b3b177b667"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 fuel-gas-price-algorithm = { version = "0.40.0", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.58.2", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.58.2", path = "../fuel-vm/fuel-vm", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 fuel-gas-price-algorithm = { version = "0.40.0", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.58.2", path = "../fuel-vm/fuel-vm", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.58.2", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"

--- a/benches/src/db_lookup_times_utils/utils.rs
+++ b/benches/src/db_lookup_times_utils/utils.rs
@@ -90,7 +90,9 @@ fn get_block_multi_get_method(
         .ok_or(anyhow!("empty raw block"))?;
     let block: CompressedBlock = postcard::from_bytes(raw_block.as_slice())?;
     let tx_ids = block.transactions().iter();
-    let raw_txs = database.multi_get(BenchDbColumn::Transactions.id(), tx_ids)?;
+    let raw_txs: Vec<_> = database
+        .multi_get(BenchDbColumn::Transactions.id(), tx_ids)
+        .try_collect()?;
     let txs: Vec<Transaction> = raw_txs
         .iter()
         .flatten()

--- a/crates/client/src/client/schema/primitives.rs
+++ b/crates/client/src/client/schema/primitives.rs
@@ -177,7 +177,7 @@ impl LowerHex for TxPointer {
     }
 }
 
-#[derive(cynic::Scalar, Debug, Clone)]
+#[derive(cynic::Scalar, Debug, Clone, PartialEq, Eq)]
 pub struct HexString(pub Bytes);
 
 impl From<HexString> for Vec<u8> {
@@ -194,7 +194,7 @@ impl Deref for HexString {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Bytes(pub Vec<u8>);
 
 impl FromStr for Bytes {

--- a/crates/fuel-core/src/database/block.rs
+++ b/crates/fuel-core/src/database/block.rs
@@ -18,7 +18,7 @@ use fuel_core_storage::{
             FuelBlockMerkleMetadata,
         },
         FuelBlocks,
-        Transactions,
+        // Transactions,
     },
     Error as StorageError,
     Result as StorageResult,
@@ -36,8 +36,7 @@ use fuel_core_types::{
     fuel_merkle::binary::MerkleTree,
     fuel_types::BlockHeight,
 };
-use itertools::Itertools;
-use std::borrow::Cow;
+// use std::borrow::Cow;
 
 impl OffChainIterableKeyValueView {
     pub fn get_block_height(&self, id: &BlockId) -> StorageResult<Option<BlockHeight>> {
@@ -65,22 +64,24 @@ impl OnChainIterableKeyValueView {
     /// Retrieve the full block and all associated transactions
     pub fn get_full_block(&self, height: &BlockHeight) -> StorageResult<Option<Block>> {
         let db_block = self.storage::<FuelBlocks>().get(height)?;
-        if let Some(block) = db_block {
+        if let Some(_block) = db_block {
             // fetch all the transactions
             // TODO: Use multiget when it's implemented.
             //  https://github.com/FuelLabs/fuel-core/issues/2344
 
-            let transaction_ids = Box::new(block.transactions().iter());
-            let txs = self
-                .storage::<Transactions>()
-                .get_multi(transaction_ids)
-                .map(|tx| {
-                    tx.and_then(|tx| {
-                        tx.ok_or(not_found!(Transactions)).map(Cow::into_owned)
-                    })
-                })
-                .try_collect()?;
-            Ok(Some(block.into_owned().uncompress(txs)))
+            // let transaction_ids = Box::new(block.transactions().iter());
+            // let txs = self
+            //    .storage::<Transactions>()
+            //    .get_multi(transaction_ids)
+            //    .map(|tx| {
+            //        tx.and_then(|tx| {
+            //            tx.ok_or(not_found!(Transactions)).map(Cow::into_owned)
+            //        })
+            //    })
+            //    .try_collect()?;
+            //
+            // Ok(Some(block.into_owned().uncompress(txs)))
+            Ok(None)
         } else {
             Ok(None)
         }

--- a/crates/fuel-core/src/database/block.rs
+++ b/crates/fuel-core/src/database/block.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use fuel_core_storage::{
     iter::{
-        IntoBoxedIter,
+        IntoBoxedIterSend,
         IterDirection,
         IteratorOverTable,
     },
@@ -68,7 +68,7 @@ impl OnChainIterableKeyValueView {
         let db_block = self.storage::<FuelBlocks>().get(height)?;
 
         if let Some(block) = db_block {
-            let transaction_ids = block.transactions().iter().into_boxed();
+            let transaction_ids = block.transactions().iter().into_boxed_send();
             let txs = <Self as StorageBatchInspect<Transactions>>::get_batch(
                 self,
                 transaction_ids,

--- a/crates/fuel-core/src/graphql_api/database.rs
+++ b/crates/fuel-core/src/graphql_api/database.rs
@@ -151,8 +151,6 @@ impl ReadView {
         &self,
         tx_ids: Vec<TxId>,
     ) -> Vec<StorageResult<Transaction>> {
-        // TODO: Use multiget when it's implemented.
-        //  https://github.com/FuelLabs/fuel-core/issues/2344
         let on_chain_results: BTreeMap<_, _> = tx_ids
             .iter()
             .enumerate()
@@ -178,11 +176,7 @@ impl ReadView {
         let mut results = on_chain_results;
         results.extend(off_chain_results);
 
-        // let result = tx_ids
-        //    .iter()
-        //    .map(|tx_id| self.transaction(tx_id))
-        //    .collect::<Vec<_>>();
-        // Give a chance to other tasks to run.
+        // Give a chance for other tasks to run.
         tokio::task::yield_now().await;
 
         results.into_values().collect()

--- a/crates/fuel-core/src/graphql_api/database.rs
+++ b/crates/fuel-core/src/graphql_api/database.rs
@@ -165,7 +165,7 @@ impl ReadView {
         }
     }
 
-    pub async fn extend_with_off_chain_results(
+    async fn extend_with_off_chain_results(
         &self,
         on_chain_results: BTreeMap<(usize, &TxId), StorageResult<Transaction>>,
     ) -> Vec<StorageResult<Transaction>> {

--- a/crates/fuel-core/src/graphql_api/database.rs
+++ b/crates/fuel-core/src/graphql_api/database.rs
@@ -9,8 +9,8 @@ use fuel_core_services::yield_stream::StreamYieldExt;
 use fuel_core_storage::{
     iter::{
         BoxedIterSend,
-        IntoBoxedIterSend,
         IntoBoxedIter,
+        IntoBoxedIterSend,
         IterDirection,
     },
     transactional::AtomicView,

--- a/crates/fuel-core/src/graphql_api/database.rs
+++ b/crates/fuel-core/src/graphql_api/database.rs
@@ -147,10 +147,7 @@ impl ReadView {
     }
 
     // TODO: Test case to ensure order is preserved
-    pub async fn transactions(
-        &self,
-        tx_ids: Vec<TxId>,
-    ) -> Vec<StorageResult<Transaction>> {
+    pub async fn transactions(&self, tx_ids: &[TxId]) -> Vec<StorageResult<Transaction>> {
         let on_chain_results: BTreeMap<_, _> = tx_ids
             .iter()
             .enumerate()

--- a/crates/fuel-core/src/graphql_api/database.rs
+++ b/crates/fuel-core/src/graphql_api/database.rs
@@ -163,6 +163,7 @@ impl ReadView {
             transactions
         }
     }
+
     pub async fn extend_with_off_chain_results(
         &self,
         on_chain_results: BTreeMap<(usize, &TxId), StorageResult<Transaction>>,

--- a/crates/fuel-core/src/graphql_api/database.rs
+++ b/crates/fuel-core/src/graphql_api/database.rs
@@ -146,7 +146,6 @@ impl ReadView {
         }
     }
 
-    // TODO: Test case to ensure order is preserved
     pub async fn transactions(&self, tx_ids: &[TxId]) -> Vec<StorageResult<Transaction>> {
         let on_chain_results: BTreeMap<_, _> = tx_ids
             .iter()

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -16,7 +16,6 @@ use fuel_core_storage::{
     },
     Error as StorageError,
     Result as StorageResult,
-    StorageBatchInspect,
     StorageInspect,
     StorageRead,
 };
@@ -174,9 +173,7 @@ pub trait DatabaseDaCompressedBlocks {
 }
 
 /// Trait that specifies all the getters required for messages.
-pub trait DatabaseMessages:
-    StorageInspect<Messages, Error = StorageError> + StorageBatchInspect<Messages>
-{
+pub trait DatabaseMessages: StorageInspect<Messages, Error = StorageError> {
     fn all_messages(
         &self,
         start_message_id: Option<Nonce>,
@@ -199,10 +196,9 @@ pub trait DatabaseRelayedTransactions {
 }
 
 /// Trait that specifies all the getters required for coins
-pub trait DatabaseCoins:
-    StorageInspect<Coins, Error = StorageError> + StorageBatchInspect<Coins>
-{
+pub trait DatabaseCoins: StorageInspect<Coins, Error = StorageError> {
     fn coin(&self, utxo_id: UtxoId) -> StorageResult<Coin>;
+
     fn coins<'a>(
         &'a self,
         utxo_ids: BoxedIter<'a, &'a UtxoId>,

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use fuel_core_services::stream::BoxStream;
 use fuel_core_storage::{
     iter::{
+        BoxedIterSend,
         BoxedIter,
         IterDirection,
     },
@@ -79,21 +80,21 @@ pub trait OffChainDatabase: Send + Sync {
         owner: &Address,
         start_coin: Option<UtxoId>,
         direction: IterDirection,
-    ) -> BoxedIter<'_, StorageResult<UtxoId>>;
+    ) -> BoxedIterSend<'_, StorageResult<UtxoId>>;
 
     fn owned_message_ids(
         &self,
         owner: &Address,
         start_message_id: Option<Nonce>,
         direction: IterDirection,
-    ) -> BoxedIter<'_, StorageResult<Nonce>>;
+    ) -> BoxedIterSend<'_, StorageResult<Nonce>>;
 
     fn owned_transactions_ids(
         &self,
         owner: Address,
         start: Option<TxPointer>,
         direction: IterDirection,
-    ) -> BoxedIter<StorageResult<(TxPointer, TxId)>>;
+    ) -> BoxedIterSend<StorageResult<(TxPointer, TxId)>>;
 
     fn contract_salt(&self, contract_id: &ContractId) -> StorageResult<Salt>;
 
@@ -103,7 +104,7 @@ pub trait OffChainDatabase: Send + Sync {
         &self,
         height: Option<BlockHeight>,
         direction: IterDirection,
-    ) -> BoxedIter<'_, StorageResult<CompressedBlock>>;
+    ) -> BoxedIterSend<'_, StorageResult<CompressedBlock>>;
 
     fn old_block_consensus(&self, height: &BlockHeight) -> StorageResult<Consensus>;
 
@@ -156,7 +157,7 @@ pub trait DatabaseBlocks {
         &self,
         height: Option<BlockHeight>,
         direction: IterDirection,
-    ) -> BoxedIter<'_, StorageResult<CompressedBlock>>;
+    ) -> BoxedIterSend<'_, StorageResult<CompressedBlock>>;
 
     fn latest_height(&self) -> StorageResult<BlockHeight>;
 
@@ -178,7 +179,7 @@ pub trait DatabaseMessages: StorageInspect<Messages, Error = StorageError> {
         &self,
         start_message_id: Option<Nonce>,
         direction: IterDirection,
-    ) -> BoxedIter<'_, StorageResult<Message>>;
+    ) -> BoxedIterSend<'_, StorageResult<Message>>;
 
     fn message_batch<'a>(
         &'a self,
@@ -199,7 +200,10 @@ pub trait DatabaseRelayedTransactions {
 pub trait DatabaseCoins: StorageInspect<Coins, Error = StorageError> {
     fn coin(&self, utxo_id: UtxoId) -> StorageResult<Coin>;
 
-    fn coins<'a>(&'a self, utxo_ids: &'a [UtxoId]) -> BoxedIter<'a, StorageResult<Coin>>;
+    fn coins<'a>(
+        &'a self,
+        utxo_ids: &'a [UtxoId],
+    ) -> BoxedIter<'a, StorageResult<Coin>>;
 }
 
 /// Trait that specifies all the getters required for contract.
@@ -212,7 +216,7 @@ pub trait DatabaseContracts:
         contract: ContractId,
         start_asset: Option<AssetId>,
         direction: IterDirection,
-    ) -> BoxedIter<StorageResult<ContractBalance>>;
+    ) -> BoxedIterSend<StorageResult<ContractBalance>>;
 }
 
 /// Trait that specifies all the getters required for chain metadata.

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -108,7 +108,12 @@ pub trait OffChainDatabase: Send + Sync {
 
     fn old_block_consensus(&self, height: &BlockHeight) -> StorageResult<Consensus>;
 
-    fn old_transaction(&self, id: &TxId) -> StorageResult<Option<Transaction>>;
+    fn old_transaction(&self, id: &TxId) -> StorageResult<Transaction>;
+
+    fn old_transactions<'a>(
+        &'a self,
+        ids: BoxedIter<'a, &'a TxId>,
+    ) -> BoxedIter<'a, StorageResult<Transaction>>;
 
     fn relayed_tx_status(
         &self,

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -199,10 +199,7 @@ pub trait DatabaseRelayedTransactions {
 pub trait DatabaseCoins: StorageInspect<Coins, Error = StorageError> {
     fn coin(&self, utxo_id: UtxoId) -> StorageResult<Coin>;
 
-    fn coins<'a>(
-        &'a self,
-        utxo_ids: BoxedIter<'a, &'a UtxoId>,
-    ) -> BoxedIter<'a, StorageResult<Coin>>;
+    fn coins<'a>(&'a self, utxo_ids: &'a [UtxoId]) -> BoxedIter<'a, StorageResult<Coin>>;
 }
 
 /// Trait that specifies all the getters required for contract.

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -16,6 +16,7 @@ use fuel_core_storage::{
     },
     Error as StorageError,
     Result as StorageResult,
+    StorageBatchInspect,
     StorageInspect,
     StorageRead,
 };
@@ -159,7 +160,9 @@ pub trait DatabaseDaCompressedBlocks {
 }
 
 /// Trait that specifies all the getters required for messages.
-pub trait DatabaseMessages: StorageInspect<Messages, Error = StorageError> {
+pub trait DatabaseMessages:
+    StorageInspect<Messages, Error = StorageError> + StorageBatchInspect<Messages>
+{
     fn all_messages(
         &self,
         start_message_id: Option<Nonce>,

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -169,6 +169,11 @@ pub trait DatabaseMessages:
         direction: IterDirection,
     ) -> BoxedIter<'_, StorageResult<Message>>;
 
+    fn message_batch<'a>(
+        &'a self,
+        ids: BoxedIter<'a, &'a Nonce>,
+    ) -> BoxedIter<'a, StorageResult<Message>>;
+
     fn message_exists(&self, nonce: &Nonce) -> StorageResult<bool>;
 }
 

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use fuel_core_services::stream::BoxStream;
 use fuel_core_storage::{
     iter::{
-        BoxedIterSend,
         BoxedIter,
+        BoxedIterSend,
         IterDirection,
     },
     tables::{
@@ -200,10 +200,7 @@ pub trait DatabaseRelayedTransactions {
 pub trait DatabaseCoins: StorageInspect<Coins, Error = StorageError> {
     fn coin(&self, utxo_id: UtxoId) -> StorageResult<Coin>;
 
-    fn coins<'a>(
-        &'a self,
-        utxo_ids: &'a [UtxoId],
-    ) -> BoxedIter<'a, StorageResult<Coin>>;
+    fn coins<'a>(&'a self, utxo_ids: &'a [UtxoId]) -> BoxedIter<'a, StorageResult<Coin>>;
 }
 
 /// Trait that specifies all the getters required for contract.

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -198,7 +198,7 @@ pub trait DatabaseRelayedTransactions {
     ) -> StorageResult<Option<RelayedTransactionStatus>>;
 }
 
-/// Trait that specifies all the getters reqired for coins
+/// Trait that specifies all the getters required for coins
 pub trait DatabaseCoins:
     StorageInspect<Coins, Error = StorageError> + StorageBatchInspect<Coins>
 {

--- a/crates/fuel-core/src/query/balance/asset_query.rs
+++ b/crates/fuel-core/src/query/balance/asset_query.rs
@@ -170,7 +170,7 @@ impl<'a> AssetsQuery<'a> {
             })
             .try_filter_map(move |chunk| async move {
                 let chunk = database.messages(chunk).await;
-                Ok::<_, StorageError>(Some(futures::stream::iter(chunk)))
+                Ok::<_, StorageError>(Some(chunk))
             })
             .try_flatten()
             .filter(|result| {

--- a/crates/fuel-core/src/query/coin.rs
+++ b/crates/fuel-core/src/query/coin.rs
@@ -1,9 +1,6 @@
 use crate::fuel_core_graphql_api::database::ReadView;
 use fuel_core_storage::{
-    iter::{
-        IntoBoxedIter,
-        IterDirection,
-    },
+    iter::IterDirection,
     Error as StorageError,
     Result as StorageResult,
 };
@@ -27,7 +24,7 @@ impl ReadView {
         &self,
         utxo_ids: Vec<UtxoId>,
     ) -> impl Iterator<Item = StorageResult<Coin>> + '_ {
-        let coins: Vec<_> = self.on_chain.coins(utxo_ids.iter().into_boxed()).collect();
+        let coins: Vec<_> = self.on_chain.coins(&utxo_ids).collect();
 
         // Give a chance for other tasks to run.
         tokio::task::yield_now().await;

--- a/crates/fuel-core/src/query/coin.rs
+++ b/crates/fuel-core/src/query/coin.rs
@@ -4,11 +4,8 @@ use fuel_core_storage::{
         IntoBoxedIter,
         IterDirection,
     },
-    // not_found,
-    // tables::Coins,
     Error as StorageError,
     Result as StorageResult,
-    // StorageAsRef,
 };
 use fuel_core_types::{
     entities::coins::coin::Coin,
@@ -24,15 +21,6 @@ use futures::{
 impl ReadView {
     pub fn coin(&self, utxo_id: UtxoId) -> StorageResult<Coin> {
         self.on_chain.coin(utxo_id)
-        // let coin = self
-        //    .on_chain
-        //    .as_ref()
-        //    .storage::<Coins>()
-        //    .get(&utxo_id)?
-        //    .ok_or(not_found!(Coins))?
-        //    .into_owned();
-
-        // Ok(coin.uncompress(utxo_id))
     }
 
     pub async fn coins(
@@ -40,10 +28,8 @@ impl ReadView {
         utxo_ids: Vec<UtxoId>,
     ) -> impl Iterator<Item = StorageResult<Coin>> + '_ {
         let coins: Vec<_> = self.on_chain.coins(utxo_ids.iter().into_boxed()).collect();
-        // TODO: Use multiget when it's implemented.
-        //  https://github.com/FuelLabs/fuel-core/issues/2344
-        // let coins = utxo_ids.into_iter().map(|id| self.coin(id));
-        // Give a chance to other tasks to run.
+
+        // Give a chance for other tasks to run.
         tokio::task::yield_now().await;
         coins.into_iter()
     }

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -1,7 +1,7 @@
 use crate::fuel_core_graphql_api::database::ReadView;
 use fuel_core_storage::{
     iter::{
-        BoxedIter,
+        BoxedIterSend,
         IntoBoxedIter,
         IterDirection,
     },
@@ -53,20 +53,20 @@ pub trait MessageQueryData: Send + Sync {
         owner: &Address,
         start_message_id: Option<Nonce>,
         direction: IterDirection,
-    ) -> BoxedIter<StorageResult<Nonce>>;
+    ) -> BoxedIterSend<StorageResult<Nonce>>;
 
     fn owned_messages(
         &self,
         owner: &Address,
         start_message_id: Option<Nonce>,
         direction: IterDirection,
-    ) -> BoxedIter<StorageResult<Message>>;
+    ) -> BoxedIterSend<StorageResult<Message>>;
 
     fn all_messages(
         &self,
         start_message_id: Option<Nonce>,
         direction: IterDirection,
-    ) -> BoxedIter<StorageResult<Message>>;
+    ) -> BoxedIterSend<StorageResult<Message>>;
 }
 
 impl ReadView {

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -2,6 +2,7 @@ use crate::fuel_core_graphql_api::database::ReadView;
 use fuel_core_storage::{
     iter::{
         BoxedIter,
+        IntoBoxedIter,
         IterDirection,
     },
     not_found,
@@ -80,7 +81,7 @@ impl ReadView {
 
     pub async fn messages(
         &self,
-        _ids: Vec<Nonce>,
+        ids: Vec<Nonce>,
     ) -> impl Stream<Item = StorageResult<Message>> {
         // let ids = Box::new(ids.iter());
         // let messages: Vec<_> = self
@@ -93,8 +94,10 @@ impl ReadView {
         //    })
         //    .collect();
 
-        // TODO
-        let messages = Vec::new();
+        let messages: Vec<_> = self
+            .on_chain
+            .message_batch(ids.iter().into_boxed())
+            .collect();
 
         //// TODO: Use multiget when it's implemented.
         ////  https://github.com/FuelLabs/fuel-core/issues/2344

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -83,27 +83,14 @@ impl ReadView {
         &self,
         ids: Vec<Nonce>,
     ) -> impl Stream<Item = StorageResult<Message>> {
-        // let ids = Box::new(ids.iter());
-        // let messages: Vec<_> = self
-        //    .on_chain
-        //    .as_ref()
-        //    .storage::<Messages>()
-        //    .get_multi(Box::new(ids))
-        //    .map(|res| {
-        //        res.and_then(|opt| opt.ok_or(not_found!(Messages)).map(Cow::into_owned))
-        //    })
-        //    .collect();
-
         let messages: Vec<_> = self
             .on_chain
             .message_batch(ids.iter().into_boxed())
             .collect();
 
-        //// TODO: Use multiget when it's implemented.
-        ////  https://github.com/FuelLabs/fuel-core/issues/2344
-        // let messages = ids.into_iter().map(|id| self.message(&id));
-        //// Give a chance to other tasks to run.
+        // Give a chance for other tasks to run.
         tokio::task::yield_now().await;
+
         futures::stream::iter(messages)
     }
 

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -80,18 +80,21 @@ impl ReadView {
 
     pub async fn messages(
         &self,
-        ids: Vec<Nonce>,
+        _ids: Vec<Nonce>,
     ) -> impl Stream<Item = StorageResult<Message>> {
-        let ids = Box::new(ids.iter());
-        let messages: Vec<_> = self
-            .on_chain
-            .as_ref()
-            .storage::<Messages>()
-            .get_multi(Box::new(ids))
-            .map(|res| {
-                res.and_then(|opt| opt.ok_or(not_found!(Messages)).map(Cow::into_owned))
-            })
-            .collect();
+        // let ids = Box::new(ids.iter());
+        // let messages: Vec<_> = self
+        //    .on_chain
+        //    .as_ref()
+        //    .storage::<Messages>()
+        //    .get_multi(Box::new(ids))
+        //    .map(|res| {
+        //        res.and_then(|opt| opt.ok_or(not_found!(Messages)).map(Cow::into_owned))
+        //    })
+        //    .collect();
+
+        // TODO
+        let messages = Vec::new();
 
         //// TODO: Use multiget when it's implemented.
         ////  https://github.com/FuelLabs/fuel-core/issues/2344

--- a/crates/fuel-core/src/query/tx.rs
+++ b/crates/fuel-core/src/query/tx.rs
@@ -50,7 +50,7 @@ impl ReadView {
             })
             .try_filter_map(move |chunk| async move {
                 let tx_ids = chunk.iter().map(|(_, tx_id)| *tx_id).collect::<Vec<_>>();
-                let txs = self.transactions(tx_ids).await;
+                let txs = self.transactions(&tx_ids).await;
                 let txs = txs
                     .into_iter()
                     .zip(chunk)

--- a/crates/fuel-core/src/schema/block.rs
+++ b/crates/fuel-core/src/schema/block.rs
@@ -144,7 +144,7 @@ impl Block {
             .filter_map(move |tx_ids: Vec<TxId>| {
                 let async_query = query.as_ref().clone();
                 async move {
-                    let txs = async_query.transactions(tx_ids.clone()).await;
+                    let txs = async_query.transactions(&tx_ids).await;
                     let txs = txs
                         .into_iter()
                         .zip(tx_ids.into_iter())

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -173,7 +173,7 @@ impl TxQuery {
                                 .iter()
                                 .map(|sorted| sorted.tx_id.0)
                                 .collect::<Vec<_>>();
-                            let txs = async_query.transactions(tx_ids).await;
+                            let txs = async_query.transactions(&tx_ids).await;
                             let txs = txs.into_iter().zip(chunk.into_iter()).map(
                                 |(result, sorted)| {
                                     result.map(|tx| {

--- a/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
@@ -26,10 +26,10 @@ use fuel_core_storage::{
     blueprint::BlueprintInspect,
     codec::Encode,
     iter::{
-        BoxedIterSend,
         BoxedIter,
-        IntoBoxedIterSend,
+        BoxedIterSend,
         IntoBoxedIter,
+        IntoBoxedIterSend,
         IterDirection,
         IteratorOverTable,
     },

--- a/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
@@ -170,7 +170,6 @@ impl OffChainDatabase for OffChainIterableKeyValueView {
     fn old_transaction(&self, id: &TxId) -> StorageResult<Transaction> {
         self.storage_as_ref::<OldTransactions>()
             .get(id)?
-            // Note: Breaking change (previously we returned not_found!(Transactions))
             .ok_or(not_found!(OldTransactions))
             .map(|tx| tx.into_owned())
     }

--- a/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
@@ -26,7 +26,9 @@ use fuel_core_storage::{
     blueprint::BlueprintInspect,
     codec::Encode,
     iter::{
+        BoxedIterSend,
         BoxedIter,
+        IntoBoxedIterSend,
         IntoBoxedIter,
         IterDirection,
         IteratorOverTable,
@@ -97,10 +99,10 @@ impl OffChainDatabase for OffChainIterableKeyValueView {
         owner: &Address,
         start_coin: Option<UtxoId>,
         direction: IterDirection,
-    ) -> BoxedIter<'_, StorageResult<UtxoId>> {
+    ) -> BoxedIterSend<'_, StorageResult<UtxoId>> {
         self.owned_coins_ids(owner, start_coin, Some(direction))
             .map(|res| res.map_err(StorageError::from))
-            .into_boxed()
+            .into_boxed_send()
     }
 
     fn owned_message_ids(
@@ -108,10 +110,10 @@ impl OffChainDatabase for OffChainIterableKeyValueView {
         owner: &Address,
         start_message_id: Option<Nonce>,
         direction: IterDirection,
-    ) -> BoxedIter<'_, StorageResult<Nonce>> {
+    ) -> BoxedIterSend<'_, StorageResult<Nonce>> {
         self.owned_message_ids(owner, start_message_id, Some(direction))
             .map(|result| result.map_err(StorageError::from))
-            .into_boxed()
+            .into_boxed_send()
     }
 
     fn owned_transactions_ids(
@@ -119,14 +121,14 @@ impl OffChainDatabase for OffChainIterableKeyValueView {
         owner: Address,
         start: Option<TxPointer>,
         direction: IterDirection,
-    ) -> BoxedIter<StorageResult<(TxPointer, TxId)>> {
+    ) -> BoxedIterSend<StorageResult<(TxPointer, TxId)>> {
         let start = start.map(|tx_pointer| OwnedTransactionIndexCursor {
             block_height: tx_pointer.block_height(),
             tx_idx: tx_pointer.tx_index(),
         });
         self.owned_transactions(owner, start, Some(direction))
             .map(|result| result.map_err(StorageError::from))
-            .into_boxed()
+            .into_boxed_send()
     }
 
     fn contract_salt(&self, contract_id: &ContractId) -> StorageResult<Salt> {
@@ -153,10 +155,10 @@ impl OffChainDatabase for OffChainIterableKeyValueView {
         &self,
         height: Option<BlockHeight>,
         direction: IterDirection,
-    ) -> BoxedIter<'_, StorageResult<CompressedBlock>> {
+    ) -> BoxedIterSend<'_, StorageResult<CompressedBlock>> {
         self.iter_all_by_start::<OldFuelBlocks>(height.as_ref(), Some(direction))
             .map(|r| r.map(|(_, block)| block))
-            .into_boxed()
+            .into_boxed_send()
     }
 
     fn old_block_consensus(&self, height: &BlockHeight) -> StorageResult<Consensus> {

--- a/crates/fuel-core/src/service/adapters/graphql_api/on_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/on_chain.rs
@@ -18,10 +18,10 @@ use crate::{
 };
 use fuel_core_storage::{
     iter::{
-        BoxedIterSend,
         BoxedIter,
-        IntoBoxedIterSend,
+        BoxedIterSend,
         IntoBoxedIter,
+        IntoBoxedIterSend,
         IterDirection,
         IteratorOverTable,
     },
@@ -149,10 +149,7 @@ impl DatabaseCoins for OnChainIterableKeyValueView {
         Ok(coin.uncompress(utxo_id))
     }
 
-    fn coins<'a>(
-        &'a self,
-        utxo_ids: &'a [UtxoId],
-    ) -> BoxedIter<'a, StorageResult<Coin>> {
+    fn coins<'a>(&'a self, utxo_ids: &'a [UtxoId]) -> BoxedIter<'a, StorageResult<Coin>> {
         <Self as StorageBatchInspect<Coins>>::get_batch(
             self,
             utxo_ids.iter().into_boxed_send(),

--- a/crates/fuel-core/src/service/adapters/graphql_api/on_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/on_chain.rs
@@ -23,12 +23,14 @@ use fuel_core_storage::{
     not_found,
     tables::{
         FuelBlocks,
+        Messages,
         SealedBlockConsensus,
         Transactions,
     },
     Error as StorageError,
     Result as StorageResult,
     StorageAsRef,
+    StorageBatchInspect,
 };
 use fuel_core_types::{
     blockchain::{
@@ -100,6 +102,15 @@ impl DatabaseMessages for OnChainIterableKeyValueView {
     ) -> BoxedIter<'_, StorageResult<Message>> {
         self.all_messages(start_message_id, Some(direction))
             .map(|result| result.map_err(StorageError::from))
+            .into_boxed()
+    }
+
+    fn message_batch<'a>(
+        &'a self,
+        ids: BoxedIter<'a, &'a Nonce>,
+    ) -> BoxedIter<'a, StorageResult<Message>> {
+        self.get_batch(ids)
+            .map(|result| result.and_then(|opt| opt.ok_or(not_found!(Messages))))
             .into_boxed()
     }
 

--- a/crates/fuel-core/src/service/adapters/graphql_api/on_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/on_chain.rs
@@ -109,7 +109,7 @@ impl DatabaseMessages for OnChainIterableKeyValueView {
         &'a self,
         ids: BoxedIter<'a, &'a Nonce>,
     ) -> BoxedIter<'a, StorageResult<Message>> {
-        self.get_batch(ids)
+        <Self as StorageBatchInspect<Messages>>::get_batch(self, ids)
             .map(|result| result.and_then(|opt| opt.ok_or(not_found!(Messages))))
             .into_boxed()
     }

--- a/crates/fuel-core/src/service/genesis/importer/import_task.rs
+++ b/crates/fuel-core/src/service/genesis/importer/import_task.rs
@@ -166,7 +166,7 @@ mod tests {
     use fuel_core_storage::{
         column::Column,
         iter::{
-            BoxedIter,
+            BoxedIterSend,
             IterDirection,
             IterableStore,
         },
@@ -551,7 +551,7 @@ mod tests {
             _: Option<&[u8]>,
             _: Option<&[u8]>,
             _: IterDirection,
-        ) -> BoxedIter<KVItem> {
+        ) -> BoxedIterSend<KVItem> {
             unimplemented!()
         }
 
@@ -561,7 +561,7 @@ mod tests {
             _: Option<&[u8]>,
             _: Option<&[u8]>,
             _: IterDirection,
-        ) -> BoxedIter<KeyItem> {
+        ) -> BoxedIterSend<KeyItem> {
             unimplemented!()
         }
     }

--- a/crates/fuel-core/src/state/data_source.rs
+++ b/crates/fuel-core/src/state/data_source.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use fuel_core_storage::{
     iter::{
-        BoxedIterSend,
         BoxedIter,
+        BoxedIterSend,
         IterDirection,
         IterableStore,
     },

--- a/crates/fuel-core/src/state/data_source.rs
+++ b/crates/fuel-core/src/state/data_source.rs
@@ -44,6 +44,7 @@ where
 impl<Description, Stage> KeyValueInspect for DataSource<Description, Stage>
 where
     Description: DatabaseDescription,
+    Stage: Send + Sync,
 {
     type Column = Description::Column;
 
@@ -76,6 +77,7 @@ where
 impl<Description, Stage> IterableStore for DataSource<Description, Stage>
 where
     Description: DatabaseDescription,
+    Stage: Send + Sync,
 {
     fn iter_store(
         &self,

--- a/crates/fuel-core/src/state/data_source.rs
+++ b/crates/fuel-core/src/state/data_source.rs
@@ -64,6 +64,14 @@ where
         self.data.get(key, column)
     }
 
+    fn get_batch<'a>(
+        &'a self,
+        keys: BoxedIter<'a, Vec<u8>>,
+        column: Self::Column,
+    ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
+        self.data.get_batch(keys, column)
+    }
+
     fn read(
         &self,
         key: &[u8],

--- a/crates/fuel-core/src/state/data_source.rs
+++ b/crates/fuel-core/src/state/data_source.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use fuel_core_storage::{
     iter::{
+        BoxedIterSend,
         BoxedIter,
         IterDirection,
         IterableStore,
@@ -96,7 +97,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KVItem> {
+    ) -> BoxedIterSend<KVItem> {
         self.data.iter_store(column, prefix, start, direction)
     }
 
@@ -106,7 +107,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<fuel_core_storage::kv_store::KeyItem> {
+    ) -> BoxedIterSend<fuel_core_storage::kv_store::KeyItem> {
         self.data.iter_store_keys(column, prefix, start, direction)
     }
 }

--- a/crates/fuel-core/src/state/data_source.rs
+++ b/crates/fuel-core/src/state/data_source.rs
@@ -15,7 +15,10 @@ use fuel_core_storage::{
     },
     Result as StorageResult,
 };
-use std::sync::Arc;
+use std::{
+    borrow::Cow,
+    sync::Arc,
+};
 
 #[allow(type_alias_bounds)]
 pub type DataSourceType<Description>
@@ -66,7 +69,7 @@ where
 
     fn get_batch<'a>(
         &'a self,
-        keys: BoxedIter<'a, Vec<u8>>,
+        keys: BoxedIter<'a, Cow<'a, [u8]>>,
         column: Self::Column,
     ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
         self.data.get_batch(keys, column)

--- a/crates/fuel-core/src/state/generic_database.rs
+++ b/crates/fuel-core/src/state/generic_database.rs
@@ -18,6 +18,7 @@ use fuel_core_storage::{
     PredicateStorageRequirements,
     Result as StorageResult,
     StorageAsRef,
+    StorageBatchInspect,
     StorageInspect,
     StorageRead,
     StorageSize,
@@ -61,6 +62,20 @@ where
 
     fn contains_key(&self, key: &M::Key) -> Result<bool, Self::Error> {
         self.storage.storage::<M>().contains_key(key)
+    }
+}
+
+impl<Storage, M> StorageBatchInspect<M> for GenericDatabase<Storage>
+where
+    M: Mappable,
+    StructuredStorage<Storage>: StorageBatchInspect<M>,
+{
+    fn get_batch<'a>(
+        &'a self,
+        keys: Box<dyn Iterator<Item = &'a <M as Mappable>::Key> + 'a>,
+    ) -> Box<dyn Iterator<Item = StorageResult<Option<<M as Mappable>::OwnedValue>>> + 'a>
+    {
+        self.storage.get_batch(keys)
     }
 }
 

--- a/crates/fuel-core/src/state/generic_database.rs
+++ b/crates/fuel-core/src/state/generic_database.rs
@@ -1,7 +1,7 @@
 use fuel_core_storage::{
     iter::{
-        BoxedIterSend,
         BoxedIter,
+        BoxedIterSend,
         IterDirection,
         IterableStore,
     },

--- a/crates/fuel-core/src/state/generic_database.rs
+++ b/crates/fuel-core/src/state/generic_database.rs
@@ -72,9 +72,8 @@ where
 {
     fn get_batch<'a>(
         &'a self,
-        keys: Box<dyn Iterator<Item = &'a <M as Mappable>::Key> + 'a>,
-    ) -> Box<dyn Iterator<Item = StorageResult<Option<<M as Mappable>::OwnedValue>>> + 'a>
-    {
+        keys: BoxedIter<'a, &'a M::Key>,
+    ) -> BoxedIter<'a, StorageResult<Option<<M as Mappable>::OwnedValue>>> {
         self.storage.get_batch(keys)
     }
 }

--- a/crates/fuel-core/src/state/generic_database.rs
+++ b/crates/fuel-core/src/state/generic_database.rs
@@ -136,7 +136,7 @@ where
 
     fn get_batch<'a>(
         &'a self,
-        keys: BoxedIter<'a, Vec<u8>>,
+        keys: BoxedIter<'a, Cow<'a, [u8]>>,
         column: Self::Column,
     ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
         KeyValueInspect::get_batch(&self.storage, keys, column)

--- a/crates/fuel-core/src/state/generic_database.rs
+++ b/crates/fuel-core/src/state/generic_database.rs
@@ -1,5 +1,6 @@
 use fuel_core_storage::{
     iter::{
+        BoxedIterSend,
         BoxedIter,
         IterDirection,
         IterableStore,
@@ -75,7 +76,7 @@ where
         keys: Iter,
     ) -> impl Iterator<Item = fuel_core_storage::Result<Option<M::OwnedValue>>> + 'a
     where
-        Iter: 'a + Iterator<Item = &'a M::Key> + Send,
+        Iter: 'a + IntoIterator<Item = &'a M::Key>,
         M::Key: 'a,
     {
         self.storage.get_batch(keys)
@@ -166,7 +167,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KVItem> {
+    ) -> BoxedIterSend<KVItem> {
         self.storage.iter_store(column, prefix, start, direction)
     }
 
@@ -176,7 +177,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<fuel_core_storage::kv_store::KeyItem> {
+    ) -> BoxedIterSend<fuel_core_storage::kv_store::KeyItem> {
         self.storage
             .iter_store_keys(column, prefix, start, direction)
     }

--- a/crates/fuel-core/src/state/generic_database.rs
+++ b/crates/fuel-core/src/state/generic_database.rs
@@ -134,6 +134,14 @@ where
         KeyValueInspect::get(&self.storage, key, column)
     }
 
+    fn get_batch<'a>(
+        &'a self,
+        keys: BoxedIter<'a, Vec<u8>>,
+        column: Self::Column,
+    ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
+        KeyValueInspect::get_batch(&self.storage, keys, column)
+    }
+
     fn read(
         &self,
         key: &[u8],

--- a/crates/fuel-core/src/state/generic_database.rs
+++ b/crates/fuel-core/src/state/generic_database.rs
@@ -70,10 +70,14 @@ where
     M: Mappable,
     StructuredStorage<Storage>: StorageBatchInspect<M>,
 {
-    fn get_batch<'a>(
+    fn get_batch<'a, Iter>(
         &'a self,
-        keys: BoxedIter<'a, &'a M::Key>,
-    ) -> BoxedIter<'a, StorageResult<Option<<M as Mappable>::OwnedValue>>> {
+        keys: Iter,
+    ) -> impl Iterator<Item = fuel_core_storage::Result<Option<M::OwnedValue>>> + 'a
+    where
+        Iter: 'a + Iterator<Item = &'a M::Key> + Send,
+        M::Key: 'a,
+    {
         self.storage.get_batch(keys)
     }
 }

--- a/crates/fuel-core/src/state/historical_rocksdb.rs
+++ b/crates/fuel-core/src/state/historical_rocksdb.rs
@@ -29,6 +29,7 @@ use crate::{
 use fuel_core_storage::{
     iter::{
         BoxedIter,
+        BoxedIterSend,
         IntoBoxedIter,
         IterDirection,
         IterableStore,
@@ -433,7 +434,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KVItem> {
+    ) -> BoxedIterSend<KVItem> {
         self.db
             .iter_store(Column::OriginalColumn(column), prefix, start, direction)
     }
@@ -444,7 +445,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<fuel_core_storage::kv_store::KeyItem> {
+    ) -> BoxedIterSend<fuel_core_storage::kv_store::KeyItem> {
         self.db
             .iter_store_keys(Column::OriginalColumn(column), prefix, start, direction)
     }

--- a/crates/fuel-core/src/state/historical_rocksdb.rs
+++ b/crates/fuel-core/src/state/historical_rocksdb.rs
@@ -115,9 +115,10 @@ where
         let mut reverse_changes = Changes::default();
 
         for (column, column_changes) in changes {
-            let results = self
+            let results: Vec<_> = self
                 .db
-                .multi_get(*column, column_changes.iter().map(|(k, _)| k))?;
+                .multi_get(*column, column_changes.iter().map(|(k, _)| k))
+                .try_collect()?;
 
             let entry = reverse_changes
                 .entry(*column)

--- a/crates/fuel-core/src/state/in_memory/memory_store.rs
+++ b/crates/fuel-core/src/state/in_memory/memory_store.rs
@@ -16,8 +16,8 @@ use fuel_core_storage::{
     iter::{
         iterator,
         keys_iterator,
-        BoxedIter,
-        IntoBoxedIter,
+        BoxedIterSend,
+        IntoBoxedIterSend,
         IterableStore,
     },
     kv_store::{
@@ -144,8 +144,8 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KVItem> {
-        self.iter_all(column, prefix, start, direction).into_boxed()
+    ) -> BoxedIterSend<KVItem> {
+        self.iter_all(column, prefix, start, direction).into_boxed_send()
     }
 
     fn iter_store_keys(
@@ -154,9 +154,9 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<fuel_core_storage::kv_store::KeyItem> {
+    ) -> BoxedIterSend<fuel_core_storage::kv_store::KeyItem> {
         self.iter_all_keys(column, prefix, start, direction)
-            .into_boxed()
+            .into_boxed_send()
     }
 }
 

--- a/crates/fuel-core/src/state/in_memory/memory_store.rs
+++ b/crates/fuel-core/src/state/in_memory/memory_store.rs
@@ -145,7 +145,8 @@ where
         start: Option<&[u8]>,
         direction: IterDirection,
     ) -> BoxedIterSend<KVItem> {
-        self.iter_all(column, prefix, start, direction).into_boxed_send()
+        self.iter_all(column, prefix, start, direction)
+            .into_boxed_send()
     }
 
     fn iter_store_keys(

--- a/crates/fuel-core/src/state/in_memory/memory_view.rs
+++ b/crates/fuel-core/src/state/in_memory/memory_view.rs
@@ -87,7 +87,8 @@ where
         start: Option<&[u8]>,
         direction: IterDirection,
     ) -> BoxedIterSend<KVItem> {
-        self.iter_all(column, prefix, start, direction).into_boxed_send()
+        self.iter_all(column, prefix, start, direction)
+            .into_boxed_send()
     }
 
     fn iter_store_keys(

--- a/crates/fuel-core/src/state/in_memory/memory_view.rs
+++ b/crates/fuel-core/src/state/in_memory/memory_view.rs
@@ -6,8 +6,8 @@ use fuel_core_storage::{
     iter::{
         iterator,
         keys_iterator,
-        BoxedIter,
-        IntoBoxedIter,
+        BoxedIterSend,
+        IntoBoxedIterSend,
         IterDirection,
         IterableStore,
     },
@@ -86,8 +86,8 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KVItem> {
-        self.iter_all(column, prefix, start, direction).into_boxed()
+    ) -> BoxedIterSend<KVItem> {
+        self.iter_all(column, prefix, start, direction).into_boxed_send()
     }
 
     fn iter_store_keys(
@@ -96,8 +96,8 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KeyItem> {
+    ) -> BoxedIterSend<KeyItem> {
         self.iter_all_keys(column, prefix, start, direction)
-            .into_boxed()
+            .into_boxed_send()
     }
 }

--- a/crates/fuel-core/src/state/iterable_key_value_view.rs
+++ b/crates/fuel-core/src/state/iterable_key_value_view.rs
@@ -63,6 +63,14 @@ where
         self.0.get(key, column)
     }
 
+    fn get_batch<'a>(
+        &'a self,
+        keys: BoxedIter<'a, Vec<u8>>,
+        column: Self::Column,
+    ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
+        self.0.get_batch(keys, column)
+    }
+
     fn read(
         &self,
         key: &[u8],

--- a/crates/fuel-core/src/state/iterable_key_value_view.rs
+++ b/crates/fuel-core/src/state/iterable_key_value_view.rs
@@ -1,6 +1,7 @@
 use fuel_core_storage::{
     iter::{
         BoxedIter,
+        BoxedIterSend,
         IterDirection,
         IterableStore,
     },
@@ -94,7 +95,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KVItem> {
+    ) -> BoxedIterSend<KVItem> {
         self.0.iter_store(column, prefix, start, direction)
     }
 
@@ -104,7 +105,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KeyItem> {
+    ) -> BoxedIterSend<KeyItem> {
         self.0.iter_store_keys(column, prefix, start, direction)
     }
 }

--- a/crates/fuel-core/src/state/iterable_key_value_view.rs
+++ b/crates/fuel-core/src/state/iterable_key_value_view.rs
@@ -13,7 +13,10 @@ use fuel_core_storage::{
     },
     Result as StorageResult,
 };
-use std::sync::Arc;
+use std::{
+    borrow::Cow,
+    sync::Arc,
+};
 
 #[derive(Clone)]
 pub struct IterableKeyValueViewWrapper<Column>(
@@ -65,7 +68,7 @@ where
 
     fn get_batch<'a>(
         &'a self,
-        keys: BoxedIter<'a, Vec<u8>>,
+        keys: BoxedIter<'a, Cow<'a, [u8]>>,
         column: Self::Column,
     ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
         self.0.get_batch(keys, column)

--- a/crates/fuel-core/src/state/key_value_view.rs
+++ b/crates/fuel-core/src/state/key_value_view.rs
@@ -1,4 +1,5 @@
 use fuel_core_storage::{
+    iter::BoxedIter,
     kv_store::{
         KeyValueInspect,
         StorageColumn,
@@ -48,6 +49,14 @@ where
 
     fn get(&self, key: &[u8], column: Self::Column) -> StorageResult<Option<Value>> {
         self.0.get(key, column)
+    }
+
+    fn get_batch<'a>(
+        &'a self,
+        keys: BoxedIter<'a, Vec<u8>>,
+        column: Self::Column,
+    ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
+        self.0.get_batch(keys, column)
     }
 
     fn read(

--- a/crates/fuel-core/src/state/key_value_view.rs
+++ b/crates/fuel-core/src/state/key_value_view.rs
@@ -7,7 +7,10 @@ use fuel_core_storage::{
     },
     Result as StorageResult,
 };
-use std::sync::Arc;
+use std::{
+    borrow::Cow,
+    sync::Arc,
+};
 
 #[derive(Clone)]
 pub struct KeyValueViewWrapper<Column>(
@@ -53,7 +56,7 @@ where
 
     fn get_batch<'a>(
         &'a self,
-        keys: BoxedIter<'a, Vec<u8>>,
+        keys: BoxedIter<'a, Cow<'a, [u8]>>,
         column: Self::Column,
     ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
         self.0.get_batch(keys, column)

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -731,16 +731,15 @@ where
 
     fn get_multi<'a>(
         &'a self,
-        keys: Box<dyn Iterator<Item = Vec<u8>> + 'a>,
+        keys: BoxedIter<'a, Vec<u8>>,
         column: Self::Column,
-    ) -> Box<dyn Iterator<Item = StorageResult<Option<Value>>> + 'a> {
+    ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
         // TODO: Metrics
 
         let column = self.cf(column);
         let keys = keys.map(|key| (&column, key));
 
-        let values = self
-            .db
+        self.db
             .multi_get_cf_opt(keys, &self.read_options)
             .into_iter()
             .map(|value_opt| {
@@ -749,9 +748,8 @@ where
                         StorageError::Other(DatabaseError::Other(e.into()).into())
                     })
                     .map(|value| value.map(Arc::new))
-            });
-
-        Box::new(values)
+            })
+            .into_boxed()
     }
 
     fn read(

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -728,11 +728,11 @@ where
         Ok(value.map(Arc::new))
     }
 
-    fn get_multi(
-        &self,
-        _keys: Box<dyn Iterator<Item = &[u8]>>,
+    fn get_multi<'a>(
+        &'a self,
+        _keys: Box<dyn Iterator<Item = Vec<u8>> + 'a>,
         _column: Self::Column,
-    ) -> Box<dyn Iterator<Item = StorageResult<Option<Value>>>> {
+    ) -> Box<dyn Iterator<Item = StorageResult<Option<Value>>> + 'a> {
         todo!(); // TODO
     }
 

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -640,6 +640,41 @@ where
             }
         }
     }
+
+    fn register_read<T>(
+        &self,
+        result: StorageResult<Option<T>>,
+        column_id: u32,
+    ) -> StorageResult<Option<T>>
+    where
+        T: NumberOfBytes,
+    {
+        self.metrics.read_meter.inc();
+        let column_metrics = self.metrics.columns_read_statistic.get(&column_id);
+        column_metrics.map(|metric| metric.inc());
+
+        if let Ok(Some(value)) = &result {
+            self.metrics.bytes_read.inc_by(value.number_of_bytes());
+        };
+
+        result
+    }
+}
+
+trait NumberOfBytes {
+    fn number_of_bytes(&self) -> u64;
+}
+
+impl NumberOfBytes for Vec<u8> {
+    fn number_of_bytes(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl NumberOfBytes for usize {
+    fn number_of_bytes(&self) -> u64 {
+        *self as u64
+    }
 }
 
 pub(crate) struct KeyOnly;
@@ -713,20 +748,13 @@ where
     }
 
     fn get(&self, key: &[u8], column: Self::Column) -> StorageResult<Option<Value>> {
-        self.metrics.read_meter.inc();
-        let column_metrics = self.metrics.columns_read_statistic.get(&column.id());
-        column_metrics.map(|metric| metric.inc());
-
-        let value = self
+        let result = self
             .db
             .get_cf_opt(&self.cf(column), key, &self.read_options)
-            .map_err(|e| DatabaseError::Other(e.into()))?;
+            .map_err(|e| StorageError::Other(DatabaseError::Other(e.into()).into()));
 
-        if let Some(value) = &value {
-            self.metrics.bytes_read.inc_by(value.len() as u64);
-        }
-
-        Ok(value.map(Arc::new))
+        self.register_read(result, column.id())
+            .map(|opt| opt.map(Arc::new))
     }
 
     fn get_batch<'a>(
@@ -734,20 +762,20 @@ where
         keys: BoxedIter<'a, Vec<u8>>,
         column: Self::Column,
     ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
-        // TODO: Metrics
-
-        let column = self.cf(column);
-        let keys = keys.map(|key| (&column, key));
+        let column_family = self.cf(column);
+        let keys = keys.map(|key| (&column_family, key));
 
         self.db
             .multi_get_cf_opt(keys, &self.read_options)
             .into_iter()
-            .map(|value_opt| {
-                value_opt
-                    .map_err(|e| {
+            .map(move |result| {
+                self.register_read(
+                    result.map_err(|e| {
                         StorageError::Other(DatabaseError::Other(e.into()).into())
-                    })
-                    .map(|value| value.map(Arc::new))
+                    }),
+                    column.id(),
+                )
+                .map(|opt| opt.map(Arc::new))
             })
             .into_boxed()
     }
@@ -758,11 +786,7 @@ where
         column: Self::Column,
         mut buf: &mut [u8],
     ) -> StorageResult<Option<usize>> {
-        self.metrics.read_meter.inc();
-        let column_metrics = self.metrics.columns_read_statistic.get(&column.id());
-        column_metrics.map(|metric| metric.inc());
-
-        let r = self
+        let result = self
             .db
             .get_pinned_cf_opt(&self.cf(column), key, &self.read_options)
             .map_err(|e| DatabaseError::Other(e.into()))?
@@ -772,13 +796,9 @@ where
                     .map_err(|e| DatabaseError::Other(anyhow::anyhow!(e)))?;
                 StorageResult::Ok(read)
             })
-            .transpose()?;
+            .transpose();
 
-        if let Some(r) = &r {
-            self.metrics.bytes_read.inc_by(*r as u64);
-        }
-
-        Ok(r)
+        self.register_read(result, column.id())
     }
 }
 

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -48,6 +48,7 @@ use rocksdb::{
     WriteBatch,
 };
 use std::{
+    borrow::Cow,
     cmp,
     collections::BTreeMap,
     fmt,
@@ -728,7 +729,7 @@ where
 
     fn get_batch<'a>(
         &'a self,
-        keys: BoxedIter<'a, Vec<u8>>,
+        keys: BoxedIter<'a, Cow<'a, [u8]>>,
         column: Self::Column,
     ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
         self.multi_get(column.id(), keys)

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -728,6 +728,14 @@ where
         Ok(value.map(Arc::new))
     }
 
+    fn get_multi(
+        &self,
+        _keys: Box<dyn Iterator<Item = &[u8]>>,
+        _column: Self::Column,
+    ) -> Box<dyn Iterator<Item = StorageResult<Option<Value>>>> {
+        todo!(); // TODO
+    }
+
     fn read(
         &self,
         key: &[u8],

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -729,7 +729,7 @@ where
         Ok(value.map(Arc::new))
     }
 
-    fn get_multi<'a>(
+    fn get_batch<'a>(
         &'a self,
         keys: BoxedIter<'a, Vec<u8>>,
         column: Self::Column,

--- a/crates/storage/src/blueprint.rs
+++ b/crates/storage/src/blueprint.rs
@@ -139,7 +139,6 @@ where
     fn delete(storage: &mut S, key: &M::Key, column: S::Column) -> StorageResult<()>;
 }
 
-// TODO: Rename
 /// It is an extension of the blueprint that allows supporting batch operations.
 /// Usually, they are more performant than initializing/inserting/removing values one by one.
 pub trait SupportsBatching<M, S>: BlueprintMutate<M, S>

--- a/crates/storage/src/blueprint.rs
+++ b/crates/storage/src/blueprint.rs
@@ -82,7 +82,7 @@ where
     /// Returns multiple values from the storage.
     fn get_multi<'a>(
         storage: &'a S,
-        keys: Box<dyn Iterator<Item = &'a M::Key>>,
+        keys: Box<dyn Iterator<Item = &'a M::Key> + 'a>,
         column: S::Column,
     ) -> Box<dyn Iterator<Item = StorageResult<Option<M::OwnedValue>>> + 'a> {
         let keys = Box::new(

--- a/crates/storage/src/blueprint.rs
+++ b/crates/storage/src/blueprint.rs
@@ -85,9 +85,12 @@ where
         storage: &'a S,
         keys: BoxedIter<'a, &'a M::Key>,
         column: S::Column,
-    ) -> BoxedIter<'a, StorageResult<Option<M::OwnedValue>>> {
+    ) -> BoxedIter<'a, StorageResult<Option<M::OwnedValue>>>
+    where
+        Self::KeyCodec: 'a,
+    {
         let keys = keys
-            .map(|key| Self::KeyCodec::encode(key).as_bytes().into_owned())
+            .map(|key| Self::KeyCodec::encode(key).into_bytes())
             .into_boxed();
 
         storage

--- a/crates/storage/src/blueprint.rs
+++ b/crates/storage/src/blueprint.rs
@@ -86,7 +86,6 @@ where
     where
         Iter: 'a + Iterator<Item = &'a M::Key> + Send,
         M::Key: 'a,
-        Self::KeyCodec: 'a,
     {
         let keys = keys
             .map(|key| Self::KeyCodec::encode(key).into_bytes())

--- a/crates/storage/src/blueprint.rs
+++ b/crates/storage/src/blueprint.rs
@@ -81,7 +81,7 @@ where
     }
 
     /// Returns multiple values from the storage.
-    fn get_multi<'a>(
+    fn get_batch<'a>(
         storage: &'a S,
         keys: BoxedIter<'a, &'a M::Key>,
         column: S::Column,
@@ -91,7 +91,7 @@ where
             .into_boxed();
 
         storage
-            .get_multi(keys, column)
+            .get_batch(keys, column)
             .map(|result| {
                 result.and_then(|opt| {
                     opt.map(|value| {

--- a/crates/storage/src/blueprint.rs
+++ b/crates/storage/src/blueprint.rs
@@ -87,7 +87,7 @@ where
         column: S::Column,
     ) -> BoxedIter<'a, StorageResult<Option<M::OwnedValue>>> {
         let keys = keys
-            .map(|key| Self::KeyCodec::encode(&key).as_bytes().into_owned())
+            .map(|key| Self::KeyCodec::encode(key).as_bytes().into_owned())
             .into_boxed();
 
         storage

--- a/crates/storage/src/blueprint.rs
+++ b/crates/storage/src/blueprint.rs
@@ -84,10 +84,11 @@ where
         column: S::Column,
     ) -> impl Iterator<Item = crate::Result<Option<M::OwnedValue>>> + 'a
     where
-        Iter: 'a + Iterator<Item = &'a M::Key> + Send,
+        Iter: 'a + IntoIterator<Item = &'a M::Key>,
         M::Key: 'a,
     {
         let keys = keys
+            .into_iter()
             .map(|key| Self::KeyCodec::encode(key).into_bytes())
             .into_boxed();
 

--- a/crates/storage/src/blueprint/plain.rs
+++ b/crates/storage/src/blueprint/plain.rs
@@ -134,7 +134,7 @@ where
             set.map(|(key, value)| {
                 let key_encoder =
                     <M::Blueprint as BlueprintInspect<M, S>>::KeyCodec::encode(key);
-                let key_bytes = key_encoder.as_bytes().to_vec();
+                let key_bytes = key_encoder.into_bytes();
                 let value =
                     <M::Blueprint as BlueprintInspect<M, S>>::ValueCodec::encode_as_value(
                         value,
@@ -158,7 +158,7 @@ where
             set.map(|key| {
                 let key_encoder =
                     <M::Blueprint as BlueprintInspect<M, S>>::KeyCodec::encode(key);
-                let key_bytes = key_encoder.as_bytes().to_vec();
+                let key_bytes = key_encoder.into_bytes();
                 (key_bytes, WriteOperation::Remove)
             }),
         )

--- a/crates/storage/src/blueprint/sparse.rs
+++ b/crates/storage/src/blueprint/sparse.rs
@@ -326,7 +326,7 @@ where
 
         let encoded_set = set
             .map(|(key, value)| {
-                let key = KeyCodec::encode(key).as_bytes().into_owned();
+                let key = KeyCodec::encode(key).into_bytes();
                 let value = ValueCodec::encode(value).as_bytes().into_owned();
                 (key, value)
             })
@@ -346,9 +346,7 @@ where
         )?;
 
         let nodes = nodes.iter().map(|(key, value)| {
-            let key = NodeKeyCodec::<S, Nodes>::encode(key)
-                .as_bytes()
-                .into_owned();
+            let key = NodeKeyCodec::<S, Nodes>::encode(key).into_bytes();
             let value = NodeValueCodec::<S, Nodes>::encode_as_value(value);
             (key, WriteOperation::Insert(value))
         });
@@ -392,7 +390,7 @@ where
 
         let encoded_set = set
             .map(|(key, value)| {
-                let key = KeyCodec::encode(key).as_bytes().into_owned();
+                let key = KeyCodec::encode(key).into_bytes();
                 let value = ValueCodec::encode(value).as_bytes().into_owned();
                 (key, value)
             })
@@ -449,7 +447,7 @@ where
             .map_err(|err| StorageError::Other(anyhow::anyhow!("{err:?}")))?;
 
         let encoded_set = set
-            .map(|key| KeyCodec::encode(key).as_bytes().into_owned())
+            .map(|key| KeyCodec::encode(key).into_bytes())
             .collect_vec();
 
         for key_bytes in encoded_set.iter() {

--- a/crates/storage/src/codec.rs
+++ b/crates/storage/src/codec.rs
@@ -29,7 +29,7 @@ pub trait Encoder<'a> {
 /// flexibility and more performant encoding, allowing the use of slices and arrays
 /// instead of vectors in some cases. Since the [`Encoder`] returns `Cow<[u8]>`,
 /// it is always possible to take ownership of the serialized value.
-pub trait Encode<T: ?Sized> {
+pub trait Encode<T: ?Sized>: 'static {
     /// The encoder type that stores serialized object.
     type Encoder<'a>: Encoder<'a>
     where

--- a/crates/storage/src/codec.rs
+++ b/crates/storage/src/codec.rs
@@ -29,7 +29,7 @@ pub trait Encoder<'a> {
 /// flexibility and more performant encoding, allowing the use of slices and arrays
 /// instead of vectors in some cases. Since the [`Encoder`] returns `Cow<[u8]>`,
 /// it is always possible to take ownership of the serialized value.
-pub trait Encode<T: ?Sized>: 'static {
+pub trait Encode<T: ?Sized> {
     /// The encoder type that stores serialized object.
     type Encoder<'a>: Encoder<'a>
     where

--- a/crates/storage/src/codec.rs
+++ b/crates/storage/src/codec.rs
@@ -36,7 +36,7 @@ pub trait Encode<T: ?Sized> {
         T: 'a;
 
     /// Encodes the object to the bytes and passes it to the `Encoder`.
-    fn encode<'a>(t: &'a T) -> Self::Encoder<'a>;
+    fn encode(t: &T) -> Self::Encoder<'_>;
 
     /// Returns the serialized object as an [`Value`].
     fn encode_as_value(t: &T) -> Value {

--- a/crates/storage/src/iter/changes_iterator.rs
+++ b/crates/storage/src/iter/changes_iterator.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     iter::{
-        BoxedIter,
-        IntoBoxedIter,
+        BoxedIterSend,
+        IntoBoxedIterSend,
         IterDirection,
         IterableStore,
     },
@@ -61,7 +61,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KVItem> {
+    ) -> BoxedIterSend<KVItem> {
         if let Some(tree) = self.changes.get(&column.id()) {
             crate::iter::iterator(tree, prefix, start, direction)
                 .filter_map(|(key, value)| match value {
@@ -71,9 +71,9 @@ where
                     WriteOperation::Remove => None,
                 })
                 .map(Ok)
-                .into_boxed()
+                .into_boxed_send()
         } else {
-            core::iter::empty().into_boxed()
+            core::iter::empty().into_boxed_send()
         }
     }
 
@@ -83,7 +83,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<crate::kv_store::KeyItem> {
+    ) -> BoxedIterSend<crate::kv_store::KeyItem> {
         // We cannot define iter_store_keys appropriately for the `ChangesIterator`,
         // because we have to filter out the keys that were removed, which are
         // marked as `WriteOperation::Remove` in the value
@@ -95,9 +95,9 @@ where
                     WriteOperation::Remove => None,
                 })
                 .map(Ok)
-                .into_boxed()
+                .into_boxed_send()
         } else {
-            core::iter::empty().into_boxed()
+            core::iter::empty().into_boxed_send()
         }
     }
 }

--- a/crates/storage/src/kv_store.rs
+++ b/crates/storage/src/kv_store.rs
@@ -194,7 +194,11 @@ pub enum WriteOperation {
 #[impl_tools::autoimpl(for<T: trait> &mut T, Box<T>)]
 pub trait BatchOperations: KeyValueMutate {
     /// Writes the batch of the entries into the storage.
-    fn batch_write<I>(&mut self, column: Self::Column, entries: I) -> StorageResult<()>
+    fn batch_write<'a, I>(
+        &mut self,
+        column: Self::Column,
+        entries: I,
+    ) -> StorageResult<()>
     where
-        I: Iterator<Item = (Vec<u8>, WriteOperation)>;
+        I: Iterator<Item = (Cow<'a, [u8]>, WriteOperation)> + 'a;
 }

--- a/crates/storage/src/kv_store.rs
+++ b/crates/storage/src/kv_store.rs
@@ -1,7 +1,10 @@
 //! The module provides plain abstract definition of the key-value store.
 
 use crate::{
-    iter::BoxedIter,
+    iter::{
+        BoxedIter,
+        IntoBoxedIter,
+    },
     Error as StorageError,
     Result as StorageResult,
 };
@@ -14,7 +17,6 @@ use alloc::{
     vec::Vec,
 };
 
-use crate::iter::IntoBoxedIter;
 #[cfg(feature = "std")]
 use core::ops::Deref;
 
@@ -44,7 +46,7 @@ pub trait StorageColumn: Copy + core::fmt::Debug + Send + Sync + 'static {
 
 /// The definition of the key-value inspection store.
 #[impl_tools::autoimpl(for<T: trait> &T, &mut T, Box<T>)]
-pub trait KeyValueInspect: Send + Sync {
+pub trait KeyValueInspect {
     /// The type of the column.
     type Column: StorageColumn;
 

--- a/crates/storage/src/kv_store.rs
+++ b/crates/storage/src/kv_store.rs
@@ -11,6 +11,7 @@ use crate::{
 
 #[cfg(feature = "alloc")]
 use alloc::{
+    borrow::Cow,
     boxed::Box,
     string::String,
     vec::Vec,
@@ -69,7 +70,7 @@ pub trait KeyValueInspect: Send + Sync {
     /// Returns multiple values from the storage.
     fn get_batch<'a>(
         &'a self,
-        keys: BoxedIter<'a, Vec<u8>>,
+        keys: BoxedIter<'a, Cow<'a, [u8]>>,
         column: Self::Column,
     ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
         keys.map(move |key| self.get(&key, column)).into_boxed()

--- a/crates/storage/src/kv_store.rs
+++ b/crates/storage/src/kv_store.rs
@@ -62,6 +62,15 @@ pub trait KeyValueInspect {
     /// Returns the value from the storage.
     fn get(&self, key: &[u8], column: Self::Column) -> StorageResult<Option<Value>>;
 
+    /// Returns multiple values from the storage.
+    fn get_multi<'a>(
+        &'a self,
+        keys: Box<dyn Iterator<Item = &'a [u8]>>,
+        column: Self::Column,
+    ) -> Box<dyn Iterator<Item = StorageResult<Option<Value>>> + 'a> {
+        Box::new(keys.map(move |key| self.get(key, column)))
+    }
+
     /// Reads the value from the storage into the `buf` and returns the number of read bytes.
     fn read(
         &self,

--- a/crates/storage/src/kv_store.rs
+++ b/crates/storage/src/kv_store.rs
@@ -67,7 +67,7 @@ pub trait KeyValueInspect: Send + Sync {
     fn get(&self, key: &[u8], column: Self::Column) -> StorageResult<Option<Value>>;
 
     /// Returns multiple values from the storage.
-    fn get_multi<'a>(
+    fn get_batch<'a>(
         &'a self,
         keys: BoxedIter<'a, Vec<u8>>,
         column: Self::Column,

--- a/crates/storage/src/kv_store.rs
+++ b/crates/storage/src/kv_store.rs
@@ -65,10 +65,10 @@ pub trait KeyValueInspect {
     /// Returns multiple values from the storage.
     fn get_multi<'a>(
         &'a self,
-        keys: Box<dyn Iterator<Item = &'a [u8]>>,
+        keys: Box<dyn Iterator<Item = Vec<u8>> + 'a>,
         column: Self::Column,
     ) -> Box<dyn Iterator<Item = StorageResult<Option<Value>>> + 'a> {
-        Box::new(keys.map(move |key| self.get(key, column)))
+        Box::new(keys.map(move |key| self.get(&key, column)))
     }
 
     /// Reads the value from the storage into the `buf` and returns the number of read bytes.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -186,7 +186,7 @@ pub trait StorageBatchInspect<Type: Mappable> {
         keys: Iter,
     ) -> impl Iterator<Item = Result<Option<Type::OwnedValue>>> + 'a
     where
-        Iter: 'a + Iterator<Item = &'a Type::Key> + Send,
+        Iter: 'a + IntoIterator<Item = &'a Type::Key>,
         Type::Key: 'a;
 }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -177,10 +177,11 @@ pub trait StorageBatchMutate<Type: Mappable>: StorageMutate<Type> {
         Type::Key: 'a;
 }
 
-// TODO: Document
-/// TODO
+/// Allows getting batches of values from the storage,
+/// which can be faster in certain implementatoins than
+/// getting values one by one.
 pub trait StorageBatchInspect<Type: Mappable> {
-    /// TODO
+    /// Get a batch of values associated with the provided keys.
     fn get_batch<'a>(
         &'a self,
         keys: BoxedIter<'a, &'a Type::Key>,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -17,7 +17,6 @@ extern crate alloc;
 use anyhow::anyhow;
 use core::array::TryFromSliceError;
 use fuel_core_types::services::executor::Error as ExecutorError;
-use iter::BoxedIter;
 
 #[cfg(feature = "alloc")]
 use alloc::{
@@ -182,10 +181,13 @@ pub trait StorageBatchMutate<Type: Mappable>: StorageMutate<Type> {
 /// getting values one by one.
 pub trait StorageBatchInspect<Type: Mappable> {
     /// Get a batch of values associated with the provided keys.
-    fn get_batch<'a>(
+    fn get_batch<'a, Iter>(
         &'a self,
-        keys: BoxedIter<'a, &'a Type::Key>,
-    ) -> BoxedIter<'a, Result<Option<Type::OwnedValue>>>;
+        keys: Iter,
+    ) -> impl Iterator<Item = Result<Option<Type::OwnedValue>>> + 'a
+    where
+        Iter: 'a + Iterator<Item = &'a Type::Key> + Send,
+        Type::Key: 'a;
 }
 
 /// Creates `StorageError::NotFound` error with file and line information inside.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -17,6 +17,7 @@ extern crate alloc;
 use anyhow::anyhow;
 use core::array::TryFromSliceError;
 use fuel_core_types::services::executor::Error as ExecutorError;
+use iter::BoxedIter;
 
 #[cfg(feature = "alloc")]
 use alloc::{
@@ -182,8 +183,8 @@ pub trait StorageBatchInspect<Type: Mappable> {
     /// TODO
     fn get_batch<'a>(
         &'a self,
-        keys: Box<dyn Iterator<Item = &'a Type::Key> + 'a>,
-    ) -> Box<dyn Iterator<Item = Result<Option<Type::OwnedValue>>> + 'a>;
+        keys: BoxedIter<'a, &'a Type::Key>,
+    ) -> BoxedIter<'a, Result<Option<Type::OwnedValue>>>;
 }
 
 /// Creates `StorageError::NotFound` error with file and line information inside.

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -176,6 +176,16 @@ pub trait StorageBatchMutate<Type: Mappable>: StorageMutate<Type> {
         Type::Key: 'a;
 }
 
+// TODO: Document
+/// TODO
+pub trait StorageBatchInspect<Type: Mappable> {
+    /// TODO
+    fn get_batch<'a>(
+        &'a self,
+        keys: Box<dyn Iterator<Item = &'a Type::Key> + 'a>,
+    ) -> Box<dyn Iterator<Item = Result<Option<Type::OwnedValue>>> + 'a>;
+}
+
 /// Creates `StorageError::NotFound` error with file and line information inside.
 ///
 /// # Examples

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -178,7 +178,7 @@ pub trait StorageBatchMutate<Type: Mappable>: StorageMutate<Type> {
 }
 
 /// Allows getting batches of values from the storage,
-/// which can be faster in certain implementatoins than
+/// which can be faster in certain implementations than
 /// getting values one by one.
 pub trait StorageBatchInspect<Type: Mappable> {
     /// Get a batch of values associated with the provided keys.

--- a/crates/storage/src/structured_storage.rs
+++ b/crates/storage/src/structured_storage.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     iter::{
         BoxedIter,
+        BoxedIterSend,
         IterDirection,
         IterableStore,
     },
@@ -240,7 +241,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KVItem> {
+    ) -> BoxedIterSend<KVItem> {
         self.inner.iter_store(column, prefix, start, direction)
     }
 
@@ -250,7 +251,7 @@ where
         prefix: Option<&[u8]>,
         start: Option<&[u8]>,
         direction: IterDirection,
-    ) -> BoxedIter<KeyItem> {
+    ) -> BoxedIterSend<KeyItem> {
         self.inner.iter_store_keys(column, prefix, start, direction)
     }
 }
@@ -294,7 +295,7 @@ where
         keys: Iter,
     ) -> impl Iterator<Item = crate::Result<Option<M::OwnedValue>>> + 'a
     where
-        Iter: 'a + Iterator<Item = &'a M::Key> + Send,
+        Iter: 'a + IntoIterator<Item = &'a M::Key>,
         M::Key: 'a,
     {
         M::Blueprint::get_batch(self, keys, M::column())

--- a/crates/storage/src/structured_storage.rs
+++ b/crates/storage/src/structured_storage.rs
@@ -218,9 +218,13 @@ impl<S> BatchOperations for StructuredStorage<S>
 where
     S: BatchOperations,
 {
-    fn batch_write<I>(&mut self, column: Self::Column, entries: I) -> StorageResult<()>
+    fn batch_write<'a, I>(
+        &mut self,
+        column: Self::Column,
+        entries: I,
+    ) -> StorageResult<()>
     where
-        I: Iterator<Item = (Vec<u8>, WriteOperation)>,
+        I: Iterator<Item = (Cow<'a, [u8]>, WriteOperation)> + 'a,
     {
         self.inner.batch_write(column, entries)
     }

--- a/crates/storage/src/structured_storage.rs
+++ b/crates/storage/src/structured_storage.rs
@@ -148,7 +148,7 @@ where
 
     fn get_batch<'a>(
         &'a self,
-        keys: BoxedIter<'a, Vec<u8>>,
+        keys: BoxedIter<'a, Cow<'a, [u8]>>,
         column: Self::Column,
     ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
         self.inner.get_batch(keys, column)
@@ -283,6 +283,7 @@ where
     S: KeyValueInspect<Column = Column>,
     M: TableWithBlueprint<Column = Column>,
     M::Blueprint: BlueprintInspect<M, StructuredStorage<S>>,
+    <M::Blueprint as BlueprintInspect<M, StructuredStorage<S>>>::KeyCodec: 'static,
 {
     fn get_batch<'a>(
         &'a self,

--- a/crates/storage/src/structured_storage.rs
+++ b/crates/storage/src/structured_storage.rs
@@ -146,6 +146,14 @@ where
         self.inner.get(key, column)
     }
 
+    fn get_batch<'a>(
+        &'a self,
+        keys: BoxedIter<'a, Vec<u8>>,
+        column: Self::Column,
+    ) -> BoxedIter<'a, StorageResult<Option<Value>>> {
+        self.inner.get_batch(keys, column)
+    }
+
     fn read(
         &self,
         key: &[u8],

--- a/crates/storage/src/structured_storage.rs
+++ b/crates/storage/src/structured_storage.rs
@@ -59,9 +59,6 @@ use alloc::{
     fmt::Debug,
 };
 
-// TODO: Format
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
@@ -281,8 +278,8 @@ where
 {
     fn get_batch<'a>(
         &'a self,
-        keys: Box<dyn Iterator<Item = &'a M::Key> + 'a>,
-    ) -> Box<dyn Iterator<Item = StorageResult<Option<M::OwnedValue>>> + 'a> {
+        keys: BoxedIter<'a, &'a M::Key>,
+    ) -> BoxedIter<'a, StorageResult<Option<M::OwnedValue>>> {
         M::Blueprint::get_multi(self, keys, M::column())
     }
 }

--- a/crates/storage/src/structured_storage.rs
+++ b/crates/storage/src/structured_storage.rs
@@ -285,10 +285,14 @@ where
     M::Blueprint: BlueprintInspect<M, StructuredStorage<S>>,
     <M::Blueprint as BlueprintInspect<M, StructuredStorage<S>>>::KeyCodec: 'static,
 {
-    fn get_batch<'a>(
+    fn get_batch<'a, Iter>(
         &'a self,
-        keys: BoxedIter<'a, &'a M::Key>,
-    ) -> BoxedIter<'a, StorageResult<Option<M::OwnedValue>>> {
+        keys: Iter,
+    ) -> impl Iterator<Item = crate::Result<Option<M::OwnedValue>>> + 'a
+    where
+        Iter: 'a + Iterator<Item = &'a M::Key> + Send,
+        M::Key: 'a,
+    {
         M::Blueprint::get_batch(self, keys, M::column())
     }
 }

--- a/crates/storage/src/structured_storage.rs
+++ b/crates/storage/src/structured_storage.rs
@@ -280,7 +280,7 @@ where
         &'a self,
         keys: BoxedIter<'a, &'a M::Key>,
     ) -> BoxedIter<'a, StorageResult<Option<M::OwnedValue>>> {
-        M::Blueprint::get_multi(self, keys, M::column())
+        M::Blueprint::get_batch(self, keys, M::column())
     }
 }
 

--- a/crates/storage/src/transactional.rs
+++ b/crates/storage/src/transactional.rs
@@ -32,6 +32,7 @@ use alloc::{
 #[cfg(feature = "test-helpers")]
 use crate::{
     iter::{
+        BoxedIterSend,
         IterDirection,
         IterableStore,
     },
@@ -550,7 +551,7 @@ where
         _: Option<&[u8]>,
         _: Option<&[u8]>,
         _: IterDirection,
-    ) -> BoxedIter<KVItem> {
+    ) -> BoxedIterSend<KVItem> {
         unimplemented!()
     }
 
@@ -560,7 +561,7 @@ where
         _: Option<&[u8]>,
         _: Option<&[u8]>,
         _: IterDirection,
-    ) -> BoxedIter<KeyItem> {
+    ) -> BoxedIterSend<KeyItem> {
         unimplemented!()
     }
 }

--- a/crates/storage/src/transactional.rs
+++ b/crates/storage/src/transactional.rs
@@ -519,13 +519,13 @@ where
     Column: StorageColumn,
     S: KeyValueInspect<Column = Column>,
 {
-    fn batch_write<I>(&mut self, column: Column, entries: I) -> StorageResult<()>
+    fn batch_write<'a, I>(&mut self, column: Column, entries: I) -> StorageResult<()>
     where
-        I: Iterator<Item = (Vec<u8>, WriteOperation)>,
+        I: Iterator<Item = (Cow<'a, [u8]>, WriteOperation)> + 'a,
     {
         let btree = self.changes.entry(column.id()).or_default();
         entries.for_each(|(key, operation)| {
-            btree.insert(key.into(), operation);
+            btree.insert(key.to_vec().into(), operation);
         });
         Ok(())
     }


### PR DESCRIPTION
### Linked Issues
Closes #2344 

### Description
This PR adds support for getting batches of values from the storage through a new `StorageBatchInspect` trait in `fuel-core-storage`.

This trait is implemented for `StructuredStorage` and `GenericDatabase` through a new `get_batch` method added to the `KeyValueInspect` and `BluePrintInspect` traits. The `get_batch` method is implemented with the `multi-get` operation for the RocksDB based storage implementations, and uses a default blanket implementation for in-memory implementations.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog

### Before requesting review
- [x] I have reviewed the code myself
