### PR TITLE
fix(da_compression): invalid decompression of utxo id and CoinConfig fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [2551](https://github.com/FuelLabs/fuel-core/pull/2551): Enhanced the DA compressed block header to include block id.
 
+### Fixed
+- [2593](https://github.com/FuelLabs/fuel-core/pull/2593): Fixed utxo id decompression
+
 ## [Version 0.41.0]
 
 ### Added

--- a/crates/chain-config/src/config/coin.rs
+++ b/crates/chain-config/src/config/coin.rs
@@ -125,7 +125,10 @@ impl GenesisCommitment for Coin {
 pub mod coin_config_helpers {
     use crate::CoinConfig;
     use fuel_core_types::{
-        fuel_types::Address,
+        fuel_types::{
+            Address,
+            Bytes32,
+        },
         fuel_vm::SecretKey,
     };
 
@@ -137,17 +140,22 @@ pub mod coin_config_helpers {
         count: CoinCount,
     }
 
+    pub fn tx_id(count: CoinCount) -> Bytes32 {
+        let mut bytes = [0u8; 32];
+        bytes[..size_of::<CoinCount>()].copy_from_slice(&count.to_be_bytes());
+        bytes.into()
+    }
+
     impl CoinConfigGenerator {
         pub fn new() -> Self {
             Self { count: 0 }
         }
 
         pub fn generate(&mut self) -> CoinConfig {
-            let mut bytes = [0u8; 32];
-            bytes[..size_of::<CoinCount>()].copy_from_slice(&self.count.to_be_bytes());
+            let tx_id = tx_id(self.count);
 
             let config = CoinConfig {
-                tx_id: bytes.into(),
+                tx_id,
                 output_index: self.count,
                 ..Default::default()
             };

--- a/crates/chain-config/src/config/coin.rs
+++ b/crates/chain-config/src/config/coin.rs
@@ -20,7 +20,6 @@ use fuel_core_types::{
         BlockHeight,
         Bytes32,
     },
-    fuel_vm::SecretKey,
 };
 use serde::{
     Deserialize,
@@ -75,41 +74,6 @@ impl From<CoinConfig> for TableEntry<Coins> {
     }
 }
 
-/// Generates a new coin config with a unique utxo id for testing
-#[derive(Default, Debug)]
-pub struct CoinConfigGenerator {
-    count: usize,
-}
-
-impl CoinConfigGenerator {
-    pub fn new() -> Self {
-        Self { count: 0 }
-    }
-
-    pub fn generate(&mut self) -> CoinConfig {
-        let mut bytes = [0u8; 32];
-        bytes[..std::mem::size_of::<usize>()].copy_from_slice(&self.count.to_be_bytes());
-
-        let config = CoinConfig {
-            tx_id: Bytes32::from(bytes),
-            ..Default::default()
-        };
-        self.count = self.count.checked_add(1).expect("Max coin count reached");
-
-        config
-    }
-
-    pub fn generate_with(&mut self, secret: SecretKey, amount: u64) -> CoinConfig {
-        let owner = Address::from(*secret.public_key().hash());
-
-        CoinConfig {
-            amount,
-            owner,
-            ..self.generate()
-        }
-    }
-}
-
 impl CoinConfig {
     pub fn utxo_id(&self) -> UtxoId {
         UtxoId::new(self.tx_id, self.output_index)
@@ -157,6 +121,54 @@ impl GenesisCommitment for Coin {
     }
 }
 
+#[cfg(feature = "test-helpers")]
+pub mod coin_config_helpers {
+    use crate::CoinConfig;
+    use fuel_core_types::{
+        fuel_types::Address,
+        fuel_vm::SecretKey,
+    };
+
+    type CoinCount = u16;
+
+    /// Generates a new coin config with a unique utxo id for testing
+    #[derive(Default, Debug)]
+    pub struct CoinConfigGenerator {
+        count: CoinCount,
+    }
+
+    impl CoinConfigGenerator {
+        pub fn new() -> Self {
+            Self { count: 0 }
+        }
+
+        pub fn generate(&mut self) -> CoinConfig {
+            let mut bytes = [0u8; 32];
+            bytes[..size_of::<CoinCount>()].copy_from_slice(&self.count.to_be_bytes());
+
+            let config = CoinConfig {
+                tx_id: bytes.into(),
+                output_index: self.count,
+                ..Default::default()
+            };
+
+            self.count = self.count.checked_add(1).expect("Max coin count reached");
+
+            config
+        }
+
+        pub fn generate_with(&mut self, secret: SecretKey, amount: u64) -> CoinConfig {
+            let owner = Address::from(*secret.public_key().hash());
+
+            CoinConfig {
+                amount,
+                owner,
+                ..self.generate()
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_generate_unique_utxo_id() {
-        let mut generator = CoinConfigGenerator::new();
+        let mut generator = coin_config_helpers::CoinConfigGenerator::new();
         let config1 = generator.generate();
         let config2 = generator.generate();
 
@@ -180,7 +192,7 @@ mod tests {
         let secret = SecretKey::random(&mut rng);
         let amount = 1000;
 
-        let mut generator = CoinConfigGenerator::new();
+        let mut generator = coin_config_helpers::CoinConfigGenerator::new();
         let config = generator.generate_with(secret, amount);
 
         assert_eq!(config.owner, Address::from(*secret.public_key().hash()));

--- a/crates/chain-config/src/config/state.rs
+++ b/crates/chain-config/src/config/state.rs
@@ -46,7 +46,7 @@ use serde::{
 use crate::SnapshotMetadata;
 
 #[cfg(feature = "test-helpers")]
-use crate::CoinConfigGenerator;
+use crate::coin_config_helpers::CoinConfigGenerator;
 #[cfg(feature = "test-helpers")]
 use bech32::{
     ToBase32,

--- a/crates/compression/src/decompress.rs
+++ b/crates/compression/src/decompress.rs
@@ -230,9 +230,7 @@ where
         ctx: &DecompressCtx<D>,
     ) -> anyhow::Result<Self> {
         Ok(Transaction::mint(
-            // we should probably include the mint TxPointer in the compression if we decide to support
-            // multiple assets for mints, i.e more than 1 mint tx per block
-            Default::default(), // TODO: what should this we do with this?
+            Default::default(), // TODO: what should we do with this?
             c.input_contract.decompress(ctx).await?,
             c.output_contract.decompress(ctx).await?,
             c.mint_amount.decompress(ctx).await?,

--- a/crates/fuel-core/src/graphql_api/da_compression.rs
+++ b/crates/fuel-core/src/graphql_api/da_compression.rs
@@ -306,16 +306,14 @@ where
         &self,
         c: fuel_core_types::fuel_tx::CompressedUtxoId,
     ) -> anyhow::Result<fuel_core_types::fuel_tx::UtxoId> {
+        #[cfg(feature = "test-helpers")]
         if c.tx_pointer.block_height() == 0u32.into() {
             // This is a genesis coin, which is handled differently.
             // See CoinConfigGenerator::generate which generates the genesis coins.
-            let mut bytes = [0u8; 32];
-            bytes[..size_of::<u16>()].copy_from_slice(&c.output_index.to_be_bytes());
+            let tx_id =
+                fuel_core_chain_config::coin_config_helpers::tx_id(c.output_index);
 
-            let utxo_id = fuel_core_types::fuel_tx::UtxoId::new(
-                fuel_core_types::fuel_tx::TxId::from(bytes),
-                c.output_index,
-            );
+            let utxo_id = fuel_core_types::fuel_tx::UtxoId::new(tx_id, c.output_index);
 
             return Ok(utxo_id);
         }

--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     chain_config::{
+        coin_config_helpers::CoinConfigGenerator,
         CoinConfig,
-        CoinConfigGenerator,
     },
     combined_database::CombinedDatabase,
     database::{
@@ -246,7 +246,7 @@ pub async fn make_nodes(
                     let initial_coin = CoinConfig {
                         // set idx to prevent overlapping utxo_ids when
                         // merging with existing coins from config
-                        output_index: 2,
+                        output_index: 10,
                         ..coin_generator.generate_with(secret, 10000)
                     };
                     let tx = TransactionBuilder::script(

--- a/tests/tests/balances.rs
+++ b/tests/tests/balances.rs
@@ -1,7 +1,7 @@
 use fuel_core::{
     chain_config::{
+        coin_config_helpers::CoinConfigGenerator,
         CoinConfig,
-        CoinConfigGenerator,
         MessageConfig,
         StateConfig,
     },
@@ -334,9 +334,9 @@ async fn first_5_balances() {
 mod pagination {
     use fuel_core::{
         chain_config::{
+            coin_config_helpers::CoinConfigGenerator,
             ChainConfig,
             CoinConfig,
-            CoinConfigGenerator,
             MessageConfig,
             StateConfig,
         },

--- a/tests/tests/coin.rs
+++ b/tests/tests/coin.rs
@@ -1,7 +1,7 @@
 use fuel_core::{
     chain_config::{
+        coin_config_helpers::CoinConfigGenerator,
         CoinConfig,
-        CoinConfigGenerator,
         StateConfig,
     },
     database::Database,

--- a/tests/tests/coins.rs
+++ b/tests/tests/coins.rs
@@ -24,8 +24,8 @@ use rand::{
 mod coin {
     use super::*;
     use fuel_core::chain_config::{
+        coin_config_helpers::CoinConfigGenerator,
         ChainConfig,
-        CoinConfigGenerator,
     };
     use fuel_core_client::client::types::CoinType;
     use fuel_core_types::fuel_crypto::SecretKey;
@@ -524,7 +524,7 @@ mod message_coin {
 
 // It is combination of coins and deposit coins test cases.
 mod all_coins {
-    use fuel_core::chain_config::CoinConfigGenerator;
+    use fuel_core::chain_config::coin_config_helpers::CoinConfigGenerator;
     use fuel_core_client::client::types::CoinType;
     use fuel_core_types::blockchain::primitives::DaBlockHeight;
 


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
some investigation related to why transaction ids were mismatching before compression and after decompression

## Description
<!-- List of detailed changes -->
- Fixed CoinConfig generate function to create appropriate tx_id and output_index
- Fixed utxo id lookup
- da compression integ test asserts tx ids are the same

AI generated:

### Code Organization:

* [`crates/chain-config/src/config/coin.rs`](diffhunk://#diff-942b8fa635eb049417e89ef88024e08422c209c2952e0f5612e45531ee03a8b1R124-R171): Moved `CoinConfigGenerator` to a new `coin_config_helpers` module and updated its implementation to use a `CoinCount` type.
* Updated references to `CoinConfigGenerator` across multiple files to use the new `coin_config_helpers` module. [[1]](diffhunk://#diff-942b8fa635eb049417e89ef88024e08422c209c2952e0f5612e45531ee03a8b1L170-R182) [[2]](diffhunk://#diff-942b8fa635eb049417e89ef88024e08422c209c2952e0f5612e45531ee03a8b1L183-R195) [[3]](diffhunk://#diff-beed0a09969286877b6b2569d2e3775a9526d5328bfebe9ef04da44e16dc8492L49-R49) [[4]](diffhunk://#diff-aceecd6cf4d806ddbb7fe3edc5d757cc292c1c8b81f9df2601cdc2103cca16f2R5-L6) [[5]](diffhunk://#diff-e83ddeaff43cbea45b7b2a6c5b688054cf32fbcd7c5010fc5059d0812b1f413eR3-L4) [[6]](diffhunk://#diff-12758c6f607876b04a2fd230ac5b6c16c275c65e82390f867404ddb62345119aR27-L28) [[7]](diffhunk://#diff-12758c6f607876b04a2fd230ac5b6c16c275c65e82390f867404ddb62345119aL527-R527)

### Decompression Logic:

* [`crates/compression/src/decompress.rs`](diffhunk://#diff-d0b271dacdbc77c5808aab48fee0fa85f338d593e1adc25e8bd0205c370dd824L71-R93): Modified the decompression logic to handle mint transactions correctly and ensure the TxPointer is set appropriately. [[1]](diffhunk://#diff-d0b271dacdbc77c5808aab48fee0fa85f338d593e1adc25e8bd0205c370dd824L71-R93) [[2]](diffhunk://#diff-d0b271dacdbc77c5808aab48fee0fa85f338d593e1adc25e8bd0205c370dd824R231-R232)

### Testing and Configuration:

* [`tests/tests/da_compression.rs`](diffhunk://#diff-b7fc0c13495dc1a6096e1822748a1d512e84510d50d2ac1d56b1f9a839646342R66-R92): Enhanced the test for fetching DA compressed blocks from GraphQL by adding additional checks and ensuring the transactions' IDs match. [[1]](diffhunk://#diff-b7fc0c13495dc1a6096e1822748a1d512e84510d50d2ac1d56b1f9a839646342R66-R92) [[2]](diffhunk://#diff-b7fc0c13495dc1a6096e1822748a1d512e84510d50d2ac1d56b1f9a839646342R129-R157)

### Miscellaneous:

* Various files: Updated imports and removed unnecessary `where` clauses to clean up the codebase. [[1]](diffhunk://#diff-942b8fa635eb049417e89ef88024e08422c209c2952e0f5612e45531ee03a8b1L23) [[2]](diffhunk://#diff-d0b271dacdbc77c5808aab48fee0fa85f338d593e1adc25e8bd0205c370dd824R21) [[3]](diffhunk://#diff-d0b271dacdbc77c5808aab48fee0fa85f338d593e1adc25e8bd0205c370dd824R39) [[4]](diffhunk://#diff-715d143d62233118cd663c107e340e6d32aeb6446c02c167893656316ce13cbeL276-R276) [[5]](diffhunk://#diff-715d143d62233118cd663c107e340e6d32aeb6446c02c167893656316ce13cbeL304) [[6]](diffhunk://#diff-715d143d62233118cd663c107e340e6d32aeb6446c02c167893656316ce13cbeL317-R321)


## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
