### PR TITLE
Release v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.41.0]
+
 ### Added
 - [2547](https://github.com/FuelLabs/fuel-core/pull/2547): Replace the old Graphql gas price provider adapter with the ArcGasPriceEstimate.
 - [2445](https://github.com/FuelLabs/fuel-core/pull/2445): Added GQL endpoint for querying asset details.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,11 +165,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -230,7 +231,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -242,7 +243,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -315,7 +316,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.3.0",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "slab",
 ]
 
@@ -327,7 +328,7 @@ checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
 dependencies = [
  "async-lock 3.4.0",
  "blocking",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -341,7 +342,7 @@ dependencies = [
  "async-io 2.4.0",
  "async-lock 3.4.0",
  "blocking",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "once_cell",
 ]
 
@@ -391,7 +392,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.26.3",
- "syn 2.0.95",
+ "syn 2.0.96",
  "thiserror 1.0.69",
 ]
 
@@ -449,7 +450,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "parking",
  "polling 3.7.4",
  "rustix 0.38.43",
@@ -486,7 +487,7 @@ checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
  "async-io 2.4.0",
  "blocking",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -503,7 +504,7 @@ dependencies = [
  "blocking",
  "cfg-if",
  "event-listener 5.4.0",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "rustix 0.38.43",
  "tracing",
 ]
@@ -540,7 +541,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "gloo-timers 0.3.0",
  "kv-log-macro",
  "log",
@@ -571,7 +572,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -588,7 +589,7 @@ checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -667,13 +668,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -746,7 +747,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.11.0",
+ "uuid 1.12.0",
 ]
 
 [[package]]
@@ -817,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.54.0"
+version = "1.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249b2acaa8e02fd4718705a9494e3eb633637139aa4bb09d70965b0448e865db"
+checksum = "861d324ef69247c6f3c6823755f408a68877ffb1a9afaff6dd8b0057c760de60"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -863,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427cb637d15d63d6f9aae26358e1c9a9c09d5aa490d64b09354c8217cfef0f28"
+checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -874,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.11"
+version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
+checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -894,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
+checksum = "623a51127f24c30776c8b374295f2df78d92517386f77ba30773f15a30ce1422"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -913,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.6"
+version = "1.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05dd41a70fc74051758ee75b5c4db2c0ca070ed9229c3df50e9475cda1cb985"
+checksum = "865f7050bbc7107a6c98a397a9fcd9413690c27fa718446967cf03b2d3ac517e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -957,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.11"
+version = "1.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ddc9bd6c28aeb303477170ddd183760a956a03e083b3902a990238a7e3792d"
+checksum = "a28f6feb647fb5e0d5b50f0472c19a7db9462b74e2fec01bb0b44eedcc834e97"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1235,7 +1236,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1292,9 +1293,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -1347,7 +1348,7 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
  "piper",
 ]
 
@@ -1470,9 +1471,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "jobserver",
  "libc",
@@ -1588,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.25"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95dca1b68188a08ca6af9d96a6576150f598824bdb528c1190460c2940a0b48"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1598,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.25"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab52925392148efd3f7562f2136a81ffb778076bcc85727c6e020d6dd57cf15"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1617,7 +1618,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2111,7 +2112,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -2222,7 +2223,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2266,7 +2267,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.95",
+ "syn 2.0.96",
  "thiserror 1.0.69",
 ]
 
@@ -2290,7 +2291,7 @@ dependencies = [
  "cynic-codegen",
  "darling",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2314,7 +2315,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2325,20 +2326,20 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
+checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2346,12 +2347,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
+checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2360,7 +2361,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
- "uuid 1.11.0",
+ "uuid 1.12.0",
 ]
 
 [[package]]
@@ -2418,7 +2419,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2438,7 +2439,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "unicode-xid",
 ]
 
@@ -2555,7 +2556,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2658,7 +2659,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2749,7 +2750,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2769,7 +2770,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2789,7 +2790,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2944,7 +2945,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.95",
+ "syn 2.0.96",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -2962,7 +2963,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2988,7 +2989,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.95",
+ "syn 2.0.96",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -3325,7 +3326,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122c27ab46707017063bf1c6e0b4f3de881e22e81b4059750a0dc95033d9cc26"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "fuel-types 0.56.0",
  "serde",
  "strum 0.24.1",
@@ -3337,7 +3338,7 @@ version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "885617a606218680114122f4e1107ed5c9424e42dec05de84843e4a3a99e2cd7"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "fuel-types 0.59.1",
  "serde",
  "strum 0.24.1",
