### PR TITLE
Remove reviewers in update README action

### DIFF
--- a/.github/workflows/update_readme_versions.yml
+++ b/.github/workflows/update_readme_versions.yml
@@ -113,7 +113,6 @@ jobs:
           - Fuel Ignition: ${{ steps.get-versions.outputs.ignition_version }}
           - Testnet: ${{ steps.get-versions.outputs.testnet_version }}
           - Devnet: ${{ steps.get-versions.outputs.devnet_version }}" \
-          --reviewer FuelLabs/client \
           --base master \
           --head "$branch_name"
       env:


### PR DESCRIPTION
## Description

Currently, all the action jobs are failing because the group "FuelLabs/client" can't be seen by the Action and so it can't assign it as reviewer. This PR comes back to what we do with cargo update, we just let our repository rules determine the reviewers.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
