### PR TITLE
Make the rocksdb cache optional in config and add policy for column opening 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2416](https://github.com/FuelLabs/fuel-core/issues/2416): Define the `GasPriceServiceV1` task.
 - [2033](https://github.com/FuelLabs/fuel-core/pull/2033): Remove `Option<BlockHeight>` in favor of `BlockHeightQuery` where applicable.
 - [2472](https://github.com/FuelLabs/fuel-core/pull/2472): Added the `amountU128` field to the `Balance` GraphQL schema, providing the total balance as a `U128`. The existing `amount` field clamps any balance exceeding `U64` to `u64::MAX`.
+- [2526](https://github.com/FuelLabs/fuel-core/pull/2526): Add possibility to not have any cache set for RocksDB. Add an option to either load the RocksDB columns families on creation of the database or when the column is used.
 
 ### Fixed
 - [2365](https://github.com/FuelLabs/fuel-core/pull/2365): Fixed the error during dry run in the case of race condition.
@@ -57,6 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2154](https://github.com/FuelLabs/fuel-core/pull/2154): Transaction graphql endpoints use `TransactionType` instead of `fuel_tx::Transaction`.
 - [2446](https://github.com/FuelLabs/fuel-core/pull/2446): Use graphiql instead of graphql-playground due to known vulnerability and stale development.
 - [2379](https://github.com/FuelLabs/fuel-core/issues/2379): Change `kv_store::Value` to be `Arc<[u8]>` instead of `Arc<Vec<u8>>`.
+- [2526](https://github.com/FuelLabs/fuel-core/pull/2526): By default the cache of RocksDB is now disabled instead of being `1024 * 1024 * 1024`.
 
 ## [Version 0.40.2]
 
@@ -484,7 +486,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     The change has many minor improvements in different areas related to the state transition bytecode:
     - The state transition bytecode lies in its own file(`state_transition_bytecode.wasm`) along with the chain config file. The `ChainConfig` loads it automatically when `ChainConfig::load` is called and pushes it back when `ChainConfig::write` is called.
     - The `fuel-core` release bundle also contains the `fuel-core-wasm-executor.wasm` file of the corresponding executor version.
-    - The regenesis process now considers the last block produced by the previous network. When we create a (re)genesis block of a new network, it has the `height = last_block_of_old_netowkr + 1`. It continues the old network and doesn't overlap blocks(before, we had `old_block.height == new_genesis_block.height`).
+    - The regenesis process now considers the last block produced by the previous network. When we create a (re)genesis block of a new network, it has the `height = last_block_of_old_netowkr + 1`. It continues the old network and doesn't overlap blocks(before, we had `old_block.height == new_genesis_block.hegiht`).
     - Along with the new block height, the regenesis process also increases the state transition bytecode and consensus parameters versions. It guarantees that a new network doesn't use values from the previous network and allows us not to migrate `StateTransitionBytecodeVersions` and `ConsensusParametersVersions` tables.
     - Added a new CLI argument, `native-executor-version,` that allows overriding of the default version of the native executor. It can be useful for side rollups that have their own history of executor upgrades.
     - Replaced:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -484,7 +484,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     The change has many minor improvements in different areas related to the state transition bytecode:
     - The state transition bytecode lies in its own file(`state_transition_bytecode.wasm`) along with the chain config file. The `ChainConfig` loads it automatically when `ChainConfig::load` is called and pushes it back when `ChainConfig::write` is called.
     - The `fuel-core` release bundle also contains the `fuel-core-wasm-executor.wasm` file of the corresponding executor version.
-    - The regenesis process now considers the last block produced by the previous network. When we create a (re)genesis block of a new network, it has the `height = last_block_of_old_netowkr + 1`. It continues the old network and doesn't overlap blocks(before, we had `old_block.height == new_genesis_block.hegiht`).
+    - The regenesis process now considers the last block produced by the previous network. When we create a (re)genesis block of a new network, it has the `height = last_block_of_old_netowkr + 1`. It continues the old network and doesn't overlap blocks(before, we had `old_block.height == new_genesis_block.height`).
     - Along with the new block height, the regenesis process also increases the state transition bytecode and consensus parameters versions. It guarantees that a new network doesn't use values from the previous network and allows us not to migrate `StateTransitionBytecodeVersions` and `ConsensusParametersVersions` tables.
     - Added a new CLI argument, `native-executor-version,` that allows overriding of the default version of the native executor. It can be useful for side rollups that have their own history of executor upgrades.
     - Replaced:

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -63,7 +63,7 @@ harness = false
 name = "vm"
 
 [features]
-default = ["fuel-core/rocksdb"]
+default = ["fuel-core/rocksdb", "fuel-core/rocksdb-production"]
 
 [[bench]]
 harness = false

--- a/benches/benches/block_target_gas.rs
+++ b/benches/benches/block_target_gas.rs
@@ -27,7 +27,13 @@ use fuel_core::{
         Config,
         FuelService,
     },
-    state::historical_rocksdb::StateRewindPolicy,
+    state::{
+        historical_rocksdb::StateRewindPolicy,
+        rocks_db::{
+            ColumnsPolicy,
+            DatabaseConfig,
+        },
+    },
 };
 use fuel_core_benches::{
     default_gas_costs::default_gas_costs,
@@ -267,9 +273,12 @@ fn service_with_many_contracts(
         .unwrap();
     let _drop = rt.enter();
     let mut database = Database::rocksdb_temp(
-        Some(16 * 1024 * 1024 * 1024),
         StateRewindPolicy::NoRewind,
-        -1,
+        DatabaseConfig {
+            cache_capacity: Some(16 * 1024 * 1024 * 1024),
+            max_fds: -1,
+            columns_policy: ColumnsPolicy::OnCreation,
+        },
     )
     .expect("Failed to create database");
 

--- a/benches/benches/block_target_gas.rs
+++ b/benches/benches/block_target_gas.rs
@@ -266,7 +266,7 @@ fn service_with_many_contracts(
         .build()
         .unwrap();
     let _drop = rt.enter();
-    let mut database = Database::rocksdb_temp(StateRewindPolicy::NoRewind)
+    let mut database = Database::rocksdb_temp(None, StateRewindPolicy::NoRewind, -1)
         .expect("Failed to create database");
 
     let mut chain_config = ChainConfig::local_testnet();

--- a/benches/benches/block_target_gas.rs
+++ b/benches/benches/block_target_gas.rs
@@ -266,8 +266,12 @@ fn service_with_many_contracts(
         .build()
         .unwrap();
     let _drop = rt.enter();
-    let mut database = Database::rocksdb_temp(None, StateRewindPolicy::NoRewind, -1)
-        .expect("Failed to create database");
+    let mut database = Database::rocksdb_temp(
+        Some(16 * 1024 * 1024 * 1024),
+        StateRewindPolicy::NoRewind,
+        -1,
+    )
+    .expect("Failed to create database");
 
     let mut chain_config = ChainConfig::local_testnet();
 

--- a/benches/benches/state.rs
+++ b/benches/benches/state.rs
@@ -11,7 +11,13 @@ use fuel_core::{
         state::StateInitializer,
         Database,
     },
-    state::historical_rocksdb::StateRewindPolicy,
+    state::{
+        historical_rocksdb::StateRewindPolicy,
+        rocks_db::{
+            ColumnsPolicy,
+            DatabaseConfig,
+        },
+    },
 };
 use fuel_core_storage::{
     transactional::{
@@ -75,9 +81,12 @@ fn insert_state_single_contract_database(c: &mut Criterion) {
     let mut bench_state = |group: &mut BenchmarkGroup<WallTime>, name: &str, n: usize| {
         group.bench_function(name, |b| {
             let mut db = Database::<OnChain>::rocksdb_temp(
-                Some(16 * 1024 * 1024 * 1024),
                 StateRewindPolicy::NoRewind,
-                -1,
+                DatabaseConfig {
+                    cache_capacity: Some(16 * 1024 * 1024 * 1024),
+                    max_fds: -1,
+                    columns_policy: ColumnsPolicy::OnCreation,
+                },
             )
             .unwrap();
             let contract: ContractId = rng.gen();

--- a/benches/benches/transaction_throughput.rs
+++ b/benches/benches/transaction_throughput.rs
@@ -9,9 +9,15 @@ use criterion::{
     SamplingMode,
 };
 use ed25519_dalek::Signer;
-use fuel_core::service::{
-    config::Trigger,
-    DbType,
+use fuel_core::{
+    service::{
+        config::Trigger,
+        DbType,
+    },
+    state::rocks_db::{
+        ColumnsPolicy,
+        DatabaseConfig,
+    },
 };
 use fuel_core_benches::*;
 use fuel_core_storage::transactional::AtomicView;
@@ -97,7 +103,7 @@ where
             test_builder.database_config = DatabaseConfig {
                 cache_capacity: Some(16 * 1024 * 1024 * 1024),
                 max_fds: -1,
-                columns_policy: Default::default(),
+                columns_policy: ColumnsPolicy::OnCreation,
             };
 
             // spin up node

--- a/benches/benches/transaction_throughput.rs
+++ b/benches/benches/transaction_throughput.rs
@@ -94,8 +94,11 @@ where
             test_builder.gas_limit = Some(10_000_000_000);
             test_builder.block_size_limit = Some(1_000_000_000_000);
             test_builder.database_type = DbType::RocksDb;
-            test_builder.max_database_cache_size = Some(16 * 1024 * 1024 * 1024);
-            test_builder.max_fds = -1;
+            test_builder.database_config = DatabaseConfig {
+                cache_capacity: Some(16 * 1024 * 1024 * 1024),
+                max_fds: -1,
+                columns_policy: Default::default(),
+            };
 
             // spin up node
             let transactions: Vec<Transaction> =

--- a/benches/benches/transaction_throughput.rs
+++ b/benches/benches/transaction_throughput.rs
@@ -9,7 +9,10 @@ use criterion::{
     SamplingMode,
 };
 use ed25519_dalek::Signer;
-use fuel_core::service::config::Trigger;
+use fuel_core::service::{
+    config::Trigger,
+    DbType,
+};
 use fuel_core_benches::*;
 use fuel_core_storage::transactional::AtomicView;
 use fuel_core_types::{
@@ -90,6 +93,9 @@ where
             test_builder.utxo_validation = true;
             test_builder.gas_limit = Some(10_000_000_000);
             test_builder.block_size_limit = Some(1_000_000_000_000);
+            test_builder.database_type = DbType::RocksDb;
+            test_builder.max_database_cache_size = Some(16 * 1024 * 1024 * 1024);
+            test_builder.max_fds = -1;
 
             // spin up node
             let transactions: Vec<Transaction> =

--- a/benches/benches/vm_set/blockchain.rs
+++ b/benches/benches/vm_set/blockchain.rs
@@ -22,7 +22,10 @@ use fuel_core::{
     service::Config,
     state::{
         historical_rocksdb::HistoricalRocksDB,
-        rocks_db::DatabaseConfig,
+        rocks_db::{
+            ColumnsPolicy,
+            DatabaseConfig,
+        },
     },
 };
 use fuel_core_benches::*;
@@ -78,9 +81,9 @@ impl BenchDb {
             tmp_dir.path(),
             Default::default(),
             DatabaseConfig {
-                capacity: None,
+                cache_capacity: None,
                 max_fds: -1,
-                columns_policy: Default::default(),
+                columns_policy: ColumnsPolicy::OnCreation,
             },
         )
         .unwrap();

--- a/benches/benches/vm_set/blockchain.rs
+++ b/benches/benches/vm_set/blockchain.rs
@@ -20,7 +20,10 @@ use fuel_core::{
         GenesisDatabase,
     },
     service::Config,
-    state::historical_rocksdb::HistoricalRocksDB,
+    state::{
+        historical_rocksdb::HistoricalRocksDB,
+        rocks_db::DatabaseConfig,
+    },
 };
 use fuel_core_benches::*;
 use fuel_core_storage::{
@@ -73,10 +76,12 @@ impl BenchDb {
 
         let db = HistoricalRocksDB::<OnChain>::default_open(
             tmp_dir.path(),
-            None,
             Default::default(),
-            -1,
-            Default::default(),
+            DatabaseConfig {
+                capacity: None,
+                max_fds: -1,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let db = Arc::new(db);

--- a/benches/benches/vm_set/blockchain.rs
+++ b/benches/benches/vm_set/blockchain.rs
@@ -76,6 +76,7 @@ impl BenchDb {
             None,
             Default::default(),
             -1,
+            Default::default(),
         )
         .unwrap();
         let db = Arc::new(db);

--- a/benches/src/db_lookup_times_utils/utils.rs
+++ b/benches/src/db_lookup_times_utils/utils.rs
@@ -46,7 +46,7 @@ pub fn open_rocks_db<Description: DatabaseDescription>(
     let db = RocksDb::default_open(
         path,
         DatabaseConfig {
-            capacity: None,
+            capacity: Some(16 * 1024 * 1024 * 1024),
             max_fds: -1,
             columns_policy: ColumnsPolicy::OnCreation,
         },

--- a/benches/src/db_lookup_times_utils/utils.rs
+++ b/benches/src/db_lookup_times_utils/utils.rs
@@ -5,7 +5,10 @@ use crate::db_lookup_times_utils::full_block_table::{
 use anyhow::anyhow;
 use fuel_core::{
     database::database_description::DatabaseDescription,
-    state::rocks_db::RocksDb,
+    state::rocks_db::{
+        ColumnsPolicy,
+        RocksDb,
+    },
 };
 use fuel_core_storage::kv_store::{
     KeyValueInspect,
@@ -39,7 +42,7 @@ pub fn get_random_block_height(
 pub fn open_rocks_db<Description: DatabaseDescription>(
     path: &Path,
 ) -> Result<RocksDb<Description>> {
-    let db = RocksDb::default_open(path, None, -1)?;
+    let db = RocksDb::default_open(path, None, -1, ColumnsPolicy::OnCreation)?;
     Ok(db)
 }
 

--- a/benches/src/db_lookup_times_utils/utils.rs
+++ b/benches/src/db_lookup_times_utils/utils.rs
@@ -7,6 +7,7 @@ use fuel_core::{
     database::database_description::DatabaseDescription,
     state::rocks_db::{
         ColumnsPolicy,
+        DatabaseConfig,
         RocksDb,
     },
 };
@@ -42,7 +43,14 @@ pub fn get_random_block_height(
 pub fn open_rocks_db<Description: DatabaseDescription>(
     path: &Path,
 ) -> Result<RocksDb<Description>> {
-    let db = RocksDb::default_open(path, None, -1, ColumnsPolicy::OnCreation)?;
+    let db = RocksDb::default_open(
+        path,
+        DatabaseConfig {
+            capacity: None,
+            max_fds: -1,
+            columns_policy: ColumnsPolicy::OnCreation,
+        },
+    )?;
     Ok(db)
 }
 

--- a/benches/src/db_lookup_times_utils/utils.rs
+++ b/benches/src/db_lookup_times_utils/utils.rs
@@ -46,7 +46,7 @@ pub fn open_rocks_db<Description: DatabaseDescription>(
     let db = RocksDb::default_open(
         path,
         DatabaseConfig {
-            capacity: Some(16 * 1024 * 1024 * 1024),
+            cache_capacity: Some(16 * 1024 * 1024 * 1024),
             max_fds: -1,
             columns_policy: ColumnsPolicy::OnCreation,
         },

--- a/bin/fuel-core/src/cli/rollback.rs
+++ b/bin/fuel-core/src/cli/rollback.rs
@@ -3,7 +3,10 @@ use anyhow::Context;
 use clap::Parser;
 use fuel_core::{
     combined_database::CombinedDatabase,
-    state::historical_rocksdb::StateRewindPolicy,
+    state::{
+        historical_rocksdb::StateRewindPolicy,
+        rocks_db::ColumnsPolicy,
+    },
 };
 use rlimit::{
     getrlimit,
@@ -54,6 +57,10 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
         64 * 1024 * 1024,
         StateRewindPolicy::RewindFullRange,
         command.rocksdb_max_fds,
+        #[cfg(feature = "production")]
+        ColumnsPolicy::OnCreation,
+        #[cfg(not(feature = "production"))]
+        ColumnsPolicy::Lazy,
     )
     .map_err(Into::<anyhow::Error>::into)
     .context(format!("failed to open combined database at path {path:?}"))?;

--- a/bin/fuel-core/src/cli/rollback.rs
+++ b/bin/fuel-core/src/cli/rollback.rs
@@ -3,10 +3,7 @@ use anyhow::Context;
 use clap::Parser;
 use fuel_core::{
     combined_database::CombinedDatabase,
-    state::{
-        historical_rocksdb::StateRewindPolicy,
-        rocks_db::ColumnsPolicy,
-    },
+    state::historical_rocksdb::StateRewindPolicy,
 };
 use rlimit::{
     getrlimit,
@@ -57,10 +54,7 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
         64 * 1024 * 1024,
         StateRewindPolicy::RewindFullRange,
         command.rocksdb_max_fds,
-        #[cfg(feature = "production")]
-        ColumnsPolicy::OnCreation,
-        #[cfg(not(feature = "production"))]
-        ColumnsPolicy::Lazy,
+        Default::default(),
     )
     .map_err(Into::<anyhow::Error>::into)
     .context(format!("failed to open combined database at path {path:?}"))?;

--- a/bin/fuel-core/src/cli/rollback.rs
+++ b/bin/fuel-core/src/cli/rollback.rs
@@ -3,7 +3,10 @@ use anyhow::Context;
 use clap::Parser;
 use fuel_core::{
     combined_database::CombinedDatabase,
-    state::historical_rocksdb::StateRewindPolicy,
+    state::{
+        historical_rocksdb::StateRewindPolicy,
+        rocks_db::DatabaseConfig,
+    },
 };
 use rlimit::{
     getrlimit,
@@ -51,10 +54,12 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
     let path = command.database_path.as_path();
     let db = CombinedDatabase::open(
         path,
-        64 * 1024 * 1024,
         StateRewindPolicy::RewindFullRange,
-        command.rocksdb_max_fds,
-        Default::default(),
+        DatabaseConfig {
+            capacity: Some(64 * 1024 * 1024),
+            max_fds: command.rocksdb_max_fds,
+            columns_policy: Default::default(),
+        },
     )
     .map_err(Into::<anyhow::Error>::into)
     .context(format!("failed to open combined database at path {path:?}"))?;

--- a/bin/fuel-core/src/cli/rollback.rs
+++ b/bin/fuel-core/src/cli/rollback.rs
@@ -56,7 +56,7 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
         path,
         StateRewindPolicy::RewindFullRange,
         DatabaseConfig {
-            capacity: Some(64 * 1024 * 1024),
+            cache_capacity: Some(64 * 1024 * 1024),
             max_fds: command.rocksdb_max_fds,
             columns_policy: Default::default(),
         },

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -85,8 +85,6 @@ use tracing::{
 #[cfg(feature = "rocksdb")]
 use fuel_core::state::historical_rocksdb::StateRewindPolicy;
 
-use super::DEFAULT_DATABASE_CACHE_SIZE;
-
 #[cfg(feature = "p2p")]
 mod p2p;
 
@@ -105,12 +103,8 @@ pub struct Command {
     pub service_name: String,
 
     /// The maximum database cache size in bytes.
-    #[arg(
-        long = "max-database-cache-size",
-        default_value_t = DEFAULT_DATABASE_CACHE_SIZE,
-        env
-    )]
-    pub max_database_cache_size: usize,
+    #[arg(long = "max-database-cache-size", env)]
+    pub max_database_cache_size: Option<usize>,
 
     #[clap(
         name = "DB_PATH",

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -83,7 +83,10 @@ use tracing::{
 };
 
 #[cfg(feature = "rocksdb")]
-use fuel_core::state::historical_rocksdb::StateRewindPolicy;
+use fuel_core::state::{
+    historical_rocksdb::StateRewindPolicy,
+    rocks_db::ColumnsPolicy,
+};
 
 #[cfg(feature = "p2p")]
 mod p2p;
@@ -451,6 +454,10 @@ impl Command {
             database_path,
             database_type,
             max_database_cache_size,
+            #[cfg(all(feature = "rocksdb", feature = "production"))]
+            columns_policy: ColumnsPolicy::OnCreation,
+            #[cfg(all(feature = "rocksdb", not(feature = "production")))]
+            columns_policy: ColumnsPolicy::Lazy,
             #[cfg(feature = "rocksdb")]
             state_rewind_policy,
             #[cfg(feature = "rocksdb")]

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -83,10 +83,7 @@ use tracing::{
 };
 
 #[cfg(feature = "rocksdb")]
-use fuel_core::state::{
-    historical_rocksdb::StateRewindPolicy,
-    rocks_db::ColumnsPolicy,
-};
+use fuel_core::state::historical_rocksdb::StateRewindPolicy;
 
 #[cfg(feature = "p2p")]
 mod p2p;
@@ -454,10 +451,8 @@ impl Command {
             database_path,
             database_type,
             max_database_cache_size,
-            #[cfg(all(feature = "rocksdb", feature = "production"))]
-            columns_policy: ColumnsPolicy::OnCreation,
-            #[cfg(all(feature = "rocksdb", not(feature = "production")))]
-            columns_policy: ColumnsPolicy::Lazy,
+            #[cfg(feature = "rocksdb")]
+            columns_policy: Default::default(),
             #[cfg(feature = "rocksdb")]
             state_rewind_policy,
             #[cfg(feature = "rocksdb")]

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -34,6 +34,7 @@ use fuel_core::{
         RelayerConsensusConfig,
         VMConfig,
     },
+    state::rocks_db::ColumnsPolicy,
     txpool::config::{
         BlackList,
         Config as TxPoolConfig,
@@ -123,6 +124,20 @@ pub struct Command {
         env
     )]
     pub database_type: DbType,
+
+    #[cfg(feature = "rocksdb")]
+    /// Define policy to apply to create columns
+    ///
+    /// If `Lazy`, columns will be created when an insertion happens
+    /// If `OnCreation`, columns will be created when opening DB.
+    /// When running a node in production we advise to use `OnCreation`
+    #[clap(
+        long = "rocksdb-columns-policy",
+        env,
+        value_enum,
+        default_value_t = ColumnsPolicy::default()
+    )]
+    pub rocks_db_columns_policy: ColumnsPolicy,
 
     #[cfg(feature = "rocksdb")]
     /// Defines a specific number of file descriptors that RocksDB can use.
@@ -282,6 +297,8 @@ impl Command {
             max_database_cache_size,
             database_path,
             database_type,
+            #[cfg(feature = "rocksdb")]
+            rocks_db_columns_policy,
             #[cfg(feature = "rocksdb")]
             rocksdb_max_fds,
             #[cfg(feature = "rocksdb")]

--- a/bin/fuel-core/src/cli/snapshot.rs
+++ b/bin/fuel-core/src/cli/snapshot.rs
@@ -217,7 +217,7 @@ fn open_db(
         path,
         StateRewindPolicy::NoRewind,
         DatabaseConfig {
-            capacity: Some(capacity.unwrap_or(1024 * 1024 * 1024)),
+            cache_capacity: Some(capacity.unwrap_or(1024 * 1024 * 1024)),
             max_fds,
             columns_policy: ColumnsPolicy::OnCreation,
         },

--- a/bin/fuel-core/src/cli/snapshot.rs
+++ b/bin/fuel-core/src/cli/snapshot.rs
@@ -8,7 +8,10 @@ use fuel_core::{
     combined_database::CombinedDatabase,
     state::{
         historical_rocksdb::StateRewindPolicy,
-        rocks_db::ColumnsPolicy,
+        rocks_db::{
+            ColumnsPolicy,
+            DatabaseConfig,
+        },
     },
     types::fuel_types::ContractId,
 };
@@ -212,10 +215,12 @@ fn open_db(
 ) -> anyhow::Result<CombinedDatabase> {
     CombinedDatabase::open(
         path,
-        capacity.unwrap_or(1024 * 1024 * 1024),
         StateRewindPolicy::NoRewind,
-        max_fds,
-        ColumnsPolicy::OnCreation,
+        DatabaseConfig {
+            capacity: Some(capacity.unwrap_or(1024 * 1024 * 1024)),
+            max_fds,
+            columns_policy: ColumnsPolicy::OnCreation,
+        },
     )
     .map_err(Into::<anyhow::Error>::into)
     .context(format!("failed to open combined database at path {path:?}",))

--- a/bin/fuel-core/src/cli/snapshot.rs
+++ b/bin/fuel-core/src/cli/snapshot.rs
@@ -6,7 +6,10 @@ use clap::{
 };
 use fuel_core::{
     combined_database::CombinedDatabase,
-    state::historical_rocksdb::StateRewindPolicy,
+    state::{
+        historical_rocksdb::StateRewindPolicy,
+        rocks_db::ColumnsPolicy,
+    },
     types::fuel_types::ContractId,
 };
 use fuel_core_chain_config::ChainConfig;
@@ -212,6 +215,7 @@ fn open_db(
         capacity.unwrap_or(1024 * 1024 * 1024),
         StateRewindPolicy::NoRewind,
         max_fds,
+        ColumnsPolicy::OnCreation,
     )
     .map_err(Into::<anyhow::Error>::into)
     .context(format!("failed to open combined database at path {path:?}",))

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -265,10 +265,7 @@ where
         let db = RocksDb::<Historical<Description>>::default_open_temp_with_params(
             max_database_cache_size.into(),
             max_fds,
-            #[cfg(feature = "rocksdb-production")]
-            crate::state::rocks_db::ColumnsPolicy::Lazy,
-            #[cfg(not(feature = "rocksdb-production"))]
-            crate::state::rocks_db::ColumnsPolicy::OnCreation,
+            Default::default(),
         )?;
         let historical_db = HistoricalRocksDB::new(db, state_rewind_policy)?;
         let data = Arc::new(historical_db);
@@ -1123,7 +1120,7 @@ mod tests {
             1024 * 1024 * 1024,
             Default::default(),
             512,
-            crate::state::rocks_db::ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .unwrap();
         // rocks db fails

--- a/crates/fuel-core/src/graphql_api/indexation.rs
+++ b/crates/fuel-core/src/graphql_api/indexation.rs
@@ -356,11 +356,7 @@ mod tests {
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                capacity: Default::default(),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -420,11 +416,7 @@ mod tests {
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                capacity: Default::default(),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -499,11 +491,7 @@ mod tests {
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                capacity: Default::default(),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -614,11 +602,7 @@ mod tests {
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                capacity: Default::default(),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -655,11 +639,7 @@ mod tests {
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                capacity: Default::default(),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -700,11 +680,7 @@ mod tests {
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                capacity: Default::default(),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let mut tx = db.write_transaction();

--- a/crates/fuel-core/src/graphql_api/indexation.rs
+++ b/crates/fuel-core/src/graphql_api/indexation.rs
@@ -238,7 +238,6 @@ mod tests {
                 MessageBalances,
             },
         },
-        state::rocks_db::ColumnsPolicy,
     };
 
     impl PartialEq for IndexationError {
@@ -358,7 +357,7 @@ mod tests {
             None,
             Default::default(),
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -420,7 +419,7 @@ mod tests {
             None,
             Default::default(),
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -497,7 +496,7 @@ mod tests {
             None,
             Default::default(),
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -610,7 +609,7 @@ mod tests {
             None,
             Default::default(),
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -649,7 +648,7 @@ mod tests {
             None,
             Default::default(),
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -692,7 +691,7 @@ mod tests {
             None,
             Default::default(),
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .unwrap();
         let mut tx = db.write_transaction();

--- a/crates/fuel-core/src/graphql_api/indexation.rs
+++ b/crates/fuel-core/src/graphql_api/indexation.rs
@@ -238,6 +238,7 @@ mod tests {
                 MessageBalances,
             },
         },
+        state::rocks_db::DatabaseConfig,
     };
 
     impl PartialEq for IndexationError {
@@ -354,10 +355,12 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
-            None,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: Default::default(),
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -416,10 +419,12 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
-            None,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: Default::default(),
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -493,10 +498,12 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
-            None,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: Default::default(),
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -606,10 +613,12 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
-            None,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: Default::default(),
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -645,10 +654,12 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
-            None,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: Default::default(),
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let mut tx = db.write_transaction();
@@ -688,10 +699,12 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let mut db: Database<OffChain> = Database::open_rocksdb(
             tmp_dir.path(),
-            None,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: Default::default(),
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let mut tx = db.write_transaction();

--- a/crates/fuel-core/src/graphql_api/indexation.rs
+++ b/crates/fuel-core/src/graphql_api/indexation.rs
@@ -238,6 +238,7 @@ mod tests {
                 MessageBalances,
             },
         },
+        state::rocks_db::ColumnsPolicy,
     };
 
     impl PartialEq for IndexationError {
@@ -352,9 +353,14 @@ mod tests {
     fn balances_enabled_flag_is_respected() {
         use tempfile::TempDir;
         let tmp_dir = TempDir::new().unwrap();
-        let mut db: Database<OffChain> =
-            Database::open_rocksdb(tmp_dir.path(), None, Default::default(), 512)
-                .unwrap();
+        let mut db: Database<OffChain> = Database::open_rocksdb(
+            tmp_dir.path(),
+            None,
+            Default::default(),
+            512,
+            ColumnsPolicy::Lazy,
+        )
+        .unwrap();
         let mut tx = db.write_transaction();
 
         const BALANCES_ARE_DISABLED: bool = false;
@@ -409,9 +415,14 @@ mod tests {
     fn coins() {
         use tempfile::TempDir;
         let tmp_dir = TempDir::new().unwrap();
-        let mut db: Database<OffChain> =
-            Database::open_rocksdb(tmp_dir.path(), None, Default::default(), 512)
-                .unwrap();
+        let mut db: Database<OffChain> = Database::open_rocksdb(
+            tmp_dir.path(),
+            None,
+            Default::default(),
+            512,
+            ColumnsPolicy::Lazy,
+        )
+        .unwrap();
         let mut tx = db.write_transaction();
 
         const BALANCES_ARE_ENABLED: bool = true;
@@ -481,9 +492,14 @@ mod tests {
     fn messages() {
         use tempfile::TempDir;
         let tmp_dir = TempDir::new().unwrap();
-        let mut db: Database<OffChain> =
-            Database::open_rocksdb(tmp_dir.path(), None, Default::default(), 512)
-                .unwrap();
+        let mut db: Database<OffChain> = Database::open_rocksdb(
+            tmp_dir.path(),
+            None,
+            Default::default(),
+            512,
+            ColumnsPolicy::Lazy,
+        )
+        .unwrap();
         let mut tx = db.write_transaction();
 
         const BALANCES_ARE_ENABLED: bool = true;
@@ -589,9 +605,14 @@ mod tests {
     fn coin_balance_overflow_does_not_error() {
         use tempfile::TempDir;
         let tmp_dir = TempDir::new().unwrap();
-        let mut db: Database<OffChain> =
-            Database::open_rocksdb(tmp_dir.path(), None, Default::default(), 512)
-                .unwrap();
+        let mut db: Database<OffChain> = Database::open_rocksdb(
+            tmp_dir.path(),
+            None,
+            Default::default(),
+            512,
+            ColumnsPolicy::Lazy,
+        )
+        .unwrap();
         let mut tx = db.write_transaction();
 
         const BALANCES_ARE_ENABLED: bool = true;
@@ -623,9 +644,14 @@ mod tests {
     fn message_balance_overflow_does_not_error() {
         use tempfile::TempDir;
         let tmp_dir = TempDir::new().unwrap();
-        let mut db: Database<OffChain> =
-            Database::open_rocksdb(tmp_dir.path(), None, Default::default(), 512)
-                .unwrap();
+        let mut db: Database<OffChain> = Database::open_rocksdb(
+            tmp_dir.path(),
+            None,
+            Default::default(),
+            512,
+            ColumnsPolicy::Lazy,
+        )
+        .unwrap();
         let mut tx = db.write_transaction();
 
         const BALANCES_ARE_ENABLED: bool = true;
@@ -661,9 +687,14 @@ mod tests {
     fn coin_balance_underflow_causes_error() {
         use tempfile::TempDir;
         let tmp_dir = TempDir::new().unwrap();
-        let mut db: Database<OffChain> =
-            Database::open_rocksdb(tmp_dir.path(), None, Default::default(), 512)
-                .unwrap();
+        let mut db: Database<OffChain> = Database::open_rocksdb(
+            tmp_dir.path(),
+            None,
+            Default::default(),
+            512,
+            ColumnsPolicy::Lazy,
+        )
+        .unwrap();
         let mut tx = db.write_transaction();
 
         const BALANCES_ARE_ENABLED: bool = true;

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -120,6 +120,8 @@ impl Config {
             max_database_cache_size: Some(10 * 1024 * 1024),
             database_path: Default::default(),
             #[cfg(feature = "rocksdb")]
+            columns_policy: crate::state::rocks_db::ColumnsPolicy::Lazy,
+            #[cfg(feature = "rocksdb")]
             database_type: DbType::RocksDb,
             #[cfg(not(feature = "rocksdb"))]
             database_type: DbType::InMemory,

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -104,6 +104,8 @@ impl Config {
 
     #[cfg(feature = "test-helpers")]
     pub fn local_node_with_reader(snapshot_reader: SnapshotReader) -> Self {
+        use crate::state::rocks_db::DatabaseConfig;
+
         let block_importer = fuel_core_importer::Config::new(false);
         let latest_block = snapshot_reader.last_block_config();
         // In tests, we always want to use the native executor as a default configuration.
@@ -117,10 +119,13 @@ impl Config {
 
         let combined_db_config = CombinedDatabaseConfig {
             // Set the cache for tests = 10MB
-            max_database_cache_size: Some(10 * 1024 * 1024),
-            database_path: Default::default(),
             #[cfg(feature = "rocksdb")]
-            columns_policy: Default::default(),
+            database_config: DatabaseConfig {
+                cache_capacity: Some(10 * 1024 * 1024),
+                columns_policy: Default::default(),
+                max_fds: 512,
+            },
+            database_path: Default::default(),
             #[cfg(feature = "rocksdb")]
             database_type: DbType::RocksDb,
             #[cfg(not(feature = "rocksdb"))]
@@ -128,8 +133,6 @@ impl Config {
             #[cfg(feature = "rocksdb")]
             state_rewind_policy:
                 crate::state::historical_rocksdb::StateRewindPolicy::RewindFullRange,
-            #[cfg(feature = "rocksdb")]
-            max_fds: 512,
         };
         let starting_gas_price = 0;
         let gas_price_change_percent = 0;

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -120,7 +120,7 @@ impl Config {
             max_database_cache_size: Some(10 * 1024 * 1024),
             database_path: Default::default(),
             #[cfg(feature = "rocksdb")]
-            columns_policy: crate::state::rocks_db::ColumnsPolicy::Lazy,
+            columns_policy: Default::default(),
             #[cfg(feature = "rocksdb")]
             database_type: DbType::RocksDb,
             #[cfg(not(feature = "rocksdb"))]

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -117,7 +117,7 @@ impl Config {
 
         let combined_db_config = CombinedDatabaseConfig {
             // Set the cache for tests = 10MB
-            max_database_cache_size: 10 * 1024 * 1024,
+            max_database_cache_size: Some(10 * 1024 * 1024),
             database_path: Default::default(),
             #[cfg(feature = "rocksdb")]
             database_type: DbType::RocksDb,

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -236,7 +236,7 @@ pub struct VMConfig {
 }
 
 #[derive(
-    Clone, Debug, Display, Eq, PartialEq, EnumString, EnumVariantNames, ValueEnum,
+    Clone, Copy, Debug, Display, Eq, PartialEq, EnumString, EnumVariantNames, ValueEnum,
 )]
 #[strum(serialize_all = "kebab_case")]
 pub enum DbType {

--- a/crates/fuel-core/src/state/historical_rocksdb.rs
+++ b/crates/fuel-core/src/state/historical_rocksdb.rs
@@ -18,7 +18,10 @@ use crate::{
         },
         iterable_key_value_view::IterableKeyValueViewWrapper,
         key_value_view::KeyValueViewWrapper,
-        rocks_db::RocksDb,
+        rocks_db::{
+            ColumnsPolicy,
+            RocksDb,
+        },
         ColumnType,
         IterableKeyValueView,
         KeyValueView,
@@ -109,9 +112,14 @@ where
         capacity: Option<usize>,
         state_rewind_policy: StateRewindPolicy,
         max_fds: i32,
+        columns_policy: ColumnsPolicy,
     ) -> DatabaseResult<Self> {
-        let db =
-            RocksDb::<Historical<Description>>::default_open(path, capacity, max_fds)?;
+        let db = RocksDb::<Historical<Description>>::default_open(
+            path,
+            capacity,
+            max_fds,
+            columns_policy,
+        )?;
         Ok(Self {
             state_rewind_policy,
             db,

--- a/crates/fuel-core/src/state/historical_rocksdb.rs
+++ b/crates/fuel-core/src/state/historical_rocksdb.rs
@@ -18,10 +18,7 @@ use crate::{
         },
         iterable_key_value_view::IterableKeyValueViewWrapper,
         key_value_view::KeyValueViewWrapper,
-        rocks_db::{
-            ColumnsPolicy,
-            RocksDb,
-        },
+        rocks_db::RocksDb,
         ColumnType,
         IterableKeyValueView,
         KeyValueView,
@@ -67,6 +64,8 @@ use std::{
     path::Path,
 };
 
+use super::rocks_db::DatabaseConfig;
+
 pub mod description;
 pub mod modifications_history;
 pub mod view_at_height;
@@ -109,17 +108,10 @@ where
 
     pub fn default_open<P: AsRef<Path>>(
         path: P,
-        capacity: Option<usize>,
         state_rewind_policy: StateRewindPolicy,
-        max_fds: i32,
-        columns_policy: ColumnsPolicy,
+        database_config: DatabaseConfig,
     ) -> DatabaseResult<Self> {
-        let db = RocksDb::<Historical<Description>>::default_open(
-            path,
-            capacity,
-            max_fds,
-            columns_policy,
-        )?;
+        let db = RocksDb::<Historical<Description>>::default_open(path, database_config)?;
         Ok(Self {
             state_rewind_policy,
             db,

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -126,13 +126,20 @@ where
     Description: DatabaseDescription,
 {
     pub fn default_open_temp(capacity: Option<usize>) -> DatabaseResult<Self> {
+        Self::default_open_temp_with_params(capacity, 512)
+    }
+
+    pub fn default_open_temp_with_params(
+        capacity: Option<usize>,
+        max_fds: i32,
+    ) -> DatabaseResult<Self> {
         let tmp_dir = TempDir::new().unwrap();
         let path = tmp_dir.path();
         let result = Self::open(
             path,
             enum_iterator::all::<Description::Column>().collect::<Vec<_>>(),
             capacity,
-            512,
+            max_fds,
         );
         let mut db = result?;
 

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -137,11 +137,7 @@ where
     Description: DatabaseDescription,
 {
     pub fn default_open_temp(capacity: Option<usize>) -> DatabaseResult<Self> {
-        if cfg!(feature = "rocksdb-production") {
-            Self::default_open_temp_with_params(capacity, 512, ColumnsPolicy::OnCreation)
-        } else {
-            Self::default_open_temp_with_params(capacity, 512, ColumnsPolicy::Lazy)
-        }
+        Self::default_open_temp_with_params(capacity, 512, Default::default())
     }
 
     pub fn default_open_temp_with_params(
@@ -998,7 +994,7 @@ mod tests {
             old_columns.clone(),
             None,
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .expect("Failed to open database with old columns");
         drop(database_with_old_columns);
@@ -1012,7 +1008,7 @@ mod tests {
             new_columns,
             None,
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .map(|_| ());
 
@@ -1188,7 +1184,7 @@ mod tests {
             columns,
             None,
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         );
 
         // Then
@@ -1209,7 +1205,7 @@ mod tests {
             None,
             false,
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .map(|_| ());
 
@@ -1232,7 +1228,7 @@ mod tests {
             old_columns.clone(),
             None,
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         )
         .map(|_| ());
 
@@ -1329,7 +1325,7 @@ mod tests {
             part_of_columns,
             None,
             512,
-            ColumnsPolicy::Lazy,
+            Default::default(),
         );
 
         // Then

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -310,6 +310,9 @@ where
         block_opts.set_block_size(16 * 1024);
 
         let mut opts = Options::default();
+        if columns_policy == ColumnsPolicy::OnCreation {
+            opts.create_if_missing(true);
+        }
         opts.set_compression_type(DBCompressionType::Lz4);
         // TODO: Make it customizable https://github.com/FuelLabs/fuel-core/issues/1666
         opts.set_max_total_wal_size(64 * 1024 * 1024);
@@ -343,10 +346,7 @@ where
             }
         }
 
-        if columns_policy == ColumnsPolicy::OnCreation
-            || (columns_policy == ColumnsPolicy::Lazy
-                && cf_descriptors_to_open.is_empty())
-        {
+        if columns_policy == ColumnsPolicy::Lazy && cf_descriptors_to_open.is_empty() {
             opts.create_if_missing(true);
         }
 
@@ -469,6 +469,7 @@ where
     fn cf_u32(&self, column: u32) -> Arc<BoundColumnFamily> {
         let family = self.db.cf_handle(&Self::col_name(column));
 
+        dbg!("inside");
         match family {
             None => {
                 if let Some(create_family) = &self.create_family {
@@ -1228,7 +1229,7 @@ mod tests {
             old_columns.clone(),
             None,
             512,
-            Default::default(),
+            ColumnsPolicy::Lazy,
         )
         .map(|_| ());
 

--- a/crates/services/p2p/src/codecs/postcard.rs
+++ b/crates/services/p2p/src/codecs/postcard.rs
@@ -307,7 +307,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn codec__serialzation_roundtrip_using_v1_on_error_response_returns_predefined_error_code(
+    async fn codec__serialization_roundtrip_using_v1_on_error_response_returns_predefined_error_code(
     ) {
         // Given
         let response = V2ResponseMessage::SealedHeaders(Err(

--- a/tests/test-helpers/src/builder.rs
+++ b/tests/test-helpers/src/builder.rs
@@ -13,6 +13,10 @@ use fuel_core::{
         DbType,
         FuelService,
     },
+    state::rocks_db::{
+        ColumnsPolicy,
+        DatabaseConfig,
+    },
 };
 use fuel_core_client::client::FuelClient;
 use fuel_core_poa::Trigger;
@@ -99,9 +103,8 @@ pub struct TestSetupBuilder {
     pub privileged_address: Address,
     pub base_asset_id: AssetId,
     pub trigger: Trigger,
-    pub max_fds: i32,
-    pub max_database_cache_size: Option<usize>,
     pub database_type: DbType,
+    pub database_config: DatabaseConfig,
 }
 
 impl TestSetupBuilder {
@@ -241,9 +244,7 @@ impl TestSetupBuilder {
             starting_gas_price: self.starting_gas_price,
             ..Config::local_node_with_configs(chain_conf, state)
         };
-        config.combined_db_config.max_database_cache_size = self.max_database_cache_size;
-        config.combined_db_config.max_fds = self.max_fds;
-        config.combined_db_config.database_type = self.database_type;
+        config.combined_db_config.database_config = self.database_config;
 
         let srv = FuelService::new_node(config).await.unwrap();
         let client = FuelClient::from(srv.bound_address);
@@ -266,13 +267,16 @@ impl Default for TestSetupBuilder {
             gas_limit: None,
             block_size_limit: None,
             starting_block: None,
-            max_database_cache_size: None,
-            database_type: DbType::RocksDb,
             utxo_validation: true,
             privileged_address: Default::default(),
             base_asset_id: AssetId::BASE,
             trigger: Trigger::Instant,
-            max_fds: 512,
+            database_type: DbType::RocksDb,
+            database_config: DatabaseConfig {
+                cache_capacity: None,
+                max_fds: 512,
+                columns_policy: ColumnsPolicy::Lazy,
+            },
         }
     }
 }

--- a/tests/test-helpers/src/builder.rs
+++ b/tests/test-helpers/src/builder.rs
@@ -231,14 +231,16 @@ impl TestSetupBuilder {
             ..StateConfig::default()
         };
 
-        let config = Config {
+        let mut config = Config {
             utxo_validation: self.utxo_validation,
             txpool: fuel_core_txpool::config::Config::default(),
             block_production: self.trigger,
             starting_gas_price: self.starting_gas_price,
             ..Config::local_node_with_configs(chain_conf, state)
         };
-        assert_eq!(config.combined_db_config.database_type, DbType::RocksDb);
+        config.combined_db_config.max_database_cache_size = Some(16 * 1024 * 1024 * 1024);
+        config.combined_db_config.max_fds = -1;
+        config.combined_db_config.database_type = DbType::RocksDb;
 
         let srv = FuelService::new_node(config).await.unwrap();
         let client = FuelClient::from(srv.bound_address);

--- a/tests/test-helpers/src/builder.rs
+++ b/tests/test-helpers/src/builder.rs
@@ -13,10 +13,7 @@ use fuel_core::{
         DbType,
         FuelService,
     },
-    state::rocks_db::{
-        ColumnsPolicy,
-        DatabaseConfig,
-    },
+    state::rocks_db::DatabaseConfig,
 };
 use fuel_core_client::client::FuelClient;
 use fuel_core_poa::Trigger;
@@ -272,11 +269,7 @@ impl Default for TestSetupBuilder {
             base_asset_id: AssetId::BASE,
             trigger: Trigger::Instant,
             database_type: DbType::RocksDb,
-            database_config: DatabaseConfig {
-                cache_capacity: None,
-                max_fds: 512,
-                columns_policy: ColumnsPolicy::Lazy,
-            },
+            database_config: DatabaseConfig::config_for_tests(),
         }
     }
 }

--- a/tests/test-helpers/src/builder.rs
+++ b/tests/test-helpers/src/builder.rs
@@ -99,6 +99,9 @@ pub struct TestSetupBuilder {
     pub privileged_address: Address,
     pub base_asset_id: AssetId,
     pub trigger: Trigger,
+    pub max_fds: i32,
+    pub max_database_cache_size: Option<usize>,
+    pub database_type: DbType,
 }
 
 impl TestSetupBuilder {
@@ -238,9 +241,9 @@ impl TestSetupBuilder {
             starting_gas_price: self.starting_gas_price,
             ..Config::local_node_with_configs(chain_conf, state)
         };
-        config.combined_db_config.max_database_cache_size = Some(16 * 1024 * 1024 * 1024);
-        config.combined_db_config.max_fds = -1;
-        config.combined_db_config.database_type = DbType::RocksDb;
+        config.combined_db_config.max_database_cache_size = self.max_database_cache_size;
+        config.combined_db_config.max_fds = self.max_fds;
+        config.combined_db_config.database_type = self.database_type;
 
         let srv = FuelService::new_node(config).await.unwrap();
         let client = FuelClient::from(srv.bound_address);
@@ -263,10 +266,13 @@ impl Default for TestSetupBuilder {
             gas_limit: None,
             block_size_limit: None,
             starting_block: None,
+            max_database_cache_size: None,
+            database_type: DbType::RocksDb,
             utxo_validation: true,
             privileged_address: Default::default(),
             base_asset_id: AssetId::BASE,
             trigger: Trigger::Instant,
+            max_fds: 512,
         }
     }
 }

--- a/tests/tests/aws_kms.rs
+++ b/tests/tests/aws_kms.rs
@@ -1,4 +1,7 @@
-use fuel_core::combined_database::CombinedDatabase;
+use fuel_core::{
+    combined_database::CombinedDatabase,
+    state::rocks_db::DatabaseConfig,
+};
 use fuel_core_storage::transactional::AtomicView;
 use fuel_core_types::blockchain::consensus::Consensus;
 use test_helpers::fuel_core_driver::FuelCoreDriver;
@@ -49,10 +52,12 @@ async fn can_get_sealed_block_from_poa_produced_block_when_signing_with_kms() {
     let db_path = driver.kill().await;
     let db = CombinedDatabase::open(
         db_path.path(),
-        1024 * 1024,
         Default::default(),
-        512,
-        Default::default(),
+        DatabaseConfig {
+            capacity: Some(1024 * 1024),
+            max_fds: 512,
+            columns_policy: Default::default(),
+        },
     )
     .unwrap();
 

--- a/tests/tests/aws_kms.rs
+++ b/tests/tests/aws_kms.rs
@@ -1,7 +1,4 @@
-use fuel_core::{
-    combined_database::CombinedDatabase,
-    state::rocks_db::ColumnsPolicy,
-};
+use fuel_core::combined_database::CombinedDatabase;
 use fuel_core_storage::transactional::AtomicView;
 use fuel_core_types::blockchain::consensus::Consensus;
 use test_helpers::fuel_core_driver::FuelCoreDriver;
@@ -55,7 +52,7 @@ async fn can_get_sealed_block_from_poa_produced_block_when_signing_with_kms() {
         1024 * 1024,
         Default::default(),
         512,
-        ColumnsPolicy::Lazy,
+        Default::default(),
     )
     .unwrap();
 

--- a/tests/tests/aws_kms.rs
+++ b/tests/tests/aws_kms.rs
@@ -1,4 +1,7 @@
-use fuel_core::combined_database::CombinedDatabase;
+use fuel_core::{
+    combined_database::CombinedDatabase,
+    state::rocks_db::ColumnsPolicy,
+};
 use fuel_core_storage::transactional::AtomicView;
 use fuel_core_types::blockchain::consensus::Consensus;
 use test_helpers::fuel_core_driver::FuelCoreDriver;
@@ -47,8 +50,14 @@ async fn can_get_sealed_block_from_poa_produced_block_when_signing_with_kms() {
 
     // stop the node and just grab the database
     let db_path = driver.kill().await;
-    let db = CombinedDatabase::open(db_path.path(), 1024 * 1024, Default::default(), 512)
-        .unwrap();
+    let db = CombinedDatabase::open(
+        db_path.path(),
+        1024 * 1024,
+        Default::default(),
+        512,
+        ColumnsPolicy::Lazy,
+    )
+    .unwrap();
 
     let view = db.on_chain().latest_view().unwrap();
 

--- a/tests/tests/aws_kms.rs
+++ b/tests/tests/aws_kms.rs
@@ -54,7 +54,7 @@ async fn can_get_sealed_block_from_poa_produced_block_when_signing_with_kms() {
         db_path.path(),
         Default::default(),
         DatabaseConfig {
-            capacity: Some(1024 * 1024),
+            cache_capacity: Some(1024 * 1024),
             max_fds: 512,
             columns_policy: Default::default(),
         },

--- a/tests/tests/aws_kms.rs
+++ b/tests/tests/aws_kms.rs
@@ -53,11 +53,7 @@ async fn can_get_sealed_block_from_poa_produced_block_when_signing_with_kms() {
     let db = CombinedDatabase::open(
         db_path.path(),
         Default::default(),
-        DatabaseConfig {
-            cache_capacity: Some(1024 * 1024),
-            max_fds: 512,
-            columns_policy: Default::default(),
-        },
+        DatabaseConfig::config_for_tests(),
     )
     .unwrap();
 

--- a/tests/tests/health.rs
+++ b/tests/tests/health.rs
@@ -32,11 +32,7 @@ async fn can_restart_node() {
         let database = Database::open_rocksdb(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                capacity: None,
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let first_startup = FuelService::from_database(database, Config::local_node())
@@ -52,11 +48,7 @@ async fn can_restart_node() {
         let database = Database::open_rocksdb(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                capacity: None,
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let _second_startup = FuelService::from_database(database, Config::local_node())
@@ -76,7 +68,7 @@ async fn can_restart_node_with_transactions() {
             tmp_dir.path(),
             Default::default(),
             DatabaseConfig {
-                capacity: Some(capacity),
+                cache_capacity: Some(capacity),
                 max_fds: 512,
                 columns_policy: Default::default(),
             },
@@ -102,7 +94,7 @@ async fn can_restart_node_with_transactions() {
             tmp_dir.path(),
             Default::default(),
             DatabaseConfig {
-                capacity: Some(capacity),
+                cache_capacity: Some(capacity),
                 max_fds: 512,
                 columns_policy: Default::default(),
             },

--- a/tests/tests/health.rs
+++ b/tests/tests/health.rs
@@ -76,7 +76,7 @@ async fn can_restart_node_with_transactions() {
             tmp_dir.path(),
             Default::default(),
             DatabaseConfig {
-                capacity,
+                capacity: Some(capacity),
                 max_fds: 512,
                 columns_policy: Default::default(),
             },
@@ -102,7 +102,7 @@ async fn can_restart_node_with_transactions() {
             tmp_dir.path(),
             Default::default(),
             DatabaseConfig {
-                capacity,
+                capacity: Some(capacity),
                 max_fds: 512,
                 columns_policy: Default::default(),
             },

--- a/tests/tests/health.rs
+++ b/tests/tests/health.rs
@@ -28,9 +28,14 @@ async fn can_restart_node() {
 
     // start node once
     {
-        let database =
-            Database::open_rocksdb(tmp_dir.path(), None, Default::default(), 512)
-                .unwrap();
+        let database = Database::open_rocksdb(
+            tmp_dir.path(),
+            None,
+            Default::default(),
+            512,
+            Default::default(),
+        )
+        .unwrap();
         let first_startup = FuelService::from_database(database, Config::local_node())
             .await
             .unwrap();
@@ -41,9 +46,14 @@ async fn can_restart_node() {
     }
 
     {
-        let database =
-            Database::open_rocksdb(tmp_dir.path(), None, Default::default(), 512)
-                .unwrap();
+        let database = Database::open_rocksdb(
+            tmp_dir.path(),
+            None,
+            Default::default(),
+            512,
+            Default::default(),
+        )
+        .unwrap();
         let _second_startup = FuelService::from_database(database, Config::local_node())
             .await
             .unwrap();
@@ -57,9 +67,14 @@ async fn can_restart_node_with_transactions() {
 
     {
         // Given
-        let database =
-            CombinedDatabase::open(tmp_dir.path(), capacity, Default::default(), 512)
-                .unwrap();
+        let database = CombinedDatabase::open(
+            tmp_dir.path(),
+            capacity,
+            Default::default(),
+            512,
+            Default::default(),
+        )
+        .unwrap();
         let service = FuelService::from_combined_database(database, Config::local_node())
             .await
             .unwrap();
@@ -76,9 +91,14 @@ async fn can_restart_node_with_transactions() {
 
     {
         // When
-        let database =
-            CombinedDatabase::open(tmp_dir.path(), capacity, Default::default(), 512)
-                .unwrap();
+        let database = CombinedDatabase::open(
+            tmp_dir.path(),
+            capacity,
+            Default::default(),
+            512,
+            Default::default(),
+        )
+        .unwrap();
         let service = FuelService::from_combined_database(database, Config::local_node())
             .await
             .unwrap();

--- a/tests/tests/health.rs
+++ b/tests/tests/health.rs
@@ -59,7 +59,6 @@ async fn can_restart_node() {
 
 #[tokio::test]
 async fn can_restart_node_with_transactions() {
-    let capacity = 1024 * 1024;
     let tmp_dir = tempfile::TempDir::new().unwrap();
 
     {
@@ -67,11 +66,7 @@ async fn can_restart_node_with_transactions() {
         let database = CombinedDatabase::open(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                cache_capacity: Some(capacity),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let service = FuelService::from_combined_database(database, Config::local_node())
@@ -93,11 +88,7 @@ async fn can_restart_node_with_transactions() {
         let database = CombinedDatabase::open(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                cache_capacity: Some(capacity),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let service = FuelService::from_combined_database(database, Config::local_node())

--- a/tests/tests/health.rs
+++ b/tests/tests/health.rs
@@ -5,6 +5,7 @@ use fuel_core::{
         Config,
         FuelService,
     },
+    state::rocks_db::DatabaseConfig,
     types::fuel_tx::Transaction,
 };
 use fuel_core_client::client::FuelClient;

--- a/tests/tests/health.rs
+++ b/tests/tests/health.rs
@@ -30,10 +30,12 @@ async fn can_restart_node() {
     {
         let database = Database::open_rocksdb(
             tmp_dir.path(),
-            None,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: None,
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let first_startup = FuelService::from_database(database, Config::local_node())
@@ -48,10 +50,12 @@ async fn can_restart_node() {
     {
         let database = Database::open_rocksdb(
             tmp_dir.path(),
-            None,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: None,
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let _second_startup = FuelService::from_database(database, Config::local_node())
@@ -69,10 +73,12 @@ async fn can_restart_node_with_transactions() {
         // Given
         let database = CombinedDatabase::open(
             tmp_dir.path(),
-            capacity,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity,
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let service = FuelService::from_combined_database(database, Config::local_node())
@@ -93,10 +99,12 @@ async fn can_restart_node_with_transactions() {
         // When
         let database = CombinedDatabase::open(
             tmp_dir.path(),
-            capacity,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity,
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let service = FuelService::from_combined_database(database, Config::local_node())

--- a/tests/tests/relayer.rs
+++ b/tests/tests/relayer.rs
@@ -342,7 +342,7 @@ async fn can_restart_node_with_relayer_data() {
             tmp_dir.path(),
             Default::default(),
             DatabaseConfig {
-                capacity: Some(capacity),
+                cache_capacity: Some(capacity),
                 max_fds: 512,
                 columns_policy: Default::default(),
             },
@@ -369,7 +369,7 @@ async fn can_restart_node_with_relayer_data() {
             tmp_dir.path(),
             Default::default(),
             DatabaseConfig {
-                capacity: Some(capacity),
+                cache_capacity: Some(capacity),
                 max_fds: 512,
                 columns_policy: Default::default(),
             },

--- a/tests/tests/relayer.rs
+++ b/tests/tests/relayer.rs
@@ -15,6 +15,7 @@ use fuel_core::{
         Config,
         FuelService,
     },
+    state::rocks_db::DatabaseConfig,
 };
 use fuel_core_client::client::{
     pagination::{
@@ -332,10 +333,12 @@ async fn can_restart_node_with_relayer_data() {
         // Given
         let database = CombinedDatabase::open(
             tmp_dir.path(),
-            capacity,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: Some(capacity),
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
 
@@ -357,10 +360,12 @@ async fn can_restart_node_with_relayer_data() {
         // When
         let database = CombinedDatabase::open(
             tmp_dir.path(),
-            capacity,
             Default::default(),
-            512,
-            Default::default(),
+            DatabaseConfig {
+                capacity: Some(capacity),
+                max_fds: 512,
+                columns_policy: Default::default(),
+            },
         )
         .unwrap();
         let service = FuelService::from_combined_database(database, config)

--- a/tests/tests/relayer.rs
+++ b/tests/tests/relayer.rs
@@ -333,7 +333,6 @@ async fn can_restart_node_with_relayer_data() {
         .try_into()
         .unwrap()]);
 
-    let capacity = 1024 * 1024;
     let tmp_dir = tempfile::TempDir::new().unwrap();
 
     {
@@ -341,11 +340,7 @@ async fn can_restart_node_with_relayer_data() {
         let database = CombinedDatabase::open(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                cache_capacity: Some(capacity),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
 
@@ -368,11 +363,7 @@ async fn can_restart_node_with_relayer_data() {
         let database = CombinedDatabase::open(
             tmp_dir.path(),
             Default::default(),
-            DatabaseConfig {
-                cache_capacity: Some(capacity),
-                max_fds: 512,
-                columns_policy: Default::default(),
-            },
+            DatabaseConfig::config_for_tests(),
         )
         .unwrap();
         let service = FuelService::from_combined_database(database, config)

--- a/tests/tests/relayer.rs
+++ b/tests/tests/relayer.rs
@@ -330,9 +330,14 @@ async fn can_restart_node_with_relayer_data() {
 
     {
         // Given
-        let database =
-            CombinedDatabase::open(tmp_dir.path(), capacity, Default::default(), 512)
-                .unwrap();
+        let database = CombinedDatabase::open(
+            tmp_dir.path(),
+            capacity,
+            Default::default(),
+            512,
+            Default::default(),
+        )
+        .unwrap();
 
         let service = FuelService::from_combined_database(database, config.clone())
             .await
@@ -350,9 +355,14 @@ async fn can_restart_node_with_relayer_data() {
 
     {
         // When
-        let database =
-            CombinedDatabase::open(tmp_dir.path(), capacity, Default::default(), 512)
-                .unwrap();
+        let database = CombinedDatabase::open(
+            tmp_dir.path(),
+            capacity,
+            Default::default(),
+            512,
+            Default::default(),
+        )
+        .unwrap();
         let service = FuelService::from_combined_database(database, config)
             .await
             .unwrap();


### PR DESCRIPTION
## Description
Cache is now an option and can be enable or disabled for each rocksdb instances.

A new rocksdb config has been added to choose between the mode that open columns on database in a lazy way (useful for tests) and the mode that open all columns at once at start (useful for production and benches). Benches now use the `rocksdb-production` feature of fuel-core.

In order to be more future-proof on the database configuration options, a `DatabaseConfig` structure has been created and is used across the code.

## Breaking change

Before, if `max-database-cache-size` was unspecified then `DEFAULT_DATABASE_CACHE_SIZE` was used.
Now it make the cache disabled.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

