### PR TITLE
Bump to 0.40.4 versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3422,7 +3422,7 @@ dependencies = [
  "fuel-core-sync",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3472,7 +3472,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-sync",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "futures",
  "itertools 0.12.1",
  "num_enum",
@@ -3493,11 +3493,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.40.3"
+version = "0.40.4"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3512,7 +3512,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3542,7 +3542,7 @@ dependencies = [
  "derivative",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3560,14 +3560,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more 0.99.18",
  "eventsource-client",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -3584,22 +3584,22 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "clap 4.5.23",
  "fuel-core-client",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "fuel-core-compression",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "paste",
  "postcard",
  "proptest",
@@ -3612,30 +3612,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3643,7 +3643,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "futures",
  "hex",
  "humantime-serde",
@@ -3660,12 +3660,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "hex",
  "parking_lot",
  "serde",
@@ -3674,14 +3674,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
  "enum-iterator",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "fuel-gas-price-algorithm",
  "futures",
  "num_enum",
@@ -3698,14 +3698,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "mockall",
  "parking_lot",
  "rayon",
@@ -3716,18 +3716,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "clap 4.5.23",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "atty",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3766,7 +3766,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3802,7 +3802,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "mockall",
  "rand",
  "serde",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3823,7 +3823,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "mockall",
  "proptest",
  "rand",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3848,7 +3848,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "futures",
  "mockall",
  "once_cell",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3892,7 +3892,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -3907,13 +3907,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "fuel-vm 0.58.2",
  "impl-tools",
  "itertools 0.12.1",
@@ -3931,13 +3931,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "futures",
  "mockall",
  "rand",
@@ -3972,7 +3972,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3998,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "ctor",
  "tracing",
@@ -4008,7 +4008,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4017,7 +4017,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "futures",
  "mockall",
  "num-rational",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4069,13 +4069,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "derive_more 0.99.18",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "fuel-core-wasm-executor",
  "ntest",
  "parking_lot",
@@ -4086,13 +4086,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "postcard",
  "proptest",
  "serde",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.40.3"
+version = "0.40.4"
 dependencies = [
  "proptest",
  "rand",
@@ -9691,7 +9691,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.40.3",
+ "fuel-core-types 0.40.4",
  "futures",
  "itertools 0.12.1",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,41 +52,41 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.40.3"
+version = "0.40.4"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.40.3", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.40.3", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.40.3", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.40.3", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.40.3", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.40.3", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.40.3", path = "./crates/client" }
-fuel-core-compression = { version = "0.40.3", path = "./crates/compression" }
-fuel-core-database = { version = "0.40.3", path = "./crates/database" }
-fuel-core-metrics = { version = "0.40.3", path = "./crates/metrics" }
-fuel-core-services = { version = "0.40.3", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.40.3", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.40.3", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.40.3", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.40.3", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.40.3", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.40.3", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.40.3", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.40.3", path = "./crates/services/p2p" }
-fuel-core-producer = { version = "0.40.3", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.40.3", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.40.3", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.40.3", path = "./crates/services/txpool_v2" }
-fuel-core-storage = { version = "0.40.3", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.40.3", path = "./crates/trace" }
-fuel-core-types = { version = "0.40.3", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.40.4", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.40.4", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.40.4", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.40.4", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.40.4", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.40.4", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.40.4", path = "./crates/client" }
+fuel-core-compression = { version = "0.40.4", path = "./crates/compression" }
+fuel-core-database = { version = "0.40.4", path = "./crates/database" }
+fuel-core-metrics = { version = "0.40.4", path = "./crates/metrics" }
+fuel-core-services = { version = "0.40.4", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.40.4", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.40.4", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.40.4", path = "./crates/services/consensus_module/poa" }
+fuel-core-shared-sequencer = { version = "0.40.4", path = "crates/services/shared-sequencer" }
+fuel-core-executor = { version = "0.40.4", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.40.4", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.40.4", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.40.4", path = "./crates/services/p2p" }
+fuel-core-producer = { version = "0.40.4", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.40.4", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.40.4", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.40.4", path = "./crates/services/txpool_v2" }
+fuel-core-storage = { version = "0.40.4", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.40.4", path = "./crates/trace" }
+fuel-core-types = { version = "0.40.4", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.40.3", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.40.3", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.40.4", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.40.4", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.40.3", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.40.4", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.58.2", package = "fuel-vm", default-features = false }

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -157,16 +157,16 @@ impl<S, R> Executor<S, R> {
         ("0-39-0", 15),
         ("0-40-0", 16),
         ("0-40-1", 17),
-        // The release 0.40.2 and 0.40.3 has the same state transition function bytecode,
+        // The release 0.40.2, 0.40.3 and 0.40.4 has the same state transition function bytecode,
         // because we don't do `cargo update` and use `Cargo.lock` file to generate
         // the exact same WASM bytecode. And new release doesn't have any changes in the
         // executor or related crates.
         //
-        // Usually even in this condition we increment the version, but in this case of 0.40.3,
+        // Usually even in this condition we increment the version, but in this case of 0.40.4,
         // we can't do that without hacks, because version 0.41.0 already is released.
-        // So we override 0.40.2 release with 0.40.3 release for now.
+        // So we override 0.40.2 release with 0.40.4 release for now.
         // ("0-40-2", 18),
-        ("0-40-3", LATEST_STATE_TRANSITION_VERSION),
+        ("0-40-4", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(


### PR DESCRIPTION
## Version 0.40.4

### Changed

- [2639](https://github.com/FuelLabs/fuel-core/pull/2639): Refactor fetching `latest_height` from `OnChainIterableKeyValueView` to instead use height at the time of its creation.

### Fixed

- [2638](https://github.com/FuelLabs/fuel-core/pull/2638): Optimize the `cumulative_percent_change` function used in estimation of gas price, convert multiple async functions to sync.
