### PR TITLE
fix(docs): typo preventing ci checks from passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -484,7 +484,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     The change has many minor improvements in different areas related to the state transition bytecode:
     - The state transition bytecode lies in its own file(`state_transition_bytecode.wasm`) along with the chain config file. The `ChainConfig` loads it automatically when `ChainConfig::load` is called and pushes it back when `ChainConfig::write` is called.
     - The `fuel-core` release bundle also contains the `fuel-core-wasm-executor.wasm` file of the corresponding executor version.
-    - The regenesis process now considers the last block produced by the previous network. When we create a (re)genesis block of a new network, it has the `height = last_block_of_old_netowkr + 1`. It continues the old network and doesn't overlap blocks(before, we had `old_block.height == new_genesis_block.hegiht`).
+    - The regenesis process now considers the last block produced by the previous network. When we create a (re)genesis block of a new network, it has the `height = last_block_of_old_network + 1`. It continues the old network and doesn't overlap blocks(before, we had `old_block.height == new_genesis_block.height`).
     - Along with the new block height, the regenesis process also increases the state transition bytecode and consensus parameters versions. It guarantees that a new network doesn't use values from the previous network and allows us not to migrate `StateTransitionBytecodeVersions` and `ConsensusParametersVersions` tables.
     - Added a new CLI argument, `native-executor-version,` that allows overriding of the default version of the native executor. It can be useful for side rollups that have their own history of executor upgrades.
     - Replaced:

--- a/crates/services/p2p/src/codecs/postcard.rs
+++ b/crates/services/p2p/src/codecs/postcard.rs
@@ -307,7 +307,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn codec__serialzation_roundtrip_using_v1_on_error_response_returns_predefined_error_code(
+    async fn codec__serialization_roundtrip_using_v1_on_error_response_returns_predefined_error_code(
     ) {
         // Given
         let response = V2ResponseMessage::SealedHeaders(Err(


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->
Fixed typos prevent ci checks from passing on other prs

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
