### PR TITLE
Release 0.41.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.41.3]
+
+### Fixed
+- [2626](https://github.com/FuelLabs/fuel-core/pull/2626): Avoid needs of RocksDB features in tests modules.
+
 ## [Version 0.41.2]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3400,7 +3400,7 @@ dependencies = [
  "fuel-core-sync",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3451,7 +3451,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-sync",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "futures",
  "hex",
  "itertools 0.12.1",
@@ -3473,11 +3473,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.41.2"
+version = "0.41.3"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3492,7 +3492,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3523,7 +3523,7 @@ dependencies = [
  "derivative",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3541,14 +3541,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more 0.99.18",
  "eventsource-client",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -3565,23 +3565,23 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "clap",
  "fuel-core-client",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fuel-core-compression",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "paste",
  "postcard",
  "proptest",
@@ -3594,30 +3594,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3625,7 +3625,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "futures",
  "hex",
  "humantime-serde",
@@ -3642,12 +3642,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "hex",
  "parking_lot",
  "serde",
@@ -3656,14 +3656,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
  "enum-iterator",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "fuel-gas-price-algorithm",
  "futures",
  "mockito",
@@ -3683,14 +3683,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "mockall",
  "parking_lot",
  "rayon",
@@ -3701,18 +3701,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "clap",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "atty",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3751,7 +3751,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3791,7 +3791,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "mockall",
  "rand",
  "serde",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3812,7 +3812,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "mockall",
  "proptest",
  "rand",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3837,7 +3837,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "futures",
  "mockall",
  "once_cell",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3881,7 +3881,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -3897,13 +3897,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "fuel-vm 0.59.1",
  "impl-tools",
  "itertools 0.12.1",
@@ -3921,13 +3921,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "futures",
  "mockall",
  "rand",
@@ -3962,7 +3962,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "ctor",
  "tracing",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4010,7 +4010,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "futures",
  "mockall",
  "num-rational",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4062,13 +4062,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "fuel-core-wasm-executor",
  "parking_lot",
  "postcard",
@@ -4078,13 +4078,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "postcard",
  "proptest",
  "serde",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "proptest",
  "rand",
@@ -9810,7 +9810,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.2",
+ "fuel-core-types 0.41.3",
  "futures",
  "itertools 0.12.1",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,41 +57,41 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.41.2"
+version = "0.41.3"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.41.2", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.41.2", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.41.2", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.41.2", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.41.2", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.41.2", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.41.2", path = "./crates/client" }
-fuel-core-compression = { version = "0.41.2", path = "./crates/compression" }
-fuel-core-database = { version = "0.41.2", path = "./crates/database" }
-fuel-core-metrics = { version = "0.41.2", path = "./crates/metrics" }
-fuel-core-services = { version = "0.41.2", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.41.2", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.41.2", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.41.2", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.41.2", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.41.2", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.41.2", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.41.2", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.41.2", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.41.2", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.41.2", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.41.2", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.41.2", path = "./crates/services/txpool_v2" }
-fuel-core-storage = { version = "0.41.2", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.41.2", path = "./crates/trace" }
-fuel-core-types = { version = "0.41.2", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.41.3", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.41.3", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.41.3", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.41.3", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.41.3", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.41.3", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.41.3", path = "./crates/client" }
+fuel-core-compression = { version = "0.41.3", path = "./crates/compression" }
+fuel-core-database = { version = "0.41.3", path = "./crates/database" }
+fuel-core-metrics = { version = "0.41.3", path = "./crates/metrics" }
+fuel-core-services = { version = "0.41.3", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.41.3", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.41.3", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.41.3", path = "./crates/services/consensus_module/poa" }
+fuel-core-shared-sequencer = { version = "0.41.3", path = "crates/services/shared-sequencer" }
+fuel-core-executor = { version = "0.41.3", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.41.3", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.41.3", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.41.3", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.41.3", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.41.3", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.41.3", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.41.3", path = "./crates/services/txpool_v2" }
+fuel-core-storage = { version = "0.41.3", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.41.3", path = "./crates/trace" }
+fuel-core-types = { version = "0.41.3", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.41.2", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.41.2", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.41.3", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.41.3", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.41.2", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.41.3", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.59.1", package = "fuel-vm", default-features = false }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ git clone https://github.com/FuelLabs/fuel-core.git
 
 Go to the latest release tag for ignition on the `fuel-core` repository :
 ```
-git checkout v0.41.2
+git checkout v0.41.3
 ```
 
 Build your node binary:

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -304,7 +304,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 19,
+  "genesis_state_transition_version": 20,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -308,7 +308,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 19,
+  "genesis_state_transition_version": 20,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -158,7 +158,8 @@ impl<S, R> Executor<S, R> {
         ("0-40-0", 16),
         ("0-40-1", 17),
         ("0-40-2", 18),
-        ("0-41-2", LATEST_STATE_TRANSITION_VERSION),
+        ("0-41-2", 19),
+        ("0-41-3", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -166,7 +166,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 19;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 20;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Version 0.41.3

### Fixed
- [2626](https://github.com/FuelLabs/fuel-core/pull/2626): Avoid needs of RocksDB features in tests modules

## What's Changed

- fix(rocksdb): import when rocksdb is enabled within local_node_with_reader fn by @rymnc in #2626