### PR TITLE
fix(gas_price_service_v1): FailedTooIncludeL2BlockData -> FailedToIncludeL2BlockData

### DIFF
--- a/crates/fuel-gas-price-algorithm/src/v1.rs
+++ b/crates/fuel-gas-price-algorithm/src/v1.rs
@@ -16,7 +16,7 @@ pub enum Error {
     #[error("Could not calculate cost per byte: {bytes:?} bytes, {cost:?} cost")]
     CouldNotCalculateCostPerByte { bytes: u128, cost: u128 },
     #[error("Failed to include L2 block data: {0}")]
-    FailedTooIncludeL2BlockData(String),
+    FailedToIncludeL2BlockData(String),
     #[error("L2 block expected but not found in unrecorded blocks: {height}")]
     L2BlockExpectedNotFound { height: u32 },
 }


### PR DESCRIPTION
## Description
The enum should be `FailedToIncludeL2BlockData` not `FailedTooIncludeL2BlockData`

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
