### PR TITLE
bugfix: Improve the `BlockCommitterHttpApi` client to use `url` apis better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [2551](https://github.com/FuelLabs/fuel-core/pull/2551): Enhanced the DA compressed block header to include block id.
 
+### Fixed
+- [2599](https://github.com/FuelLabs/fuel-core/pull/2599): Use the proper `url` apis to construct full url path in `BlockCommitterHttpApi` client
+
 ## [Version 0.41.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,6 +3891,7 @@ dependencies = [
  "tendermint-rpc",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/services/gas_price_service/src/v1/da_source_service/block_committer_costs.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service/block_committer_costs.rs
@@ -131,8 +131,9 @@ impl BlockCommitterApi for BlockCommitterHttpApi {
         // Specific: http://localhost:8080/v1/costs?variant=specific&value=19098935&limit=5
         if let Some(url) = &self.url {
             tracing::debug!("getting da costs by l2 block number: {l2_block_number}");
-            let formatted_url = format!("{url}/v1/costs?variant=specific&value={l2_block_number}&limit={NUMBER_OF_BUNDLES}");
-            let response = self.client.get(formatted_url).send().await?;
+            let path = format!("/v1/costs?variant=specific&value={l2_block_number}&limit={NUMBER_OF_BUNDLES}");
+            let full_path = url.join(&path)?;
+            let response = self.client.get(full_path).send().await?;
             let parsed = response.json::<Vec<RawDaBlockCosts>>().await?;
             Ok(parsed)
         } else {
@@ -147,6 +148,7 @@ mod test_block_committer_http_api {
 
     use super::*;
     use fake_server::FakeServer;
+    use url::Url;
 
     #[test]
     fn get_costs_by_l2_block_number__when_url_is_none__then_returns_empty_vec() {

--- a/crates/services/gas_price_service/src/v1/da_source_service/block_committer_costs.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service/block_committer_costs.rs
@@ -128,7 +128,7 @@ impl BlockCommitterApi for BlockCommitterHttpApi {
         &self,
         l2_block_number: u32,
     ) -> DaBlockCostsResult<Vec<RawDaBlockCosts>> {
-        // Specific: http://localhost:8080/v1/costs?variant=specific&value=19098935&limit=5
+        // Specific: http://committer.url/v1/costs?variant=specific&value=19098935&limit=5
         if let Some(url) = &self.url {
             tracing::debug!("getting da costs by l2 block number: {l2_block_number}");
             let path = format!("/v1/costs?variant=specific&value={l2_block_number}&limit={NUMBER_OF_BUNDLES}");

--- a/crates/services/gas_price_service/src/v1/da_source_service/block_committer_costs.rs
+++ b/crates/services/gas_price_service/src/v1/da_source_service/block_committer_costs.rs
@@ -148,7 +148,6 @@ mod test_block_committer_http_api {
 
     use super::*;
     use fake_server::FakeServer;
-    use url::Url;
 
     #[test]
     fn get_costs_by_l2_block_number__when_url_is_none__then_returns_empty_vec() {

--- a/crates/services/shared-sequencer/Cargo.toml
+++ b/crates/services/shared-sequencer/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0"
 tendermint-rpc = { version = "0.36", features = ["http-client"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [features]
 test-helpers = []

--- a/crates/services/shared-sequencer/src/http_api.rs
+++ b/crates/services/shared-sequencer/src/http_api.rs
@@ -102,7 +102,9 @@ pub async fn estimate_transaction(
 }
 
 pub async fn get_account_prefix(api_url: &str) -> anyhow::Result<String> {
-    let r = reqwest::get(format!("{api_url}/cosmos/auth/v1beta1/bech32")).await?;
+    let path = "/cosmos/auth/v1beta1/bech32";
+    let full_url = Url::parse(api_url)?.join(path).unwrap();
+    let r = reqwest::get(full_url).await?;
     let text = r.text().await?;
     let resp: api_types::AccountPrefix =
         serde_json::from_str(&text).with_context(|| format!("response text {text}"))?;
@@ -110,10 +112,9 @@ pub async fn get_account_prefix(api_url: &str) -> anyhow::Result<String> {
 }
 
 pub async fn chain_id(api_url: &str) -> anyhow::Result<String> {
-    let r = reqwest::get(format!(
-        "{api_url}/cosmos/base/tendermint/v1beta1/node_info"
-    ))
-    .await?;
+    let path = "/cosmos/base/tendermint/v1beta1/node_info";
+    let full_url = Url::parse(api_url)?.join(path).unwrap();
+    let r = reqwest::get(full_url).await?;
     let text = r.text().await?;
     let resp: api_types::NodeInfo =
         serde_json::from_str(&text).with_context(|| format!("response text {text}"))?;
@@ -121,7 +122,9 @@ pub async fn chain_id(api_url: &str) -> anyhow::Result<String> {
 }
 
 pub async fn config(api_url: &str) -> anyhow::Result<api_types::Config> {
-    let r = reqwest::get(format!("{api_url}/cosmos/base/node/v1beta1/config")).await?;
+    let path = "/cosmos/base/node/v1beta1/config";
+    let full_url = Url::parse(api_url)?.join(path).unwrap();
+    let r = reqwest::get(full_url).await?;
     let text = r.text().await?;
     let resp: api_types::Config =
         serde_json::from_str(&text).with_context(|| format!("response text {text}"))?;
@@ -129,7 +132,9 @@ pub async fn config(api_url: &str) -> anyhow::Result<api_types::Config> {
 }
 
 pub async fn coin_denom(api_url: &str) -> anyhow::Result<String> {
-    let r = reqwest::get(format!("{api_url}/cosmos/staking/v1beta1/params")).await?;
+    let path = "/cosmos/staking/v1beta1/params";
+    let full_url = Url::parse(api_url)?.join(path).unwrap();
+    let r = reqwest::get(full_url).await?;
     let text = r.text().await?;
     let resp: api_types::StakingParams =
         serde_json::from_str(&text).with_context(|| format!("response text {text}"))?;
@@ -140,7 +145,9 @@ pub async fn get_account(
     api_url: &str,
     id: AccountId,
 ) -> anyhow::Result<AccountMetadata> {
-    let r = reqwest::get(format!("{api_url}/cosmos/auth/v1beta1/accounts/{id}")).await?;
+    let path = format!("/cosmos/auth/v1beta1/accounts/{id}");
+    let full_url = Url::parse(api_url)?.join(&path).unwrap();
+    let r = reqwest::get(full_url).await?;
     let text = r.text().await?;
     let resp: api_types::AccountResponse =
         serde_json::from_str(&text).with_context(|| format!("response text {text}"))?;
@@ -168,10 +175,9 @@ pub struct TopicInfo {
 
 pub async fn get_topic(api_url: &str, id: [u8; 32]) -> anyhow::Result<Option<TopicInfo>> {
     let id_b64 = BASE64_STANDARD.encode(id);
-    let r = reqwest::get(format!(
-        "{api_url}/fuelsequencer/sequencing/v1/topic/{id_b64}"
-    ))
-    .await?;
+    let path = format!("/fuelsequencer/sequencing/v1/topic/{id_b64}");
+    let full_url = Url::parse(api_url)?.join(&path).unwrap();
+    let r = reqwest::get(full_url).await?;
     if r.status() == 404 {
         return Ok(None);
     }

--- a/crates/services/shared-sequencer/src/http_api.rs
+++ b/crates/services/shared-sequencer/src/http_api.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use base64::prelude::*;
 use cosmrs::AccountId;
+use url::Url;
 
 mod api_types {
     use serde::Deserialize;
@@ -87,8 +88,10 @@ pub async fn estimate_transaction(
     let request = SimulateRequest {
         tx_bytes: tx_bytes.to_string(),
     };
+    let path = "/cosmos/tx/v1beta1/simulate";
+    let full_url = Url::parse(api_url)?.join(path).unwrap();
     let r = reqwest::Client::new()
-        .post(format!("{api_url}/cosmos/tx/v1beta1/simulate"))
+        .post(full_url)
         .json(&request)
         .send()
         .await?;


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->
Before we were just building a String from the `Url` type, rather than using its apis. That was bad and this is more robust. I feel like it could be more precise than this, but I'm not finding a better way looking at the `url` docs.
