### PR TITLE
refactor: Use `tokio::watch` in block height subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,7 +3373,6 @@ dependencies = [
  "itertools 0.12.1",
  "mockall",
  "num_cpus",
- "parking_lot",
  "paste",
  "postcard",
  "proptest",

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -49,7 +49,6 @@ hyper = { workspace = true }
 indicatif = { workspace = true, default-features = true }
 itertools = { workspace = true }
 num_cpus = { version = "1.16.0", optional = true }
-parking_lot = { workspace = true }
 paste = { workspace = true }
 postcard = { workspace = true, optional = true }
 rand = { workspace = true }

--- a/crates/fuel-core/src/graphql_api/block_height_subscription.rs
+++ b/crates/fuel-core/src/graphql_api/block_height_subscription.rs
@@ -1,54 +1,37 @@
-use std::{
-    cmp::Reverse,
-    collections::BTreeMap,
-    sync::Arc,
-};
-
 use fuel_core_types::fuel_types::BlockHeight;
-use parking_lot::RwLock;
-use tokio::sync::oneshot;
+use std::sync::Arc;
+use tokio::sync::{
+    watch,
+    Mutex,
+};
 
 #[derive(Default)]
 pub struct Handler {
-    inner: Arc<RwLock<HandlersMapInner>>,
+    inner: watch::Sender<BlockHeight>,
 }
 
 impl Handler {
     pub fn new(block_height: BlockHeight) -> Handler {
         Self {
-            inner: Arc::new(RwLock::new(HandlersMapInner::new(block_height))),
+            inner: watch::channel(block_height).0,
         }
     }
 
     pub fn subscribe(&self) -> Subscriber {
         Subscriber {
-            inner: self.inner.clone(),
+            inner: Arc::new(Mutex::new(self.inner.subscribe())),
         }
     }
 
-    pub fn notify_and_update(&self, block_height: BlockHeight) {
-        let to_notify = {
-            let mut inner_map = self.inner.write();
-
-            // get all sending endpoint corresponding to subscribers that are waiting for a block height
-            // that is at most `block_height`.
-            let to_notify = inner_map.tx_handles.split_off(&Reverse(block_height));
-            inner_map.latest_seen_block_height = block_height;
-
-            to_notify.into_values().flatten()
-        };
-
-        for tx in to_notify {
-            if let Err(e) = tx.send(()) {
-                tracing::warn!("Failed to notify block height subscriber: {:?}", e);
-            }
-        }
+    pub fn notify_and_update(&self, block_height: BlockHeight) -> anyhow::Result<()> {
+        self.inner.send(block_height)?;
+        Ok(())
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct Subscriber {
-    inner: Arc<RwLock<HandlersMapInner>>,
+    inner: Arc<Mutex<watch::Receiver<BlockHeight>>>,
 }
 
 impl Subscriber {
@@ -56,43 +39,16 @@ impl Subscriber {
         &self,
         block_height: BlockHeight,
     ) -> anyhow::Result<()> {
-        let future = {
-            let mut inner_map = self.inner.write();
+        self.inner
+            .lock()
+            .await
+            .wait_for(|seen_height| *seen_height >= block_height)
+            .await?;
 
-            if inner_map.latest_seen_block_height >= block_height {
-                return Ok(());
-            }
-
-            let (tx, rx) = oneshot::channel();
-            let handlers = inner_map
-                .tx_handles
-                .entry(Reverse(block_height))
-                .or_default();
-            handlers.push(tx);
-            rx
-        };
-
-        future.await.map_err(|e| {
-            anyhow::anyhow!("The block height subscription channel was closed: {:?}", e)
-        })
+        Ok(())
     }
 
-    pub fn latest_seen_block_height(&self) -> BlockHeight {
-        self.inner.read().latest_seen_block_height
-    }
-}
-
-#[derive(Debug, Default)]
-struct HandlersMapInner {
-    tx_handles: BTreeMap<Reverse<BlockHeight>, Vec<oneshot::Sender<()>>>,
-    latest_seen_block_height: BlockHeight,
-}
-
-impl HandlersMapInner {
-    fn new(latest_seen_block_height: BlockHeight) -> Self {
-        Self {
-            tx_handles: BTreeMap::new(),
-            latest_seen_block_height,
-        }
+    pub async fn latest_seen_block_height(&self) -> BlockHeight {
+        *self.inner.lock().await.borrow()
     }
 }

--- a/crates/fuel-core/src/graphql_api/required_fuel_block_height_extension.rs
+++ b/crates/fuel-core/src/graphql_api/required_fuel_block_height_extension.rs
@@ -151,8 +151,10 @@ impl Extension for RequiredFuelBlockHeightInner {
         next: NextExecute<'_>,
     ) -> Response {
         if let Some(required_block_height) = self.required_height.get() {
-            let current_block_height =
-                self.block_height_subscriber.latest_seen_block_height();
+            let current_block_height = self
+                .block_height_subscriber
+                .latest_seen_block_height()
+                .await;
 
             match BlockHeightComparison::from_block_heights(
                 required_block_height,
@@ -200,8 +202,10 @@ impl Extension for RequiredFuelBlockHeightInner {
 
         let mut response = next.run(ctx, operation_name).await;
 
-        let current_block_height =
-            self.block_height_subscriber.latest_seen_block_height();
+        let current_block_height = self
+            .block_height_subscriber
+            .latest_seen_block_height()
+            .await;
         // Dereference to display the value in decimal base.
         let current_block_height: u32 = *current_block_height;
         response.extensions.insert(

--- a/crates/fuel-core/src/graphql_api/worker_service.rs
+++ b/crates/fuel-core/src/graphql_api/worker_service.rs
@@ -203,7 +203,7 @@ where
 
         // Notify subscribers and update last seen block height
         self.block_height_subscription_handler
-            .notify_and_update(*height);
+            .notify_and_update(*height)?;
         // Get all the subscribers that need to be notified that the block height
         // has been reached.
 


### PR DESCRIPTION
Proposal to simplify block height subscription implementation