### PR TITLE
chore: Add code owners for fraud proofs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,3 +31,6 @@ benches/ @xgreenx @Dentosal @MitchTurner @netrome
 
 # Code owners for docs
 docs/ @xgreenx @Dentosal @MitchTurner @netrome
+
+# Code owners for the fraud proofs
+crates/fraud_proofs @xgreenx @netrome @acerone85 @rymnc


### PR DESCRIPTION
Adding myself, @xgreenx, @acerone85 and @rymnc as code owners for the new fraud proof related crate(s).