### PR TITLE
Integration test for balances and (non)retryable messages

### DIFF
--- a/tests/tests/relayer.rs
+++ b/tests/tests/relayer.rs
@@ -590,7 +590,7 @@ async fn balances_do_not_return_retryable_messages() {
     })
     .await;
     if let Err(_) = result {
-        panic!("Off-chain worker didn't process balances withing timeout")
+        panic!("Off-chain worker didn't process balances within timeout")
     }
     // Then
 

--- a/tests/tests/relayer.rs
+++ b/tests/tests/relayer.rs
@@ -22,7 +22,7 @@ use fuel_core_client::client::{
         PaginationRequest,
     },
     types::{
-        message::MessageStatus,
+        CoinType,
         RelayedTransactionStatus as ClientRelayedTransactionStatus,
         TransactionStatus,
     },


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/2474

## Description
This PR changes the following:
1. Adds new test in `tests/tests/relayer.rs` - to ensure that only **non**-retryable messages contribute to the balance returned from `balance()`, `balances()` and `coins_to_spend()`[^1] endpoints
2. Modifies the `balance()` test in `tests/tests/balances.rs` to also include some retryable message which is expected **not** to contribute to the total balance.
   * for `balances()` and `coins_to_spend()` it was already the case

1<sup>st</sup> test checks the behavior of the actual blockchain operations while the 2<sup>nd</sup> tests the proper initialization of the balances index at genesis.

## Checklist
- [X] Breaking changes are clearly marked as such in the PR description and changelog
- [X] New behavior is reflected in tests

### Before requesting review
- [X] I have reviewed the code myself

[^1]: currently, `coins_to_spend()` is not using indexation, this will change when [this PR](https://github.com/FuelLabs/fuel-core/pull/2463) is merged.