@@ -3356,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3387,7 +3388,7 @@ dependencies = [
  "fuel-core-sync",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3417,7 +3418,7 @@ dependencies = [
  "tower-http 0.4.4",
  "tracing",
  "url",
- "uuid 1.11.0",
+ "uuid 1.12.0",
 ]
 
 [[package]]
@@ -3438,7 +3439,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-sync",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "futures",
  "hex",
  "itertools 0.12.1",
@@ -3460,11 +3461,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.40.2"
+version = "0.41.0"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3479,7 +3480,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3502,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3510,7 +3511,7 @@ dependencies = [
  "derivative",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3528,14 +3529,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more 0.99.18",
  "eventsource-client",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -3552,22 +3553,22 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "clap",
  "fuel-core-client",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "fuel-core-compression",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "paste",
  "postcard",
  "proptest",
@@ -3580,30 +3581,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3611,7 +3612,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "futures",
  "hex",
  "humantime-serde",
@@ -3628,12 +3629,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "hex",
  "parking_lot",
  "serde",
@@ -3642,14 +3643,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "enum-iterator",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "fuel-gas-price-algorithm",
  "futures",
  "mockito",
@@ -3669,14 +3670,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "mockall",
  "parking_lot",
  "rayon",
@@ -3687,18 +3688,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "clap",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -3711,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3726,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3737,7 +3738,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3767,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3776,7 +3777,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "mockall",
  "rand",
  "serde",
@@ -3789,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3797,7 +3798,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "mockall",
  "proptest",
  "rand",
@@ -3808,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3822,7 +3823,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "futures",
  "mockall",
  "once_cell",
@@ -3841,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3858,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3866,7 +3867,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -3881,13 +3882,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "fuel-vm 0.59.1",
  "impl-tools",
  "itertools 0.12.1",
@@ -3905,13 +3906,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "futures",
  "mockall",
  "rand",
@@ -3946,7 +3947,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3974,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "ctor",
  "tracing",
@@ -3984,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3994,7 +3995,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "futures",
  "mockall",
  "num-rational",
@@ -4026,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4046,13 +4047,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "fuel-core-wasm-executor",
  "parking_lot",
  "postcard",
@@ -4062,13 +4063,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "postcard",
  "proptest",
  "serde",
@@ -4120,7 +4121,7 @@ checksum = "3f49fdbfc1615d88d2849650afc2b0ac2fecd69661ebadd31a073d8416747764"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -4132,13 +4133,13 @@ checksum = "8703ee10001e6a52ad9a0d8411ca5a92098de978ccfbdddd0ba185f3a7405b4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "synstructure",
 ]
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "proptest",
  "rand",
@@ -4207,7 +4208,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aae44611588d199dd119e4a0ebd8eb7ae4cde6bf8b4d12715610b1f5e5b731"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "derivative",
  "derive_more 0.99.18",
  "fuel-asm 0.56.0",
@@ -4229,7 +4230,7 @@ version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806498d953bc989995425f1bb7c17890f5538a3664c6ec3b5d8a77c63d617421"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "derive_more 1.0.0",
  "educe",
  "fuel-asm 0.59.1",
@@ -4277,7 +4278,7 @@ checksum = "64fc4695efac9207276f6229f2dd9811848b328a13604a698f7bce1d452bd986"
 dependencies = [
  "async-trait",
  "backtrace",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "derivative",
  "derive_more 0.99.18",
  "ethnum",
@@ -4309,7 +4310,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backtrace",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "derive_more 0.99.18",
  "educe",
  "ethnum",
@@ -4418,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand 2.3.0",
  "futures-core",
@@ -4447,7 +4448,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4457,7 +4458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "rustls-pki-types",
 ]
 
@@ -5059,7 +5060,7 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.5.2",
  "hyper-util",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -5249,7 +5250,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5374,7 +5375,7 @@ dependencies = [
  "autocfg",
  "impl-tools-lib",
  "proc-macro-error2",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5386,7 +5387,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5397,7 +5398,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5582,9 +5583,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -6062,7 +6063,7 @@ dependencies = [
  "quinn",
  "rand",
  "ring 0.17.8",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "socket2 0.5.8",
  "thiserror 1.0.69",
  "tokio",
@@ -6123,7 +6124,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6175,7 +6176,7 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring 0.17.8",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
  "x509-parser",
@@ -6240,7 +6241,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -6251,7 +6252,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "libc",
 ]
 
@@ -6383,9 +6384,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 dependencies = [
  "value-bag",
 ]
@@ -6411,7 +6412,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.5",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -6535,9 +6536,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -6785,7 +6786,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "libc",
 ]
@@ -6796,7 +6797,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6940,7 +6941,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7042,9 +7043,9 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944fa20996a25aded6b4795c6d63f10014a7a83f8be9828a11860b08c5fc4a67"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -7053,16 +7054,15 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b0deead1528fd0e5947a8546a9642a9777c25f6e1e26f34c97b204bbb465bd"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7273,7 +7273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "ucd-trie",
 ]
 
@@ -7297,7 +7297,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7361,7 +7361,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7399,7 +7399,7 @@ checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7565,7 +7565,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -7636,12 +7636,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7699,9 +7699,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -7714,7 +7714,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -7739,7 +7739,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7750,7 +7750,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -7815,7 +7815,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7828,7 +7828,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -7975,9 +7975,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "socket2 0.5.8",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -7993,10 +7993,10 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.1.0",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8072,11 +8072,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.2.0"
+version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
+checksum = "c6928fa44c097620b706542d428957635951bade7143269085389d42c8a4927e"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -8126,7 +8126,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -8163,7 +8163,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8298,7 +8298,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -8529,7 +8529,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -8550,9 +8550,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -8696,7 +8696,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8810,7 +8810,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -8880,7 +8880,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8903,7 +8903,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -8954,7 +8954,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9078,13 +9078,13 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -9138,7 +9138,7 @@ dependencies = [
  "async-net",
  "async-process",
  "blocking",
- "futures-lite 2.5.0",
+ "futures-lite 2.6.0",
 ]
 
 [[package]]
