### PR TITLE
Add print of collision reason in TxPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2617](https://github.com/FuelLabs/fuel-core/pull/2617): Add integration skeleton of parallel-executor.
 - [2553](https://github.com/FuelLabs/fuel-core/pull/2553): Scaffold global merkle root storage crate.
 - [2598](https://github.com/FuelLabs/fuel-core/pull/2598): Add initial test suite for global merkle root storage updates.
+- [2664](https://github.com/FuelLabs/fuel-core/pull/2664): Add print with all information when a transaction is refused because of a collision.
 
 ### Fixed
 - [2632](https://github.com/FuelLabs/fuel-core/pull/2632): Improved performance of certain async trait impls in the gas price service.

--- a/crates/services/txpool_v2/src/pool/collisions.rs
+++ b/crates/services/txpool_v2/src/pool/collisions.rs
@@ -47,7 +47,10 @@ where
                 tracing::info!(
                     "Transaction {} collided with {} because of {:?}",
                     tx.id(),
-                    storage.get(collision).map(|d| d.transaction.id().to_string()).unwrap_or(String::from("Error")),
+                    storage
+                        .get(collision)
+                        .map(|d| d.transaction.id().to_string())
+                        .unwrap_or(String::from("Error")),
                     reason
                 );
                 if let Some(reason) = reason.first() {

--- a/crates/services/txpool_v2/src/pool/collisions.rs
+++ b/crates/services/txpool_v2/src/pool/collisions.rs
@@ -44,6 +44,12 @@ where
 
         for (collision, reason) in self.iter() {
             if !is_better_than_collision(tx, collision, storage)? {
+                tracing::info!(
+                    "Transaction {} collided with {} because of {:?}",
+                    tx.id(),
+                    storage.get(collision).map(|d| d.transaction.id().to_string()).unwrap_or(String::from("Error")),
+                    reason
+                );
                 if let Some(reason) = reason.first() {
                     return Err(reason.clone());
                 } else {


### PR DESCRIPTION
## Description
This can allow us to make more easy debugging when a transaction had a collision.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
