### PR TITLE
fix: Typo in test comment

### DIFF
--- a/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
+++ b/crates/fraud_proofs/global_merkle_root/storage/src/update.rs
@@ -599,7 +599,7 @@ mod tests {
     #[test]
     /// When encountering a transaction with a contract created output,
     /// `process_output` should ensure an appropriate contract UTxO is
-    /// populated in the `ContractCreated` table.
+    /// populated in the `ContractsLatestUtxo` table.
     fn process_output__should_insert_latest_contract_utxo_when_contract_created() {
         let mut rng = StdRng::seed_from_u64(1337);
 
@@ -641,7 +641,7 @@ mod tests {
     #[test]
     /// When encountering a transaction with a contract output,
     /// `process_output` should ensure an appropriate contract UTxO is
-    /// populated in the `ContractCreated` table.
+    /// populated in the `ContractsLatestUtxo` table.
     fn process_output__should_update_latest_contract_utxo_when_interacting_with_contract()
     {
         let mut rng = StdRng::seed_from_u64(1337);


### PR DESCRIPTION
This PR fixes a tiny typo in two test comments, as observed by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2598#discussion_r1950983141.