### PR TITLE
Fix RocksDB closing

### DIFF
--- a/.changes/fixed/2730.md
+++ b/.changes/fixed/2730.md
@@ -1,0 +1,1 @@
+Fixed RocksDB closing issue that potentially could panic.

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -142,6 +142,7 @@ impl<Description> Drop for RocksDb<Description> {
         // Drop the snapshot before the db.
         // Dropping the snapshot after the db will cause a sigsegv.
         self.snapshot = None;
+        self.db.cancel_all_background_work(true);
     }
 }
 


### PR DESCRIPTION
Used the idea from the comment: https://github.com/facebook/rocksdb/issues/11349#issuecomment-2587107605

To address `pthread lock: Invalid argument` error in CI: https://github.com/FuelLabs/fuel-core/actions/runs/13423553399/job/37501700277
