### PR TITLE
fix(gas_price_service_v1): ensure that the algo updater is synced to l2 block height

### DIFF
--- a/crates/services/gas_price_service/src/v1/tests.rs
+++ b/crates/services/gas_price_service/src/v1/tests.rs
@@ -745,9 +745,6 @@ fn arb_block() -> Block<Transaction> {
 
 #[tokio::test]
 async fn uninitialized_task__init__if_metadata_behind_l2_height_then_sync() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
-        .try_init();
     // given
     let metadata_height = 100;
     let l2_height = 200;
@@ -780,13 +777,19 @@ async fn uninitialized_task__init__if_metadata_behind_l2_height_then_sync() {
         empty_block_stream(),
         gas_price_db,
         FakeDABlockCost::never_returns(),
-        onchain_db,
+        onchain_db.clone(),
     )
     .unwrap();
 
     // when
-    service.init().await.unwrap();
+    let gas_price_service = service.init().await.unwrap();
 
     // then
-    // no panic
+    // sleep to allow the service to sync
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let on_chain_height = u32::from(onchain_db.height);
+    let algo_updater_height = gas_price_service.algorithm_updater().l2_block_height;
+
+    assert_eq!(on_chain_height, algo_updater_height);
 }

--- a/crates/services/gas_price_service/src/v1/tests.rs
+++ b/crates/services/gas_price_service/src/v1/tests.rs
@@ -742,6 +742,9 @@ fn arb_block() -> Block<Transaction> {
 
 #[tokio::test]
 async fn uninitialized_task__init__if_metadata_behind_l2_height_then_sync() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .try_init();
     // given
     let metadata_height = 100;
     let l2_height = 200;


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->
We didn't have this check in the `uninitialized_task__init__if_metadata_behind_l2_height_then_sync` test, which caused us to miss the duped algo updater.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
