### PR TITLE
chore: Add entire team as code owners for the changelog and `Cargo.lock`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,3 +34,7 @@ docs/ @xgreenx @Dentosal @MitchTurner @netrome
 
 # Code owners for the fraud proofs
 crates/fraud_proofs @xgreenx @netrome @acerone85 @rymnc
+
+# Code owners for common files
+CHANGELOG.md @xgreenx @Dentosal @MitchTurner @netrome @acerone @rafal-ch @rymnc @AurelienFT
+Cargo.lock @xgreenx @Dentosal @MitchTurner @netrome @acerone @rafal-ch @rymnc @AurelienFT

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,5 +36,5 @@ docs/ @xgreenx @Dentosal @MitchTurner @netrome
 crates/fraud_proofs @xgreenx @netrome @acerone85 @rymnc
 
 # Code owners for common files
-CHANGELOG.md @xgreenx @Dentosal @MitchTurner @netrome @acerone @rafal-ch @rymnc @AurelienFT
-Cargo.lock @xgreenx @Dentosal @MitchTurner @netrome @acerone @rafal-ch @rymnc @AurelienFT
+CHANGELOG.md @xgreenx @Dentosal @MitchTurner @netrome @acerone85 @rafal-ch @rymnc @AurelienFT
+Cargo.lock @xgreenx @Dentosal @MitchTurner @netrome @acerone85 @rafal-ch @rymnc @AurelienFT


### PR DESCRIPTION
Because virtually every PR may change these, and anyone in the team should be able to vet changes to these files.