### PR TITLE
Bump versions to 0.41.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.41.7]
+
 ## [Version 0.41.6]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3402,7 +3402,7 @@ dependencies = [
  "fuel-core-sync",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3453,7 +3453,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-sync",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "futures",
  "hex",
  "itertools 0.12.1",
@@ -3475,11 +3475,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.41.6"
+version = "0.41.7"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3494,7 +3494,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3525,7 +3525,7 @@ dependencies = [
  "derivative",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3543,14 +3543,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more 0.99.19",
  "eventsource-client",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -3567,23 +3567,23 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "clap",
  "fuel-core-client",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fuel-core-compression",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "paste",
  "postcard",
  "proptest",
@@ -3596,30 +3596,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3627,7 +3627,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "futures",
  "hex",
  "humantime-serde",
@@ -3644,12 +3644,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "hex",
  "parking_lot",
  "serde",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3666,7 +3666,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "fuel-gas-price-algorithm",
  "futures",
  "mockito",
@@ -3686,12 +3686,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-global-merkle-root-storage"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "num_enum",
  "postcard",
  "rand",
@@ -3701,14 +3701,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "mockall",
  "parking_lot",
  "rayon",
@@ -3719,18 +3719,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "clap",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "atty",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3769,7 +3769,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3799,17 +3799,17 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-parallel-executor"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "fuel-core-storage",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "fuel-core-upgradable-executor",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3818,7 +3818,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "mockall",
  "rand",
  "serde",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "mockall",
  "proptest",
  "rand",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3864,7 +3864,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "futures",
  "mockall",
  "once_cell",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3908,7 +3908,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -3924,13 +3924,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "fuel-vm 0.59.1",
  "impl-tools",
  "itertools 0.12.1",
@@ -3948,13 +3948,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "futures",
  "mockall",
  "rand",
@@ -3989,7 +3989,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "ctor",
  "tracing",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4037,7 +4037,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "futures",
  "mockall",
  "num-rational",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4089,13 +4089,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "fuel-core-wasm-executor",
  "parking_lot",
  "postcard",
@@ -4105,13 +4105,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "postcard",
  "proptest",
  "serde",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.41.6"
+version = "0.41.7"
 dependencies = [
  "proptest",
  "rand",
@@ -9851,7 +9851,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.6",
+ "fuel-core-types 0.41.7",
  "futures",
  "itertools 0.12.1",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,42 +59,42 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.41.6"
+version = "0.41.7"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.41.6", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.41.6", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.41.6", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.41.6", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.41.6", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.41.6", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.41.6", path = "./crates/client" }
-fuel-core-compression = { version = "0.41.6", path = "./crates/compression" }
-fuel-core-database = { version = "0.41.6", path = "./crates/database" }
-fuel-core-metrics = { version = "0.41.6", path = "./crates/metrics" }
-fuel-core-services = { version = "0.41.6", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.41.6", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.41.6", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.41.6", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.41.6", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.41.6", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.41.6", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.41.6", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.41.6", path = "./crates/services/p2p" }
-fuel-core-parallel-executor = { version = "0.41.6", path = "./crates/services/parallel-executor" }
-fuel-core-producer = { version = "0.41.6", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.41.6", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.41.6", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.41.6", path = "./crates/services/txpool_v2" }
-fuel-core-storage = { version = "0.41.6", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.41.6", path = "./crates/trace" }
-fuel-core-types = { version = "0.41.6", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.41.7", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.41.7", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.41.7", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.41.7", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.41.7", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.41.7", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.41.7", path = "./crates/client" }
+fuel-core-compression = { version = "0.41.7", path = "./crates/compression" }
+fuel-core-database = { version = "0.41.7", path = "./crates/database" }
+fuel-core-metrics = { version = "0.41.7", path = "./crates/metrics" }
+fuel-core-services = { version = "0.41.7", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.41.7", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.41.7", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.41.7", path = "./crates/services/consensus_module/poa" }
+fuel-core-shared-sequencer = { version = "0.41.7", path = "crates/services/shared-sequencer" }
+fuel-core-executor = { version = "0.41.7", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.41.7", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.41.7", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.41.7", path = "./crates/services/p2p" }
+fuel-core-parallel-executor = { version = "0.41.7", path = "./crates/services/parallel-executor" }
+fuel-core-producer = { version = "0.41.7", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.41.7", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.41.7", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.41.7", path = "./crates/services/txpool_v2" }
+fuel-core-storage = { version = "0.41.7", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.41.7", path = "./crates/trace" }
+fuel-core-types = { version = "0.41.7", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.41.6", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.41.6", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.41.7", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.41.7", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.41.6", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.41.7", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.59.1", package = "fuel-vm", default-features = false }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ git clone https://github.com/FuelLabs/fuel-core.git
 
 Go to the latest release tag for ignition on the `fuel-core` repository :
 ```
-git checkout v0.41.6
+git checkout v0.41.7
 ```
 
 Build your node binary:

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -304,7 +304,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 21,
+  "genesis_state_transition_version": 22,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -308,7 +308,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 21,
+  "genesis_state_transition_version": 22,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -160,7 +160,8 @@ impl<S, R> Executor<S, R> {
         ("0-40-2", 18),
         ("0-41-4", 19),
         ("0-41-5", 20),
-        ("0-41-6", LATEST_STATE_TRANSITION_VERSION),
+        ("0-41-6", 21),
+        ("0-41-7", LATEST_STATE_TRANSITION_VERSION)
     ];
 
     pub fn new(

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -161,7 +161,7 @@ impl<S, R> Executor<S, R> {
         ("0-41-4", 19),
         ("0-41-5", 20),
         ("0-41-6", 21),
-        ("0-41-7", LATEST_STATE_TRANSITION_VERSION)
+        ("0-41-7", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -166,7 +166,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 21;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 22;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Version 0.41.7

### Fixed
- [2710](https://github.com/FuelLabs/fuel-core/pull/2710): Update Fuel-VM to fix compressed transaction backward compatibility.
