### PR TITLE
fix(nextest): override timeout for slow ci tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,7 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 5 }
+
+# really slow test on ci
+[[profile.default.overrides]]
+filter = 'test(poa_interval_produces_nonempty_blocks_at_correct_rate)'
+slow-timeout = { period = "420s", terminate-after = 5 }


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- A lot of PRs fail due to this test being slow only in the CI environment, could be due to disk bandwidth on the runners

## Description
<!-- List of detailed changes -->
- Adds an override to `nextest.toml` for the specific test that often times out

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?

