### PR TITLE
Fix balances query endpoint cost without indexation and behavior coins to spend with one parameter at zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - [2632](https://github.com/FuelLabs/fuel-core/pull/2632): Improved performance of certain async trait impls in the gas price service.
+- [2662](https://github.com/FuelLabs/fuel-core/pull/2662): Fix balances query endpoint cost without indexation and behavior coins to spend with one parameter at zero.
 
 ## [Version 0.41.4]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3797,10 +3797,10 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-parallel-executor"
-version = "0.41.0"
+version = "0.41.4"
 dependencies = [
  "fuel-core-storage",
- "fuel-core-types 0.41.0",
+ "fuel-core-types 0.41.4",
  "fuel-core-upgradable-executor",
  "tokio",
 ]

--- a/crates/fuel-core/src/coins_query.rs
+++ b/crates/fuel-core/src/coins_query.rs
@@ -65,11 +65,6 @@ pub enum CoinsQueryError {
     IncorrectMessageForeignKeyInIndex,
     #[error("error while processing the query: {0}")]
     UnexpectedInternalState(&'static str),
-    #[error("both total and max must be greater than 0 (provided total: {provided_total}, provided max: {provided_max})")]
-    IncorrectQueryParameters {
-        provided_total: u64,
-        provided_max: u16,
-    },
     #[error("coins to spend index contains incorrect key")]
     IncorrectCoinsToSpendIndexKey,
 }
@@ -300,10 +295,7 @@ pub async fn select_coins_to_spend(
     const DUST_TO_BIG_COINS_FACTOR: u16 = 5;
 
     if total == 0 || max == 0 {
-        return Err(CoinsQueryError::IncorrectQueryParameters {
-            provided_total: total,
-            provided_max: max,
-        });
+        return Ok(vec![])
     }
 
     let adjusted_total = total.saturating_mul(TOTAL_AMOUNT_ADJUSTMENT_FACTOR);
@@ -1412,8 +1404,7 @@ mod tests {
             .await;
 
             // Then
-            assert!(matches!(result, Err(actual_error)
-                if CoinsQueryError::IncorrectQueryParameters{ provided_total: 101, provided_max: 0 } == actual_error));
+            assert_eq!(result, Ok(Vec::new()));
         }
 
         #[tokio::test]
@@ -1440,8 +1431,7 @@ mod tests {
             .await;
 
             // Then
-            assert!(matches!(result, Err(actual_error)
-                if CoinsQueryError::IncorrectQueryParameters{ provided_total: 0, provided_max: 101 } == actual_error));
+            assert_eq!(result, Ok(Vec::new()));
         }
 
         #[tokio::test]

--- a/crates/fuel-core/src/schema/balance.rs
+++ b/crates/fuel-core/src/schema/balance.rs
@@ -97,6 +97,8 @@ impl BalanceQuery {
     // Rust SDK sends a query with child_complexity ≅ 11 and we want to support slightly more
     // than 10k items in a single query (so we target 11k). The total complexity would be 11k * 11 = 121k,
     // but since our default limit is 80k, we need the 0.66 factor.
+    // We use the expected cost for the balance_query to differiate between indexation case and non-indexation case.
+    // We assume that the balance_query cost is 0 when the indexation is available.
     #[graphql(complexity = "if query_costs().balance_query == 0 { \
         (child_complexity as f32 * first.unwrap_or_default() as f32 * 0.66) as usize + \
         (child_complexity as f32 * last.unwrap_or_default() as f32 * 0.66) as usize

--- a/crates/fuel-core/src/schema/balance.rs
+++ b/crates/fuel-core/src/schema/balance.rs
@@ -97,10 +97,10 @@ impl BalanceQuery {
     // Rust SDK sends a query with child_complexity ≅ 11 and we want to support slightly more
     // than 10k items in a single query (so we target 11k). The total complexity would be 11k * 11 = 121k,
     // but since our default limit is 80k, we need the 0.66 factor.
-    #[graphql(complexity = "query_costs().balance_query +
+    #[graphql(complexity = "if query_costs().balance_query == 0 { \
         (child_complexity as f32 * first.unwrap_or_default() as f32 * 0.66) as usize + \
         (child_complexity as f32 * last.unwrap_or_default() as f32 * 0.66) as usize
-    ")]
+    } else { query_costs().balance_query }")]
     async fn balances(
         &self,
         ctx: &Context<'_>,


### PR DESCRIPTION
## Description
The two changes has been packed in one PR to speed up the release process given our deadlines.

The balance query endpoint cost if useful for the TSSDK team.
The coins to spend behaviour change roll back to the previous behavior, asked by Rust SDK team

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] Ts SDK team
