### PR TITLE
Dedicated threads for the block importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Version 0.41.6]
 
-### Changed
-- [2618](https://github.com/FuelLabs/fuel-core/pull/2618): Parallelize block/transaction changes creation in Importer
-
 ### Added
 - [2668](https://github.com/FuelLabs/fuel-core/pull/2668): Expose gas price service test helpers
 - [2621](https://github.com/FuelLabs/fuel-core/pull/2598): Global merkle root storage updates process upgrade transactions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,7 +3691,6 @@ dependencies = [
  "fuel-core-trace",
  "fuel-core-types 0.41.7",
  "mockall",
- "parking_lot",
  "rayon",
  "test-case",
  "tokio",

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -397,8 +397,7 @@ pub struct BlockProducerAdapter {
 
 #[derive(Clone)]
 pub struct BlockImporterAdapter {
-    pub block_importer:
-        Arc<fuel_core_importer::Importer<Database, ExecutorAdapter, VerifierAdapter>>,
+    pub block_importer: Arc<fuel_core_importer::Importer>,
 }
 
 impl BlockImporterAdapter {

--- a/crates/fuel-core/src/service/adapters/block_importer.rs
+++ b/crates/fuel-core/src/service/adapters/block_importer.rs
@@ -69,11 +69,7 @@ impl BlockImporterAdapter {
         executor: ExecutorAdapter,
         verifier: VerifierAdapter,
     ) -> Self {
-        let metrics = config.metrics;
         let importer = Importer::new(chain_id, config, database, executor, verifier);
-        if metrics {
-            importer.init_metrics();
-        }
         Self {
             block_importer: Arc::new(importer),
         }

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -206,6 +206,11 @@ pub async fn execute_and_commit_genesis_block(
     config: &Config,
     db: &CombinedDatabase,
 ) -> anyhow::Result<()> {
+    use fuel_core_importer::ports::{
+        MockBlockVerifier,
+        MockValidator,
+    };
+
     let result = execute_genesis_block(StateWatcher::default(), config, db).await?;
     let importer = fuel_core_importer::Importer::new(
         config
@@ -215,8 +220,8 @@ pub async fn execute_and_commit_genesis_block(
             .chain_id(),
         config.block_importer.clone(),
         db.on_chain().clone(),
-        (),
-        (),
+        MockValidator::default(),
+        MockBlockVerifier::default(),
     );
     importer.commit_result(result).await?;
     Ok(())

--- a/crates/services/importer/Cargo.toml
+++ b/crates/services/importer/Cargo.toml
@@ -15,7 +15,7 @@ derive_more = { workspace = true }
 fuel-core-metrics = { workspace = true }
 fuel-core-storage = { workspace = true, features = ["std"] }
 fuel-core-types = { workspace = true, features = ["std"] }
-parking_lot = { workspace = true }
+mockall = { workspace = true, optional = true }
 rayon = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
@@ -23,11 +23,11 @@ tracing = { workspace = true }
 [dev-dependencies]
 fuel-core-trace = { path = "./../../trace" }
 fuel-core-types = { path = "./../../types", features = ["test-helpers"] }
-mockall = { workspace = true }
 test-case = { workspace = true }
 
 [features]
 test-helpers = [
+  "dep:mockall",
   "fuel-core-types/test-helpers",
   "fuel-core-storage/test-helpers",
 ]

--- a/crates/services/importer/src/error.rs
+++ b/crates/services/importer/src/error.rs
@@ -1,0 +1,81 @@
+use fuel_core_storage::{
+    Error as StorageError,
+    MerkleRoot,
+};
+use fuel_core_types::{
+    blockchain::primitives::BlockId,
+    fuel_types::BlockHeight,
+    services::executor,
+};
+use tokio::sync::{
+    mpsc,
+    oneshot,
+    TryAcquireError,
+};
+
+#[derive(Debug, derive_more::Display, derive_more::From)]
+pub enum Error {
+    #[display(fmt = "The commit is already in the progress: {_0}.")]
+    Semaphore(TryAcquireError),
+    #[display(
+        fmt = "The wrong state of database during insertion of the genesis block."
+    )]
+    InvalidUnderlyingDatabaseGenesisState,
+    #[display(fmt = "The wrong state of storage after execution of the block.\
+        The actual root is {_1:?}, when the expected root is {_0:?}.")]
+    InvalidDatabaseStateAfterExecution(Option<MerkleRoot>, Option<MerkleRoot>),
+    #[display(fmt = "Got overflow during increasing the height.")]
+    Overflow,
+    #[display(fmt = "The non-generic block can't have zero height.")]
+    ZeroNonGenericHeight,
+    #[display(fmt = "The actual height is {_1}, when the next expected height is {_0}.")]
+    IncorrectBlockHeight(BlockHeight, BlockHeight),
+    #[display(
+        fmt = "Got another block id after validation of the block. Expected {_0} != Actual {_1}"
+    )]
+    BlockIdMismatch(BlockId, BlockId),
+    #[display(fmt = "Some of the block fields are not valid: {_0}.")]
+    FailedVerification(anyhow::Error),
+    #[display(fmt = "The execution of the block failed: {_0}.")]
+    FailedExecution(executor::Error),
+    #[display(fmt = "It is not possible to execute the genesis block.")]
+    ExecuteGenesis,
+    #[display(fmt = "The database already contains the data at the height {_0}.")]
+    NotUnique(BlockHeight),
+    #[display(fmt = "The previous block processing is not finished yet.")]
+    PreviousBlockProcessingNotFinished,
+    #[display(fmt = "The send command to the inner task failed.")]
+    SendCommandToInnerTaskFailed,
+    #[display(fmt = "The inner import task is not running.")]
+    InnerTaskIsNotRunning,
+    #[from]
+    Storage(StorageError),
+    UnsupportedConsensusVariant(String),
+    ActiveBlockResultsSemaphoreClosed(tokio::sync::AcquireError),
+    RayonTaskWasCanceled,
+}
+
+impl From<Error> for anyhow::Error {
+    fn from(error: Error) -> Self {
+        anyhow::Error::msg(error)
+    }
+}
+
+impl From<oneshot::error::RecvError> for Error {
+    fn from(_: oneshot::error::RecvError) -> Self {
+        Error::InnerTaskIsNotRunning
+    }
+}
+
+impl<T> From<mpsc::error::SendError<T>> for Error {
+    fn from(_: mpsc::error::SendError<T>) -> Self {
+        Error::SendCommandToInnerTaskFailed
+    }
+}
+
+#[cfg(test)]
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        format!("{self}") == format!("{other}")
+    }
+}

--- a/crates/services/importer/src/importer.rs
+++ b/crates/services/importer/src/importer.rs
@@ -1,4 +1,6 @@
 use crate::{
+    error::Error,
+    local_runner::LocalRunner,
     ports::{
         BlockVerifier,
         DatabaseTransaction,
@@ -16,16 +18,10 @@ use fuel_core_storage::{
         Changes,
         StorageChanges,
     },
-    Error as StorageError,
-    MerkleRoot,
 };
 use fuel_core_types::{
     blockchain::{
-        consensus::{
-            Consensus,
-            Sealed,
-        },
-        primitives::BlockId,
+        consensus::Consensus,
         SealedBlock,
     },
     fuel_tx::{
@@ -42,20 +38,17 @@ use fuel_core_types::{
             UncommittedResult,
         },
         executor::{
-            self,
+            Event,
+            TransactionExecutionStatus,
             ValidationResult,
         },
-        Uncommitted,
     },
 };
-use parking_lot::Mutex;
 use std::{
-    ops::{
-        Deref,
-        DerefMut,
-    },
+    ops::Deref,
     sync::Arc,
     time::{
+        Duration,
         Instant,
         SystemTime,
         UNIX_EPOCH,
@@ -63,117 +56,137 @@ use std::{
 };
 use tokio::sync::{
     broadcast,
+    mpsc,
+    oneshot,
     OwnedSemaphorePermit,
     Semaphore,
-    TryAcquireError,
 };
 use tracing::warn;
 
 #[cfg(test)]
 pub mod test;
 
-#[derive(Debug, derive_more::Display, derive_more::From)]
-pub enum Error {
-    #[display(fmt = "The commit is already in the progress: {_0}.")]
-    SemaphoreError(TryAcquireError),
-    #[display(
-        fmt = "The wrong state of database during insertion of the genesis block."
-    )]
-    InvalidUnderlyingDatabaseGenesisState,
-    #[display(fmt = "The wrong state of storage after execution of the block.\
-        The actual root is {_1:?}, when the expected root is {_0:?}.")]
-    InvalidDatabaseStateAfterExecution(Option<MerkleRoot>, Option<MerkleRoot>),
-    #[display(fmt = "Got overflow during increasing the height.")]
-    Overflow,
-    #[display(fmt = "The non-generic block can't have zero height.")]
-    ZeroNonGenericHeight,
-    #[display(fmt = "The actual height is {_1}, when the next expected height is {_0}.")]
-    IncorrectBlockHeight(BlockHeight, BlockHeight),
-    #[display(
-        fmt = "Got another block id after validation of the block. Expected {_0} != Actual {_1}"
-    )]
-    BlockIdMismatch(BlockId, BlockId),
-    #[display(fmt = "Some of the block fields are not valid: {_0}.")]
-    FailedVerification(anyhow::Error),
-    #[display(fmt = "The execution of the block failed: {_0}.")]
-    FailedExecution(executor::Error),
-    #[display(fmt = "It is not possible to execute the genesis block.")]
-    ExecuteGenesis,
-    #[display(fmt = "The database already contains the data at the height {_0}.")]
-    NotUnique(BlockHeight),
-    #[display(fmt = "The previous block processing is not finished yet.")]
-    PreviousBlockProcessingNotFinished,
-    #[from]
-    StorageError(StorageError),
-    UnsupportedConsensusVariant(String),
-    ActiveBlockResultsSemaphoreClosed(tokio::sync::AcquireError),
-    RayonTaskWasCanceled,
-    TaskError(String),
+enum CommitInput {
+    Uncommitted(UncommittedResult<Changes>),
+    PrepareImportResult(PrepareImportResult),
 }
 
-impl From<Error> for anyhow::Error {
-    fn from(error: Error) -> Self {
-        anyhow::Error::msg(error)
-    }
+enum Commands {
+    CommitResult {
+        result: CommitInput,
+        permit: OwnedSemaphorePermit,
+        callback: oneshot::Sender<Result<(), Error>>,
+    },
+    #[cfg(test)]
+    VerifyAndExecuteBlock {
+        sealed_block: SealedBlock,
+        callback: oneshot::Sender<Result<UncommittedResult<Changes>, Error>>,
+    },
+    PrepareImportResult {
+        sealed_block: SealedBlock,
+        callback: oneshot::Sender<Result<PrepareImportResult, Error>>,
+    },
 }
 
-#[cfg(test)]
-impl PartialEq for Error {
-    fn eq(&self, other: &Self) -> bool {
-        format!("{self}") == format!("{other}")
-    }
-}
-
-pub struct Importer<D, E, V> {
-    database: Arc<Mutex<D>>,
-    executor: Arc<E>,
-    verifier: Arc<V>,
+struct ImporterInner<D, E, V> {
+    database: D,
+    executor: E,
+    verifier: V,
     chain_id: ChainId,
     broadcast: broadcast::Sender<ImporterResult>,
+    commands: mpsc::Receiver<Commands>,
+    /// Enables prometheus metrics for this fuel-service
+    metrics: bool,
+}
+
+pub struct Importer {
+    broadcast: broadcast::Sender<ImporterResult>,
     guard: Semaphore,
+    commands: mpsc::Sender<Commands>,
     /// The semaphore tracks the number of unprocessed `SharedImportResult`.
     /// If the number of unprocessed results is more than the threshold,
     /// the block importer stops committing new blocks and waits for
     /// the resolution of the previous one.
     active_import_results: Arc<Semaphore>,
-    process_thread: rayon::ThreadPool,
-    /// Enables prometheus metrics for this fuel-service
-    metrics: bool,
+    inner: Option<std::thread::JoinHandle<()>>,
 }
 
-impl<D, E, V> Importer<D, E, V> {
-    pub fn new(
+impl Drop for Importer {
+    fn drop(&mut self) {
+        // Dropping the sender will close the receiver and stop the inner importer.
+        let (empty_sender, _) = mpsc::channel(1);
+        let sender = core::mem::replace(&mut self.commands, empty_sender);
+        drop(sender);
+
+        let inner = self.inner.take();
+
+        if let Some(inner) = inner {
+            let result = inner.join();
+
+            if let Err(err) = result {
+                tracing::error!("The inner importer thread panicked: {:?}", err);
+            }
+        }
+    }
+}
+
+impl Importer {
+    pub fn new<D, E, V>(
         chain_id: ChainId,
         config: Config,
         database: D,
         executor: E,
         verifier: V,
-    ) -> Self {
+    ) -> Self
+    where
+        D: ImporterDatabase + Transactional + 'static,
+        E: Validator + 'static,
+        V: BlockVerifier + 'static,
+    {
         // We use semaphore as a back pressure mechanism instead of a `broadcast`
         // channel because we want to prevent committing to the database results
         // that will not be processed.
         let max_block_notify_buffer = config.max_block_notify_buffer;
         let (broadcast, _) = broadcast::channel(max_block_notify_buffer);
-        let process_thread = rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build()
-            .expect("Failed to create a thread pool for the block processing");
+        let (sender, receiver) = mpsc::channel(1);
+
+        let mut inner = ImporterInner {
+            database,
+            executor,
+            verifier,
+            chain_id,
+            commands: receiver,
+            broadcast: broadcast.clone(),
+            metrics: config.metrics,
+        };
+
+        if config.metrics {
+            inner.init_metrics();
+        }
+
+        let inner = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("Failed to create tokio runtime for importer inner task");
+            runtime.block_on(inner.run());
+        });
 
         Self {
-            database: Arc::new(Mutex::new(database)),
-            executor: Arc::new(executor),
-            verifier: Arc::new(verifier),
-            chain_id,
             broadcast,
+            commands: sender,
             active_import_results: Arc::new(Semaphore::new(max_block_notify_buffer)),
             guard: Semaphore::new(1),
-            process_thread,
-            metrics: config.metrics,
+            inner: Some(inner),
         }
     }
 
     #[cfg(test)]
-    pub fn default_config(database: D, executor: E, verifier: V) -> Self {
+    pub fn default_config<D, E, V>(database: D, executor: E, verifier: V) -> Self
+    where
+        D: ImporterDatabase + Transactional + 'static,
+        E: Validator + 'static,
+        V: BlockVerifier + 'static,
+    {
         Self::new(
             Default::default(),
             Default::default(),
@@ -196,33 +209,13 @@ impl<D, E, V> Importer<D, E, V> {
                     "The semaphore was acquired before. It is a problem \
                     because the current architecture doesn't expect that."
                 );
-                Err(Error::SemaphoreError(err))
+                Err(Error::Semaphore(err))
             }
         }
     }
-
-    async fn async_run<OP, Output>(&self, op: OP) -> Result<Output, Error>
-    where
-        OP: FnOnce() -> Output,
-        OP: Send,
-        Output: Send,
-    {
-        let (sender, receiver) = tokio::sync::oneshot::channel();
-        self.process_thread.scope_fifo(|_| {
-            let result = op();
-            let _ = sender.send(result);
-        });
-        let result = receiver.await.map_err(|_| Error::RayonTaskWasCanceled)?;
-        Ok(result)
-    }
 }
 
-impl<D, E, V> Importer<D, E, V>
-where
-    D: ImporterDatabase + Transactional,
-    E: Send + Sync,
-    V: Send + Sync,
-{
+impl Importer {
     /// The method commits the result of the block execution attaching the consensus data.
     /// It expects that the `UncommittedResult` contains the result of the block
     /// execution(It includes the block itself), but not more.
@@ -245,7 +238,7 @@ where
         // Await until all receivers of the notification process the result.
         const TIMEOUT: u64 = 20;
         let await_result = tokio::time::timeout(
-            tokio::time::Duration::from_secs(TIMEOUT),
+            Duration::from_secs(TIMEOUT),
             self.active_import_results.clone().acquire_owned(),
         )
         .await;
@@ -259,47 +252,138 @@ where
         };
         let permit = permit.map_err(Error::ActiveBlockResultsSemaphoreClosed)?;
 
-        self.async_run(move || {
-            let mut guard = self
-                .database
-                .try_lock()
-                .expect("Semaphore prevents concurrent access to the database");
-            let database = guard.deref_mut();
-            let block_changes = create_block_changes(
-                &self.chain_id,
-                &result.result().sealed_block,
-                database,
-            )?;
-            self._commit_result(result, block_changes, permit, database)
+        self.run_commit_result(permit, CommitInput::Uncommitted(result))
+            .await
+    }
+
+    async fn run_commit_result(
+        &self,
+        permit: OwnedSemaphorePermit,
+        result: CommitInput,
+    ) -> Result<(), Error> {
+        let (sender, receiver) = oneshot::channel();
+        let command = Commands::CommitResult {
+            result,
+            permit,
+            callback: sender,
+        };
+        self.commands.send(command).await?;
+        receiver.await?
+    }
+
+    #[cfg(test)]
+    async fn run_verify_and_execute_block(
+        &self,
+        sealed_block: SealedBlock,
+    ) -> Result<UncommittedResult<Changes>, Error> {
+        let (sender, receiver) = oneshot::channel();
+        let command = Commands::VerifyAndExecuteBlock {
+            sealed_block,
+            callback: sender,
+        };
+        self.commands.send(command).await?;
+        receiver.await?
+    }
+
+    async fn run_prepare_import_result(
+        &self,
+        sealed_block: SealedBlock,
+    ) -> Result<PrepareImportResult, Error> {
+        let (sender, receiver) = oneshot::channel();
+        let command = Commands::PrepareImportResult {
+            sealed_block,
+            callback: sender,
+        };
+        self.commands.send(command).await?;
+        receiver.await?
+    }
+}
+
+impl<D, E, V> ImporterInner<D, E, V>
+where
+    D: ImporterDatabase + Transactional,
+    E: Send + Sync,
+    V: Send + Sync,
+{
+    /// The method commits the result of the block execution attaching the consensus data.
+    /// It expects that the `UncommittedResult` contains the result of the block
+    /// execution(It includes the block itself), but not more.
+    ///
+    /// It doesn't do any checks regarding block validity(execution, fields, signing, etc.).
+    /// It only checks the validity of the database.
+    ///
+    /// After the commit into the database notifies about a new imported block.
+    pub fn commit_result(
+        &mut self,
+        runner: &LocalRunner,
+        permit: OwnedSemaphorePermit,
+        result: CommitInput,
+    ) -> Result<(), Error> {
+        runner.run(move || {
+            let result = match result {
+                CommitInput::Uncommitted(result) => {
+                    let block_changes = create_block_changes(
+                        &self.chain_id,
+                        &result.result().sealed_block,
+                        &self.database,
+                    )?;
+
+                    PrepareImportResult {
+                        result,
+                        block_changes,
+                    }
+                }
+                CommitInput::PrepareImportResult(result) => result,
+            };
+
+            self._commit_result(result, permit)
         })
-        .await?
     }
 
     /// The method commits the result of the block execution and notifies about a new imported block.
     #[tracing::instrument(
         skip_all,
         fields(
-            block_id = %result.result().sealed_block.entity.id(),
-            height = **result.result().sealed_block.entity.header().height(),
-            tx_status = ?result.result().tx_status,
+            block_id = % prepare.result.result().sealed_block.entity.id(),
+            height = * * prepare.result.result().sealed_block.entity.header().height(),
+            tx_status = ? prepare.result.result().tx_status,
         ),
         err
     )]
     fn _commit_result(
-        &self,
-        result: UncommittedResult<Changes>,
-        block_changes: Changes,
+        &mut self,
+        prepare: PrepareImportResult,
         permit: OwnedSemaphorePermit,
-        database: &mut D,
     ) -> Result<(), Error> {
+        let PrepareImportResult {
+            result,
+            block_changes,
+        } = prepare;
+
         let (result, changes) = result.into();
         let block = &result.sealed_block.entity;
         let actual_next_height = *block.header().height();
 
+        // Importer expects that `UncommittedResult` contains the result of block
+        // execution without block itself.
+        let expected_block_root = self.database.latest_block_root()?;
+
+        let db_after_execution = self.database.storage_transaction(changes);
+        let actual_block_root = db_after_execution.latest_block_root()?;
+
+        if actual_block_root != expected_block_root {
+            return Err(Error::InvalidDatabaseStateAfterExecution(
+                expected_block_root,
+                actual_block_root,
+            ))
+        }
+
+        let changes = db_after_execution.into_changes();
+
         #[cfg(feature = "test-helpers")]
         let changes_clone = changes.clone();
 
-        database
+        self.database
             .commit_changes(StorageChanges::ChangesList(vec![block_changes, changes]))?;
 
         if self.metrics {
@@ -326,8 +410,6 @@ where
         // correctly in more mission critical areas (such as _commit_result)
         let current_block_height = self
             .database
-            .try_lock()
-            .expect("Init function is the first to access the database")
             .latest_block_height()
             .unwrap_or_default()
             .unwrap_or_default();
@@ -391,11 +473,98 @@ where
     }
 }
 
-impl<IDatabase, E, V> Importer<IDatabase, E, V>
+struct VerifyAndExecutionResult {
+    tx_status: Vec<TransactionExecutionStatus>,
+    events: Vec<Event>,
+    changes: Changes,
+}
+
+struct PrepareImportResult {
+    result: UncommittedResult<Changes>,
+    block_changes: Changes,
+}
+
+impl<IDatabase, E, V> ImporterInner<IDatabase, E, V>
 where
+    IDatabase: ImporterDatabase + Transactional,
     E: Validator,
     V: BlockVerifier,
 {
+    async fn run(&mut self) {
+        let local_runner = LocalRunner::new().expect("Failed to create the local runner");
+        while let Some(command) = self.commands.recv().await {
+            match command {
+                Commands::CommitResult {
+                    result,
+                    permit,
+                    callback,
+                } => {
+                    let result = self.commit_result(&local_runner, permit, result);
+                    let _ = callback.send(result);
+                }
+                #[cfg(test)]
+                Commands::VerifyAndExecuteBlock {
+                    sealed_block,
+                    callback,
+                } => {
+                    let result =
+                        self.verify_and_execute_block(&local_runner, sealed_block);
+                    let _ = callback.send(result);
+                }
+                Commands::PrepareImportResult {
+                    sealed_block,
+                    callback,
+                } => {
+                    let result = self.prepare_import_result(&local_runner, sealed_block);
+                    let _ = callback.send(result);
+                }
+            }
+        }
+    }
+
+    /// Prepares the block for committing. It includes the execution of the block,
+    /// the validation of the block fields, and preparing the changes
+    /// to the database with the block and transactions.
+    pub fn prepare_import_result(
+        &self,
+        runner: &LocalRunner,
+        sealed_block: SealedBlock,
+    ) -> Result<PrepareImportResult, Error> {
+        let sealed_block_ref = &sealed_block;
+
+        let block_changes =
+            || create_block_changes(&self.chain_id, sealed_block_ref, &self.database);
+
+        let execution = || {
+            Self::verify_and_execute_block_inner(
+                &self.executor,
+                &self.verifier,
+                sealed_block_ref,
+            )
+        };
+
+        let (block_changes_result, execution_result) =
+            runner.run_in_parallel(block_changes, execution);
+
+        let result = execution_result?;
+        let block_changes = block_changes_result?;
+
+        let VerifyAndExecutionResult {
+            tx_status,
+            events,
+            changes,
+        } = result;
+        let import_result =
+            ImportResult::new_from_network(sealed_block, tx_status, events);
+
+        let result = UncommittedResult::new(import_result, changes);
+
+        Ok(PrepareImportResult {
+            result,
+            block_changes,
+        })
+    }
+
     /// Performs all checks required to commit the block, it includes the execution of
     /// the block(As a result returns the uncommitted state).
     ///
@@ -407,27 +576,42 @@ where
     ///
     /// Returns `Err` if the block is invalid for committing. Otherwise, it returns the
     /// `Ok` with the uncommitted state.
+    #[cfg(test)]
     pub fn verify_and_execute_block(
         &self,
+        runner: &LocalRunner,
         sealed_block: SealedBlock,
     ) -> Result<UncommittedResult<Changes>, Error> {
-        Self::verify_and_execute_block_inner(
-            self.executor.clone(),
-            self.verifier.clone(),
-            sealed_block,
-        )
+        runner.run(move || {
+            let result = Self::verify_and_execute_block_inner(
+                &self.executor,
+                &self.verifier,
+                &sealed_block,
+            );
+
+            let VerifyAndExecutionResult {
+                tx_status,
+                events,
+                changes,
+            } = result?;
+
+            let import_result =
+                ImportResult::new_from_network(sealed_block, tx_status, events);
+
+            Ok(UncommittedResult::new(import_result, changes))
+        })
     }
 
     fn verify_and_execute_block_inner(
-        executor: Arc<E>,
-        verifier: Arc<V>,
-        sealed_block: SealedBlock,
-    ) -> Result<UncommittedResult<Changes>, Error> {
-        let consensus = sealed_block.consensus;
-        let block = sealed_block.entity;
+        executor: &E,
+        verifier: &V,
+        sealed_block: &SealedBlock,
+    ) -> Result<VerifyAndExecutionResult, Error> {
+        let consensus = &sealed_block.consensus;
+        let block = &sealed_block.entity;
         let sealed_block_id = block.id();
 
-        let result_of_verification = verifier.verify_block_fields(&consensus, &block);
+        let result_of_verification = verifier.verify_block_fields(consensus, block);
         if let Err(err) = result_of_verification {
             return Err(Error::FailedVerification(err))
         }
@@ -440,7 +624,7 @@ where
         }
 
         let (ValidationResult { tx_status, events }, changes) = executor
-            .validate(&block)
+            .validate(block)
             .map_err(Error::FailedExecution)?
             .into();
 
@@ -451,68 +635,32 @@ where
             return Err(Error::BlockIdMismatch(sealed_block_id, actual_block_id))
         }
 
-        let sealed_block = Sealed {
-            entity: block,
-            consensus,
+        let result = VerifyAndExecutionResult {
+            tx_status,
+            events,
+            changes,
         };
-        let import_result =
-            ImportResult::new_from_network(sealed_block, tx_status, events);
 
-        Ok(Uncommitted::new(import_result, changes))
+        Ok(result)
     }
 }
 
-impl<IDatabase, E, V> Importer<IDatabase, E, V>
-where
-    IDatabase: ImporterDatabase + Transactional + 'static,
-    E: Validator + 'static,
-    V: BlockVerifier + 'static,
-{
+impl Importer {
     /// The method validates the `Block` fields and commits the `SealedBlock`.
-    /// It is a combination of the [`Importer::verify_and_execute_block`] and [`Importer::commit_result`].
     pub async fn execute_and_commit(
         &self,
         sealed_block: SealedBlock,
     ) -> Result<(), Error> {
         let _guard = self.lock()?;
 
-        let block_changes = std::thread::spawn({
-            let sealed_block = sealed_block.clone();
-            let database = self.database.clone();
-            let chain_id = self.chain_id;
-            move || {
-                let mut guard = database
-                    .try_lock()
-                    .expect("Semaphore prevents concurrent access to the database");
-                let database = guard.deref_mut();
-                create_block_changes(&chain_id, &sealed_block, database)
-            }
-        });
-
-        let executor = self.executor.clone();
-        let verifier = self.verifier.clone();
-        let (result, execute_time) = self
-            .async_run(|| {
-                let start = Instant::now();
-                let result = Self::verify_and_execute_block_inner(
-                    executor,
-                    verifier,
-                    sealed_block,
-                );
-                let execute_time = start.elapsed().as_secs_f64();
-                (result, execute_time)
-            })
-            .await?;
-
-        let result = result?;
-        let block_changes = block_changes.join().map_err(|e| {
-            Error::TaskError(format!("Error while waiting for block changes: {:?}", e))
-        })??;
+        let start = Instant::now();
+        let result = self.run_prepare_import_result(sealed_block).await?;
+        let execute_time = start.elapsed().as_secs_f64();
 
         // Await until all receivers of the notification process the result.
         const TIMEOUT: u64 = 20;
         let await_result = tokio::time::timeout(
-            tokio::time::Duration::from_secs(TIMEOUT),
+            Duration::from_secs(TIMEOUT),
             self.active_import_results.clone().acquire_owned(),
         )
         .await;
@@ -526,30 +674,17 @@ where
         };
         let permit = permit.map_err(Error::ActiveBlockResultsSemaphoreClosed)?;
 
+        let start = Instant::now();
         let commit_result = self
-            .async_run(move || {
-                let mut guard = self
-                    .database
-                    .try_lock()
-                    .expect("Semaphore prevents concurrent access to the database");
-                let database = guard.deref_mut();
+            .run_commit_result(permit, CommitInput::PrepareImportResult(result))
+            .await;
 
-                let start = Instant::now();
-                self._commit_result(result, block_changes, permit, database)
-                    .map(|_| start)
-            })
-            .await?;
-
-        let time = if let Ok(start_instant) = commit_result {
-            let commit_time = start_instant.elapsed().as_secs_f64();
-            execute_time + commit_time
-        } else {
-            execute_time
-        };
+        let commit_time = start.elapsed().as_secs_f64();
+        let time = execute_time + commit_time;
 
         importer_metrics().execute_and_commit_duration.observe(time);
-        // return execution result
-        commit_result.map(|_| ())
+
+        commit_result
     }
 }
 
@@ -579,7 +714,7 @@ impl Awaiter {
 fn create_block_changes<D: ImporterDatabase + Transactional>(
     chain_id: &ChainId,
     sealed_block: &SealedBlock,
-    database: &mut D,
+    database: &D,
 ) -> Result<Changes, Error> {
     let consensus = &sealed_block.consensus;
     let actual_next_height = *sealed_block.entity.header().height();
@@ -627,23 +762,11 @@ fn create_block_changes<D: ImporterDatabase + Transactional>(
         ))
     }
 
-    // Importer expects that `UncommittedResult` contains the result of block
-    // execution without block itself.
-    let expected_block_root = database.latest_block_root()?;
+    let mut transaction = database.storage_transaction(Changes::new());
 
-    let mut db_after_execution = database.storage_transaction(Default::default());
-    let actual_block_root = db_after_execution.latest_block_root()?;
-
-    if actual_block_root != expected_block_root {
-        return Err(Error::InvalidDatabaseStateAfterExecution(
-            expected_block_root,
-            actual_block_root,
-        ))
-    }
-
-    if !db_after_execution.store_new_block(chain_id, sealed_block)? {
+    if !transaction.store_new_block(chain_id, sealed_block)? {
         return Err(Error::NotUnique(actual_next_height))
     }
 
-    Ok(db_after_execution.into_changes())
+    Ok(transaction.into_changes())
 }

--- a/crates/services/importer/src/lib.rs
+++ b/crates/services/importer/src/lib.rs
@@ -6,7 +6,9 @@
 use fuel_core_types::services::block_importer::SharedImportResult;
 
 pub mod config;
+pub mod error;
 pub mod importer;
+pub mod local_runner;
 pub mod ports;
 
 pub use config::Config;

--- a/crates/services/importer/src/local_runner.rs
+++ b/crates/services/importer/src/local_runner.rs
@@ -1,0 +1,68 @@
+pub struct LocalRunner {
+    process_thread: rayon::ThreadPool,
+}
+
+impl LocalRunner {
+    pub fn new() -> anyhow::Result<Self> {
+        let process_thread = rayon::ThreadPoolBuilder::new()
+            // 1 thread for execution, 1 thread for block serialization
+            .num_threads(2)
+            .build()
+            .map_err(|e|{
+                anyhow::anyhow!("Failed to create a thread pool for the block processing: {e}")
+            })?;
+
+        Ok(Self { process_thread })
+    }
+
+    pub fn run<OP, Output>(&self, op: OP) -> Output
+    where
+        OP: FnOnce() -> Output,
+        OP: Send,
+        Output: Send,
+    {
+        self.process_thread.install(op)
+    }
+
+    pub fn run_in_parallel<A, RA, B, RB>(&self, oper_a: A, oper_b: B) -> (RA, RB)
+    where
+        A: FnOnce() -> RA + Send,
+        B: FnOnce() -> RB + Send,
+        RA: Send,
+        RB: Send,
+    {
+        self.process_thread.join(oper_a, oper_b)
+    }
+}
+
+#[test]
+fn local_executor_executes_two_tasks_in_parallel() {
+    use std::time::{
+        Duration,
+        Instant,
+    };
+
+    let runner = LocalRunner::new().unwrap();
+
+    let sleep_time = Duration::from_secs(5);
+
+    let start = Instant::now();
+
+    // Given
+    let task_1 = || {
+        println!("Thread 1 started");
+        std::thread::sleep(sleep_time)
+    };
+    let task_2 = || {
+        println!("Thread 2 started");
+        std::thread::sleep(sleep_time)
+    };
+
+    println!("Running futures");
+    // When
+    runner.run_in_parallel(task_1, task_2);
+
+    // Then
+    let elapsed = start.elapsed();
+    assert!(elapsed < 2 * sleep_time);
+}

--- a/crates/services/importer/src/ports.rs
+++ b/crates/services/importer/src/ports.rs
@@ -13,7 +13,7 @@ use fuel_core_storage::{
     transactional::{
         Changes,
         ConflictPolicy,
-        Modifiable,
+        ReadTransaction,
         StorageChanges,
         StorageTransaction,
         WriteTransaction,
@@ -40,7 +40,7 @@ use fuel_core_types::{
     },
 };
 
-#[cfg_attr(test, mockall::automock(type Database = crate::importer::test::MockDatabase;))]
+#[cfg_attr(any(test, feature = "test-helpers"), mockall::automock(type Database = crate::importer::test::MockDatabase;))]
 /// The executors port.
 pub trait Validator: Send + Sync {
     /// Executes the block and returns the result of execution with uncommitted database
@@ -59,7 +59,7 @@ pub trait Transactional {
         Self: 'a;
 
     /// Returns the storage transaction based on the `Changes`.
-    fn storage_transaction(&mut self, changes: Changes) -> Self::Transaction<'_>;
+    fn storage_transaction(&self, changes: Changes) -> Self::Transaction<'_>;
 }
 
 /// The alias port used by the block importer.
@@ -91,14 +91,11 @@ pub trait DatabaseTransaction {
         block: &SealedBlock,
     ) -> StorageResult<bool>;
 
-    /// Commits the changes to the underlying storage.
-    fn commit(self) -> StorageResult<()>;
-
     /// Returns the changes of the transaction.
     fn into_changes(self) -> Changes;
 }
 
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(any(test, feature = "test-helpers"), mockall::automock)]
 /// The verifier of the block.
 pub trait BlockVerifier: Send + Sync {
     /// Verifies the consistency of the block fields for the block's height.
@@ -115,12 +112,12 @@ pub trait BlockVerifier: Send + Sync {
 
 impl<S> Transactional for S
 where
-    S: KeyValueInspect<Column = Column> + Modifiable,
+    S: KeyValueInspect<Column = Column>,
 {
-    type Transaction<'a> = StorageTransaction<&'a mut S> where Self: 'a;
+    type Transaction<'a> = StorageTransaction<&'a S> where Self: 'a;
 
-    fn storage_transaction(&mut self, changes: Changes) -> Self::Transaction<'_> {
-        self.write_transaction()
+    fn storage_transaction(&self, changes: Changes) -> Self::Transaction<'_> {
+        self.read_transaction()
             .with_changes(changes)
             .with_policy(ConflictPolicy::Fail)
     }
@@ -128,7 +125,7 @@ where
 
 impl<S> DatabaseTransaction for StorageTransaction<S>
 where
-    S: KeyValueInspect<Column = Column> + Modifiable,
+    S: KeyValueInspect<Column = Column>,
 {
     fn latest_block_root(&self) -> StorageResult<Option<MerkleRoot>> {
         Ok(self
@@ -162,11 +159,6 @@ where
         }
         storage.commit()?;
         Ok(!found)
-    }
-
-    fn commit(self) -> StorageResult<()> {
-        self.commit()?;
-        Ok(())
     }
 
     fn into_changes(self) -> Changes {

--- a/tests/tests/recovery.rs
+++ b/tests/tests/recovery.rs
@@ -167,6 +167,8 @@ async fn _gas_price_updater__can_recover_on_startup_when_gas_price_db_is_behind(
         Some(BlockHeight::new(height))
     );
 
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
     let diff = height - lower_height;
     for _ in 0..diff {
         let _ = database.gas_price().rollback_last_block();

--- a/tests/tests/trigger_integration/instant.rs
+++ b/tests/tests/trigger_integration/instant.rs
@@ -50,7 +50,7 @@ async fn poa_instant_trigger_is_produces_instantly() {
         )
         .add_fee_input()
         .finalize_as_transaction();
-        let _tx_id = client.submit(&tx).await.unwrap();
+        let _tx_id = client.submit_and_await_commit(&tx).await.unwrap();
         let count = client
             .blocks(PaginationRequest {
                 cursor: None,


### PR DESCRIPTION
Removed cloning of the block and utilized the feature of rayon runtime with scoped parallel jobs execution. 
Moved code to catch `InvalidDatabaseStateAfterExecution` to the right place. 
Removed requirements from the database to be modifiable. 
Fixed the not working `async` part of the block importer. Before importing of the block were blocking the tokio task and `await` never was reached.