@@ -9290,7 +9290,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9301,7 +9301,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9354,7 +9354,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9367,7 +9367,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9426,21 +9426,21 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.13.1"
+version = "12.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf08b42a6f9469bd8584daee39a1352c8133ccabc5151ccccb15896ef047d99a"
+checksum = "8150eae9699e3c73a3e6431dc1f80d87748797c0457336af23e94c1de619ed24"
 dependencies = [
  "debugid",
  "memmap2",
  "stable_deref_trait",
- "uuid 1.11.0",
+ "uuid 1.12.0",
 ]
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.13.1"
+version = "12.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f73b5a5bd4da72720c45756a2d11edf110116b87f998bda59b97be8c2c7cf1"
+checksum = "95f4a9846f7a8933b6d198c022faa2c9bd89e1a970bed9d9a98d25708bf8de17"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -9460,9 +9460,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9492,7 +9492,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9512,7 +9512,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
 ]
@@ -9705,7 +9705,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid 1.11.0",
+ "uuid 1.12.0",
  "walkdir",
 ]
 
@@ -9765,7 +9765,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9776,7 +9776,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "test-case-core",
 ]
 
@@ -9795,7 +9795,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.40.2",
+ "fuel-core-types 0.41.0",
  "futures",
  "itertools 0.12.1",
  "rand",
@@ -9813,7 +9813,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -9827,11 +9827,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.10",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -9842,18 +9842,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -10017,7 +10017,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -10046,7 +10046,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "tokio",
 ]
 
@@ -10250,7 +10250,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -10308,7 +10308,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -10556,9 +10556,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom",
 ]
