### PR TITLE
Fix last iteration in sequential opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2369](https://github.com/FuelLabs/fuel-core/pull/2369): The `transaction_insertion_time_in_thread_pool_milliseconds` metric is properly collected.
 - [2413](https://github.com/FuelLabs/fuel-core/issues/2413): block production immediately errors if unable to lock the mutex.
 - [2389](https://github.com/FuelLabs/fuel-core/pull/2389): Fix construction of reverse iterator in RocksDB.
+- [2479](https://github.com/FuelLabs/fuel-core/pull/2479): Fix an error on the last iteration of the read and write sequential opcodes on contract storage.
 
 ### Changed
 - [2295](https://github.com/FuelLabs/fuel-core/pull/2295): `CombinedDb::from_config` now respects `state_rewind_policy` with tmp RocksDB.

--- a/crates/storage/src/vm_storage.rs
+++ b/crates/storage/src/vm_storage.rs
@@ -345,12 +345,12 @@ where
 
         let mut results = Vec::new();
         for i in 0..range {
+            if i != 0 {
+                key.increase()?;
+            }
             key.to_big_endian(state_key.as_mut());
             let multikey = ContractsStateKey::new(contract_id, &state_key);
             results.push(self.database.storage::<ContractsState>().get(&multikey)?);
-            if i.saturating_add(1) != range {
-                key.increase()?;
-            }
         }
         Ok(results)
     }
@@ -375,6 +375,9 @@ where
         let mut key_bytes = Bytes32::zeroed();
         let mut found_unset = 0u32;
         for (idx, value) in values.iter().enumerate() {
+            if idx != 0 {
+                current_key.increase()?;
+            }
             current_key.to_big_endian(key_bytes.as_mut());
 
             let option = self
@@ -386,10 +389,6 @@ where
                 found_unset = found_unset
                     .checked_add(1)
                     .expect("We've checked it above via `values.len()`");
-            }
-
-            if idx.saturating_add(1) != values.len() {
-                current_key.increase()?;
             }
         }
 
@@ -407,7 +406,10 @@ where
         let mut current_key = U256::from_big_endian(start_key.as_ref());
 
         let mut key_bytes = Bytes32::zeroed();
-        for _ in 0..range {
+        for i in 0..range {
+            if i != 0 {
+                current_key.increase()?;
+            }
             current_key.to_big_endian(key_bytes.as_mut());
 
             let option = self
@@ -416,8 +418,6 @@ where
                 .take(&(contract_id, &key_bytes).into())?;
 
             found_unset |= option.is_none();
-
-            current_key.increase()?;
         }
 
         if found_unset {

--- a/tests/tests/vm_storage.rs
+++ b/tests/tests/vm_storage.rs
@@ -201,7 +201,6 @@ mod tests {
             )
             .map_err(|_| ())
             .map(|v| v == 0);
-        dbg!(&insert_status);
 
         // check stored data
         let results: Vec<_> = (0..insertion_range.len())
@@ -265,6 +264,11 @@ mod tests {
     &[([0; 32], vec![0; 32]), (key(2), vec![0; 32])], [0; 32], 3
     => (vec![], false)
     ; "remove multiple slots over partially uninitialized middle range"
+    )]
+    #[test_case(
+    &[(*u256_to_bytes32(U256::MAX), vec![0; 32])], *u256_to_bytes32(U256::MAX), 1
+    => (vec![], true)
+    ; "try to modify only the last value of storage"
     )]
     fn remove_range(
         prefilled_slots: &[([u8; 32], Vec<u8>)],

--- a/tests/tests/vm_storage.rs
+++ b/tests/tests/vm_storage.rs
@@ -86,6 +86,11 @@ mod tests {
     => Err(())
     ; "read fails on partially initialized range if keyspace exceeded"
     )]
+    #[test_case(
+    &[(*u256_to_bytes32(U256::MAX), vec![0; 32])], *u256_to_bytes32(U256::MAX), 1
+    => Ok(vec![Some(vec![0; 32])])
+    ; "read success when reading last key"
+    )]
     fn read_sequential_range(
         prefilled_slots: &[([u8; 32], Vec<u8>)],
         start_key: [u8; 32],
@@ -161,6 +166,11 @@ mod tests {
     => Err(())
     ; "insert fails if start_key + range > u256::MAX"
     )]
+    #[test_case(
+    &[(*u256_to_bytes32(U256::MAX), vec![0; 32])], *u256_to_bytes32(U256::MAX), &[vec![1; 32]]
+    => Ok(true)
+    ; "try to modify only the last value of storage"
+    )]
     fn insert_range(
         prefilled_slots: &[([u8; 32], Vec<u8>)],
         start_key: [u8; 32],
@@ -191,6 +201,7 @@ mod tests {
             )
             .map_err(|_| ())
             .map(|v| v == 0);
+        dbg!(&insert_status);
 
         // check stored data
         let results: Vec<_> = (0..insertion_range.len())


### PR DESCRIPTION
Fixes https://github.com/FuelLabs/fuel-core/issues/2022

Previously the read and write of the last key of the contract state was creating error because of multiple bad checks of limits. Also the key was increase in all case at the end of the loop causing the `increase()` to fail on overflow even if there is values to be inserted left.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here