### PR TITLE
Patch transaction pool ordering zero tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [2387](https://github.com/FuelLabs/fuel-core/pull/2387): Update description `tx-max-depth` flag.
 - [2630](https://github.com/FuelLabs/fuel-core/pull/2630): Removed some noisy `tracing::info!` logs
+- [2643](https://github.com/FuelLabs/fuel-core/pull/2643): Before this fix when tip is zero, transactions that use 30M have the same priority as transactions with 1M gas. Now they are correctly ordered.
 
 ### Added
 - [2553](https://github.com/FuelLabs/fuel-core/pull/2553): Scaffold global merkle root storage crate.

--- a/crates/services/txpool_v2/src/selection_algorithms/ratio_tip_gas.rs
+++ b/crates/services/txpool_v2/src/selection_algorithms/ratio_tip_gas.rs
@@ -109,7 +109,8 @@ where
 
     fn key(store_entry: &StorageData) -> Key {
         let transaction = &store_entry.transaction;
-        let tip_gas_ratio = RatioTipGas::new(transaction.tip(), transaction.max_gas());
+        let tip_gas_ratio =
+            RatioTipGas::new(transaction.tip().saturating_add(1), transaction.max_gas());
 
         Key {
             ratio: tip_gas_ratio,


### PR DESCRIPTION
## Description
Before this fix when tip is zero, transactions that use 30M have the same priority as transactions with 1M gas. Now they are correctly ordered

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here