### PR TITLE
fault_proving(global_roots): Initial test suite for merklized storage updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - [2553](https://github.com/FuelLabs/fuel-core/pull/2553): Scaffold global merkle root storage crate.
+- [2598](https://github.com/FuelLabs/fuel-core/pull/2598): Add initial test suite for global merkle root storage updates.
 
 ### Fixed
 - [2632](https://github.com/FuelLabs/fuel-core/pull/2632): Improved performance of certain async trait impls in the gas price service.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-types 0.41.4",
  "num_enum",
+ "rand",
  "strum 0.25.0",
  "strum_macros 0.25.3",
 ]

--- a/crates/fraud_proofs/global_merkle_root/storage/Cargo.toml
+++ b/crates/fraud_proofs/global_merkle_root/storage/Cargo.toml
@@ -23,7 +23,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 
 [dev-dependencies]
-fuel-core-storage = { workspace = true, features = ["alloc", "test-helpers"] }
+fuel-core-storage = { workspace = true, default-features = false, features = ["alloc", "test-helpers"] }
 rand = { workspace = true }
 
 [features]

--- a/crates/fraud_proofs/global_merkle_root/storage/Cargo.toml
+++ b/crates/fraud_proofs/global_merkle_root/storage/Cargo.toml
@@ -23,7 +23,10 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 
 [dev-dependencies]
-fuel-core-storage = { workspace = true, default-features = false, features = ["alloc", "test-helpers"] }
+fuel-core-storage = { workspace = true, default-features = false, features = [
+  "alloc",
+  "test-helpers",
+] }
 rand = { workspace = true }
 
 [features]

--- a/crates/fraud_proofs/global_merkle_root/storage/Cargo.toml
+++ b/crates/fraud_proofs/global_merkle_root/storage/Cargo.toml
@@ -22,6 +22,10 @@ num_enum = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 
+[dev-dependencies]
+fuel-core-storage = { workspace = true, features = ["alloc", "test-helpers"] }
+rand = { workspace = true }
+
 [features]
 default = ["std"]
 std = ["fuel-core-storage/std", "fuel-core-types/std"]

--- a/crates/fraud_proofs/global_merkle_root/storage/src/lib.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::cast_possible_truncation)]
 #![deny(unused_crate_dependencies)]
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate alloc;
 

