### PR TITLE
fault_proving(compression): temporal registry implementations

### DIFF
--- a/.changes/added/2731.md
+++ b/.changes/added/2731.md
@@ -1,0 +1,1 @@
+Include `TemporalRegistry` trait implementations for v2 tables.

--- a/crates/fuel-core/src/graphql_api/storage/da_compression/v2/evictor_cache.rs
+++ b/crates/fuel-core/src/graphql_api/storage/da_compression/v2/evictor_cache.rs
@@ -70,13 +70,15 @@ impl Mappable for DaCompressionTemporalRegistryEvictorCacheV2 {
 /// Encoder for the V2 version of the DaCompressionTemporalRegistry for EvictorCache.
 pub struct DaCompressionTemporalEvictorCacheV2Encoder;
 
-impl fuel_core_storage::codec::Encode<MetadataKey>
+impl fuel_core_storage::codec::Encode<RegistryKey>
     for DaCompressionTemporalEvictorCacheV2Encoder
 {
-    type Encoder<'a> = [u8; 1];
+    type Encoder<'a> = [u8; RegistryKey::SIZE];
 
-    fn encode(value: &MetadataKey) -> Self::Encoder<'_> {
-        [*value as u8]
+    fn encode(value: &RegistryKey) -> Self::Encoder<'_> {
+        let mut bytes = [0u8; RegistryKey::SIZE];
+        bytes.copy_from_slice(value.as_ref());
+        bytes
     }
 }
 


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
part 2/3 of https://github.com/FuelLabs/fuel-core/issues/2568

## Description
<!-- List of detailed changes -->

Implementation of the `TemporalRegistry` trait for version 2 (v2) tables and the handling of off-chain database transactions. Below is a summary of the most important changes:

### TemporalRegistry Trait Implementations

* Added `TemporalRegistry` trait implementations for v2 tables, including `Address`, `AssetId`, `ContractId`, `ScriptCode`, and `PredicateCode`. This includes methods for reading, writing, and indexing registry values, as well as handling timestamps.

### Off-Chain Database Transactions

* Introduced conditional compilation for off-chain database transactions, separating v1 and v2 implementations. The v2 implementation includes additional traits and methods to support the new `TemporalRegistry` v2 tables. [[1]](diffhunk://#diff-49095c45844c0809b8d244f4555fb1eaac1ee48612c103e553ab396d0dfe93c9L390-R393) [[2]](diffhunk://#diff-49095c45844c0809b8d244f4555fb1eaac1ee48612c103e553ab396d0dfe93c9R442-R526)
* Updated the `OffChainDatabaseTransaction` trait to include new storage mutation traits specific to v2 tables.

### Code Refactoring

* Refactored the `DaCompressionTemporalEvictorCacheV2Encoder` to use `RegistryKey` instead of `MetadataKey`, ensuring consistency with the new v2 table implementations.


## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
