### PR TITLE
Add metrics to gas price service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- [2635](https://github.com/FuelLabs/fuel-core/pull/2635): Add metrics to gas price service
+
 ### Changed
 - [2630](https://github.com/FuelLabs/fuel-core/pull/2630): Removed some noisy `tracing::info!` logs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3661,6 +3661,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "enum-iterator",
+ "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-types 0.41.4",

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -562,6 +562,8 @@ impl Command {
             disabled_metrics.is_enabled(Module::Importer),
         );
 
+        let gas_price_metrics = disabled_metrics.is_enabled(Module::GasPrice);
+
         let da_compression = match da_compression {
             Some(retention) => {
                 DaCompressionConfig::Enabled(fuel_core_compression::Config {
@@ -710,6 +712,7 @@ impl Command {
             max_da_gas_price_change_percent: gas_price_change_percent,
             da_gas_price_p_component,
             da_gas_price_d_component,
+            gas_price_metrics,
             activity_normal_range_size: 100,
             activity_capped_range_size: 0,
             activity_decrease_range_size: 0,

--- a/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
@@ -83,6 +83,7 @@ impl From<Config> for V1AlgorithmConfig {
             starting_recorded_height: value
                 .starting_recorded_height
                 .map(BlockHeight::from),
+            record_metrics: value.gas_price_metrics,
         }
     }
 }

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -91,6 +91,7 @@ pub struct Config {
     pub max_da_gas_price_change_percent: u16,
     pub da_gas_price_p_component: i64,
     pub da_gas_price_d_component: i64,
+    pub gas_price_metrics: bool,
     pub activity_normal_range_size: u16,
     pub activity_capped_range_size: u16,
     pub activity_decrease_range_size: u16,
@@ -148,6 +149,7 @@ impl Config {
         let gas_price_change_percent = 0;
         let min_gas_price = 0;
         let gas_price_threshold_percent = 50;
+        let gas_price_metrics = false;
 
         Self {
             graphql_config: GraphQLConfig {
@@ -214,6 +216,7 @@ impl Config {
             max_da_gas_price_change_percent: 0,
             da_gas_price_p_component: 0,
             da_gas_price_d_component: 0,
+            gas_price_metrics,
             activity_normal_range_size: 0,
             activity_capped_range_size: 0,
             activity_decrease_range_size: 0,

--- a/crates/metrics/src/config.rs
+++ b/crates/metrics/src/config.rs
@@ -15,6 +15,7 @@ pub enum Module {
     Producer,
     TxPool,
     GraphQL, // TODO[RC]: Not used... yet.
+    GasPrice,
 }
 
 /// Configuration for disabling metrics.

--- a/crates/metrics/src/gas_price_metrics.rs
+++ b/crates/metrics/src/gas_price_metrics.rs
@@ -1,7 +1,8 @@
 use prometheus_client::metrics::gauge::Gauge;
 use std::sync::OnceLock;
+use crate::global_registry;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct GasPriceMetrics {
     pub real_gas_price: Gauge,
     pub exec_gas_price: Gauge,
@@ -11,6 +12,74 @@ pub struct GasPriceMetrics {
     pub predicted_profit: Gauge,
     pub unrecorded_bytes: Gauge,
     pub latest_cost_per_byte: Gauge,
+}
+
+impl Default for GasPriceMetrics {
+    fn default() -> Self {
+        let real_gas_price = Gauge::default();
+        let exec_gas_price = Gauge::default();
+        let da_gas_price = Gauge::default();
+        let total_reward = Gauge::default();
+        let total_known_costs = Gauge::default();
+        let predicted_profit = Gauge::default();
+        let unrecorded_bytes = Gauge::default();
+        let latest_cost_per_byte = Gauge::default();
+
+        let metrics = GasPriceMetrics {
+            real_gas_price,
+            exec_gas_price,
+            da_gas_price,
+            total_reward,
+            total_known_costs,
+            predicted_profit,
+            unrecorded_bytes,
+            latest_cost_per_byte,
+        };
+
+        let mut registry = global_registry().registry.lock();
+        registry.register(
+            "gas_price_service_real_gas_price",
+            "The real gas price used on the most recent block",
+            metrics.real_gas_price.clone(),
+        );
+        registry.register(
+            "gas_price_service_exec_gas_price",
+            "The requested execution gas price for the next block",
+            metrics.exec_gas_price.clone(),
+        );
+        registry.register(
+            "gas_price_service_da_gas_price",
+            "The requested data availability gas price for the next block",
+            metrics.da_gas_price.clone(),
+        );
+        registry.register(
+            "gas_price_service_total_reward",
+            "The total reward received from DA gas price fees",
+            metrics.total_reward.clone(),
+        );
+        registry.register(
+            "gas_price_service_total_known_costs",
+            "The total known costs for committing L2 blocks to DA",
+            metrics.total_known_costs.clone(),
+        );
+        registry.register(
+            "gas_price_service_predicted_profit",
+            "The predicted profit based on the rewards, known costs, and predicted costs from price per byte",
+            metrics.predicted_profit.clone(),
+        );
+        registry.register(
+            "gas_price_service_unrecorded_bytes",
+            "The total bytes of all L2 blocks waiting to be recorded on DA",
+            metrics.unrecorded_bytes.clone(),
+        );
+        registry.register(
+            "gas_price_service_latest_cost_per_byte",
+            "The latest cost per byte to record L2 blocks on DA",
+            metrics.latest_cost_per_byte.clone(),
+        );
+
+        metrics
+    }
 }
 
 static GAS_PRICE_METRICS: OnceLock<GasPriceMetrics> = OnceLock::new();

--- a/crates/metrics/src/gas_price_metrics.rs
+++ b/crates/metrics/src/gas_price_metrics.rs
@@ -1,0 +1,21 @@
+use std::sync::OnceLock;
+use prometheus_client::metrics::gauge::Gauge;
+
+
+#[derive(Debug, Default)]
+pub struct GasPriceMetrics {
+    pub real_gas_price: Gauge,
+    pub exec_gas_price: Gauge,
+    pub da_gas_price: Gauge,
+    pub total_reward: Gauge,
+    pub total_known_costs: Gauge,
+    pub predicted_profit: Gauge,
+    pub unrecorded_bytes: Gauge,
+    pub latest_cost_per_byte: Gauge,
+}
+
+static GAS_PRICE_METRICS: OnceLock<GasPriceMetrics> = OnceLock::new();
+
+pub fn gas_price_metrics() -> &'static GasPriceMetrics {
+    GAS_PRICE_METRICS.get_or_init(GasPriceMetrics::default)
+}

--- a/crates/metrics/src/gas_price_metrics.rs
+++ b/crates/metrics/src/gas_price_metrics.rs
@@ -1,6 +1,5 @@
-use std::sync::OnceLock;
 use prometheus_client::metrics::gauge::Gauge;
-
+use std::sync::OnceLock;
 
 #[derive(Debug, Default)]
 pub struct GasPriceMetrics {

--- a/crates/metrics/src/gas_price_metrics.rs
+++ b/crates/metrics/src/gas_price_metrics.rs
@@ -1,6 +1,6 @@
+use crate::global_registry;
 use prometheus_client::metrics::gauge::Gauge;
 use std::sync::OnceLock;
-use crate::global_registry;
 
 #[derive(Debug)]
 pub struct GasPriceMetrics {

--- a/crates/metrics/src/gas_price_metrics.rs
+++ b/crates/metrics/src/gas_price_metrics.rs
@@ -12,6 +12,7 @@ pub struct GasPriceMetrics {
     pub predicted_profit: Gauge,
     pub unrecorded_bytes: Gauge,
     pub latest_cost_per_byte: Gauge,
+    pub recorded_height: Gauge,
 }
 
 impl Default for GasPriceMetrics {
@@ -24,6 +25,7 @@ impl Default for GasPriceMetrics {
         let predicted_profit = Gauge::default();
         let unrecorded_bytes = Gauge::default();
         let latest_cost_per_byte = Gauge::default();
+        let recorded_height = Gauge::default();
 
         let metrics = GasPriceMetrics {
             real_gas_price,
@@ -34,6 +36,7 @@ impl Default for GasPriceMetrics {
             predicted_profit,
             unrecorded_bytes,
             latest_cost_per_byte,
+            recorded_height,
         };
 
         let mut registry = global_registry().registry.lock();
@@ -76,6 +79,12 @@ impl Default for GasPriceMetrics {
             "gas_price_service_latest_cost_per_byte",
             "The latest cost per byte to record L2 blocks on DA",
             metrics.latest_cost_per_byte.clone(),
+        );
+
+        registry.register(
+            "gas_price_service_recorded_height",
+            "The height of the latest L2 block recorded on DA",
+            metrics.recorded_height.clone(),
         );
 
         metrics

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -28,6 +28,8 @@ pub mod importer;
 pub mod p2p_metrics;
 pub mod txpool_metrics;
 
+pub mod gas_price_metrics;
+
 static GLOBAL_REGISTER: OnceLock<GlobalRegistry> = OnceLock::new();
 
 pub fn global_registry() -> &'static GlobalRegistry {

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -23,12 +23,11 @@ mod buckets;
 pub mod config;
 pub mod core_metrics;
 pub mod futures;
+pub mod gas_price_metrics;
 pub mod graphql_metrics;
 pub mod importer;
 pub mod p2p_metrics;
 pub mod txpool_metrics;
-
-pub mod gas_price_metrics;
 
 static GLOBAL_REGISTER: OnceLock<GlobalRegistry> = OnceLock::new();
 

--- a/crates/services/gas_price_service/Cargo.toml
+++ b/crates/services/gas_price_service/Cargo.toml
@@ -12,6 +12,7 @@ repository = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 enum-iterator = { workspace = true }
+fuel-core-metrics = { workspace = true }
 fuel-core-services = { workspace = true }
 fuel-core-storage = { workspace = true, features = ["std"] }
 fuel-core-types = { workspace = true, features = ["std"] }

--- a/crates/services/gas_price_service/src/v1/metadata.rs
+++ b/crates/services/gas_price_service/src/v1/metadata.rs
@@ -59,6 +59,18 @@ impl V1Metadata {
         };
         Ok(metadata)
     }
+
+    pub fn new_exec_gas_price(&self) -> u64 {
+        self.new_scaled_exec_price
+            .checked_div(self.gas_price_factor.get())
+            .unwrap_or(0)
+    }
+
+    pub fn new_da_gas_price(&self) -> u64 {
+        self.new_scaled_da_gas_price
+            .checked_div(self.gas_price_factor.get())
+            .unwrap_or(0)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/services/gas_price_service/src/v1/metadata.rs
+++ b/crates/services/gas_price_service/src/v1/metadata.rs
@@ -94,6 +94,7 @@ pub struct V1AlgorithmConfig {
     /// The interval at which the `DaSourceService` polls for new data
     pub da_poll_interval: Option<Duration>,
     pub starting_recorded_height: Option<BlockHeight>,
+    pub record_metrics: bool,
 }
 
 pub fn updater_from_config(

--- a/crates/services/gas_price_service/src/v1/service.rs
+++ b/crates/services/gas_price_service/src/v1/service.rs
@@ -131,6 +131,8 @@ where
     latest_l2_block: Arc<AtomicU32>,
     /// Initial Recorded Height
     initial_recorded_height: Option<BlockHeight>,
+    /// Metrics will be recorded if true
+    record_metrics: bool,
 }
 
 impl<L2, DA, StorageTxProvider> GasPriceServiceV1<L2, DA, StorageTxProvider>
@@ -208,6 +210,7 @@ where
         storage_tx_provider: AtomicStorage,
         latest_l2_block: Arc<AtomicU32>,
         initial_recorded_height: Option<BlockHeight>,
+        record_metrics: bool,
     ) -> Self {
         let da_source_channel = da_source_adapter_handle.shared.clone().subscribe();
         Self {
@@ -221,6 +224,7 @@ where
             storage_tx_provider,
             latest_l2_block,
             initial_recorded_height,
+            record_metrics,
         }
     }
 
@@ -654,6 +658,7 @@ mod tests {
             block_activity_threshold: 20,
             da_poll_interval: None,
             starting_recorded_height: None,
+            record_metrics: false,
         };
         let inner = database();
         let (algo_updater, shared_algo) = initialize_algorithm(
@@ -690,6 +695,7 @@ mod tests {
             inner,
             latest_l2_height,
             None,
+            false,
         );
         let read_algo = service.next_block_algorithm();
         let mut watcher = StateWatcher::default();
@@ -742,6 +748,7 @@ mod tests {
             block_activity_threshold: 20,
             da_poll_interval: None,
             starting_recorded_height: None,
+            record_metrics: false,
         };
         let mut inner = database();
         let mut tx = inner.write_transaction();
@@ -787,6 +794,7 @@ mod tests {
             inner,
             latest_l2_block,
             None,
+            false,
         );
         let read_algo = service.next_block_algorithm();
         let initial_price = read_algo.next_gas_price();
@@ -823,6 +831,7 @@ mod tests {
             block_activity_threshold: 20,
             da_poll_interval: None,
             starting_recorded_height: None,
+            record_metrics: false,
         }
     }
 
@@ -892,6 +901,7 @@ mod tests {
             inner,
             latest_l2_height,
             None,
+            false,
         );
         let read_algo = service.next_block_algorithm();
         let initial_price = read_algo.next_gas_price();
@@ -985,6 +995,7 @@ mod tests {
             inner,
             latest_l2_height,
             None,
+            false,
         );
         let read_algo = service.next_block_algorithm();
         let initial_price = read_algo.next_gas_price();
@@ -1028,6 +1039,7 @@ mod tests {
             block_activity_threshold: 20,
             da_poll_interval: None,
             starting_recorded_height: None,
+            record_metrics: false,
         }
     }
 
@@ -1167,6 +1179,7 @@ mod tests {
             atomic_storage,
             latest_l2_height,
             Some(expected_recorded_height),
+            false,
         );
         let read_algo = service.next_block_algorithm();
         let initial_price = read_algo.next_gas_price();

--- a/crates/services/gas_price_service/src/v1/service.rs
+++ b/crates/services/gas_price_service/src/v1/service.rs
@@ -309,7 +309,7 @@ where
         AtomicStorage::commit_transaction(storage_tx)?;
         let new_algo = self.algorithm_updater.algorithm();
         tracing::debug!("Updating gas price: {}", &new_algo.calculate());
-        self.shared_algo.update(new_algo).await;
+        self.shared_algo.update(new_algo);
         let best_recorded_height = new_recorded_height.or(old_recorded_height);
         Self::record_metrics(&metadata, gas_price, best_recorded_height);
         // Clear the buffer after committing changes

--- a/crates/services/gas_price_service/src/v1/service.rs
+++ b/crates/services/gas_price_service/src/v1/service.rs
@@ -267,7 +267,7 @@ where
             None => {
                 // Sets it on first run
                 let initial = self.initial_recorded_height.take();
-                (initial, initial)
+                (None, initial)
             }
         };
 

--- a/crates/services/gas_price_service/src/v1/tests.rs
+++ b/crates/services/gas_price_service/src/v1/tests.rs
@@ -302,6 +302,7 @@ fn zero_threshold_arbitrary_config() -> V1AlgorithmConfig {
         block_activity_threshold: 0,
         da_poll_interval: None,
         starting_recorded_height: None,
+        record_metrics: false,
     }
 }
 
@@ -338,6 +339,7 @@ fn different_arb_config() -> V1AlgorithmConfig {
         block_activity_threshold: 0,
         da_poll_interval: None,
         starting_recorded_height: None,
+        record_metrics: false,
     }
 }
 
@@ -409,6 +411,7 @@ async fn next_gas_price__affected_by_new_l2_block() {
         inner,
         latest_l2_height,
         None,
+        false,
     );
 
     let read_algo = service.next_block_algorithm();
@@ -468,6 +471,7 @@ async fn run__new_l2_block_saves_old_metadata() {
         inner,
         latest_l2_height,
         None,
+        false,
     );
     let mut watcher = StateWatcher::started();
 
@@ -529,6 +533,7 @@ async fn run__new_l2_block_updates_latest_gas_price_arc() {
         inner,
         latest_l2_height,
         None,
+        false,
     );
     let mut watcher = StateWatcher::started();
 
@@ -589,6 +594,7 @@ async fn run__updates_da_service_latest_l2_height() {
         inner,
         latest_l2_height,
         None,
+        false,
     );
     let mut watcher = StateWatcher::started();
 

--- a/crates/services/gas_price_service/src/v1/uninitialized_task.rs
+++ b/crates/services/gas_price_service/src/v1/uninitialized_task.rs
@@ -211,6 +211,7 @@ where
             ),
         };
 
+        let record_metrics = self.config.record_metrics;
         let poll_duration = self.config.da_poll_interval;
         let latest_l2_height = Arc::new(AtomicU32::new(latest_block_height));
 
@@ -233,6 +234,7 @@ where
                 self.gas_price_db,
                 Arc::clone(&latest_l2_height),
                 Some(starting_recorded_height),
+                record_metrics,
             );
             Ok(service)
         } else {
@@ -261,6 +263,7 @@ where
                 self.gas_price_db,
                 Arc::clone(&latest_l2_height),
                 Some(starting_recorded_height),
+                record_metrics,
             );
             Ok(service)
         }


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->

A lot of the data that effects the gas price is somewhat opaque. Up until now, it's been hard to read without direct access to the Gas Price DB. This will give us visibility into:
```rs
pub struct GasPriceMetrics {
    pub real_gas_price: Gauge,
    pub exec_gas_price: Gauge,
    pub da_gas_price: Gauge,
    pub total_reward: Gauge,
    pub total_known_costs: Gauge,
    pub predicted_profit: Gauge,
    pub unrecorded_bytes: Gauge,
    pub latest_cost_per_byte: Gauge,
    pub recorded_height: Gauge,
}
```
which allows us to make charts like (plz ignore the gaps, this was just testing the visualizations):
<img width="1398" alt="image" src="https://github.com/user-attachments/assets/cd3388be-b543-47af-af1c-490dafe2d276" />

### Before requesting review
- [x] I have reviewed the code myself