--- a/crates/fraud_proofs/global_merkle_root/storage/src/lib.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::cast_possible_truncation)]
 #![deny(unused_crate_dependencies)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
 extern crate alloc;
 

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -342,7 +342,7 @@ mod tests {
         // Given
         let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
         let mut storage_tx = storage.write_transaction();
-        let mut update_tx = storage_tx.update_transaction();
+        let mut update_tx = storage_tx.construct_update_merkleized_tables_transaction();
 
         let tx_pointer = random_tx_pointer(&mut rng);
         let utxo_id = random_utxo_id(&mut rng);
@@ -386,7 +386,8 @@ mod tests {
         // Given
         let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
         let mut storage_tx = storage.write_transaction();
-        let mut storage_update_tx = storage_tx.update_transaction();
+        let mut storage_update_tx =
+            storage_tx.construct_update_merkleized_tables_transaction();
 
         let tx_pointer = random_tx_pointer(&mut rng);
         let utxo_id = random_utxo_id(&mut rng);
@@ -428,7 +429,8 @@ mod tests {
         // Given
         let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
         let mut storage_tx = storage.write_transaction();
-        let mut storage_update_tx = storage_tx.update_transaction();
+        let mut storage_update_tx =
+            storage_tx.construct_update_merkleized_tables_transaction();
 
         let tx_pointer = random_tx_pointer(&mut rng);
         let utxo_id = random_utxo_id(&mut rng);
@@ -477,7 +479,8 @@ mod tests {
         // Given
         let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
         let mut storage_tx = storage.write_transaction();
-        let mut storage_update_tx = storage_tx.update_transaction();
+        let mut storage_update_tx =
+            storage_tx.construct_update_merkleized_tables_transaction();
 
         let output_amount = rng.gen();
         let output_address = random_address(&mut rng);
@@ -543,17 +546,19 @@ mod tests {
         contract_id
     }
 
-    trait UpdateTransaction<'a>: Sized + 'a {
+    trait ConstructUpdateMerkleizedTablesTransactionForTests<'a>: Sized + 'a {
         type Storage;
-        fn update_transaction(
+        fn construct_update_merkleized_tables_transaction(
             self,
         ) -> UpdateMerkleizedTablesTransaction<'a, Self::Storage>;
     }
 
-    impl<'a, Storage> UpdateTransaction<'a> for &'a mut StorageTransaction<Storage> {
+    impl<'a, Storage> ConstructUpdateMerkleizedTablesTransactionForTests<'a>
+        for &'a mut StorageTransaction<Storage>
+    {
         type Storage = Storage;
 
-        fn update_transaction(
+        fn construct_update_merkleized_tables_transaction(
             self,
         ) -> UpdateMerkleizedTablesTransaction<'a, Self::Storage> {
             UpdateMerkleizedTablesTransaction {

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -505,17 +505,27 @@ mod tests {
             .process_output(tx_pointer, utxo_id, &inputs, &output)
             .unwrap();
 
+        let coin_was_inserted_before_process_input = !storage_update_tx
+            .storage
+            .storage_as_ref::<Coins>()
+            .get(&utxo_id)
+            .unwrap()
+            .is_none();
+
         storage_update_tx.process_input(&input).unwrap();
 
         storage_tx.commit().unwrap();
 
-        // Then
-        assert!(storage
+        let coin_doesnt_exist_after_process_input = storage
             .read_transaction()
             .storage_as_ref::<Coins>()
             .get(&utxo_id)
             .unwrap()
-            .is_none());
+            .is_none();
+
+        // Then
+        assert!(coin_was_inserted_before_process_input);
+        assert!(coin_doesnt_exist_after_process_input);
     }
 
     fn random_utxo_id(rng: &mut impl rand::RngCore) -> UtxoId {

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -505,12 +505,12 @@ mod tests {
             .process_output(tx_pointer, utxo_id, &inputs, &output)
             .unwrap();
 
-        let coin_was_inserted_before_process_input = !storage_update_tx
+        let coin_was_inserted_before_process_input = storage_update_tx
             .storage
             .storage_as_ref::<Coins>()
             .get(&utxo_id)
             .unwrap()
-            .is_none();
+            .is_some();
 
         storage_update_tx.process_input(&input).unwrap();
 

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -64,7 +64,7 @@ use fuel_core_types::{
 };
 
 pub trait UpdateMerkleizedTables: Sized {
-    fn update_merklized_tables(
+    fn update_merkleized_tables(
         self,
         chain_id: ChainId,
         block: &Block,
@@ -75,12 +75,12 @@ impl<Storage> UpdateMerkleizedTables for &mut StorageTransaction<Storage>
 where
     Storage: KeyValueInspect<Column = Column>,
 {
-    fn update_merklized_tables(
+    fn update_merkleized_tables(
         self,
         chain_id: ChainId,
         block: &Block,
     ) -> anyhow::Result<Self> {
-        let mut update_transaction = UpdateMerklizedTablesTransaction {
+        let mut update_transaction = UpdateMerkleizedTablesTransaction {
             chain_id,
             storage: self,
         };
@@ -91,12 +91,12 @@ where
     }
 }
 
-struct UpdateMerklizedTablesTransaction<'a, Storage> {
+struct UpdateMerkleizedTablesTransaction<'a, Storage> {
     chain_id: ChainId,
     storage: &'a mut StorageTransaction<Storage>,
 }
 
-impl<'a, Storage> UpdateMerklizedTablesTransaction<'a, Storage>
+impl<'a, Storage> UpdateMerkleizedTablesTransaction<'a, Storage>
 where
     Storage: KeyValueInspect<Column = Column>,
 {
@@ -547,7 +547,7 @@ mod tests {
         type Storage;
         fn update_transaction(
             self,
-        ) -> UpdateMerklizedTablesTransaction<'a, Self::Storage>;
+        ) -> UpdateMerkleizedTablesTransaction<'a, Self::Storage>;
     }
 
     impl<'a, Storage> UpdateTransaction<'a> for &'a mut StorageTransaction<Storage> {
@@ -555,8 +555,8 @@ mod tests {
 
         fn update_transaction(
             self,
-        ) -> UpdateMerklizedTablesTransaction<'a, Self::Storage> {
-            UpdateMerklizedTablesTransaction {
+        ) -> UpdateMerkleizedTablesTransaction<'a, Self::Storage> {
+            UpdateMerkleizedTablesTransaction {
                 chain_id: ChainId::default(),
                 storage: self,
             }

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -342,7 +342,8 @@ mod tests {
         // Given
         let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
         let mut storage_tx = storage.write_transaction();
-        let mut update_tx = storage_tx.construct_update_merkleized_tables_transaction();
+        let mut storage_update_tx =
+            storage_tx.construct_update_merkleized_tables_transaction();
 
         let tx_pointer = random_tx_pointer(&mut rng);
         let utxo_id = random_utxo_id(&mut rng);
@@ -357,7 +358,7 @@ mod tests {
         };
 
         // When
-        update_tx
+        storage_update_tx
             .process_output(tx_pointer, utxo_id, &inputs, &output)
             .unwrap();
 

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -63,7 +63,7 @@ use fuel_core_types::{
     },
 };
 
-pub trait UpdateMerkleizedTables: Sized {
+pub trait UpdateMerkleizedTables {
     fn update_merkleized_tables(
         &mut self,
         chain_id: ChainId,

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -331,6 +331,9 @@ mod tests {
     };
 
     #[test]
+    /// When encountering a transaction with a coin output,
+    /// `process_output` should ensure this coin is
+    /// populated in the `Coins` table.
     fn process_output__should_insert_coin() {
         let mut rng = StdRng::seed_from_u64(1337);
 
@@ -372,6 +375,9 @@ mod tests {
     }
 
     #[test]
+    /// When encountering a transaction with a contract created output,
+    /// `process_output` should ensure an appropriate contract UTxO is
+    /// populated in the `ContractCreated` table.
     fn process_output__should_insert_latest_contract_utxo_when_contract_created() {
         let mut rng = StdRng::seed_from_u64(1337);
 
@@ -410,6 +416,9 @@ mod tests {
     }
 
     #[test]
+    /// When encountering a transaction with a contract output,
+    /// `process_output` should ensure an appropriate contract UTxO is
+    /// populated in the `ContractCreated` table.
     fn process_output__should_update_latest_contract_utxo_when_interacting_with_contract()
     {
         let mut rng = StdRng::seed_from_u64(1337);
@@ -456,6 +465,10 @@ mod tests {
     }
 
     #[test]
+    /// When encountering a transaction with a coin input,
+    /// `process_input` should ensure this coin is
+    /// removed from the `Coins` table, as this coin is no longer
+    /// a part of the active UTxO set.
     fn process_input__should_remove_coin() {
         let mut rng = StdRng::seed_from_u64(1337);
 

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -63,12 +63,12 @@ use fuel_core_types::{
     },
 };
 
-pub trait UpdateMerkleizedTables {
+pub trait UpdateMerkleizedTables: Sized {
     fn update_merklized_tables(
         self,
         chain_id: ChainId,
         block: &Block,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<Self>;
 }
 
 impl<Storage> UpdateMerkleizedTables for &mut StorageTransaction<Storage>
@@ -79,13 +79,15 @@ where
         self,
         chain_id: ChainId,
         block: &Block,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Self> {
         let mut update_transaction = UpdateMerklizedTablesTransaction {
             chain_id,
             storage: self,
         };
 
-        update_transaction.process_block(block)
+        update_transaction.process_block(block)?;
+
+        Ok(self)
     }
 }
 

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -65,21 +65,21 @@ use fuel_core_types::{
 
 pub trait UpdateMerkleizedTables: Sized {
     fn update_merkleized_tables(
-        self,
+        &mut self,
         chain_id: ChainId,
         block: &Block,
-    ) -> anyhow::Result<Self>;
+    ) -> anyhow::Result<&mut Self>;
 }
 
-impl<Storage> UpdateMerkleizedTables for &mut StorageTransaction<Storage>
+impl<Storage> UpdateMerkleizedTables for StorageTransaction<Storage>
 where
     Storage: KeyValueInspect<Column = Column>,
 {
     fn update_merkleized_tables(
-        self,
+        &mut self,
         chain_id: ChainId,
         block: &Block,
-    ) -> anyhow::Result<Self> {
+    ) -> anyhow::Result<&mut Self> {
         let mut update_transaction = UpdateMerkleizedTablesTransaction {
             chain_id,
             storage: self,

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -65,18 +65,18 @@ use fuel_core_types::{
 
 pub trait UpdateMerkleizedTables {
     fn update_merklized_tables(
-        &mut self,
+        self,
         chain_id: ChainId,
         block: &Block,
     ) -> anyhow::Result<()>;
 }
 
-impl<Storage> UpdateMerkleizedTables for StorageTransaction<Storage>
+impl<Storage> UpdateMerkleizedTables for &mut StorageTransaction<Storage>
 where
     Storage: KeyValueInspect<Column = Column>,
 {
     fn update_merklized_tables(
-        &mut self,
+        self,
         chain_id: ChainId,
         block: &Block,
     ) -> anyhow::Result<()> {
@@ -305,6 +305,246 @@ impl TransactionOutputs for Transaction {
     }
 }
 
-// TODO(#2582): Add tests (https://github.com/FuelLabs/fuel-core/issues/2582)
-#[test]
-fn dummy() {}
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use super::*;
+
+    use fuel_core_storage::{
+        structured_storage::test::InMemoryStorage,
+        transactional::{
+            ReadTransaction,
+            WriteTransaction,
+        },
+        StorageAsRef,
+    };
+    use fuel_core_types::fuel_tx::{
+        Bytes32,
+        ContractId,
+        TxId,
+    };
+
+    use rand::{
+        rngs::StdRng,
+        Rng,
+        SeedableRng,
+    };
+
+    #[test]
+    fn process_output__should_insert_coin() {
+        let mut rng = StdRng::seed_from_u64(1337);
+
+        // Given
+        let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
+        let mut storage_tx = storage.write_transaction();
+        let mut update_tx = storage_tx.update_transaction();
+
+        let tx_pointer = random_tx_pointer(&mut rng);
+        let utxo_id = random_utxo_id(&mut rng);
+        let inputs = vec![];
+
+        let output_amount = rng.gen();
+        let output_address = random_address(&mut rng);
+        let output = Output::Coin {
+            to: output_address,
+            amount: output_amount,
+            asset_id: AssetId::zeroed(),
+        };
+
+        // When
+        update_tx
+            .process_output(tx_pointer, utxo_id, &inputs, &output)
+            .unwrap();
+
+        storage_tx.commit().unwrap();
+
+        let inserted_coin = storage
+            .read_transaction()
+            .storage_as_ref::<Coins>()
+            .get(&utxo_id)
+            .unwrap()
+            .unwrap()
+            .into_owned();
+
+        // Then
+        assert_eq!(*inserted_coin.amount(), output_amount);
+        assert_eq!(*inserted_coin.owner(), output_address);
+    }
+
+    #[test]
+    fn process_output__should_insert_latest_contract_utxo_when_contract_created() {
+        let mut rng = StdRng::seed_from_u64(1337);
+
+        // Given
+        let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
+        let mut storage_tx = storage.write_transaction();
+        let mut update_tx = storage_tx.update_transaction();
+
+        let tx_pointer = random_tx_pointer(&mut rng);
+        let utxo_id = random_utxo_id(&mut rng);
+        let inputs = vec![];
+
+        let contract_id = random_contract_id(&mut rng);
+        let output = Output::ContractCreated {
+            contract_id,
+            state_root: Bytes32::zeroed(),
+        };
+
+        // When
+        update_tx
+            .process_output(tx_pointer, utxo_id, &inputs, &output)
+            .unwrap();
+
+        storage_tx.commit().unwrap();
+
+        let inserted_contract_utxo = storage
+            .read_transaction()
+            .storage_as_ref::<ContractsLatestUtxo>()
+            .get(&contract_id)
+            .unwrap()
+            .unwrap()
+            .into_owned();
+
+        // Then
+        assert_eq!(inserted_contract_utxo.utxo_id(), &utxo_id);
+    }
+
+    #[test]
+    fn process_output__should_update_latest_contract_utxo_when_interacting_with_contract()
+    {
+        let mut rng = StdRng::seed_from_u64(1337);
+
+        // Given
+        let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
+        let mut storage_tx = storage.write_transaction();
+        let mut update_tx = storage_tx.update_transaction();
+
+        let tx_pointer = random_tx_pointer(&mut rng);
+        let utxo_id = random_utxo_id(&mut rng);
+
+        let contract_id = random_contract_id(&mut rng);
+        let input_contract = input::contract::Contract {
+            contract_id,
+            ..Default::default()
+        };
+        let inputs = vec![Input::Contract(input_contract)];
+
+        let output_contract = output::contract::Contract {
+            input_index: 0,
+            ..Default::default()
+        };
+
+        let output = Output::Contract(output_contract);
+
+        // When
+        update_tx
+            .process_output(tx_pointer, utxo_id, &inputs, &output)
+            .unwrap();
+
+        storage_tx.commit().unwrap();
+
+        let inserted_contract_utxo = storage
+            .read_transaction()
+            .storage_as_ref::<ContractsLatestUtxo>()
+            .get(&contract_id)
+            .unwrap()
+            .unwrap()
+            .into_owned();
+
+        // Then
+        assert_eq!(inserted_contract_utxo.utxo_id(), &utxo_id);
+    }
+
+    #[test]
+    fn process_input__should_remove_coin() {
+        let mut rng = StdRng::seed_from_u64(1337);
+
+        // Given
+        let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
+        let mut storage_tx = storage.write_transaction();
+        let mut update_tx = storage_tx.update_transaction();
+
+        let output_amount = rng.gen();
+        let output_address = random_address(&mut rng);
+        let tx_pointer = random_tx_pointer(&mut rng);
+        let utxo_id = random_utxo_id(&mut rng);
+        let inputs = vec![];
+
+        let output = Output::Coin {
+            to: output_address,
+            amount: output_amount,
+            asset_id: AssetId::zeroed(),
+        };
+
+        let input = Input::CoinSigned(CoinSigned {
+            utxo_id,
+            ..Default::default()
+        });
+
+        // When
+        update_tx
+            .process_output(tx_pointer, utxo_id, &inputs, &output)
+            .unwrap();
+
+        update_tx.process_input(&input).unwrap();
+
+        storage_tx.commit().unwrap();
+
+        // Then
+        assert!(storage
+            .read_transaction()
+            .storage_as_ref::<Coins>()
+            .get(&utxo_id)
+            .unwrap()
+            .is_none());
+    }
+
+    fn random_utxo_id(rng: &mut impl rand::RngCore) -> UtxoId {
+        let mut txid = TxId::default();
+        rng.fill_bytes(txid.as_mut());
+        let output_index = rng.gen();
+
+        UtxoId::new(txid, output_index)
+    }
+
+    fn random_tx_pointer(rng: &mut impl rand::RngCore) -> TxPointer {
+        let block_height = BlockHeight::new(rng.gen());
+        let tx_index = rng.gen();
+
+        TxPointer::new(block_height, tx_index)
+    }
+
+    fn random_address(rng: &mut impl rand::RngCore) -> Address {
+        let mut address = Address::default();
+        rng.fill_bytes(address.as_mut());
+
+        address
+    }
+
+    fn random_contract_id(rng: &mut impl rand::RngCore) -> ContractId {
+        let mut contract_id = ContractId::default();
+        rng.fill_bytes(contract_id.as_mut());
+
+        contract_id
+    }
+
+    trait UpdateTransaction<'a>: Sized + 'a {
+        type Storage;
+        fn update_transaction(
+            self,
+        ) -> UpdateMerklizedTablesTransaction<'a, Self::Storage>;
+    }
+
+    impl<'a, Storage> UpdateTransaction<'a> for &'a mut StorageTransaction<Storage> {
+        type Storage = Storage;
+
+        fn update_transaction(
+            self,
+        ) -> UpdateMerklizedTablesTransaction<'a, Self::Storage> {
+            UpdateMerklizedTablesTransaction {
+                chain_id: ChainId::default(),
+                storage: self,
+            }
+        }
+    }
+}

--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -378,7 +378,7 @@ mod tests {
         // Given
         let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
         let mut storage_tx = storage.write_transaction();
-        let mut update_tx = storage_tx.update_transaction();
+        let mut storage_update_tx = storage_tx.update_transaction();
 
         let tx_pointer = random_tx_pointer(&mut rng);
         let utxo_id = random_utxo_id(&mut rng);
@@ -391,7 +391,7 @@ mod tests {
         };
 
         // When
-        update_tx
+        storage_update_tx
             .process_output(tx_pointer, utxo_id, &inputs, &output)
             .unwrap();
 
@@ -417,7 +417,7 @@ mod tests {
         // Given
         let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
         let mut storage_tx = storage.write_transaction();
-        let mut update_tx = storage_tx.update_transaction();
+        let mut storage_update_tx = storage_tx.update_transaction();
 
         let tx_pointer = random_tx_pointer(&mut rng);
         let utxo_id = random_utxo_id(&mut rng);
@@ -437,7 +437,7 @@ mod tests {
         let output = Output::Contract(output_contract);
 
         // When
-        update_tx
+        storage_update_tx
             .process_output(tx_pointer, utxo_id, &inputs, &output)
             .unwrap();
 
@@ -462,7 +462,7 @@ mod tests {
         // Given
         let mut storage: InMemoryStorage<Column> = InMemoryStorage::default();
         let mut storage_tx = storage.write_transaction();
-        let mut update_tx = storage_tx.update_transaction();
+        let mut storage_update_tx = storage_tx.update_transaction();
 
         let output_amount = rng.gen();
         let output_address = random_address(&mut rng);
@@ -482,11 +482,11 @@ mod tests {
         });
 
         // When
-        update_tx
+        storage_update_tx
             .process_output(tx_pointer, utxo_id, &inputs, &output)
             .unwrap();
 
-        update_tx.process_input(&input).unwrap();
+        storage_update_tx.process_input(&input).unwrap();
 
         storage_tx.commit().unwrap();
 


### PR DESCRIPTION
Closes #2582 

## Description
This PR adds an initial test suite for the merkelized storage update functionality. These tests ensure that the insertion and deletion behavior for coins (except message coins, to be added in #2597) and contract UTXOs is correct.
