### PR TITLE
Update tai64 to fix the wrong time offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,7 +3790,7 @@ version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "derive_more",
+ "derive_more 0.99.18",
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
@@ -8757,9 +8757,9 @@ dependencies = [
 
 [[package]]
 name = "tai64"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7401421025f4132e6c1f7af5e7f8287383969f36e6628016cd509b8d3da9dc"
+checksum = "014639506e4f425c78e823eabf56e71c093f940ae55b43e58f682e7bc2f5887a"
 dependencies = [
  "serde",
 ]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -27,7 +27,7 @@ itertools = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
-tai64 = { version = "4.0", features = ["serde"] }
+tai64 = { version = "4.1", features = ["serde"] }
 thiserror = "1.0"
 tracing = "0.1"
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -27,7 +27,7 @@ fuel-vm-private = { workspace = true, default-features = false, features = [
 rand = { workspace = true, optional = true }
 secrecy = "0.8"
 serde = { workspace = true, features = ["derive"], optional = true }
-tai64 = { version = "4.0", features = ["serde"] }
+tai64 = { version = "4.1", features = ["serde"] }
 zeroize = "1.5"
 
 [features]


### PR DESCRIPTION
## Linked Issues/PRs
https://github.com/FuelLabs/fuel-core/issues/2338
https://github.com/RustCrypto/formats/pull/1583
https://github.com/RustCrypto/formats/pull/1590

## Description
I have fixed the wrong offset and added an automation for future update in crate `tai64`(https://github.com/RustCrypto/formats/pull/1583) and they merged it and made a new release (https://github.com/RustCrypto/formats/pull/1590). This PR updates to the new version.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here