### PR TITLE
Add generation of docker images on release/master push

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -2,6 +2,9 @@ name: Docker Images
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
   release:
     types: [ published ]
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -2,6 +2,8 @@ name: Docker Images
 
 on:
   workflow_dispatch:
+  release:
+    types: [ published ]
 
 env:
   GIT_BRANCH: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Description
Docker Images are useful for our DevOps team. In case of release we should generate them automatically for them and all the users.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
