### PR TITLE
Ignore receipts from failed transactions in `message_receipts_proof`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2369](https://github.com/FuelLabs/fuel-core/pull/2369): The `transaction_insertion_time_in_thread_pool_milliseconds` metric is properly collected.
 - [2413](https://github.com/FuelLabs/fuel-core/issues/2413): block production immediately errors if unable to lock the mutex.
 - [2389](https://github.com/FuelLabs/fuel-core/pull/2389): Fix construction of reverse iterator in RocksDB.
+- [2478](https://github.com/FuelLabs/fuel-core/pull/2478): Fix proof created by `message_receipts_proof` function by ignoring the receipts from failed transactions to match `message_outbox_root`.
 
 ### Changed
 - [2295](https://github.com/FuelLabs/fuel-core/pull/2295): `CombinedDb::from_config` now respects `state_rewind_policy` with tmp RocksDB.

--- a/crates/fuel-core/src/query/message.rs
+++ b/crates/fuel-core/src/query/message.rs
@@ -456,10 +456,10 @@ mod tests {
                 data: Some(vec![i; 32]),
             });
         }
-        block.transactions_mut().push(valid_tx_id.clone());
+        block.transactions_mut().push(valid_tx_id);
         database.insert_block(1u32.into(), block.clone());
         database.insert_transaction_status(
-            valid_tx_id.clone(),
+            valid_tx_id,
             TransactionStatus::Success {
                 time: Tai64::UNIX_EPOCH,
                 block_height: 1u32.into(),
@@ -469,7 +469,7 @@ mod tests {
                 result: None,
             },
         );
-        database.insert_receipts(valid_tx_id.clone(), valid_tx_receipts.clone());
+        database.insert_receipts(valid_tx_id, valid_tx_receipts.clone());
 
         // Get the message proof with the valid transaction
         let message_proof_valid_tx = message_receipts_proof(
@@ -481,7 +481,7 @@ mod tests {
 
         // Add an invalid transaction with receipts to the block
         let invalid_tx_id = Bytes32::new([2; 32]);
-        block.transactions_mut().push(invalid_tx_id.clone());
+        block.transactions_mut().push(invalid_tx_id);
         database.insert_block(1u32.into(), block.clone());
         let mut invalid_tx_receipts = vec![];
         for i in 0..100 {
@@ -496,7 +496,7 @@ mod tests {
             });
         }
         database.insert_transaction_status(
-            invalid_tx_id.clone(),
+            invalid_tx_id,
             TransactionStatus::Failed {
                 time: Tai64::UNIX_EPOCH,
                 block_height: 1u32.into(),
@@ -506,7 +506,7 @@ mod tests {
                 receipts: invalid_tx_receipts.clone(),
             },
         );
-        database.insert_receipts(invalid_tx_id.clone(), invalid_tx_receipts.clone());
+        database.insert_receipts(invalid_tx_id, invalid_tx_receipts.clone());
 
         // When
         // Get the message proof with the same message id

--- a/crates/fuel-core/src/query/message/test.rs
+++ b/crates/fuel-core/src/query/message/test.rs
@@ -65,7 +65,6 @@ mockall::mock! {
             message_block_height: &BlockHeight,
             commit_block_height: &BlockHeight,
         ) -> StorageResult<MerkleProof>;
-        fn receipts(&self, transaction_id: &TxId) -> StorageResult<Vec<Receipt>>;
         fn transaction_status(&self, transaction_id: &TxId) -> StorageResult<TransactionStatus>;
     }
 }
@@ -96,20 +95,6 @@ async fn can_build_message_proof() {
 
     let mut data = MockProofDataStorage::new();
     let mut count = 0;
-
-    data.expect_receipts().returning({
-        let receipts = receipts.to_vec();
-        let other_receipts = other_receipts.to_vec();
-        move |txn_id| {
-            if *txn_id == transaction_id {
-                Ok(receipts.clone())
-            } else {
-                let r = other_receipts[count..=count].to_vec();
-                count += 1;
-                Ok(r)
-            }
-        }
-    });
 
     let commit_block_header = PartialBlockHeader {
         application: ApplicationHeader {

--- a/crates/types/src/entities/relayer/message.rs
+++ b/crates/types/src/entities/relayer/message.rs
@@ -249,6 +249,7 @@ pub struct MerkleProof {
     pub proof_index: u64,
 }
 
+#[derive(Debug, PartialEq, Eq)]
 /// Proves to da layer that this message was included in a Fuel block.
 pub struct MessageProof {
     /// Proof that message is contained within the provided block header.


### PR DESCRIPTION
Resolves #2421 

In this PR we changed the  `message_receipts_proof` to ignore the receipts from the failed transactions.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
