### PR TITLE
Remove txpool request client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - [2638](https://github.com/FuelLabs/fuel-core/pull/2638): Optimize the `cumulative_percent_change` function used in estimation of gas price, convert multiple async functions to sync.
+- [2641](https://github.com/FuelLabs/fuel-core/pull/2641): Remove `txPoolStats` requirement from fuel core client
 
 ## [Version 0.40.3]
 

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -755,6 +755,7 @@ type NodeInfo {
 	maxSize: U64!
 	maxDepth: U64!
 	nodeVersion: String!
+	txPoolStats: TxPoolStats!
 	peers: [PeerInfo!]!
 }
 

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -755,7 +755,6 @@ type NodeInfo {
 	maxSize: U64!
 	maxDepth: U64!
 	nodeVersion: String!
-	txPoolStats: TxPoolStats!
 	peers: [PeerInfo!]!
 }
 

--- a/crates/client/src/client/schema/node_info.rs
+++ b/crates/client/src/client/schema/node_info.rs
@@ -27,7 +27,6 @@ pub struct NodeInfo {
     pub max_size: U64,
     pub max_depth: U64,
     pub node_version: String,
-    pub tx_pool_stats: TxPoolStats,
 }
 
 #[derive(cynic::QueryFragment, Clone, Debug)]

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__node_info__tests__node_info_query_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__node_info__tests__node_info_query_gql_output.snap
@@ -12,11 +12,6 @@ query {
     maxSize
     maxDepth
     nodeVersion
-    txPoolStats {
-      txCount
-      totalGas
-      totalSize
-    }
   }
 }
 

--- a/crates/client/src/client/types/node_info.rs
+++ b/crates/client/src/client/types/node_info.rs
@@ -1,7 +1,4 @@
-use crate::client::schema::{
-    self,
-    node_info::TxPoolStats,
-};
+use crate::client::schema;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NodeInfo {
@@ -12,7 +9,6 @@ pub struct NodeInfo {
     pub max_size: u64,
     pub max_depth: u64,
     pub node_version: String,
-    pub tx_pool_stats: TxPoolStats,
 }
 
 // GraphQL Translation
@@ -27,7 +23,6 @@ impl From<schema::node_info::NodeInfo> for NodeInfo {
             max_size: value.max_size.into(),
             max_depth: value.max_depth.into(),
             node_version: value.node_version,
-            tx_pool_stats: value.tx_pool_stats,
         }
     }
 }


### PR DESCRIPTION
## Description
Avoid breaking the client if the node is not updated and do not have the `txpoolstats` field
