### PR TITLE
chore(async_trait): reduce usage of async_trait for small types again

### DIFF
--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -284,10 +284,9 @@ pub trait P2pPort: Send + Sync {
 }
 
 /// Trait for defining how to estimate gas price for future blocks
-#[async_trait::async_trait]
 pub trait GasPriceEstimate: Send + Sync {
     /// The worst case scenario for gas price at a given horizon
-    async fn worst_case_gas_price(&self, height: BlockHeight) -> Option<u64>;
+    fn worst_case_gas_price(&self, height: BlockHeight) -> Option<u64>;
 }
 
 /// Trait for getting VM memory.

--- a/crates/fuel-core/src/schema/gas_price.rs
+++ b/crates/fuel-core/src/schema/gas_price.rs
@@ -101,7 +101,6 @@ impl EstimateGasPriceQuery {
         let gas_price_provider = ctx.data_unchecked::<GasPriceProvider>();
         let gas_price = gas_price_provider
             .worst_case_gas_price(target_block.into())
-            .await
             .ok_or(async_graphql::Error::new(format!(
                 "Failed to estimate gas price for block, algorithm not yet set: {target_block:?}"
             )))?;

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -100,7 +100,7 @@ mod universal_gas_price_provider_tests {
     use super::*;
     use proptest::proptest;
 
-    async fn _worst_case__correctly_calculates_value(
+    fn _worst_case__correctly_calculates_value(
         gas_price: u64,
         starting_height: u32,
         block_horizon: u32,
@@ -112,10 +112,7 @@ mod universal_gas_price_provider_tests {
 
         // when
         let target_height = starting_height.saturating_add(block_horizon);
-        let estimated = subject
-            .worst_case_gas_price(target_height.into())
-            .await
-            .unwrap();
+        let estimated = subject.worst_case_gas_price(target_height.into()).unwrap();
 
         // then
         let mut actual = gas_price;
@@ -137,13 +134,12 @@ mod universal_gas_price_provider_tests {
             block_horizon in 0..10_000u32,
             percentage: u16,
         ) {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(_worst_case__correctly_calculates_value(
+            _worst_case__correctly_calculates_value(
                 gas_price,
                 starting_height,
                 block_horizon,
                 percentage,
-            ));
+            );
         }
     }
 
@@ -155,15 +151,13 @@ mod universal_gas_price_provider_tests {
             block_horizon in 0..10_000u32,
             percentage: u16
         ) {
-            let rt = tokio::runtime::Runtime::new().unwrap();
-
             // given
             let subject = UniversalGasPriceProvider::new(starting_height, gas_price, percentage);
 
             // when
             let target_height = starting_height.saturating_add(block_horizon);
 
-            let _ = rt.block_on(subject.worst_case_gas_price(target_height.into()));
+            let _ = subject.worst_case_gas_price(target_height.into());
 
             // then
             // doesn't panic with an overflow
@@ -273,9 +267,8 @@ impl TxPoolGasPriceProvider for UniversalGasPriceProvider<u32, u64> {
     }
 }
 
-#[async_trait::async_trait]
 impl GasPriceEstimate for UniversalGasPriceProvider<u32, u64> {
-    async fn worst_case_gas_price(&self, height: BlockHeight) -> Option<u64> {
+    fn worst_case_gas_price(&self, height: BlockHeight) -> Option<u64> {
         let (best_height, best_gas_price) = self.get_height_and_gas_price();
         let percentage = self.percentage;
 

--- a/crates/fuel-core/src/service/adapters/graphql_api.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api.rs
@@ -181,9 +181,8 @@ impl worker::TxPool for TxPoolAdapter {
     }
 }
 
-#[async_trait::async_trait]
 impl GasPriceEstimate for StaticGasPrice {
-    async fn worst_case_gas_price(&self, _height: BlockHeight) -> Option<u64> {
+    fn worst_case_gas_price(&self, _height: BlockHeight) -> Option<u64> {
         Some(self.gas_price)
     }
 }

--- a/crates/fuel-core/src/service/adapters/sync.rs
+++ b/crates/fuel-core/src/service/adapters/sync.rs
@@ -142,7 +142,6 @@ impl PeerReport for P2PAdapterPeerReport {
     }
 }
 
-#[async_trait::async_trait]
 impl BlockImporterPort for BlockImporterAdapter {
     fn committed_height_stream(&self) -> BoxStream<BlockHeight> {
         use futures::StreamExt;
@@ -160,7 +159,6 @@ impl BlockImporterPort for BlockImporterAdapter {
     }
 }
 
-#[async_trait::async_trait]
 impl ConsensusPort for ConsensusAdapter {
     fn check_sealed_header(&self, header: &SealedBlockHeader) -> anyhow::Result<bool> {
         Ok(self.block_verifier.verify_consensus(header))

--- a/crates/services/gas_price_service/src/common/gas_price_algorithm.rs
+++ b/crates/services/gas_price_service/src/common/gas_price_algorithm.rs
@@ -23,7 +23,7 @@ where
         Self(Arc::new(parking_lot::RwLock::new(algorithm)))
     }
 
-    pub async fn update(&mut self, new_algo: A) {
+    pub fn update(&mut self, new_algo: A) {
         let mut write_lock = self.0.write();
         *write_lock = new_algo;
     }
@@ -37,7 +37,7 @@ where
         self.0.read().next_gas_price()
     }
 
-    pub async fn worst_case_gas_price(&self, block_height: BlockHeight) -> u64 {
+    pub fn worst_case_gas_price(&self, block_height: BlockHeight) -> u64 {
         self.0.read().worst_case_gas_price(block_height)
     }
 }

--- a/crates/services/gas_price_service/src/v0/service.rs
+++ b/crates/services/gas_price_service/src/v0/service.rs
@@ -62,8 +62,8 @@ where
         self.shared_algo.clone()
     }
 
-    async fn update(&mut self, new_algorithm: AlgorithmV0) {
-        self.shared_algo.update(new_algorithm).await;
+    fn update(&mut self, new_algorithm: AlgorithmV0) {
+        self.shared_algo.update(new_algorithm);
     }
 
     fn validate_block_gas_capacity(
@@ -115,7 +115,7 @@ where
             }
         }
 
-        self.update(self.algorithm_updater.algorithm()).await;
+        self.update(self.algorithm_updater.algorithm());
         Ok(())
     }
 }

--- a/crates/services/gas_price_service/src/v1/service.rs
+++ b/crates/services/gas_price_service/src/v1/service.rs
@@ -234,8 +234,8 @@ where
         &self.storage_tx_provider
     }
 
-    async fn update(&mut self, new_algorithm: AlgorithmV1) {
-        self.shared_algo.update(new_algorithm).await;
+    fn update(&mut self, new_algorithm: AlgorithmV1) {
+        self.shared_algo.update(new_algorithm);
     }
 
     fn validate_block_gas_capacity(
@@ -304,7 +304,7 @@ where
         AtomicStorage::commit_transaction(storage_tx)?;
         let new_algo = self.algorithm_updater.algorithm();
         tracing::debug!("Updating gas price: {}", &new_algo.calculate());
-        self.shared_algo.update(new_algo).await;
+        self.shared_algo.update(new_algo);
         // Clear the buffer after committing changes
         self.da_block_costs_buffer.clear();
         Ok(())
@@ -321,7 +321,7 @@ where
                 tx.set_metadata(&metadata).map_err(|err| anyhow!(err))?;
                 AtomicStorage::commit_transaction(tx)?;
                 let new_algo = self.algorithm_updater.algorithm();
-                self.shared_algo.update(new_algo).await;
+                self.shared_algo.update(new_algo);
             }
             BlockInfo::Block {
                 height,

--- a/crates/services/sync/src/import/test_helpers/pressure_block_importer.rs
+++ b/crates/services/sync/src/import/test_helpers/pressure_block_importer.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 
 pub struct PressureBlockImporter(MockBlockImporterPort, Duration, SharedCounts);
 
-#[async_trait::async_trait]
 impl BlockImporterPort for PressureBlockImporter {
     fn committed_height_stream(&self) -> BoxStream<BlockHeight> {
         self.0.committed_height_stream()

--- a/crates/services/sync/src/import/test_helpers/pressure_block_importer.rs
+++ b/crates/services/sync/src/import/test_helpers/pressure_block_importer.rs
@@ -33,7 +33,8 @@ impl BlockImporterPort for PressureBlockImporter {
 impl PressureBlockImporter {
     pub fn new(counts: SharedCounts, delays: Duration) -> Self {
         let mut mock = MockBlockImporterPort::default();
-        mock.expect_execute_and_commit().returning(move |_| Ok(()));
+        mock.expect_execute_and_commit()
+            .returning(move |_| Box::pin(async move { Ok(()) }));
         Self(mock, delays, counts)
     }
 }

--- a/crates/services/sync/src/import/test_helpers/pressure_consensus.rs
+++ b/crates/services/sync/src/import/test_helpers/pressure_consensus.rs
@@ -29,7 +29,8 @@ impl ConsensusPort for PressureConsensus {
 impl PressureConsensus {
     pub fn new(counts: SharedCounts, delays: Duration) -> Self {
         let mut mock = MockConsensusPort::default();
-        mock.expect_await_da_height().returning(|_| Ok(()));
+        mock.expect_await_da_height()
+            .returning(|_| Box::pin(async move { Ok(()) }));
         mock.expect_check_sealed_header().returning(|_| Ok(true));
         Self(mock, delays, counts)
     }

--- a/crates/services/sync/src/import/test_helpers/pressure_consensus.rs
+++ b/crates/services/sync/src/import/test_helpers/pressure_consensus.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 
 pub struct PressureConsensus(MockConsensusPort, Duration, SharedCounts);
 
-#[async_trait::async_trait]
 impl ConsensusPort for PressureConsensus {
     fn check_sealed_header(&self, header: &SealedBlockHeader) -> anyhow::Result<bool> {
         self.0.check_sealed_header(header)

--- a/crates/services/sync/src/import/tests.rs
+++ b/crates/services/sync/src/import/tests.rs
@@ -36,7 +36,7 @@ async fn test_import_0_to_5() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -86,7 +86,7 @@ async fn test_import_3_to_5() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -150,7 +150,7 @@ async fn test_import_0_to_499() {
     consensus_port
         .expect_await_da_height()
         .times(times)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
 
@@ -207,7 +207,7 @@ async fn import__signature_fails_on_header_5_only() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
         .times(1)
@@ -265,7 +265,7 @@ async fn import__keep_data_asked_in_fail_ask_header_cases() {
     consensus_port
         .expect_await_da_height()
         .times(3)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     let mut seq = Sequence::new();
@@ -368,7 +368,7 @@ async fn import__keep_data_asked_in_fail_ask_transactions_cases() {
     consensus_port
         .expect_await_da_height()
         .times(4)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     // Everything goes well on the headers part for all blocks
@@ -474,7 +474,7 @@ async fn import__keep_data_asked_in_fail_execution() {
     consensus_port
         .expect_await_da_height()
         .times(4)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     // Data is re-ask for the block 4 because his execution failed
@@ -512,15 +512,17 @@ async fn import__keep_data_asked_in_fail_execution() {
         .times(1)
         .in_sequence(&mut seq)
         .returning(|block| {
-            assert_eq!(block.entity.header().height(), &BlockHeight::new(4));
-            anyhow::bail!("Bad execution")
+            Box::pin(async move {
+                assert_eq!(block.entity.header().height(), &BlockHeight::new(4));
+                anyhow::bail!("Bad execution")
+            })
         });
     // Success execute the 3 after
     executor
         .expect_execute_and_commit()
         .times(3)
         .in_sequence(&mut seq)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
     let executor = Arc::new(executor);
     let consensus = Arc::new(consensus_port);
     let notify = Arc::new(Notify::new());
@@ -561,7 +563,7 @@ async fn import__signature_fails_on_header_4_only() {
     consensus_port
         .expect_await_da_height()
         .times(0)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -756,7 +758,7 @@ async fn import__transactions_not_found() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -802,7 +804,7 @@ async fn import__transactions_not_found_for_header_4() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -860,7 +862,7 @@ async fn import__transactions_not_found_for_header_5() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -940,7 +942,7 @@ async fn import__p2p_error_on_4_transactions() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -994,7 +996,7 @@ async fn import__consensus_error_on_4() {
     consensus_port
         .expect_await_da_height()
         .times(0)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -1044,7 +1046,7 @@ async fn import__consensus_error_on_5() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -1096,7 +1098,7 @@ async fn import__execution_error_on_header_4() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -1124,11 +1126,13 @@ async fn import__execution_error_on_header_4() {
         .expect_execute_and_commit()
         .times(1)
         .returning(|h| {
-            if **h.entity.header().height() == 4 {
-                Err(anyhow::anyhow!("Some execution error"))
-            } else {
-                Ok(())
-            }
+            Box::pin(async move {
+                if **h.entity.header().height() == 4 {
+                    Err(anyhow::anyhow!("Some execution error"))
+                } else {
+                    Ok(())
+                }
+            })
         });
 
     let state = State::new(3, 5).into();
@@ -1160,7 +1164,7 @@ async fn import__execution_error_on_header_5() {
     consensus_port
         .expect_await_da_height()
         .times(1)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -1188,11 +1192,13 @@ async fn import__execution_error_on_header_5() {
         .expect_execute_and_commit()
         .times(2)
         .returning(|h| {
-            if **h.entity.header().height() == 5 {
-                Err(anyhow::anyhow!("Some execution error"))
-            } else {
-                Ok(())
-            }
+            Box::pin(async move {
+                if **h.entity.header().height() == 5 {
+                    Err(anyhow::anyhow!("Some execution error"))
+                } else {
+                    Ok(())
+                }
+            })
         });
 
     let state = State::new(3, 5).into();
@@ -1255,7 +1261,7 @@ async fn import__can_work_in_two_loops() {
     consensus_port
         .expect_await_da_height()
         .times(2)
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers()
@@ -1411,7 +1417,7 @@ async fn import__execution_error_on_header_4_when_awaits_for_1000000_blocks() {
         .returning(|_| Ok(true));
     consensus_port
         .expect_await_da_height()
-        .returning(|_| Ok(()));
+        .returning(|_| Box::pin(async move { Ok(()) }));
 
     let mut p2p = MockPeerToPeerPort::default();
     p2p.expect_get_sealed_block_headers().returning(|range| {
@@ -1436,11 +1442,13 @@ async fn import__execution_error_on_header_4_when_awaits_for_1000000_blocks() {
         .expect_execute_and_commit()
         .times(1)
         .returning(|h| {
-            if **h.entity.header().height() == 4 {
-                Err(anyhow::anyhow!("Some execution error"))
-            } else {
-                Ok(())
-            }
+            Box::pin(async move {
+                if **h.entity.header().height() == 4 {
+                    Err(anyhow::anyhow!("Some execution error"))
+                } else {
+                    Ok(())
+                }
+            })
         });
 
     let state = State::new(3, 1000000).into();
@@ -1626,7 +1634,9 @@ impl PeerReportTestBuilder {
     fn executor(&self) -> Arc<MockBlockImporterPort> {
         let mut executor = MockBlockImporterPort::default();
 
-        executor.expect_execute_and_commit().returning(|_| Ok(()));
+        executor
+            .expect_execute_and_commit()
+            .returning(|_| Box::pin(async move { Ok(()) }));
 
         Arc::new(executor)
     }
@@ -1636,7 +1646,7 @@ impl PeerReportTestBuilder {
 
         consensus_port
             .expect_await_da_height()
-            .returning(|_| Ok(()));
+            .returning(|_| Box::pin(async move { Ok(()) }));
 
         let check_sealed_header = self.check_sealed_header.unwrap_or(true);
         consensus_port
@@ -1701,7 +1711,7 @@ impl DefaultMocks for MockConsensusPort {
         consensus_port
             .expect_await_da_height()
             .times(t.next().unwrap())
-            .returning(|_| Ok(()));
+            .returning(|_| Box::pin(async move { Ok(()) }));
         consensus_port
     }
 }
@@ -1747,7 +1757,7 @@ impl DefaultMocks for MockBlockImporterPort {
         executor
             .expect_execute_and_commit()
             .times(t)
-            .returning(move |_| Ok(()));
+            .returning(move |_| Box::pin(async move { Ok(()) }));
         executor
     }
 }

--- a/crates/services/sync/src/ports.rs
+++ b/crates/services/sync/src/ports.rs
@@ -65,17 +65,18 @@ pub trait PeerToPeerPort {
 }
 
 #[cfg_attr(any(test, feature = "benchmarking"), mockall::automock)]
-#[async_trait::async_trait]
 /// Port for communication with the consensus service.
 pub trait ConsensusPort {
     /// Check if the given sealed block header is valid.
     fn check_sealed_header(&self, header: &SealedBlockHeader) -> anyhow::Result<bool>;
     /// await for this DA height to be sync'd.
-    async fn await_da_height(&self, da_height: &DaBlockHeight) -> anyhow::Result<()>;
+    fn await_da_height(
+        &self,
+        da_height: &DaBlockHeight,
+    ) -> impl core::future::Future<Output = anyhow::Result<()>> + Send;
 }
 
 #[cfg_attr(any(test, feature = "benchmarking"), mockall::automock)]
-#[async_trait::async_trait]
 /// Port for communication with the block importer.
 pub trait BlockImporterPort {
     /// Stream of newly committed block heights.
@@ -83,5 +84,8 @@ pub trait BlockImporterPort {
 
     /// Execute the given sealed block
     /// and commit it to the database.
-    async fn execute_and_commit(&self, block: SealedBlock) -> anyhow::Result<()>;
+    fn execute_and_commit(
+        &self,
+        block: SealedBlock,
+    ) -> impl core::future::Future<Output = anyhow::Result<()>> + Send;
 }

--- a/crates/services/sync/src/service/tests.rs
+++ b/crates/services/sync/src/service/tests.rs
@@ -61,13 +61,15 @@ async fn test_new_service() {
     let (tx, mut rx) = tokio::sync::mpsc::channel(100);
     importer.expect_execute_and_commit().returning(move |h| {
         tx.try_send(**h.entity.header().height()).unwrap();
-        Ok(())
+        Box::pin(async { Ok(()) })
     });
     let mut consensus = MockConsensusPort::default();
     consensus
         .expect_check_sealed_header()
         .returning(|_| Ok(true));
-    consensus.expect_await_da_height().returning(|_| Ok(()));
+    consensus
+        .expect_await_da_height()
+        .returning(|_| Box::pin(async { Ok(()) }));
     let params = Config {
         block_stream_buffer_size: 10,
         header_batch_size: 10,


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->

this pr description is AI generated, pls take with a grain of salt

This pull request includes several changes to remove asynchronous traits and methods, converting them to synchronous ones across various files. The most important changes include modifying the `GasPriceEstimate` trait and its implementations, updating test functions, and adjusting mock expectations.

### Conversion to Synchronous Methods:

* [`crates/fuel-core/src/graphql_api/ports.rs`](diffhunk://#diff-49095c45844c0809b8d244f4555fb1eaac1ee48612c103e553ab396d0dfe93c9L287-R289): Removed the `async_trait` attribute from the `GasPriceEstimate` trait and changed `worst_case_gas_price` to a synchronous method.
* [`crates/fuel-core/src/service/adapters.rs`](diffhunk://#diff-c710afba67d6633c23d5f7487e423036b27c9f20ec4a8a1541827b366d6e346bL276-R271): Updated the `GasPriceEstimate` implementations for `UniversalGasPriceProvider` and `StaticGasPrice` to synchronous methods. [[1]](diffhunk://#diff-c710afba67d6633c23d5f7487e423036b27c9f20ec4a8a1541827b366d6e346bL276-R271) [[2]](diffhunk://#diff-28c7fdbc1cb25f3e25156f2a0efdd72cf86a6462fe131be225b15b48d6d3f524L184-R185)
* [`crates/services/gas_price_service/src/common/gas_price_algorithm.rs`](diffhunk://#diff-38ab61925731d592d431bf2123324895adde7b539dfdc8de04a97f9efcd6c79dL26-R26): Changed the `update` and `worst_case_gas_price` methods to synchronous. [[1]](diffhunk://#diff-38ab61925731d592d431bf2123324895adde7b539dfdc8de04a97f9efcd6c79dL26-R26) [[2]](diffhunk://#diff-38ab61925731d592d431bf2123324895adde7b539dfdc8de04a97f9efcd6c79dL40-R40)

### Updates to Test Functions:

* [`crates/fuel-core/src/service/adapters.rs`](diffhunk://#diff-c710afba67d6633c23d5f7487e423036b27c9f20ec4a8a1541827b366d6e346bL103-R103): Adjusted test functions to remove asynchronous calls and runtime blocks. [[1]](diffhunk://#diff-c710afba67d6633c23d5f7487e423036b27c9f20ec4a8a1541827b366d6e346bL103-R103) [[2]](diffhunk://#diff-c710afba67d6633c23d5f7487e423036b27c9f20ec4a8a1541827b366d6e346bL140-R142) [[3]](diffhunk://#diff-c710afba67d6633c23d5f7487e423036b27c9f20ec4a8a1541827b366d6e346bL158-R160)
* [`crates/services/sync/src/import/tests.rs`](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL39-R39): Updated mock expectations to return pinned async blocks for various test functions. [[1]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL39-R39) [[2]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL89-R89) [[3]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL153-R153) [[4]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL210-R210) [[5]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL268-R268) [[6]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL371-R371) [[7]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL477-R477) [[8]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cR515-R525) [[9]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL564-R566) [[10]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL759-R761) [[11]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL805-R807) [[12]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL863-R865) [[13]](diffhunk://#diff-06109df4a98a700afefcb2fbc43df2a20e44469d5e95c437f239f865a8e57d4cL943-R945)

### Removal of `async_trait`:

* [`crates/fuel-core/src/service/adapters/sync.rs`](diffhunk://#diff-a58d36e1c68bf12145a84b084168b8b751c6178232ae412ed33bfec68723d894L145): Removed `async_trait` from `BlockImporterPort` and `ConsensusPort` implementations. [[1]](diffhunk://#diff-a58d36e1c68bf12145a84b084168b8b751c6178232ae412ed33bfec68723d894L145) [[2]](diffhunk://#diff-a58d36e1c68bf12145a84b084168b8b751c6178232ae412ed33bfec68723d894L163)
* [`crates/services/sync/src/import/test_helpers/pressure_block_importer.rs`](diffhunk://#diff-f648b60371e32529d1a465ff14688f3719d3e9fc88a05ccf6997384cb2f80bcaL17): Removed `async_trait` from `BlockImporterPort` implementation.
* [`crates/services/sync/src/import/test_helpers/pressure_consensus.rs`](diffhunk://#diff-d377102e8f2624e710b799cb32de729d17cfde1e1a644596e856c9fb0edfceb2L16): Removed `async_trait` from `ConsensusPort` implementation.

These changes collectively simplify the codebase by removing unnecessary asynchronous complexity, making the code more straightforward and potentially improving performance.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)
