### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 * @xgreenx @Dentosal @MitchTurner
 
 # Code owners for the gas price algorithm
-crates/fuel-gas-price-algorithm @MitchTurner @rafal-ch
+crates/fuel-gas-price-algorithm @xgreenx @Dentosal @MitchTurner @rafal-ch
 
 # Code owners for the transaction pool
-crates/services/txpool_v2 @AurelienFT
+crates/services/txpool_v2 @xgreenx @Dentosal @MitchTurner @AurelienFT


### PR DESCRIPTION
## Problem

In the last PR we saw that the global code owners permissions was not working when a PR have modifications on a folder with specific codeowners.

## Diagnostic and solution

The problem is that the `CODEOWNERS` file doesn't have any inheritance and take the latest rule in the file as the code owner. Sources : https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file / https://stackoverflow.com/questions/73398405/does-codeowners-inherit-owners

So if a modification was done in TxPool then the TxPool (that is the last one) will override all of the precedent one. The only solution we have to have the behavior we want is to re-add the global code owners on the specific rules too.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
