### PR TITLE
Change `read` behavior on the `InMemoryTransaction` to use offset and allow not equal buf size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [2667](https://github.com/FuelLabs/fuel-core/pull/2667): Populate `Blobs` table in global merkle root storage.
 - [2652](https://github.com/FuelLabs/fuel-core/pull/2652): Global Merkle Root storage crate: Add Raw contract bytecode to global merkle root storage when processing Create transactions.
 
+### Fixed
+- [2673](https://github.com/FuelLabs/fuel-core/pull/2673): Change read behavior on the InMemoryTransaction to use offset and allow not equal buf size (fix CCP and LDC broken from https://github.com/FuelLabs/fuel-vm/pull/847)
+
 ## [Version 0.41.5]
 
 ### Changed

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -915,19 +915,19 @@ where
             .map(|value| {
                 let bytes_len = value.len();
                 let start = offset;
-                let end = offset.saturating_add(buf.len());
+                let buf_len = buf.len();
+                let end = offset.saturating_add(buf_len);
 
                 if end > bytes_len {
                     return Err(StorageError::Other(anyhow::anyhow!(
-                        "Offset `{offset}` is out of bounds `{bytes_len}` \
-                        for key `{:?}` and column `{column:?}`",
+                        "Offset `{offset}` + buf_len `{buf_len}` read until {end} which is out of bounds `{bytes_len}` for key `{:?}` and column `{column:?}`",
                         key
                     )));
                 }
 
                 let starting_from_offset = &value[start..end];
                 buf[..].copy_from_slice(starting_from_offset);
-                Ok(buf.len())
+                Ok(buf_len)
             })
             .transpose()?;
 

--- a/crates/storage/src/kv_store.rs
+++ b/crates/storage/src/kv_store.rs
@@ -71,11 +71,12 @@ pub trait KeyValueInspect {
             .map(|value| {
                 let bytes_len = value.as_ref().len();
                 let start = offset;
-                let end = offset.saturating_add(buf.len());
+                let buf_len = buf.len();
+                let end = offset.saturating_add(buf_len);
 
                 if end > bytes_len {
                     return Err(anyhow::anyhow!(
-                        "Offset `{offset}` is out of bounds `{bytes_len}` for key `{:?}`",
+                        "Offset `{offset}` + buf_len `{buf_len}` read until {end} which is out of bounds `{bytes_len}` for key `{:?}`",
                         key
                     )
                     .into());
@@ -83,7 +84,7 @@ pub trait KeyValueInspect {
 
                 let starting_from_offset = &value.as_ref()[start..end];
                 buf[..].copy_from_slice(starting_from_offset);
-                Ok(buf.len())
+                Ok(buf_len)
             })
             .transpose()
     }

--- a/crates/storage/src/transactional.rs
+++ b/crates/storage/src/transactional.rs
@@ -670,8 +670,8 @@ mod test {
             let storage = InMemoryStorage::<Column>::default();
             let mut view = storage.read_transaction();
             let key = vec![0xA, 0xB, 0xC];
-            let expected = Value::from([1, 2, 3]);
-            view.put(&key, Column::Metadata, expected.clone()).unwrap();
+            let value = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, value).unwrap();
             // test
             let mut buf = [0; 3];
             let ret = view.read(&key, Column::Metadata, 0, &mut buf).unwrap();
@@ -686,8 +686,8 @@ mod test {
             let storage = InMemoryStorage::<Column>::default();
             let mut view = storage.read_transaction();
             let key = vec![0xA, 0xB, 0xC];
-            let expected = Value::from([1, 2, 3]);
-            view.put(&key, Column::Metadata, expected.clone()).unwrap();
+            let value = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, value).unwrap();
             // test
             let mut buf = [0; 2];
             let ret = view.read(&key, Column::Metadata, 0, &mut buf).unwrap();
@@ -697,13 +697,29 @@ mod test {
         }
 
         #[test]
+        fn read_returns_from_view_with_offset() {
+            // setup
+            let storage = InMemoryStorage::<Column>::default();
+            let mut view = storage.read_transaction();
+            let key = vec![0xA, 0xB, 0xC];
+            let value = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, value).unwrap();
+            // test
+            let mut buf = [0; 2];
+            let ret = view.read(&key, Column::Metadata, 1, &mut buf).unwrap();
+            // verify
+            assert_eq!(ret, Some(2));
+            assert_eq!(buf, [2, 3]);
+        }
+
+        #[test]
         fn read_returns_from_view_buf_bigger() {
             // setup
             let storage = InMemoryStorage::<Column>::default();
             let mut view = storage.read_transaction();
             let key = vec![0xA, 0xB, 0xC];
-            let expected = Value::from([1, 2, 3]);
-            view.put(&key, Column::Metadata, expected.clone()).unwrap();
+            let value = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, value).unwrap();
             // test
             let mut buf = [0; 4];
             let ret = view.read(&key, Column::Metadata, 0, &mut buf).unwrap_err();
@@ -717,8 +733,8 @@ mod test {
             let storage = InMemoryStorage::<Column>::default();
             let mut view = storage.read_transaction();
             let key = vec![0xA, 0xB, 0xC];
-            let expected = Value::from([1, 2, 3]);
-            view.put(&key, Column::Metadata, expected.clone()).unwrap();
+            let value = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, value).unwrap();
             // test
             let mut buf = [0; 3];
             let ret = view.read(&key, Column::Metadata, 1, &mut buf).unwrap_err();

--- a/crates/storage/src/transactional.rs
+++ b/crates/storage/src/transactional.rs
@@ -398,14 +398,21 @@ where
         if let Some(operation) = self.get_from_changes(key, column) {
             match operation {
                 WriteOperation::Insert(value) => {
-                    let read = value.len();
-                    if read != buf.len() {
-                        return Err(crate::Error::Other(anyhow::anyhow!(
-                            "Buffer size is not equal to the value size"
-                        )));
+                    let bytes_len = value.as_ref().len();
+                    let start = offset;
+                    let end = offset.saturating_add(buf.len());
+
+                    if end > bytes_len {
+                        return Err(anyhow::anyhow!(
+                            "Offset `{offset}` is out of bounds `{bytes_len}` for key `{:?}`",
+                            key
+                        )
+                        .into());
                     }
-                    buf.copy_from_slice(value.as_ref());
-                    Ok(Some(read))
+
+                    let starting_from_offset = &value.as_ref()[start..end];
+                    buf[..].copy_from_slice(starting_from_offset);
+                    Ok(Some(buf.len()))
                 }
                 WriteOperation::Remove => Ok(None),
             }
@@ -655,6 +662,70 @@ mod test {
     mod key_value_functionality {
         use super::*;
         use crate::column::Column;
+
+        #[test]
+        fn read_returns_from_view_exact_size() {
+            // setup
+            let storage = InMemoryStorage::<Column>::default();
+            let mut view = storage.read_transaction();
+            let key = vec![0xA, 0xB, 0xC];
+            let expected = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, expected.clone()).unwrap();
+            // test
+            let mut buf = [0; 3];
+            let ret = view.read(&key, Column::Metadata, 0, &mut buf).unwrap();
+            // verify
+            assert_eq!(ret, Some(3));
+            assert_eq!(buf, [1, 2, 3]);
+        }
+
+        #[test]
+        fn read_returns_from_view_buf_smaller() {
+            // setup
+            let storage = InMemoryStorage::<Column>::default();
+            let mut view = storage.read_transaction();
+            let key = vec![0xA, 0xB, 0xC];
+            let expected = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, expected.clone()).unwrap();
+            // test
+            let mut buf = [0; 2];
+            let ret = view.read(&key, Column::Metadata, 0, &mut buf).unwrap();
+            // verify
+            assert_eq!(ret, Some(2));
+            assert_eq!(buf, [1, 2]);
+        }
+
+        #[test]
+        fn read_returns_from_view_buf_bigger() {
+            // setup
+            let storage = InMemoryStorage::<Column>::default();
+            let mut view = storage.read_transaction();
+            let key = vec![0xA, 0xB, 0xC];
+            let expected = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, expected.clone()).unwrap();
+            // test
+            let mut buf = [0; 4];
+            let ret = view.read(&key, Column::Metadata, 0, &mut buf).unwrap();
+            // verify
+            assert_eq!(ret, Some(3));
+            assert_eq!(buf, [1, 2, 3, 0]);
+        }
+
+        #[test]
+        fn read_returns_from_view_buf_bigger_because_offset() {
+            // setup
+            let storage = InMemoryStorage::<Column>::default();
+            let mut view = storage.read_transaction();
+            let key = vec![0xA, 0xB, 0xC];
+            let expected = Value::from([1, 2, 3]);
+            view.put(&key, Column::Metadata, expected.clone()).unwrap();
+            // test
+            let mut buf = [0; 3];
+            let ret = view.read(&key, Column::Metadata, 1, &mut buf).unwrap();
+            // verify
+            assert_eq!(ret, Some(2));
+            assert_eq!(buf, [2, 3, 0]);
+        }
 
         #[test]
         fn get_returns_from_view() {


### PR DESCRIPTION
## Linked Issues/PRs
closes https://github.com/FuelLabs/fuel-core/issues/2672

## Description
Change code of `read` of `InMemoryTransaction` to match the other `read` functions

Tests had been added and the error in `read` function has been improved to be more clear.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
