### PR TITLE
Lock-free `latest_l2_height` in gas price service

### DIFF
--- a/crates/services/gas_price_service/src/v1/da_source_service.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service.rs
@@ -37,15 +37,12 @@ mod tests {
     use fuel_core_types::fuel_types::BlockHeight;
     use std::{
         sync::{
+            atomic::AtomicU32,
             Arc,
             Mutex,
         },
         time::Duration,
     };
-
-    fn latest_l2_height(height: u32) -> Arc<Mutex<BlockHeight>> {
-        Arc::new(Mutex::new(BlockHeight::new(height)))
-    }
 
     #[tokio::test]
     async fn run__when_da_block_cost_source_gives_value_shared_state_is_updated() {
@@ -59,7 +56,7 @@ mod tests {
         let notifier = Arc::new(tokio::sync::Notify::new());
         let da_block_costs_source =
             DummyDaBlockCosts::new(Ok(expected_da_cost.clone()), notifier.clone());
-        let latest_l2_height = Arc::new(Mutex::new(BlockHeight::new(10u32)));
+        let latest_l2_height = Arc::new(AtomicU32::new(10u32));
         let service = new_da_service(
             da_block_costs_source,
             Some(Duration::from_millis(1)),
@@ -83,7 +80,7 @@ mod tests {
         let notifier = Arc::new(tokio::sync::Notify::new());
         let da_block_costs_source =
             DummyDaBlockCosts::new(Err(anyhow::anyhow!("boo!")), notifier.clone());
-        let latest_l2_height = latest_l2_height(0);
+        let latest_l2_height = Arc::new(AtomicU32::new(0));
         let service = new_da_service(
             da_block_costs_source,
             Some(Duration::from_millis(1)),
@@ -116,7 +113,7 @@ mod tests {
         let notifier = Arc::new(tokio::sync::Notify::new());
         let da_block_costs_source =
             DummyDaBlockCosts::new(Ok(unexpected_costs.clone()), notifier.clone());
-        let latest_l2_height = latest_l2_height(l2_height);
+        let latest_l2_height = Arc::new(AtomicU32::new(l2_height));
         let service = new_da_service(
             da_block_costs_source,
             Some(Duration::from_millis(1)),
@@ -147,7 +144,7 @@ mod tests {
         let notifier = Arc::new(tokio::sync::Notify::new());
         let da_block_costs_source =
             DummyDaBlockCosts::new(Ok(unexpected_costs.clone()), notifier.clone());
-        let latest_l2_height = latest_l2_height(l2_height);
+        let latest_l2_height = Arc::new(AtomicU32::new(l2_height));
         let mut service = DaSourceService::new(
             da_block_costs_source,
             Some(Duration::from_millis(1)),
@@ -178,7 +175,7 @@ mod tests {
         let notifier = Arc::new(tokio::sync::Notify::new());
         let da_block_costs_source =
             DummyDaBlockCosts::new(Ok(unexpected_costs.clone()), notifier.clone());
-        let latest_l2_height = latest_l2_height(l2_height);
+        let latest_l2_height = Arc::new(AtomicU32::new(l2_height));
         let (sender, mut receiver) =
             tokio::sync::broadcast::channel(DA_BLOCK_COSTS_CHANNEL_SIZE);
         let mut service = DaSourceService::new_with_sender(

--- a/crates/services/gas_price_service/src/v1/da_source_service/service.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service/service.rs
@@ -7,6 +7,10 @@ use fuel_core_services::{
 };
 use std::{
     sync::{
+        atomic::{
+            AtomicU32,
+            Ordering,
+        },
         Arc,
         Mutex,
     },
@@ -43,7 +47,7 @@ pub struct DaSourceService<Source> {
     poll_interval: Interval,
     source: Source,
     shared_state: SharedState,
-    latest_l2_height: Arc<Mutex<BlockHeight>>,
+    latest_l2_height: Arc<AtomicU32>,
     recorded_height: Option<BlockHeight>,
 }
 
@@ -57,7 +61,7 @@ where
     pub fn new(
         source: Source,
         poll_interval: Option<Duration>,
-        latest_l2_height: Arc<Mutex<BlockHeight>>,
+        latest_l2_height: Arc<AtomicU32>,
         recorded_height: Option<BlockHeight>,
     ) -> Self {
         let (sender, _) = tokio::sync::broadcast::channel(DA_BLOCK_COSTS_CHANNEL_SIZE);
@@ -77,7 +81,7 @@ where
     pub fn new_with_sender(
         source: Source,
         poll_interval: Option<Duration>,
-        latest_l2_height: Arc<Mutex<BlockHeight>>,
+        latest_l2_height: Arc<AtomicU32>,
         recorded_height: Option<BlockHeight>,
         sender: Sender<DaBlockCosts>,
     ) -> Self {
@@ -103,7 +107,7 @@ where
             .filter_costs_that_have_values_greater_than_l2_block_height(da_block_costs)?;
         tracing::debug!(
             "the latest l2 height is: {:?}",
-            *self.latest_l2_height.lock().unwrap()
+            self.latest_l2_height.load(Ordering::Acquire)
         );
         for da_block_costs in filtered_block_costs {
             tracing::debug!("Sending block costs: {:?}", da_block_costs);
@@ -124,12 +128,9 @@ where
         &self,
         da_block_costs: Vec<DaBlockCosts>,
     ) -> Result<impl Iterator<Item = DaBlockCosts>> {
-        let latest_l2_height = *self
-            .latest_l2_height
-            .lock()
-            .map_err(|err| anyhow::anyhow!("lock error: {:?}", err))?;
+        let latest_l2_height = self.latest_l2_height.load(Ordering::Acquire);
         let iter = da_block_costs.into_iter().filter(move |da_block_costs| {
-            let end = BlockHeight::from(*da_block_costs.l2_blocks.end());
+            let end = *da_block_costs.l2_blocks.end();
             end < latest_l2_height
         });
         Ok(iter)
@@ -206,11 +207,11 @@ where
     }
 }
 
-#[cfg(feature = "test-helpers")]
+#[cfg(any(test, feature = "test-helpers"))]
 pub fn new_da_service<S: DaBlockCostsSource>(
     da_source: S,
     poll_interval: Option<Duration>,
-    latest_l2_height: Arc<Mutex<BlockHeight>>,
+    latest_l2_height: Arc<AtomicU32>,
 ) -> ServiceRunner<DaSourceService<S>> {
     ServiceRunner::new(DaSourceService::new(
         da_source,


### PR DESCRIPTION
## Description
This PR removes the `Mutex` around the `latest_l2_height` in the gas price service.

### Before requesting review
- [X] I have reviewed the code myself
