### PR TITLE
fault_proving(compression): include commitment to registry in compressed block header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [2551](https://github.com/FuelLabs/fuel-core/pull/2551): Enhanced the DA compressed block header to include block id.
+- [2571](https://github.com/FuelLabs/fuel-core/pull/2571): Enhanced the DA compressed block header to include registry id.
 
 ## [Version 0.41.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3582,6 +3582,7 @@ dependencies = [
  "enum_dispatch",
  "fuel-core-compression",
  "fuel-core-types 0.41.0",
+ "fuel-crypto 0.59.1",
  "paste",
  "postcard",
  "proptest",

--- a/crates/compression/Cargo.toml
+++ b/crates/compression/Cargo.toml
@@ -24,6 +24,7 @@ fuel-core-types = { workspace = true, features = [
   "serde",
   "da-compression",
 ] }
+fuel-crypto = { version = "0.59.1", optional = true }
 paste = { workspace = true }
 rand = { workspace = true, optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -43,4 +44,4 @@ test-helpers = [
   "fuel-core-types/random",
   "fuel-core-types/std",
 ]
-fault-proving = []
+fault-proving = ["dep:fuel-crypto"]

--- a/crates/compression/src/compressed_block_payload/mod.rs
+++ b/crates/compression/src/compressed_block_payload/mod.rs
@@ -1,3 +1,4 @@
 pub mod v0;
 
+#[cfg(feature = "fault-proving")]
 pub mod v1;

--- a/crates/compression/src/compressed_block_payload/v1.rs
+++ b/crates/compression/src/compressed_block_payload/v1.rs
@@ -1,5 +1,8 @@
 use crate::{
-    registry::RegistrationsPerTable,
+    registry::{
+        RegistrationsPerTable,
+        RegistryId,
+    },
     VersionedBlockPayload,
 };
 use fuel_core_types::{
@@ -31,10 +34,15 @@ pub struct CompressedBlockHeader {
     pub consensus: ConsensusHeader<Empty>,
     // The block id.
     pub block_id: BlockId,
+    // The registry id.
+    pub registry_id: RegistryId,
 }
 
-impl From<&BlockHeader> for CompressedBlockHeader {
-    fn from(header: &BlockHeader) -> Self {
+impl CompressedBlockHeader {
+    fn from_header_and_registry(
+        header: &BlockHeader,
+        registry: &RegistrationsPerTable,
+    ) -> Self {
         let ConsensusHeader {
             prev_root,
             height,
@@ -56,6 +64,7 @@ impl From<&BlockHeader> for CompressedBlockHeader {
                 generated: Empty {},
             },
             block_id: header.id(),
+            registry_id: registry.id(),
         }
     }
 }
@@ -114,7 +123,10 @@ impl CompressedBlockPayloadV1 {
         transactions: Vec<CompressedTransaction>,
     ) -> Self {
         Self {
-            header: CompressedBlockHeader::from(header),
+            header: CompressedBlockHeader::from_header_and_registry(
+                header,
+                &registrations,
+            ),
             registrations,
             transactions,
         }

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -274,6 +274,7 @@ mod tests {
                     generated: Empty,
                 },
                 block_id: BlockId::from_str("0xecea85c17070bc2e65f911310dbd01198f4436052ebba96cded9ddf30c58dd1a").unwrap(),
+                registry_id: registrations.id(),
             };
 
 
@@ -302,6 +303,7 @@ mod tests {
 
             if let VersionedCompressedBlock::V1(block) = decompressed {
                 assert_eq!(block.header.block_id, header.block_id);
+                assert_eq!(block.header.registry_id, header.registry_id);
             } else {
                 panic!("Expected V1 block, got {:?}", decompressed);
             }

--- a/crates/compression/src/registry.rs
+++ b/crates/compression/src/registry.rs
@@ -14,6 +14,9 @@ use fuel_core_types::{
     tai64::Tai64,
 };
 
+#[cfg(feature = "fault-proving")]
+pub type RegistryId = fuel_core_types::fuel_tx::Bytes32;
+
 macro_rules! tables {
     ($($ident:ty: $type:ty),*) => { paste::paste! {
         #[doc = "RegistryKey namespaces"]
@@ -90,10 +93,25 @@ macro_rules! tables {
 
                 Ok(())
             }
+
+            #[cfg(feature = "fault-proving")]
+            pub fn id(&self) -> RegistryId {
+                let mut hasher = fuel_crypto::Hasher::default();
+
+                $(
+                    for (key, value) in self.$ident.iter() {
+                        hasher.input(key);
+                        hasher.input(value);
+                    }
+                )*
+
+                hasher.digest()
+            }
         }
     }};
 }
 
+// Don't change the order of these, it will affect the order of hashing
 tables!(
     address: Address,
     asset_id: AssetId,


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- closes https://github.com/FuelLabs/fuel-core/issues/2568



## Description
<!-- List of detailed changes -->
We implement a function `id` for `RegistrationsPerTable` which yields a `RegistryId` that is included within the `CompressedBlockHeader`

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
