### PR TITLE
Use latest gas price to estimate next price for tx pool checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2551](https://github.com/FuelLabs/fuel-core/pull/2551): Enhanced the DA compressed block header to include block id.
 
 ### Fixed
+- [2612](https://github.com/FuelLabs/fuel-core/pull/2612): Use latest gas price to estimate next block gas price in tx pool instead of using algorithm directly
 - [2599](https://github.com/FuelLabs/fuel-core/pull/2599): Use the proper `url` apis to construct full url path in `BlockCommitterHttpApi` client
 
 ## [Version 0.41.0]

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -94,7 +94,7 @@ impl StaticGasPrice {
 }
 
 #[cfg(test)]
-mod arc_gas_price_estimate_tests {
+mod universal_gas_price_provider_tests {
     #![allow(non_snake_case)]
 
     use super::*;
@@ -167,6 +167,42 @@ mod arc_gas_price_estimate_tests {
 
             // then
             // doesn't panic with an overflow
+        }
+    }
+
+    fn _next_gas_price__correctly_calculates_value(
+        gas_price: u64,
+        starting_height: u32,
+        percentage: u16,
+    ) {
+        // given
+        let subject =
+            UniversalGasPriceProvider::new(starting_height, gas_price, percentage);
+
+        // when
+        let estimated = subject.next_gas_price();
+
+        // then
+        let change_amount = gas_price
+            .saturating_mul(percentage as u64)
+            .saturating_div(100);
+        let actual = gas_price.saturating_add(change_amount);
+
+        assert!(estimated >= actual);
+    }
+
+    proptest! {
+        #[test]
+        fn next_gas_price__correctly_calculates_value(
+            gas_price: u64,
+            starting_height: u32,
+            percentage: u16,
+        ) {
+            _next_gas_price__correctly_calculates_value(
+                gas_price,
+                starting_height,
+                percentage,
+            )
         }
     }
 }

--- a/crates/fuel-core/src/service/adapters/fuel_gas_price_provider.rs
+++ b/crates/fuel-core/src/service/adapters/fuel_gas_price_provider.rs
@@ -3,7 +3,6 @@ use fuel_core_gas_price_service::common::gas_price_algorithm::{
     SharedGasPriceAlgo,
 };
 use fuel_core_producer::block_producer::gas_price::GasPriceProvider as ProducerGasPriceProvider;
-use fuel_core_txpool::ports::GasPriceProvider as TxPoolGasPriceProvider;
 use fuel_core_types::fuel_types::BlockHeight;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -61,14 +60,5 @@ where
 {
     async fn next_gas_price(&self) -> anyhow::Result<u64> {
         Ok(self.next_gas_price())
-    }
-}
-
-impl<A> TxPoolGasPriceProvider for FuelGasPriceProvider<A>
-where
-    A: GasPriceAlgorithm + Send + Sync + 'static,
-{
-    fn next_gas_price(&self) -> u64 {
-        self.next_gas_price()
     }
 }

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -22,7 +22,6 @@ use crate::{
             fuel_gas_price_provider::FuelGasPriceProvider,
             graphql_api::GraphQLBlockImporter,
             import_result_provider::ImportResultProvider,
-            ArcGasPriceEstimate,
             BlockImporterAdapter,
             BlockProducerAdapter,
             ConsensusParametersProvider,
@@ -32,6 +31,7 @@ use crate::{
             SharedMemoryPool,
             SystemTime,
             TxPoolAdapter,
+            UniversalGasPriceProvider,
             VerifierAdapter,
         },
         Config,
@@ -203,7 +203,11 @@ pub fn init_sub_services(
         database.on_chain().clone(),
     )?;
     let (gas_price_algo, latest_gas_price) = gas_price_service_v1.shared.clone();
-    let gas_price_provider = FuelGasPriceProvider::new(gas_price_algo.clone());
+    let universal_gas_price_provider = UniversalGasPriceProvider::new_from_inner(
+        latest_gas_price,
+        DEFAULT_GAS_PRICE_CHANGE_PERCENT,
+    );
+    let producer_gas_price_provider = FuelGasPriceProvider::new(gas_price_algo.clone());
 
     let txpool = fuel_core_txpool::new_service(
         chain_id,
@@ -213,7 +217,7 @@ pub fn init_sub_services(
         database.on_chain().clone(),
         consensus_parameters_provider.clone(),
         last_height,
-        gas_price_provider.clone(),
+        universal_gas_price_provider.clone(),
         executor.clone(),
     );
     let tx_pool_adapter = TxPoolAdapter::new(txpool.shared.clone());
@@ -241,7 +245,7 @@ pub fn init_sub_services(
         executor: Arc::new(executor.clone()),
         relayer: Box::new(relayer_adapter.clone()),
         lock: Mutex::new(()),
-        gas_price_provider: gas_price_provider.clone(),
+        gas_price_provider: producer_gas_price_provider.clone(),
         consensus_parameters_provider: consensus_parameters_provider.clone(),
     };
     let producer_adapter = BlockProducerAdapter::new(block_producer);
@@ -324,10 +328,6 @@ pub fn init_sub_services(
         chain_name,
     };
 
-    let graphql_gas_price_provider = ArcGasPriceEstimate::new_from_inner(
-        latest_gas_price,
-        DEFAULT_GAS_PRICE_CHANGE_PERCENT,
-    );
     let graph_ql = fuel_core_graphql_api::api_service::new_service(
         *genesis_block.header().height(),
         graphql_config,
@@ -338,7 +338,7 @@ pub fn init_sub_services(
         Box::new(producer_adapter),
         Box::new(poa_adapter.clone()),
         Box::new(p2p_adapter),
-        Box::new(graphql_gas_price_provider),
+        Box::new(universal_gas_price_provider),
         Box::new(consensus_parameters_provider),
         SharedMemoryPool::new(config.memory_pool_size),
     )?;

--- a/crates/services/txpool_v2/src/lib.rs
+++ b/crates/services/txpool_v2/src/lib.rs
@@ -53,7 +53,7 @@ mod storage;
 mod tx_status_stream;
 mod update_sender;
 
-type GasPrice = Word;
+pub type GasPrice = Word;
 
 #[cfg(test)]
 mod tests;

--- a/tests/tests/tx/utxo_validation.rs
+++ b/tests/tests/tx/utxo_validation.rs
@@ -129,10 +129,14 @@ async fn submit_utxo_verified_tx_below_min_gas_price_fails() {
 
     assert!(result.is_err());
     let error = result.err().unwrap().to_string();
-    assert!(error.contains(
-        "The provided max fee can't cover the transaction cost. \
-            The minimal gas price should be 10, while it is 0"
-    ));
+    assert!(
+        error.contains(
+            "The provided max fee can't cover the transaction cost. \
+            The minimal gas price should be 11, while it is 0"
+        ),
+        "{}",
+        error
+    );
 }
 
 // verify that dry run can disable utxo_validation by simulating a transaction with unsigned


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description

There are 3 services that rely on the gas price: producer, tx pool, and graphql. In 0.41.0, graphql used the latest block, but the producer and tx pool use the actual next gas price.

This works great on the producer node, but for all the sentries that also have tx pools they need to be perfectly in sync with the block producer or else the expected gas prices will be different.

The new change has the tx pool behave the same as graphql, where it has access to the latest block and can calculate the (worst case) gas price for the next block.

This is already what the end users are doing to set a max fee on their tx, so it shouldn't exclude any txs that should be in there.

Sentries will reject txs if they don't have the correct parameters, this solves this problem by using the "worst case" for next gas price based on the the latest actual block. 

## Checklist
- [x] New behavior is reflected in tests