### PR TITLE
fix(notify_cancel): removed usage of async trait and made the trait dyn incompatible

### DIFF
--- a/crates/fuel-core/src/lib.rs
+++ b/crates/fuel-core/src/lib.rs
@@ -93,7 +93,6 @@ impl ShutdownListener {
     }
 }
 
-#[async_trait::async_trait]
 impl NotifyCancel for ShutdownListener {
     async fn wait_until_cancelled(&self) -> anyhow::Result<()> {
         self.token.cancelled().await;

--- a/crates/fuel-core/src/service/genesis/exporter.rs
+++ b/crates/fuel-core/src/service/genesis/exporter.rs
@@ -65,25 +65,26 @@ use super::{
     NotifyCancel,
 };
 
-pub struct Exporter<Fun> {
+pub struct Exporter<Fun, N> {
     db: CombinedDatabase,
     prev_chain_config: ChainConfig,
     writer: Fun,
     group_size: usize,
-    task_manager: TaskManager<SnapshotFragment>,
+    task_manager: TaskManager<SnapshotFragment, N>,
     multi_progress: MultipleProgressReporter,
 }
 
-impl<Fun> Exporter<Fun>
+impl<Fun, N> Exporter<Fun, N>
 where
     Fun: Fn() -> anyhow::Result<SnapshotWriter>,
+    N: NotifyCancel + Send + Sync + Clone + 'static,
 {
     pub fn new(
         db: CombinedDatabase,
         prev_chain_config: ChainConfig,
         writer: Fun,
         group_size: usize,
-        cancel_token: impl NotifyCancel + Send + Sync + 'static,
+        cancel_token: N,
     ) -> Self {
         Self {
             db,

--- a/crates/fuel-core/src/service/genesis/importer.rs
+++ b/crates/fuel-core/src/service/genesis/importer.rs
@@ -73,9 +73,9 @@ mod on_chain;
 
 const GROUPS_NUMBER_FOR_PARALLELIZATION: usize = 10;
 
-pub struct SnapshotImporter {
+pub struct SnapshotImporter<N = StateWatcher> {
     db: CombinedGenesisDatabase,
-    task_manager: TaskManager<()>,
+    task_manager: TaskManager<(), N>,
     genesis_block: Block,
     snapshot_reader: SnapshotReader,
     multi_progress_reporter: MultipleProgressReporter,


### PR DESCRIPTION


## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->

The code will bloat a little more, but that's fine :_) we don't have dyn dispatch for `NotifyCancel` anymore.



This pull request introduces changes to the `fuel-core` crate, primarily focusing on enhancing the flexibility and functionality of the `TaskManager` and `CancellationToken` structures. The changes include adding a generic parameter to these structures and updating related implementations to accommodate this new parameter.

Key changes include:

### Enhancements to Task Management:

* [`crates/fuel-core/src/service/genesis/task_manager.rs`](diffhunk://#diff-c22d48a385f976cd771e8cb7c28d17e3cf2096cfa06752611bf6c7ee1a77ae83L11-L22): Introduced a generic parameter `N` to the `TaskManager` and `CancellationToken` structures, allowing for more flexible cancellation handling. Updated the `NotifyCancel` trait to return a future instead of using `async_trait`. [[1]](diffhunk://#diff-c22d48a385f976cd771e8cb7c28d17e3cf2096cfa06752611bf6c7ee1a77ae83L11-L22) [[2]](diffhunk://#diff-c22d48a385f976cd771e8cb7c28d17e3cf2096cfa06752611bf6c7ee1a77ae83L33) [[3]](diffhunk://#diff-c22d48a385f976cd771e8cb7c28d17e3cf2096cfa06752611bf6c7ee1a77ae83L53-R61) [[4]](diffhunk://#diff-c22d48a385f976cd771e8cb7c28d17e3cf2096cfa06752611bf6c7ee1a77ae83L69-R81) [[5]](diffhunk://#diff-c22d48a385f976cd771e8cb7c28d17e3cf2096cfa06752611bf6c7ee1a77ae83L87-R104) [[6]](diffhunk://#diff-c22d48a385f976cd771e8cb7c28d17e3cf2096cfa06752611bf6c7ee1a77ae83L109-R113)

### Updates to Genesis Exporter and Importer:

* [`crates/fuel-core/src/service/genesis/exporter.rs`](diffhunk://#diff-e7916e60a2d3ed838c5e0e668a697360da9c84bf37db278938a88bd829daf34dL68-R87): Modified the `Exporter` struct to include the new generic parameter `N` and updated its implementation accordingly.
* [`crates/fuel-core/src/service/genesis/importer.rs`](diffhunk://#diff-24642391bda7217130a665037de61e936e0ae88613e6af1b583759698512b1e8L76-R78): Updated the `SnapshotImporter` struct to include the new generic parameter `N` and adjusted its implementation.

### Modifications to Import Task:

* [`crates/fuel-core/src/service/genesis/importer/import_task.rs`](diffhunk://#diff-954b9280f787dd90eda70a58c77f53b3543e8286462d498dcda45536ca7a175fR27): Updated the `run` method to accept a `CancellationToken` with the new generic parameter `N` and modified the `never_cancel` test function to reflect this change. [[1]](diffhunk://#diff-954b9280f787dd90eda70a58c77f53b3543e8286462d498dcda45536ca7a175fR27) [[2]](diffhunk://#diff-954b9280f787dd90eda70a58c77f53b3543e8286462d498dcda45536ca7a175fL103-R107) [[3]](diffhunk://#diff-954b9280f787dd90eda70a58c77f53b3543e8286462d498dcda45536ca7a175fL612-R616)

### Removal of Async Trait:

* [`crates/fuel-core/src/lib.rs`](diffhunk://#diff-56f4bee7f587862b3c7b4c2dd26310911042ff83f449e4421c1704471e6fa98cL96): Removed the `async_trait` annotation from the `NotifyCancel` implementation for `ShutdownListener`.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
