### PR TITLE
Update `height_expiration_txs` to not grow indefinitely

### DIFF
--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -525,7 +525,7 @@ where
     /// Remove transaction and its dependents.
     pub fn remove_transaction_and_dependents(
         &mut self,
-        tx_ids: Vec<TxId>,
+        tx_ids: impl Iterator<Item = TxId>,
     ) -> Vec<ArcPoolTx> {
         let mut removed_transactions = vec![];
         for tx_id in tx_ids {

--- a/crates/services/txpool_v2/src/service.rs
+++ b/crates/services/txpool_v2/src/service.rs
@@ -345,12 +345,24 @@ where
                 let expired_txs = height_expiration_txs.remove(&height);
                 if let Some(expired_txs) = expired_txs {
                     let mut tx_pool = self.pool.write();
-                    removed_txs
-                        .extend(tx_pool.remove_transaction_and_dependents(expired_txs));
+                    removed_txs.extend(
+                        tx_pool
+                            .remove_transaction_and_dependents(expired_txs.into_iter()),
+                    );
                 }
             }
         }
         for tx in removed_txs {
+            {
+                let mut height_expiration_txs = self.pruner.height_expiration_txs.write();
+                let expiration = tx.expiration();
+                if expiration < u32::MAX.into() {
+                    if let Some(expired_txs) = height_expiration_txs.get_mut(&expiration)
+                    {
+                        expired_txs.remove(&tx.id());
+                    }
+                }
+            }
             self.shared_state
                 .tx_status_sender
                 .send_squeezed_out(tx.id(), Error::Removed(RemovedReason::Ttl));
@@ -486,7 +498,7 @@ where
                     if expiration < u32::MAX.into() {
                         let mut lock = height_expiration_txs.write();
                         let block_height_expiration = lock.entry(expiration).or_default();
-                        block_height_expiration.push(tx_id);
+                        block_height_expiration.insert(tx_id);
                     }
 
                     let duration = submitted_time
@@ -662,10 +674,20 @@ where
         let removed;
         {
             let mut pool = self.pool.write();
-            removed = pool.remove_transaction_and_dependents(txs_to_remove);
+            removed = pool.remove_transaction_and_dependents(txs_to_remove.into_iter());
         }
 
         for tx in removed {
+            {
+                let mut height_expiration_txs = self.pruner.height_expiration_txs.write();
+                let expiration = tx.expiration();
+                if expiration < u32::MAX.into() {
+                    if let Some(expired_txs) = height_expiration_txs.get_mut(&expiration)
+                    {
+                        expired_txs.remove(&tx.id());
+                    }
+                }
+            }
             self.shared_state
                 .tx_status_sender
                 .send_squeezed_out(tx.id(), Error::Removed(RemovedReason::Ttl));

--- a/crates/services/txpool_v2/src/service/pruner.rs
+++ b/crates/services/txpool_v2/src/service/pruner.rs
@@ -6,6 +6,7 @@ use fuel_core_types::{
 use std::{
     collections::{
         BTreeMap,
+        HashSet,
         VecDeque,
     },
     time::SystemTime,
@@ -13,7 +14,7 @@ use std::{
 
 pub(super) struct TransactionPruner {
     pub time_txs_submitted: Shared<VecDeque<(SystemTime, TxId)>>,
-    pub height_expiration_txs: Shared<BTreeMap<BlockHeight, Vec<TxId>>>,
+    pub height_expiration_txs: Shared<BTreeMap<BlockHeight, HashSet<TxId>>>,
     pub ttl_timer: tokio::time::Interval,
     pub txs_ttl: tokio::time::Duration,
 }


### PR DESCRIPTION
## Linked Issues/PRs
https://github.com/FuelLabs/fuel-core/issues/2564

## Description
At a cost of some performance, because we now iterate over an `HashSet` instead of a `Vec`, we remove transactions from `height_expiration_txs` when we prune them and when they are inserted on a block which is the two cases where a transaction can be removed. Maybe we should be clearer on the code where the tx are removed and regroup the behaviour in the same place

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
