### PR TITLE
Make genesis block timestamp hardcoded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fix
+
+- [2476](https://github.com/FuelLabs/fuel-core/pull/2476): Hardcode the timestamp of the genesis block.
+
 ## [Version 0.40.1]
 
 - [2450](https://github.com/FuelLabs/fuel-core/pull/2450): Added support for posting blocks to the shared sequencer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9437,9 +9437,9 @@ dependencies = [
 
 [[package]]
 name = "tai64"
-version = "4.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014639506e4f425c78e823eabf56e71c093f940ae55b43e58f682e7bc2f5887a"
+checksum = "ed7401421025f4132e6c1f7af5e7f8287383969f36e6628016cd509b8d3da9dc"
 dependencies = [
  "serde",
 ]

--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -33,8 +33,8 @@ fuel-core-shared-sequencer = { workspace = true, optional = true }
 fuel-core-types = { workspace = true, features = ["std"] }
 hex = { workspace = true }
 humantime = "2.1"
-pyroscope = "0.5"
-pyroscope_pprofrs = "0.2.7"
+pyroscope = "=0.5.7"
+pyroscope_pprofrs = "=0.2.7"
 serde_json = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -34,7 +34,7 @@ fuel-core-types = { workspace = true, features = ["std"] }
 hex = { workspace = true }
 humantime = "2.1"
 pyroscope = "0.5"
-pyroscope_pprofrs = "0.2"
+pyroscope_pprofrs = "0.2.7"
 serde_json = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -30,7 +30,8 @@ reqwest = { version = "0.11.16", default-features = false, features = [
 ] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
-tai64 = { version = "4.0", features = ["serde"] }
+# We force the version because 4.1.0 update leap seconds that breaks our timestamps
+tai64 = { version = "=4.0.0", features = ["serde"] }
 thiserror = "1.0"
 tracing = "0.1"
 

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -285,7 +285,8 @@ pub fn create_genesis_block(config: &Config) -> Block {
             consensus: ConsensusHeader::<Empty> {
                 prev_root,
                 height,
-                time: fuel_core_types::tai64::Tai64::UNIX_EPOCH,
+                // The time is set to UNIX_EPOCH + 10 leap seconds to make backward compatibility
+                time: fuel_core_types::tai64::Tai64(4611686018427387914),
                 generated: Empty,
             },
         },

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -29,7 +29,8 @@ k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 rand = { workspace = true, optional = true }
 secrecy = "0.8"
 serde = { workspace = true, features = ["derive"], optional = true }
-tai64 = { version = "4.0", features = ["serde"] }
+# We force the version because 4.1.0 update leap seconds that breaks our timestamps
+tai64 = { version = "=4.0.0", features = ["serde"] }
 zeroize = "1.5"
 
 [dev-dependencies]

--- a/version-compatibility/forkless-upgrade/src/genesis.rs
+++ b/version-compatibility/forkless-upgrade/src/genesis.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test__genesis_block__hash() {
+    // Given
     let latest_node = LatestFuelCoreDriver::spawn(&[
         "--debug",
         "--poa-instant",
@@ -16,7 +17,7 @@ async fn test__genesis_block__hash() {
         IGNITION_TESTNET_SNAPSHOT,
         "--enable-relayer",
         "--relayer",
-        "https://eth-mainnet.public.blastapi.io",
+        "https://google.com",
         "--relayer-da-deploy-height",
         "5791365",
         "--relayer-v2-listening-contracts",
@@ -25,13 +26,14 @@ async fn test__genesis_block__hash() {
     .await
     .unwrap();
 
-    // Given
+    // When
     let original_block = latest_node
         .client
         .block_by_height(0u32.into())
         .await
         .expect("Failed to get blocks")
         .expect("Genesis block should exists");
+    // Then
     // The hash of the genesis block should always be
     // `0x19ac99bf59711aca047b28443e599e26f733291c2fa45f5f309b2c5c9712b215`
     // regardless of the changes that we made.

--- a/version-compatibility/forkless-upgrade/src/genesis.rs
+++ b/version-compatibility/forkless-upgrade/src/genesis.rs
@@ -32,6 +32,9 @@ async fn test__genesis_block__hash() {
         .await
         .expect("Failed to get blocks")
         .expect("Genesis block should exists");
+    // The hash of the genesis block should always be
+    // `0x19ac99bf59711aca047b28443e599e26f733291c2fa45f5f309b2c5c9712b215`
+    // regardless of the changes that we made.
     assert_eq!(
         original_block.id,
         Bytes32::from_str(

--- a/version-compatibility/forkless-upgrade/src/genesis.rs
+++ b/version-compatibility/forkless-upgrade/src/genesis.rs
@@ -1,0 +1,42 @@
+#![allow(non_snake_case)]
+use crate::tests_helper::{
+    LatestFuelCoreDriver,
+    IGNITION_TESTNET_SNAPSHOT,
+};
+use latest_fuel_core_type::fuel_tx::Bytes32;
+use std::str::FromStr;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test__genesis_block__hash() {
+    let latest_node = LatestFuelCoreDriver::spawn(&[
+        "--debug",
+        "--poa-instant",
+        "true",
+        "--snapshot",
+        IGNITION_TESTNET_SNAPSHOT,
+        "--enable-relayer",
+        "--relayer",
+        "https://eth-mainnet.public.blastapi.io",
+        "--relayer-da-deploy-height",
+        "5791365",
+        "--relayer-v2-listening-contracts",
+        "0x768f9459E3339A1F7d59CcF24C80Eb4A711a01FB",
+    ])
+    .await
+    .unwrap();
+
+    // Given
+    let original_block = latest_node
+        .client
+        .block_by_height(0u32.into())
+        .await
+        .expect("Failed to get blocks")
+        .expect("Genesis block should exists");
+    assert_eq!(
+        original_block.id,
+        Bytes32::from_str(
+            "0x19ac99bf59711aca047b28443e599e26f733291c2fa45f5f309b2c5c9712b215"
+        )
+        .unwrap()
+    )
+}

--- a/version-compatibility/forkless-upgrade/src/lib.rs
+++ b/version-compatibility/forkless-upgrade/src/lib.rs
@@ -6,6 +6,8 @@ mod backward_compatibility;
 #[cfg(test)]
 mod forward_compatibility;
 #[cfg(test)]
+mod genesis;
+#[cfg(test)]
 pub(crate) mod tests_helper;
 
 #[cfg(test)]


### PR DESCRIPTION
Genesis block need to always have the same timestamp. We updated `formats` that changed the leap seconds and changed the timestamp of genesis. This PR hardcode it forever. 

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