@@ -10641,34 +10641,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -10679,9 +10680,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10689,22 +10690,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -10722,7 +10726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
 dependencies = [
  "ahash",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "hashbrown 0.14.5",
  "indexmap 2.7.0",
  "semver",
@@ -10747,7 +10751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe501caefeb9f7b15360bdd7e47ad96e20223846f1c7db485ae5820ba5acc3d2"
 dependencies = [
  "anyhow",
- "bitflags 2.6.0",
+ "bitflags 2.8.0",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -10820,7 +10824,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -10919,7 +10923,7 @@ checksum = "a2bde986038b819bc43a21fef0610aeb47aabfe3ea09ca3533a7b81023b84ec6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -10936,9 +10940,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11224,9 +11228,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -11429,7 +11433,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -11451,7 +11455,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -11471,7 +11475,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -11492,7 +11496,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -11514,7 +11518,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,41 +57,41 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.40.2"
+version = "0.41.0"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.40.2", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.40.2", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.40.2", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.40.2", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.40.2", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.40.2", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.40.2", path = "./crates/client" }
-fuel-core-compression = { version = "0.40.2", path = "./crates/compression" }
-fuel-core-database = { version = "0.40.2", path = "./crates/database" }
-fuel-core-metrics = { version = "0.40.2", path = "./crates/metrics" }
-fuel-core-services = { version = "0.40.2", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.40.2", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.40.2", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.40.2", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.40.2", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.40.2", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.40.2", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.40.2", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.40.2", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.40.2", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.40.2", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.40.2", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.40.2", path = "./crates/services/txpool_v2" }
-fuel-core-storage = { version = "0.40.2", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.40.2", path = "./crates/trace" }
-fuel-core-types = { version = "0.40.2", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.41.0", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.41.0", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.41.0", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.41.0", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.41.0", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.41.0", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.41.0", path = "./crates/client" }
+fuel-core-compression = { version = "0.41.0", path = "./crates/compression" }
+fuel-core-database = { version = "0.41.0", path = "./crates/database" }
+fuel-core-metrics = { version = "0.41.0", path = "./crates/metrics" }
+fuel-core-services = { version = "0.41.0", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.41.0", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.41.0", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.41.0", path = "./crates/services/consensus_module/poa" }
+fuel-core-shared-sequencer = { version = "0.41.0", path = "crates/services/shared-sequencer" }
+fuel-core-executor = { version = "0.41.0", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.41.0", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.41.0", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.41.0", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.41.0", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.41.0", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.41.0", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.41.0", path = "./crates/services/txpool_v2" }
+fuel-core-storage = { version = "0.41.0", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.41.0", path = "./crates/trace" }
+fuel-core-types = { version = "0.41.0", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.40.2", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.40.2", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.41.0", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.41.0", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.40.2", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.41.0", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.59.1", package = "fuel-vm", default-features = false }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ git clone https://github.com/FuelLabs/fuel-core.git
 
 Go to the latest release tag for ignition on the `fuel-core` repository :
 ```
-git checkout v0.40.2
+git checkout v0.41.0
 ```
 
 Build your node binary:

--- a/benches/src/db_lookup_times_utils/mod.rs
+++ b/benches/src/db_lookup_times_utils/mod.rs
@@ -23,7 +23,7 @@ mod tests {
     const TEST_TX_COUNT: u32 = 10;
 
     fn setup_test_db() -> RocksDb<BenchDatabase> {
-        RocksDb::default_open_temp(None).unwrap()
+        RocksDb::default_open_temp().unwrap()
     }
 
     #[test]

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -304,7 +304,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 18,
+  "genesis_state_transition_version": 19,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/bin/fuel-core/src/cli/rollback.rs
+++ b/bin/fuel-core/src/cli/rollback.rs
@@ -5,7 +5,10 @@ use fuel_core::{
     combined_database::CombinedDatabase,
     state::{
         historical_rocksdb::StateRewindPolicy,
-        rocks_db::DatabaseConfig,
+        rocks_db::{
+            ColumnsPolicy,
+            DatabaseConfig,
+        },
     },
 };
 use rlimit::{
@@ -58,7 +61,7 @@ pub async fn exec(command: Command) -> anyhow::Result<()> {
         DatabaseConfig {
             cache_capacity: Some(64 * 1024 * 1024),
             max_fds: command.rocksdb_max_fds,
-            columns_policy: Default::default(),
+            columns_policy: ColumnsPolicy::Lazy,
         },
     )
     .map_err(Into::<anyhow::Error>::into)

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -308,7 +308,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 18,
+  "genesis_state_transition_version": 19,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -67,10 +67,6 @@ pub use fuel_core_database::Error;
 pub type Result<T> = core::result::Result<T, Error>;
 
 // TODO: Extract `Database` and all belongs into `fuel-core-database`.
-use crate::database::database_description::{
-    gas_price::GasPriceDatabase,
-    indexation_availability,
-};
 #[cfg(feature = "rocksdb")]
 use crate::state::{
     historical_rocksdb::{
@@ -82,6 +78,13 @@ use crate::state::{
         DatabaseConfig,
         RocksDb,
     },
+};
+use crate::{
+    database::database_description::{
+        gas_price::GasPriceDatabase,
+        indexation_availability,
+    },
+    state::rocks_db::ColumnsPolicy,
 };
 #[cfg(feature = "rocksdb")]
 use std::path::Path;
@@ -290,7 +293,7 @@ where
                 DatabaseConfig {
                     cache_capacity: None,
                     max_fds: 512,
-                    columns_policy: Default::default(),
+                    columns_policy: ColumnsPolicy::Lazy,
                 },
             )
             .expect("Failed to create a temporary database")

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -133,13 +133,8 @@ impl Config {
         let utxo_validation = false;
 
         let combined_db_config = CombinedDatabaseConfig {
-            // Set the cache for tests = 10MB
             #[cfg(feature = "rocksdb")]
-            database_config: DatabaseConfig {
-                cache_capacity: Some(10 * 1024 * 1024),
-                columns_policy: Default::default(),
-                max_fds: 512,
-            },
+            database_config: DatabaseConfig::config_for_tests(),
             database_path: Default::default(),
             #[cfg(feature = "rocksdb")]
             database_type: DbType::RocksDb,

--- a/crates/fuel-core/src/state/historical_rocksdb.rs
+++ b/crates/fuel-core/src/state/historical_rocksdb.rs
@@ -670,7 +670,7 @@ mod tests {
     #[test]
     fn historical_rocksdb_read_original_database_works() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db =
             HistoricalRocksDB::new(rocks_db, StateRewindPolicy::RewindFullRange).unwrap();
 
@@ -710,7 +710,7 @@ mod tests {
     #[test]
     fn historical_rocksdb_read_latest_view_works() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db =
             HistoricalRocksDB::new(rocks_db, StateRewindPolicy::RewindFullRange).unwrap();
 
@@ -750,7 +750,7 @@ mod tests {
     #[test]
     fn state_rewind_policy__no_rewind__create_view_at__fails() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db =
             HistoricalRocksDB::new(rocks_db, StateRewindPolicy::NoRewind).unwrap();
 
@@ -777,7 +777,7 @@ mod tests {
     #[test]
     fn state_rewind_policy__no_rewind__rollback__fails() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db =
             HistoricalRocksDB::new(rocks_db, StateRewindPolicy::NoRewind).unwrap();
 
@@ -800,7 +800,7 @@ mod tests {
     #[test]
     fn state_rewind_policy__rewind_range_1__cleanup_in_range_works() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db = HistoricalRocksDB::new(
             rocks_db,
             StateRewindPolicy::RewindRange {
@@ -847,7 +847,7 @@ mod tests {
     #[test]
     fn state_rewind_policy__rewind_range_1__rollback_works() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db = HistoricalRocksDB::new(
             rocks_db,
             StateRewindPolicy::RewindRange {
@@ -885,7 +885,7 @@ mod tests {
     #[test]
     fn state_rewind_policy__rewind_range_1__rollback_uses_v2() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db = HistoricalRocksDB::new(
             rocks_db,
             StateRewindPolicy::RewindRange {
@@ -920,7 +920,7 @@ mod tests {
     #[test]
     fn state_rewind_policy__rewind_range_1__rollback_during_migration_works() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db = HistoricalRocksDB::new(
             rocks_db,
             StateRewindPolicy::RewindRange {
@@ -994,7 +994,7 @@ mod tests {
     #[test]
     fn rollback_last_block_works_with_v2() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
 
         let historical_rocks_db =
             HistoricalRocksDB::new(rocks_db, StateRewindPolicy::RewindFullRange).unwrap();
@@ -1027,7 +1027,7 @@ mod tests {
     #[test]
     fn state_rewind_policy__rewind_range_1__second_rollback_fails() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db = HistoricalRocksDB::new(
             rocks_db,
             StateRewindPolicy::RewindRange {
@@ -1057,7 +1057,7 @@ mod tests {
     fn state_rewind_policy__rewind_range_10__rollbacks_work() {
         const ITERATIONS: usize = 100;
 
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db = HistoricalRocksDB::new(
             rocks_db,
             StateRewindPolicy::RewindRange {

--- a/crates/fuel-core/src/state/historical_rocksdb/view_at_height.rs
+++ b/crates/fuel-core/src/state/historical_rocksdb/view_at_height.rs
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn historical_rocksdb_view_at_each_height_works() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db =
             HistoricalRocksDB::new(rocks_db, StateRewindPolicy::RewindFullRange).unwrap();
 
@@ -189,7 +189,7 @@ mod tests {
     #[test]
     fn historical_rocksdb_view_at_each_height_works_when_multiple_modifications() {
         // Given
-        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp(None).unwrap();
+        let rocks_db = RocksDb::<Historical<OnChain>>::default_open_temp().unwrap();
         let historical_rocks_db =
             HistoricalRocksDB::new(rocks_db, StateRewindPolicy::RewindFullRange).unwrap();
 

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -155,11 +155,11 @@ impl<Description> RocksDb<Description>
 where
     Description: DatabaseDescription,
 {
-    pub fn default_open_temp(capacity: Option<usize>) -> DatabaseResult<Self> {
+    pub fn default_open_temp() -> DatabaseResult<Self> {
         Self::default_open_temp_with_params(DatabaseConfig {
-            cache_capacity: capacity,
+            cache_capacity: None,
             max_fds: 512,
-            columns_policy: Default::default(),
+            columns_policy: ColumnsPolicy::Lazy,
         })
     }
 

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -157,7 +157,8 @@ impl<S, R> Executor<S, R> {
         ("0-39-0", 15),
         ("0-40-0", 16),
         ("0-40-1", 17),
-        ("0-40-2", LATEST_STATE_TRANSITION_VERSION),
+        ("0-40-2", 18),
+        ("0-41-0", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -166,7 +166,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 18;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 19;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Version v0.41.0

### Added
- [2547](https://github.com/FuelLabs/fuel-core/pull/2547): Replace the old Graphql gas price provider adapter with the ArcGasPriceEstimate.
- [2445](https://github.com/FuelLabs/fuel-core/pull/2445): Added GQL endpoint for querying asset details.
- [2442](https://github.com/FuelLabs/fuel-core/pull/2442): Add uninitialized task for V1 gas price service
- [2154](https://github.com/FuelLabs/fuel-core/pull/2154): Added `Unknown` variant to `ConsensusParameters` graphql queries
- [2154](https://github.com/FuelLabs/fuel-core/pull/2154): Added `Unknown` variant to `Block` graphql queries
- [2154](https://github.com/FuelLabs/fuel-core/pull/2154): Added `TransactionType` type in `fuel-client`
- [2321](https://github.com/FuelLabs/fuel-core/pull/2321): New metrics for the TxPool:
    - The size of transactions in the txpool (`txpool_tx_size`)
    - The time spent by a transaction in the txpool in seconds (`txpool_tx_time_in_txpool_seconds`)
    - The number of transactions in the txpool (`txpool_number_of_transactions`)
    - The number of transactions pending verification before entering the txpool (`txpool_number_of_transactions_pending_verification`)
    - The number of executable transactions in the txpool (`txpool_number_of_executable_transactions`)
    - The time it took to select transactions for inclusion in a block in microseconds (`txpool_select_transactions_time_microseconds`)
    - The time it took to insert a transaction in the txpool in microseconds (`transaction_insertion_time_in_thread_pool_microseconds`)
- [2385](https://github.com/FuelLabs/fuel-core/pull/2385): Added new histogram buckets for some of the TxPool metrics, optimize the way they are collected.
- [2347](https://github.com/FuelLabs/fuel-core/pull/2364): Add activity concept in order to protect against infinitely increasing DA gas price scenarios
- [2362](https://github.com/FuelLabs/fuel-core/pull/2362): Added a new request_response protocol version `/fuel/req_res/0.0.2`. In comparison with `/fuel/req/0.0.1`, which returns an empty response when a request cannot be fulfilled, this version returns more meaningful error codes. Nodes still support the version `0.0.1` of the protocol to guarantee backward compatibility with fuel-core nodes. Empty responses received from nodes using the old protocol `/fuel/req/0.0.1` are automatically converted into an error `ProtocolV1EmptyResponse` with error code 0, which is also the only error code implemented. More specific error codes will be added in the future.
- [2386](https://github.com/FuelLabs/fuel-core/pull/2386): Add a flag to define the maximum number of file descriptors that RocksDB can use. By default it's half of the OS limit.
- [2376](https://github.com/FuelLabs/fuel-core/pull/2376): Add a way to fetch transactions in P2P without specifying a peer.
- [2361](https://github.com/FuelLabs/fuel-core/pull/2361): Add caches to the sync service to not reask for data it already fetched from the network.
- [2327](https://github.com/FuelLabs/fuel-core/pull/2327): Add more services tests and more checks of the pool. Also add an high level documentation for users of the pool and contributors.
- [2416](https://github.com/FuelLabs/fuel-core/issues/2416): Define the `GasPriceServiceV1` task.
- [2447](https://github.com/FuelLabs/fuel-core/pull/2447): Use new `expiration` policy in the transaction pool. Add a mechanism to prune the transactions when they expired.
- [1922](https://github.com/FuelLabs/fuel-core/pull/1922): Added support for posting blocks to the shared sequencer.
- [2033](https://github.com/FuelLabs/fuel-core/pull/2033): Remove `Option<BlockHeight>` in favor of `BlockHeightQuery` where applicable.
- [2490](https://github.com/FuelLabs/fuel-core/pull/2490): Added pagination support for the `balances` GraphQL query, available only when 'balances indexation' is enabled.
- [2439](https://github.com/FuelLabs/fuel-core/pull/2439): Add gas costs for the two new zk opcodes `ecop` and `eadd` and the benches that allow to calibrate them.
- [2472](https://github.com/FuelLabs/fuel-core/pull/2472): Added the `amountU128` field to the `Balance` GraphQL schema, providing the total balance as a `U128`. The existing `amount` field clamps any balance exceeding `U64` to `u64::MAX`.
- [2526](https://github.com/FuelLabs/fuel-core/pull/2526): Add possibility to not have any cache set for RocksDB. Add an option to either load the RocksDB columns families on creation of the database or when the column is used.
- [2532](https://github.com/FuelLabs/fuel-core/pull/2532): Getters for inner rocksdb database handles.
- [2524](https://github.com/FuelLabs/fuel-core/pull/2524): Adds a new lock type which is optimized for certain workloads to the txpool and p2p services.
- [2535](https://github.com/FuelLabs/fuel-core/pull/2535): Expose `backup` and `restore` APIs on the `CombinedDatabase` struct to create portable backups and restore from them.
- [2550](https://github.com/FuelLabs/fuel-core/pull/2550): Add statistics and more limits infos about txpool on the node_info endpoint

### Fixed
- [2560](https://github.com/FuelLabs/fuel-core/pull/2560): Fix flaky test by increasing timeout
- [2558](https://github.com/FuelLabs/fuel-core/pull/2558): Rename `cost` and `reward` to remove `excess` wording
- [2469](https://github.com/FuelLabs/fuel-core/pull/2469): Improved the logic for syncing the gas price database with on_chain database
- [2365](https://github.com/FuelLabs/fuel-core/pull/2365): Fixed the error during dry run in the case of race condition.
- [2366](https://github.com/FuelLabs/fuel-core/pull/2366): The `importer_gas_price_for_block` metric is properly collected.
- [2369](https://github.com/FuelLabs/fuel-core/pull/2369): The `transaction_insertion_time_in_thread_pool_milliseconds` metric is properly collected.
- [2413](https://github.com/FuelLabs/fuel-core/issues/2413): block production immediately errors if unable to lock the mutex.
- [2389](https://github.com/FuelLabs/fuel-core/pull/2389): Fix construction of reverse iterator in RocksDB.
- [2479](https://github.com/FuelLabs/fuel-core/pull/2479): Fix an error on the last iteration of the read and write sequential opcodes on contract storage.
- [2478](https://github.com/FuelLabs/fuel-core/pull/2478): Fix proof created by `message_receipts_proof` function by ignoring the receipts from failed transactions to match `message_outbox_root`.
- [2485](https://github.com/FuelLabs/fuel-core/pull/2485): Hardcode the timestamp of the genesis block and version of `tai64` to avoid breaking changes for us.
- [2511](https://github.com/FuelLabs/fuel-core/pull/2511): Fix backward compatibility of V0Metadata in gas price db.

### Changed
- [2469](https://github.com/FuelLabs/fuel-core/pull/2469): Updated adapter for querying costs from DA Block committer API
- [2469](https://github.com/FuelLabs/fuel-core/pull/2469): Use the gas price from the latest block to estimate future gas prices
- [2501](https://github.com/FuelLabs/fuel-core/pull/2501): Use gas price from block for estimating future gas prices
- [2468](https://github.com/FuelLabs/fuel-core/pull/2468): Abstract unrecorded blocks concept for V1 algorithm, create new storage impl. Introduce `TransactionableStorage` trait to allow atomic changes to the storage.
- [2295](https://github.com/FuelLabs/fuel-core/pull/2295): `CombinedDb::from_config` now respects `state_rewind_policy` with tmp RocksDB.
- [2378](https://github.com/FuelLabs/fuel-core/pull/2378): Use cached hash of the topic instead of calculating it on each publishing gossip message.
- [2438](https://github.com/FuelLabs/fuel-core/pull/2438): Refactored service to use new implementation of `StorageRead::read` that takes an offset in input.
- [2429](https://github.com/FuelLabs/fuel-core/pull/2429): Introduce custom enum for representing result of running service tasks
- [2377](https://github.com/FuelLabs/fuel-core/pull/2377): Add more errors that can be returned as responses when using protocol `/fuel/req_res/0.0.2`. The errors supported are `ProtocolV1EmptyResponse` (status code `0`) for converting empty responses sent via protocol `/fuel/req_res/0.0.1`, `RequestedRangeTooLarge`(status code `1`) if the client requests a range of objects such as sealed block headers or transactions too large, `Timeout` (status code `2`) if the remote peer takes too long to fulfill a request, or `SyncProcessorOutOfCapacity` if the remote peer is fulfilling too many requests concurrently.
- [2233](https://github.com/FuelLabs/fuel-core/pull/2233): Introduce a new column `modification_history_v2` for storing the modification history in the historical rocksDB. Keys in this column are stored in big endian order. Changed the behaviour of the historical rocksDB to write changes for new block heights to the new column, and to perform lookup of values from the `modification_history_v2` table first, and then from the `modification_history` table, performing a migration upon access if necessary.
- [2383](https://github.com/FuelLabs/fuel-core/pull/2383): The `balance` and `balances` GraphQL query handlers now use index to provide the response in a more performant way. As the index is not created retroactively, the client must be initialized with an empty database and synced from the genesis block to utilize it. Otherwise, the legacy way of retrieving data will be used.
- [2463](https://github.com/FuelLabs/fuel-core/pull/2463): The `coinsToSpend` GraphQL query handler now uses index to provide the response in a more performant way. As the index is not created retroactively, the client must be initialized with an empty database and synced from the genesis block to utilize it. Otherwise, the legacy way of retrieving data will be used.
- [2556](https://github.com/FuelLabs/fuel-core/pull/2556): Ensure that the `last_recorded_height` is set for the DA gas price source.

#### Breaking
- [2469](https://github.com/FuelLabs/fuel-core/pull/2469): Move from `GasPriceServicev0` to `GasPriceServiceV1`. Include new config values.
- [2438](https://github.com/FuelLabs/fuel-core/pull/2438): The `fuel-core-client` can only work with new version of the `fuel-core`. The `0.40` and all older versions are not supported.
- [2438](https://github.com/FuelLabs/fuel-core/pull/2438): Updated `fuel-vm` to `0.59.1` release. Check [release notes](https://github.com/FuelLabs/fuel-vm/releases/tag/v0.59.0) for more details.
- [2389](https://github.com/FuelLabs/fuel-core/pull/2258): Updated the `messageProof` GraphQL schema to return a non-nullable `MessageProof`.
- [2154](https://github.com/FuelLabs/fuel-core/pull/2154): Transaction graphql endpoints use `TransactionType` instead of `fuel_tx::Transaction`.
- [2446](https://github.com/FuelLabs/fuel-core/pull/2446): Use graphiql instead of graphql-playground due to known vulnerability and stale development.
- [2379](https://github.com/FuelLabs/fuel-core/issues/2379): Change `kv_store::Value` to be `Arc<[u8]>` instead of `Arc<Vec<u8>>`.
- [2490](https://github.com/FuelLabs/fuel-core/pull/2490): Updated GraphQL complexity calculation for `balances` query to account for pagination (`first`/`last`) and nested field complexity (`child_complexity`). Queries with large pagination values or deeply nested fields may have higher complexity costs.
- [2463](https://github.com/FuelLabs/fuel-core/pull/2463): 'CoinsQueryError::MaxCoinsReached` variant has been removed. The `InsufficientCoins` variant has been renamed to `InsufficientCoinsForTheMax` and it now contains the additional `max` field
- [2463](https://github.com/FuelLabs/fuel-core/pull/2463): The number of excluded ids in the `coinsToSpend` GraphQL query is now limited to the maximum number of inputs allowed in transaction.
- [2463](https://github.com/FuelLabs/fuel-core/pull/2463): The `coinsToSpend` GraphQL query may now return different coins, depending whether the indexation is enabled or not. However, regardless of the differences, the returned coins will accurately reflect the current state of the database within the context of the query.
- [2526](https://github.com/FuelLabs/fuel-core/pull/2526): By default the cache of RocksDB is now disabled instead of being `1024 * 1024 * 1024`.

## What's Changed
* Add metrics to TxPool by @acerone85 in https://github.com/FuelLabs/fuel-core/pull/2321
* Fix collection of gas price metric by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2366
* Add documentation to run a ignition node in readme by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2363
* Fix collection of tx pool insertion time metric by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2369
* Add versioning to request response protocols by @acerone85 in https://github.com/FuelLabs/fuel-core/pull/2362
* Return reason of why proof cant be generated by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2258
* p2p: use precalculated topic hash by @yaziciahmet in https://github.com/FuelLabs/fuel-core/pull/2378
* Remove ignore RUSTSEC-2024-0336 by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2384
* Deal with negative feed back loop in DA gas price by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2364
* Add new flag for maximum file descriptors in rocksdb. by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2386
* Add codeowners for gas price algorithm crate by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2404
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/2373
* chore(gas_price_service): initialize v1 metadata by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2288
* chore(gas_price_service_v0): remove unused trait impl by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2410
* Update tai64 to fix the wrong time offset by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2409
* fix(block_producer): immediately return error if lock cannot be acquired during production by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2413
* Add a way to fetch transactions in P2P without specifying a peer  by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2376
* Add a new code owner for tx pool by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2417
* Satisfy clippy in `gas-price-analysis` by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2418
* Txpool metrics update by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2385
* Improve TxPool tests and documentation by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2327
* feat(gas_price_service_v1): define RunnableTask for GasPriceServiceV1 by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2416
* Return reason of why proof cant be generated (api change) by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2389
* Fuel/Request_Response v0.0.2: More meaningful error messages by @acerone85 in https://github.com/FuelLabs/fuel-core/pull/2377
* Fix reverse iterator in RocksDB by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2398
* Add test node herself in reserved nodes. by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2390
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/2424
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/2440
* Resolve some falky tests and improve CI times by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2401
* feat: handle `Unknown` transactions, blocks and consensus parameters by @hal3e in https://github.com/FuelLabs/fuel-core/pull/2154
* fix(p2p): cache responses to serve without roundtrip to db by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2352
* Replace task `run()` return result with custom enum by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2429
* Fix codeowners by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2444
* fix(graphql_playground): use graphiql instead by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2446
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/2453
* refactor: remove `Option<BlockHeight>` and use new enum where applicable by @matt-user in https://github.com/FuelLabs/fuel-core/pull/2033
* Fixed the error during dry run by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2365
* Add decompression traits and a test case by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/2295
* Versioned Storage for Modifications History by @acerone85 in https://github.com/FuelLabs/fuel-core/pull/2233
* Allow DA recorded blocks to come out-of-order by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2415
* feat: Change `kv_store::Value` to be Arc<[u8]> instead of Arc<Vec<u8>> by @netrome in https://github.com/FuelLabs/fuel-core/pull/2411
* Optimize balance-related queries with a cache by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2383
* fix: Add missing features to `fuel-core-tests` by @netrome in https://github.com/FuelLabs/fuel-core/pull/2467
* Keep data in fails cases in sync service by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2361
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/2470
* Revert balances amount to `U64` and introduce new `amountU128` getter by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2472
* Create uninitialized task for v1 gas price service by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2442
* Port the 0.40.2 fix of TAI on master by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2485
* Ignore RUSTSEC-2024-0421 by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2489
* Ignore receipts from failed transactions in `message_receipts_proof` by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2478
* Add unrecorded blocks abstraction to gas price algo by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2468
* Fix last iteration in sequential opcode by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2479
* fix(gas_price_service_v0): bring back removed fields, causing UB when trying to access by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2511
* Refactor fuel-core to use version of StorageRead::read with offset (Full update to 0.59.1) by @acerone85 in https://github.com/FuelLabs/fuel-core/pull/2438
* Sync the version of the `fuel-core` with minor hot fixes by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2516
* fix(docs): typo preventing ci checks from passing by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2525
* Integration test for balances and (non)retryable messages by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2505
* Add document for launching Ignition node from source and Local network from source by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2502
* Make the rocksdb cache optional in config and add policy for column opening  by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2526
* Weekly `cargo update` by @github-actions in https://github.com/FuelLabs/fuel-core/pull/2530
* chore(rocksdb): getter for inner database handle by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2532
* Use gas prices from actual blocks to calculate estimate gas prices by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2501
* chore(codeowners): gas price service codeowners by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2534
* Add zk opcodes by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2439
* Gas price simulation data retriever by @acerone85 in https://github.com/FuelLabs/fuel-core/pull/2533
* Shared sequencer integration by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/1922
* Use expiration policy by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2447
* Fixed TPS benchmark to work with latest changes by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2515
* Use indexation cache to satisfy "coins to spend" queries by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2463
* feat(txpool|p2p): use seqlock instead of small copy-able RwLocks by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2524
* Create new index for tracking Asset metadata by @maschad in https://github.com/FuelLabs/fuel-core/pull/2445
* feat(rocksdb): remove getters for internal rocksdb handles, expose `backup` instead by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2535
* Integrate with V1 algo for tests by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2469
* Lock-free `latest_l2_height` in gas price service by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2546
* chore(gas_price_service_v1): strictly ensure last_recorded_height is set, to avoid initial poll of da source by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2556
* Replace old Graphql Gas Price adapter with new latest gas price struct by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2547
* Rename cost and rewards without 'excess' by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2558
* Add current pool gas to the node info endpoint by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2550
* Pagination queries for `balances` endpoint by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2490
* 2559 Increase timeout for test by @MitchTurner in https://github.com/FuelLabs/fuel-core/pull/2560
* Add test expiration policy in executor by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2563

## New Contributors
* @yaziciahmet made their first contribution in https://github.com/FuelLabs/fuel-core/pull/2378

**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.40.0...v0.41.0