### PR TITLE
chore(rocksdb): getter for inner database handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2033](https://github.com/FuelLabs/fuel-core/pull/2033): Remove `Option<BlockHeight>` in favor of `BlockHeightQuery` where applicable.
 - [2472](https://github.com/FuelLabs/fuel-core/pull/2472): Added the `amountU128` field to the `Balance` GraphQL schema, providing the total balance as a `U128`. The existing `amount` field clamps any balance exceeding `U64` to `u64::MAX`.
 - [2526](https://github.com/FuelLabs/fuel-core/pull/2526): Add possibility to not have any cache set for RocksDB. Add an option to either load the RocksDB columns families on creation of the database or when the column is used.
+- [2532](https://github.com/FuelLabs/fuel-core/pull/2532): Getters for inner rocksdb database handles.
 
 ### Fixed
 - [2365](https://github.com/FuelLabs/fuel-core/pull/2365): Fixed the error during dry run in the case of race condition.

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -207,6 +207,17 @@ where
         state_rewind_policy: StateRewindPolicy,
         database_config: DatabaseConfig,
     ) -> Result<Self> {
+        let db = Self::open_as_rocksdb(path, state_rewind_policy, database_config)?;
+
+        Ok(Self::new(Arc::new(db)))
+    }
+
+    #[cfg(feature = "rocksdb")]
+    pub fn open_as_rocksdb(
+        path: &Path,
+        state_rewind_policy: StateRewindPolicy,
+        database_config: DatabaseConfig,
+    ) -> Result<HistoricalRocksDB<Description>> {
         use anyhow::Context;
 
         let db = HistoricalRocksDB::<Description>::default_open(
@@ -222,7 +233,7 @@ where
             )
         })?;
 
-        Ok(Self::new(Arc::new(db)))
+        Ok(db)
     }
 
     /// Converts the regular database to an unchecked database.

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -207,13 +207,14 @@ where
         state_rewind_policy: StateRewindPolicy,
         database_config: DatabaseConfig,
     ) -> Result<Self> {
-        let db = Self::open_as_rocksdb(path, state_rewind_policy, database_config)?;
+        let db =
+            Self::open_as_historical_rocksdb(path, state_rewind_policy, database_config)?;
 
         Ok(Self::new(Arc::new(db)))
     }
 
     #[cfg(feature = "rocksdb")]
-    pub fn open_as_rocksdb(
+    pub fn open_as_historical_rocksdb(
         path: &Path,
         state_rewind_policy: StateRewindPolicy,
         database_config: DatabaseConfig,

--- a/crates/fuel-core/src/state/historical_rocksdb.rs
+++ b/crates/fuel-core/src/state/historical_rocksdb.rs
@@ -106,6 +106,10 @@ where
         })
     }
 
+    pub fn inner(&self) -> &RocksDb<Historical<Description>> {
+        &self.db
+    }
+
     pub fn default_open<P: AsRef<Path>>(
         path: P,
         state_rewind_policy: StateRewindPolicy,

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -155,6 +155,11 @@ impl<Description> RocksDb<Description>
 where
     Description: DatabaseDescription,
 {
+    /// Allows consumers to get the inner db handle
+    pub fn inner(&self) -> &DB {
+        &self.db
+    }
+
     pub fn default_open_temp(capacity: Option<usize>) -> DatabaseResult<Self> {
         Self::default_open_temp_with_params(DatabaseConfig {
             cache_capacity: capacity,


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->
Should allow consumers of the library to get the inner db handle if they wanted to create a backup etc.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
