### PR TITLE
Add test for sentry gas price estimation

### DIFF
--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -83,6 +83,25 @@ pub enum BootstrapType {
     ReservedNodes,
 }
 
+/// Set of values that will be overridden in the node's configuration
+#[derive(Clone, Debug)]
+pub struct ConfigOverrides {
+    min_exec_gas_price: Option<u64>,
+}
+
+impl ConfigOverrides {
+    pub fn no_overrides() -> Self {
+        Self {
+            min_exec_gas_price: None,
+        }
+    }
+
+    pub fn min_gas_price(mut self, min_gas_price: u64) -> Self {
+        self.min_exec_gas_price = Some(min_gas_price);
+        self
+    }
+}
+
 #[derive(Clone)]
 /// Setup for a producer node
 pub struct ProducerSetup {
@@ -96,6 +115,8 @@ pub struct ProducerSetup {
     pub utxo_validation: bool,
     /// Indicates the type of initial connections.
     pub bootstrap_type: BootstrapType,
+    /// Config Overrides
+    pub config_overrides: ConfigOverrides,
 }
 
 #[derive(Clone)]
@@ -109,6 +130,8 @@ pub struct ValidatorSetup {
     pub utxo_validation: bool,
     /// Indicates the type of initial connections.
     pub bootstrap_type: BootstrapType,
+    /// Config Overrides
+    pub config_overrides: ConfigOverrides,
 }
 
 #[derive(Clone)]
@@ -285,6 +308,7 @@ pub async fn make_nodes(
                             .then_some(name)
                             .unwrap_or_else(|| format!("b:{i}")),
                         config.clone(),
+                        ConfigOverrides::no_overrides(),
                     );
                     if let Some(BootstrapSetup { pub_key, .. }) = boot {
                         update_signing_key(&mut node_config, pub_key);
@@ -303,11 +327,15 @@ pub async fn make_nodes(
     for (i, s) in producers_with_txs.into_iter().enumerate() {
         let config = config.clone();
         let name = s.as_ref().map_or(String::new(), |s| s.0.name.clone());
+        let overrides = s
+            .clone()
+            .map_or(ConfigOverrides::no_overrides(), |s| s.0.config_overrides);
         let mut node_config = make_config(
             (!name.is_empty())
                 .then_some(name)
                 .unwrap_or_else(|| format!("p:{i}")),
             config.clone(),
+            overrides,
         );
 
         let mut test_txs = Vec::with_capacity(0);
@@ -358,11 +386,15 @@ pub async fn make_nodes(
     for (i, s) in validators_setup.into_iter().enumerate() {
         let config = config.clone();
         let name = s.as_ref().map_or(String::new(), |s| s.name.clone());
+        let overrides = s
+            .clone()
+            .map_or(ConfigOverrides::no_overrides(), |s| s.config_overrides);
         let mut node_config = make_config(
             (!name.is_empty())
                 .then_some(name)
                 .unwrap_or_else(|| format!("v:{i}")),
             config.clone(),
+            overrides,
         );
         node_config.block_production = Trigger::Never;
 
@@ -420,10 +452,17 @@ fn update_signing_key(config: &mut Config, key: Address) {
     config.snapshot_reader = snapshot_reader.clone().with_chain_config(chain_config)
 }
 
-pub fn make_config(name: String, mut node_config: Config) -> Config {
+pub fn make_config(
+    name: String,
+    mut node_config: Config,
+    config_overrides: ConfigOverrides,
+) -> Config {
     node_config.p2p = Config::local_node().p2p;
     node_config.utxo_validation = true;
     node_config.name = name;
+    if let Some(min_gas_price) = config_overrides.min_exec_gas_price {
+        node_config.min_exec_gas_price = min_gas_price;
+    }
     node_config
 }
 
@@ -602,6 +641,21 @@ impl ProducerSetup {
             num_test_txs: Default::default(),
             utxo_validation: true,
             bootstrap_type: BootstrapType::BootstrapNodes,
+            config_overrides: ConfigOverrides::no_overrides(),
+        }
+    }
+
+    pub fn new_with_overrides(
+        secret: SecretKey,
+        config_overrides: ConfigOverrides,
+    ) -> Self {
+        Self {
+            name: Default::default(),
+            secret,
+            num_test_txs: Default::default(),
+            utxo_validation: true,
+            bootstrap_type: BootstrapType::BootstrapNodes,
+            config_overrides,
         }
     }
 
@@ -641,6 +695,20 @@ impl ValidatorSetup {
             name: Default::default(),
             utxo_validation: true,
             bootstrap_type: BootstrapType::BootstrapNodes,
+            config_overrides: ConfigOverrides::no_overrides(),
+        }
+    }
+
+    pub fn new_with_overrides(
+        pub_key: Address,
+        config_overrides: ConfigOverrides,
+    ) -> Self {
+        Self {
+            pub_key,
+            name: Default::default(),
+            utxo_validation: true,
+            bootstrap_type: BootstrapType::BootstrapNodes,
+            config_overrides,
         }
     }
 

--- a/crates/services/gas_price_service/src/v1/uninitialized_task.rs
+++ b/crates/services/gas_price_service/src/v1/uninitialized_task.rs
@@ -136,8 +136,13 @@ where
             .map(|x| x.into())
             .unwrap_or(latest_block_height);
 
-        let (algo_updater, shared_algo) =
-            initialize_algorithm(&config, gas_price_metadata_height, &gas_price_db)?;
+        let (algo_updater, shared_algo) = initialize_algorithm(
+            &config,
+            gas_price_metadata_height,
+            latest_block_height,
+            &gas_price_db,
+        )?;
+
         let latest_gas_price = on_chain_db
             .latest_view()?
             .get_block(&latest_block_height.into())?
@@ -146,17 +151,6 @@ where
                 Some(gas_price)
             })
             .unwrap_or(algo_updater.algorithm().next_gas_price());
-
-        let gas_price_metadata_height = gas_metadata_height
-            .map(|x| x.into())
-            .unwrap_or(latest_block_height);
-
-        let (algo_updater, shared_algo) = initialize_algorithm(
-            &config,
-            gas_price_metadata_height,
-            latest_block_height,
-            &gas_price_db,
-        )?;
 
         let latest_gas_price = LatestGasPrice::new(latest_block_height, latest_gas_price);
 

--- a/tests/tests/gas_price.rs
+++ b/tests/tests/gas_price.rs
@@ -960,12 +960,12 @@ async fn sentry__gas_price_estimate__uses_gas_price_from_produced_block() {
     // when
     let num_of_blocks = 5;
     let producer_client = FuelClient::from(producer.node.bound_address);
-    let latest_block_height = producer_client
+    let producer_block_height = producer_client
         .produce_blocks(num_of_blocks, None)
         .await
         .unwrap();
     let block = producer_client
-        .block_by_height(latest_block_height)
+        .block_by_height(producer_block_height)
         .await
         .unwrap()
         .unwrap();
@@ -988,7 +988,10 @@ async fn sentry__gas_price_estimate__uses_gas_price_from_produced_block() {
 
     // then
     let validator_client = FuelClient::from(validator.node.bound_address);
-    let estimate = validator_client.estimate_gas_price(0).await.unwrap();
+    let validator_gas_price = validator_client.estimate_gas_price(0).await.unwrap();
+    let validator_chain_info = validator_client.chain_info().await.unwrap();
+    let validator_block_height = validator_chain_info.latest_block.header.height.into();
 
-    assert_eq!(gas_price, u64::from(estimate.gas_price));
+    assert_eq!(producer_block_height, validator_block_height);
+    assert_eq!(gas_price, u64::from(validator_gas_price.gas_price));
 }

--- a/tests/tests/poa.rs
+++ b/tests/tests/poa.rs
@@ -165,6 +165,7 @@ mod p2p {
             make_config,
             make_node,
             Bootstrap,
+            ConfigOverrides,
         },
     };
     use fuel_core_poa::{
@@ -195,11 +196,19 @@ mod p2p {
         let mut config = Config::local_node();
         update_signing_key(&mut config, pub_key);
 
-        let bootstrap_config = make_config("Bootstrap".to_string(), config.clone());
+        let bootstrap_config = make_config(
+            "Bootstrap".to_string(),
+            config.clone(),
+            ConfigOverrides::no_overrides(),
+        );
         let bootstrap = Bootstrap::new(&bootstrap_config).await.unwrap();
 
         let make_node_config = |name: &str| {
-            let mut config = make_config(name.to_string(), config.clone());
+            let mut config = make_config(
+                name.to_string(),
+                config.clone(),
+                ConfigOverrides::no_overrides(),
+            );
             config.debug = true;
             config.block_production = Trigger::Interval {
                 block_time: Duration::from_secs(1),


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->

We want to make sure that the sentry gas price matches the value on blocks it receives over P2P.

## Checklist
- [x] New behavior is reflected in tests
