### PR TITLE
Rename `ConsensusParametersProvider` to `ChainStateInfoProvider`

### DIFF
--- a/.changes/changed/2761.md
+++ b/.changes/changed/2761.md
@@ -1,0 +1,1 @@
+Renamed `ConsensusParametersProvider` to `ChainStateInfoProvider` because it is now providing more than just info about consensus parameters.

--- a/crates/fuel-core/src/graphql_api/api_service.rs
+++ b/crates/fuel-core/src/graphql_api/api_service.rs
@@ -2,8 +2,8 @@ use crate::{
     fuel_core_graphql_api::{
         ports::{
             BlockProducerPort,
+            ChainStateProvider as ChainStateProviderTrait,
             ConsensusModulePort,
-            ConsensusProvider as ConsensusProviderTrait,
             GasPriceEstimate,
             OffChainDatabase,
             OnChainDatabase,
@@ -107,7 +107,7 @@ pub type P2pService = Box<dyn P2pPort>;
 
 pub type GasPriceProvider = Box<dyn GasPriceEstimate>;
 
-pub type ChainInfoProvider = Box<dyn ConsensusProviderTrait>;
+pub type ChainInfoProvider = Box<dyn ChainStateProviderTrait>;
 
 #[derive(Clone)]
 pub struct SharedState {

--- a/crates/fuel-core/src/graphql_api/api_service.rs
+++ b/crates/fuel-core/src/graphql_api/api_service.rs
@@ -107,7 +107,7 @@ pub type P2pService = Box<dyn P2pPort>;
 
 pub type GasPriceProvider = Box<dyn GasPriceEstimate>;
 
-pub type ConsensusProvider = Box<dyn ConsensusProviderTrait>;
+pub type ChainInfoProvider = Box<dyn ConsensusProviderTrait>;
 
 #[derive(Clone)]
 pub struct SharedState {
@@ -234,7 +234,7 @@ pub fn new_service<OnChain, OffChain>(
     consensus_module: ConsensusModule,
     p2p_service: P2pService,
     gas_price_provider: GasPriceProvider,
-    consensus_parameters_provider: ConsensusProvider,
+    chain_state_info_provider: ChainInfoProvider,
     memory_pool: SharedMemoryPool,
     block_height_subscriber: block_height_subscription::Subscriber,
 ) -> anyhow::Result<Service>
@@ -287,7 +287,7 @@ where
         .data(consensus_module)
         .data(p2p_service)
         .data(gas_price_provider)
-        .data(consensus_parameters_provider)
+        .data(chain_state_info_provider)
         .data(memory_pool)
         .data(block_height_subscriber.clone())
         .extension(ValidationExtension::new(

--- a/crates/fuel-core/src/graphql_api/extensions/chain_state_info.rs
+++ b/crates/fuel-core/src/graphql_api/extensions/chain_state_info.rs
@@ -12,7 +12,7 @@ use async_graphql::{
 };
 
 use crate::graphql_api::{
-    api_service::ConsensusProvider,
+    api_service::ChainInfoProvider,
     block_height_subscription,
 };
 
@@ -51,15 +51,15 @@ impl Extension for ChainStateInfoExtension {
     ) -> Response {
         let mut response = next.run(ctx, operation_name).await;
 
-        let consensus_parameters_provider = ctx.data_unchecked::<ConsensusProvider>();
+        let chain_state_info_provider = ctx.data_unchecked::<ChainInfoProvider>();
         let current_consensus_parameters_version =
-            consensus_parameters_provider.current_consensus_parameters_version();
+            chain_state_info_provider.current_consensus_parameters_version();
         response.extensions.insert(
             CURRENT_CONSENSUS_PARAMETERS_VERSION.to_string(),
             Value::Number(current_consensus_parameters_version.into()),
         );
 
-        let current_stf_version = consensus_parameters_provider.current_stf_version();
+        let current_stf_version = chain_state_info_provider.current_stf_version();
         response.extensions.insert(
             CURRENT_STF_VERSION.to_string(),
             Value::Number(current_stf_version.into()),

--- a/crates/fuel-core/src/graphql_api/ports.rs
+++ b/crates/fuel-core/src/graphql_api/ports.rs
@@ -461,7 +461,7 @@ pub mod worker {
     }
 }
 
-pub trait ConsensusProvider: Send + Sync {
+pub trait ChainStateProvider: Send + Sync {
     /// Returns current consensus parameters.
     fn current_consensus_params(&self) -> Arc<ConsensusParameters>;
 

--- a/crates/fuel-core/src/schema/balance.rs
+++ b/crates/fuel-core/src/schema/balance.rs
@@ -1,7 +1,7 @@
 use crate::{
     database::database_description::IndexationKind,
     fuel_core_graphql_api::{
-        api_service::ConsensusProvider,
+        api_service::ChainInfoProvider,
         query_costs,
     },
     schema::{
@@ -70,7 +70,7 @@ impl BalanceQuery {
     ) -> async_graphql::Result<Balance> {
         let query = ctx.read_view()?;
         let base_asset_id = *ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params()
             .base_asset_id();
         let balance = query
@@ -123,7 +123,7 @@ impl BalanceQuery {
             .into())
         }
         let base_asset_id = *ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params()
             .base_asset_id();
         let owner = filter.owner.into();

--- a/crates/fuel-core/src/schema/chain.rs
+++ b/crates/fuel-core/src/schema/chain.rs
@@ -1,6 +1,6 @@
 use crate::{
     fuel_core_graphql_api::{
-        api_service::ConsensusProvider,
+        api_service::ChainInfoProvider,
         query_costs,
     },
     graphql_api::Config,
@@ -813,7 +813,7 @@ impl ChainInfo {
         ctx: &Context<'_>,
     ) -> async_graphql::Result<ConsensusParameters> {
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
 
         Ok(ConsensusParameters(params))
@@ -822,7 +822,7 @@ impl ChainInfo {
     #[graphql(complexity = "query_costs().storage_read + child_complexity")]
     async fn gas_costs(&self, ctx: &Context<'_>) -> async_graphql::Result<GasCosts> {
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
 
         Ok(GasCosts(params.gas_costs().clone()))

--- a/crates/fuel-core/src/schema/coins.rs
+++ b/crates/fuel-core/src/schema/coins.rs
@@ -15,7 +15,7 @@ use crate::{
         IntoApiResult,
     },
     graphql_api::{
-        api_service::ConsensusProvider,
+        api_service::ChainInfoProvider,
         database::ReadView,
     },
     query::asset_query::AssetSpendTarget,
@@ -116,7 +116,7 @@ impl MessageCoin {
     #[graphql(complexity = "query_costs().storage_read")]
     async fn asset_id(&self, ctx: &Context<'_>) -> AssetId {
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
 
         let base_asset_id = *params.base_asset_id();
@@ -256,7 +256,7 @@ impl CoinQuery {
         >,
     ) -> async_graphql::Result<Vec<Vec<CoinType>>> {
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
         let max_input = params.tx_params().max_inputs();
 

--- a/crates/fuel-core/src/schema/dap.rs
+++ b/crates/fuel-core/src/schema/dap.rs
@@ -4,7 +4,7 @@ use crate::{
         Database,
         OnChainIterableKeyValueView,
     },
-    fuel_core_graphql_api::api_service::ConsensusProvider,
+    fuel_core_graphql_api::api_service::ChainInfoProvider,
     schema::scalars::{
         U32,
         U64,
@@ -325,7 +325,7 @@ impl DapMutation {
 
         let db = ctx.data_unchecked::<Database>();
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
 
         let id =
@@ -358,7 +358,7 @@ impl DapMutation {
         require_debug(ctx)?;
         let db = ctx.data_unchecked::<Database>();
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
 
         ctx.data_unchecked::<GraphStorage>()
@@ -449,7 +449,7 @@ impl DapMutation {
 
         let mut locked = ctx.data_unchecked::<GraphStorage>().lock().await;
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
 
         let vm = locked

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -6,7 +6,7 @@ use crate::{
     fuel_core_graphql_api::{
         api_service::{
             BlockProducer,
-            ConsensusProvider,
+            ChainInfoProvider,
             TxPool,
         },
         query_costs,
@@ -215,7 +215,7 @@ impl TxQuery {
         use futures::stream::StreamExt;
         let query = ctx.read_view()?;
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
         let owner = fuel_types::Address::from(owner);
 
@@ -253,7 +253,7 @@ impl TxQuery {
         let mut tx = FuelTx::from_bytes(&tx.0)?;
 
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
 
         let memory_pool = ctx.data_unchecked::<SharedMemoryPool>();
@@ -330,7 +330,7 @@ impl TxMutation {
         let config = ctx.data_unchecked::<GraphQLConfig>().clone();
         let block_producer = ctx.data_unchecked::<BlockProducer>();
         let consensus_params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
         let block_gas_limit = consensus_params.block_gas_limit();
 
@@ -383,7 +383,7 @@ impl TxMutation {
     ) -> async_graphql::Result<Transaction> {
         let txpool = ctx.data_unchecked::<TxPool>();
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
         let tx = FuelTx::from_bytes(&tx.0)?;
 
@@ -475,7 +475,7 @@ async fn submit_and_await_status<'a>(
     use tokio_stream::StreamExt;
     let txpool = ctx.data_unchecked::<TxPool>();
     let params = ctx
-        .data_unchecked::<ConsensusProvider>()
+        .data_unchecked::<ChainInfoProvider>()
         .current_consensus_params();
     let tx = FuelTx::from_bytes(&tx.0)?;
     let tx_id = tx.id(&params.chain_id());

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::{
     fuel_core_graphql_api::{
         api_service::{
-            ConsensusProvider,
+            ChainInfoProvider,
             TxPool,
         },
         database::ReadView,
@@ -415,7 +415,7 @@ impl Transaction {
     #[graphql(complexity = "query_costs().storage_read")]
     async fn input_asset_ids(&self, ctx: &Context<'_>) -> Option<Vec<AssetId>> {
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .current_consensus_params();
         let base_asset_id = params.base_asset_id();
         match &self.0 {

--- a/crates/fuel-core/src/schema/upgrades.rs
+++ b/crates/fuel-core/src/schema/upgrades.rs
@@ -1,6 +1,6 @@
 use crate::{
     graphql_api::{
-        api_service::ConsensusProvider,
+        api_service::ChainInfoProvider,
         query_costs,
         IntoApiResult,
     },
@@ -36,7 +36,7 @@ impl UpgradeQuery {
         version: ConsensusParametersVersion,
     ) -> async_graphql::Result<ConsensusParameters> {
         let params = ctx
-            .data_unchecked::<ConsensusProvider>()
+            .data_unchecked::<ChainInfoProvider>()
             .consensus_params_at_version(&version)?;
 
         Ok(ConsensusParameters(params))

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -56,8 +56,8 @@ use fuel_core_upgradable_executor::executor::Executor;
 use std::sync::Arc;
 
 pub mod block_importer;
+pub mod chain_state_info_provider;
 pub mod consensus_module;
-pub mod consensus_parameters_provider;
 pub mod executor;
 pub mod fuel_gas_price_provider;
 pub mod gas_price_adapters;
@@ -75,12 +75,12 @@ pub mod sync;
 pub mod txpool;
 
 #[derive(Debug, Clone)]
-pub struct ConsensusParametersProvider {
-    shared_state: consensus_parameters_provider::SharedState,
+pub struct ChainStateInfoProvider {
+    shared_state: chain_state_info_provider::SharedState,
 }
 
-impl ConsensusParametersProvider {
-    pub fn new(shared_state: consensus_parameters_provider::SharedState) -> Self {
+impl ChainStateInfoProvider {
+    pub fn new(shared_state: chain_state_info_provider::SharedState) -> Self {
         Self { shared_state }
     }
 }

--- a/crates/fuel-core/src/service/adapters/chain_state_info_provider.rs
+++ b/crates/fuel-core/src/service/adapters/chain_state_info_provider.rs
@@ -242,17 +242,26 @@ mod tests {
         StateWatcher,
     };
     use fuel_core_storage::{
-        tables::ConsensusParametersVersions,
+        tables::{
+            ConsensusParametersVersions,
+            StateTransitionBytecodeVersions,
+        },
         transactional::IntoTransaction,
         StorageAsMut,
     };
     use fuel_core_types::{
         blockchain::{
             block::Block,
-            header::ConsensusParametersVersion,
+            header::{
+                ConsensusParametersVersion,
+                StateTransitionBytecodeVersion,
+            },
             SealedBlock,
         },
-        fuel_tx::ConsensusParameters,
+        fuel_tx::{
+            Bytes32,
+            ConsensusParameters,
+        },
         services::block_importer::{
             ImportResult,
             SharedImportResult,
@@ -260,27 +269,39 @@ mod tests {
     };
     use futures::stream;
 
-    fn add_consensus_parameters(
+    fn add_consensus_parameters_and_stf_version(
         database: Database,
         consensus_parameters_version: ConsensusParametersVersion,
         consensus_parameters: &ConsensusParameters,
+        stf_version: StateTransitionBytecodeVersion,
     ) -> Database {
         let mut database = database.into_transaction();
         database
             .storage_as_mut::<ConsensusParametersVersions>()
             .insert(&consensus_parameters_version, consensus_parameters)
             .unwrap();
+
+        const BYTECODE_ROOT: Bytes32 = Bytes32::zeroed();
+        database
+            .storage_as_mut::<StateTransitionBytecodeVersions>()
+            .insert(&stf_version, &BYTECODE_ROOT)
+            .unwrap();
         database.commit().unwrap()
     }
 
     #[tokio::test]
     async fn latest_consensus_parameters_works() {
-        let version = 0;
+        let consensus_parameters_version = 0;
         let consensus_parameters = Default::default();
+        let stf_version = Default::default();
 
         // Given
-        let database =
-            add_consensus_parameters(Database::default(), version, &consensus_parameters);
+        let database = add_consensus_parameters_and_stf_version(
+            Database::default(),
+            consensus_parameters_version,
+            &consensus_parameters,
+            stf_version,
+        );
         let state = SharedState::new(database);
 
         // When
@@ -292,12 +313,17 @@ mod tests {
 
     #[tokio::test]
     async fn into_task_works_with_non_empty_database() {
-        let version = 0;
+        let consensus_parameters_version = 0;
         let consensus_parameters = Default::default();
+        let stf_version = Default::default();
 
         // Given
-        let non_empty_database =
-            add_consensus_parameters(Database::default(), version, &consensus_parameters);
+        let non_empty_database = add_consensus_parameters_and_stf_version(
+            Database::default(),
+            consensus_parameters_version,
+            &consensus_parameters,
+            stf_version,
+        );
         let task = Task {
             blocks_events: stream::empty().into_boxed(),
             shared_state: SharedState::new(non_empty_database),
@@ -307,7 +333,7 @@ mod tests {
         let result = task.into_task(&Default::default(), ()).await;
 
         // Then
-        result.expect("Initialization should succeed because database contains consensus parameters.");
+        result.expect("Initialization should succeed because database contains consensus parameters and stf version.");
     }
 
     #[tokio::test]
@@ -324,11 +350,11 @@ mod tests {
 
         // Then
         result.expect_err(
-            "Initialization should fails because of lack of consensus parameters",
+            "Initialization should fails because of lack of consensus parameters and stf version",
         );
     }
 
-    fn result_with_new_version(
+    fn result_with_new_consensus_parameters_version(
         version: ConsensusParametersVersion,
     ) -> SharedImportResult {
         let mut block = Block::default();
@@ -348,8 +374,10 @@ mod tests {
     async fn run_updates_the_latest_consensus_parameters_from_imported_block() {
         use futures::StreamExt;
 
-        let old_version = 0;
-        let new_version = 1234;
+        let stf_version = Default::default();
+
+        let old_consensus_parameters_version = 0;
+        let new_consensus_parameters_version = 1234;
         let old_consensus_parameters = ConsensusParameters::default();
         let mut new_consensus_parameters = ConsensusParameters::default();
         new_consensus_parameters.set_privileged_address([123; 32].into());
@@ -357,10 +385,11 @@ mod tests {
 
         let (block_sender, block_receiver) =
             tokio::sync::broadcast::channel::<SharedImportResult>(1);
-        let database_with_old_parameters = add_consensus_parameters(
+        let database_with_old_parameters = add_consensus_parameters_and_stf_version(
             Database::default(),
-            old_version,
+            old_consensus_parameters_version,
             &old_consensus_parameters,
+            stf_version,
         );
         let mut task = Task {
             blocks_events: IntoBoxStream::into_boxed(
@@ -378,14 +407,17 @@ mod tests {
         );
 
         // Given
-        add_consensus_parameters(
+        add_consensus_parameters_and_stf_version(
             database_with_old_parameters,
-            new_version,
+            new_consensus_parameters_version,
             &new_consensus_parameters,
+            stf_version,
         );
 
         // When
-        let result_with_new_version = result_with_new_version(new_version);
+        let result_with_new_version = result_with_new_consensus_parameters_version(
+            new_consensus_parameters_version,
+        );
         let _ = block_sender.send(result_with_new_version);
         let _ = task.run(&mut StateWatcher::started()).await;
 
@@ -394,5 +426,68 @@ mod tests {
             task.shared_state.latest_consensus_parameters().as_ref(),
             &new_consensus_parameters
         );
+    }
+
+    fn result_with_new_stf_version(
+        version: StateTransitionBytecodeVersion,
+    ) -> SharedImportResult {
+        let mut block = Block::default();
+        block.header_mut().set_stf_version(version);
+        let sealed_block = SealedBlock {
+            entity: block,
+            consensus: Default::default(),
+        };
+        std::sync::Arc::new(ImportResult::new_from_local(
+            sealed_block,
+            Default::default(),
+            Default::default(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn run_updates_the_latest_stf_version_from_imported_block() {
+        use futures::StreamExt;
+
+        let old_stf_version = 0;
+        let new_stf_version = 1234;
+
+        let consensus_parameters_version = 0;
+        let consensus_parameters = ConsensusParameters::default();
+
+        let (block_sender, block_receiver) =
+            tokio::sync::broadcast::channel::<SharedImportResult>(1);
+        let database_with_old_parameters = add_consensus_parameters_and_stf_version(
+            Database::default(),
+            consensus_parameters_version,
+            &consensus_parameters,
+            old_stf_version,
+        );
+        let mut task = Task {
+            blocks_events: IntoBoxStream::into_boxed(
+                tokio_stream::wrappers::BroadcastStream::new(block_receiver)
+                    .filter_map(|r| futures::future::ready(r.ok())),
+            ),
+            shared_state: SharedState::new(database_with_old_parameters.clone()),
+        }
+        .into_task(&Default::default(), ())
+        .await
+        .unwrap();
+        assert_eq!(task.shared_state.latest_stf_version(), old_stf_version);
+
+        // Given
+        add_consensus_parameters_and_stf_version(
+            database_with_old_parameters,
+            consensus_parameters_version,
+            &consensus_parameters,
+            new_stf_version,
+        );
+
+        // When
+        let result_with_new_version = result_with_new_stf_version(new_stf_version);
+        let _ = block_sender.send(result_with_new_version);
+        let _ = task.run(&mut StateWatcher::started()).await;
+
+        // Then
+        assert_eq!(task.shared_state.latest_stf_version(), new_stf_version);
     }
 }

--- a/crates/fuel-core/src/service/adapters/chain_state_info_provider.rs
+++ b/crates/fuel-core/src/service/adapters/chain_state_info_provider.rs
@@ -180,7 +180,7 @@ impl RunnableTask for Task {
 
 #[async_trait::async_trait]
 impl RunnableService for Task {
-    const NAME: &'static str = "ConsensusParametersProviderTask";
+    const NAME: &'static str = "ChainStateInfoProviderTask";
     type SharedData = SharedState;
     type Task = Self;
     type TaskParams = ();
@@ -230,7 +230,7 @@ pub fn new_service(
 mod tests {
     use crate::{
         database::Database,
-        service::adapters::consensus_parameters_provider::{
+        service::adapters::chain_state_info_provider::{
             SharedState,
             Task,
         },

--- a/crates/fuel-core/src/service/adapters/consensus_parameters_provider.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_parameters_provider.rs
@@ -62,11 +62,11 @@ impl SharedState {
     fn new(database: Database) -> Self {
         // We set versions in the `into_task` function during start of the service.
         let genesis_version = 0;
-        let latest_stf_version = 0;
+        let genesis_stf_version = 0;
 
         Self {
             latest_consensus_parameters_version: SharedRwLock::new(genesis_version),
-            latest_stf_version: SharedRwLock::new(latest_stf_version),
+            latest_stf_version: SharedRwLock::new(genesis_stf_version),
             consensus_parameters: Default::default(),
             database,
         }

--- a/crates/fuel-core/src/service/adapters/consensus_parameters_provider.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_parameters_provider.rs
@@ -199,12 +199,17 @@ impl RunnableService for Task {
             .database
             .latest_view()?
             .latest_consensus_parameters_version()?;
+        let latest_stf_version = self
+            .shared_state
+            .database
+            .latest_view()?
+            .latest_state_transition_bytecode_version()?;
+
         self.shared_state
             .cache_consensus_parameters_version(latest_consensus_parameters_version);
         self.shared_state
             .cache_consensus_parameters(latest_consensus_parameters_version)?;
-        self.shared_state
-            .cache_stf_version(latest_consensus_parameters_version);
+        self.shared_state.cache_stf_version(latest_stf_version);
 
         Ok(self)
     }

--- a/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
@@ -1,6 +1,6 @@
 use crate::{
     database::OnChainIterableKeyValueView,
-    service::adapters::ConsensusParametersProvider,
+    service::adapters::ChainStateInfoProvider,
 };
 use fuel_core_gas_price_service::{
     common::{
@@ -109,7 +109,7 @@ impl From<Config> for V1AlgorithmConfig {
     }
 }
 
-impl GasPriceSettingsProvider for ConsensusParametersProvider {
+impl GasPriceSettingsProvider for ChainStateInfoProvider {
     fn settings(
         &self,
         param_version: &ConsensusParametersVersion,

--- a/crates/fuel-core/src/service/adapters/gas_price_adapters/tests.rs
+++ b/crates/fuel-core/src/service/adapters/gas_price_adapters/tests.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use crate::service::adapters::{
-    consensus_parameters_provider,
+    chain_state_info_provider,
     gas_price_adapters::GasPriceSettings,
 };
 use fuel_core_services::SharedRwLock;
@@ -21,18 +21,18 @@ fn settings__can_retrieve_settings() {
         fuel_core_types::fuel_tx::consensus_parameters::ConsensusParametersV1::default();
     let mut hash_map = HashMap::new();
     hash_map.insert(param_version, Arc::new(params.clone().into()));
-    let shared_state = consensus_parameters_provider::SharedState {
+    let shared_state = chain_state_info_provider::SharedState {
         latest_consensus_parameters_version: SharedRwLock::new(param_version),
         consensus_parameters: SharedRwLock::new(hash_map),
         database: Default::default(),
         latest_stf_version: SharedRwLock::new(stf_version),
     };
-    let consensus_parameters_provider =
-        crate::service::adapters::ConsensusParametersProvider::new(shared_state);
+    let chain_state_info_provider =
+        crate::service::adapters::ChainStateInfoProvider::new(shared_state);
     // when
     let actual =
         crate::service::adapters::gas_price_adapters::GasPriceSettingsProvider::settings(
-            &consensus_parameters_provider,
+            &chain_state_info_provider,
             &param_version,
         )
         .unwrap();

--- a/crates/fuel-core/src/service/adapters/graphql_api.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api.rs
@@ -1,7 +1,7 @@
 use super::{
     BlockImporterAdapter,
     BlockProducerAdapter,
-    ConsensusParametersProvider,
+    ChainStateInfoProvider,
     SharedMemoryPool,
     StaticGasPrice,
 };
@@ -200,7 +200,7 @@ impl GasPriceEstimate for StaticGasPrice {
     }
 }
 
-impl ConsensusProvider for ConsensusParametersProvider {
+impl ConsensusProvider for ChainStateInfoProvider {
     fn current_consensus_params(&self) -> Arc<ConsensusParameters> {
         self.shared_state.latest_consensus_parameters()
     }

--- a/crates/fuel-core/src/service/adapters/graphql_api.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api.rs
@@ -11,7 +11,7 @@ use crate::{
         worker,
         worker::BlockAt,
         BlockProducerPort,
-        ConsensusProvider,
+        ChainStateProvider,
         DatabaseMessageProof,
         GasPriceEstimate,
         P2pPort,
@@ -200,7 +200,7 @@ impl GasPriceEstimate for StaticGasPrice {
     }
 }
 
-impl ConsensusProvider for ChainStateInfoProvider {
+impl ChainStateProvider for ChainStateInfoProvider {
     fn current_consensus_params(&self) -> Arc<ConsensusParameters> {
         self.shared_state.latest_consensus_parameters()
     }

--- a/crates/fuel-core/src/service/adapters/producer.rs
+++ b/crates/fuel-core/src/service/adapters/producer.rs
@@ -3,7 +3,7 @@ use crate::{
     service::{
         adapters::{
             BlockProducerAdapter,
-            ConsensusParametersProvider,
+            ChainStateInfoProvider,
             ExecutorAdapter,
             MaybeRelayerAdapter,
             StaticGasPrice,
@@ -15,7 +15,7 @@ use crate::{
 };
 use fuel_core_producer::{
     block_producer::gas_price::{
-        ConsensusParametersProvider as ConsensusParametersProviderTrait,
+        ChainStateInfoProvider as ChainStateInfoProviderTrait,
         GasPriceProvider,
     },
     ports::{
@@ -281,7 +281,7 @@ impl GasPriceProvider for StaticGasPrice {
     }
 }
 
-impl ConsensusParametersProviderTrait for ConsensusParametersProvider {
+impl ChainStateInfoProviderTrait for ChainStateInfoProvider {
     fn consensus_params_at_version(
         &self,
         version: &ConsensusParametersVersion,

--- a/crates/fuel-core/src/service/adapters/txpool.rs
+++ b/crates/fuel-core/src/service/adapters/txpool.rs
@@ -2,7 +2,7 @@ use crate::{
     database::OnChainIterableKeyValueView,
     service::adapters::{
         BlockImporterAdapter,
-        ConsensusParametersProvider,
+        ChainStateInfoProvider,
         P2PAdapter,
         StaticGasPrice,
     },
@@ -19,7 +19,7 @@ use fuel_core_storage::{
 };
 use fuel_core_txpool::ports::{
     BlockImporter,
-    ConsensusParametersProvider as ConsensusParametersProviderTrait,
+    ChainStateInfoProvider as ChainStateInfoProviderTrait,
     GasPriceProvider,
 };
 use fuel_core_types::{
@@ -220,7 +220,7 @@ impl GasPriceProvider for StaticGasPrice {
     }
 }
 
-impl ConsensusParametersProviderTrait for ConsensusParametersProvider {
+impl ChainStateInfoProviderTrait for ChainStateInfoProvider {
     fn latest_consensus_parameters(
         &self,
     ) -> (ConsensusParametersVersion, Arc<ConsensusParameters>) {

--- a/crates/services/producer/src/block_producer.rs
+++ b/crates/services/producer/src/block_producer.rs
@@ -90,7 +90,8 @@ impl From<Error> for anyhow::Error {
     }
 }
 
-pub struct Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider> {
+pub struct Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
+{
     pub config: Config,
     pub view_provider: ViewProvider,
     pub txpool: TxPool,
@@ -100,15 +101,15 @@ pub struct Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusP
     // execution has completed (which may take a while).
     pub lock: Mutex<()>,
     pub gas_price_provider: GasPriceProvider,
-    pub chain_state_info_provider: ConsensusProvider,
+    pub chain_state_info_provider: ChainStateProvider,
 }
 
-impl<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
-    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
+impl<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
+    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
 where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
-    ConsensusProvider: ChainStateInfoProvider,
+    ChainStateProvider: ChainStateInfoProvider,
 {
     pub async fn produce_and_execute_predefined(
         &self,
@@ -174,13 +175,13 @@ where
         Ok(result)
     }
 }
-impl<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
-    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
+impl<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
+    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
 where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ChainStateInfoProvider,
+    ChainStateProvider: ChainStateInfoProvider,
 {
     /// Produces and execute block for the specified height.
     async fn produce_and_execute<TxSource, F>(
@@ -259,15 +260,15 @@ where
     }
 }
 
-impl<ViewProvider, TxPool, Executor, TxSource, GasPriceProvider, ConsensusProvider>
-    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
+impl<ViewProvider, TxPool, Executor, TxSource, GasPriceProvider, ChainStateProvider>
+    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
 where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
     TxPool: ports::TxPool<TxSource = TxSource> + 'static,
     Executor: ports::BlockProducer<TxSource> + 'static,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ChainStateInfoProvider,
+    ChainStateProvider: ChainStateInfoProvider,
 {
     /// Produces and execute block for the specified height with transactions from the `TxPool`.
     pub async fn produce_and_execute_block_txpool(
@@ -284,14 +285,14 @@ where
     }
 }
 
-impl<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
-    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
+impl<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
+    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
 where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
     Executor: ports::BlockProducer<Vec<Transaction>> + 'static,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ChainStateInfoProvider,
+    ChainStateProvider: ChainStateInfoProvider,
 {
     /// Produces and execute block for the specified height with `transactions`.
     pub async fn produce_and_execute_block_transactions(
@@ -305,14 +306,14 @@ where
     }
 }
 
-impl<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
-    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
+impl<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
+    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
 where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
     Executor: ports::DryRunner + 'static,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ChainStateInfoProvider,
+    ChainStateProvider: ChainStateInfoProvider,
 {
     /// Simulates multiple transactions without altering any state. Does not acquire the production lock.
     /// since it is basically a "read only" operation and shouldn't get in the way of normal
@@ -384,14 +385,14 @@ where
     }
 }
 
-impl<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
-    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
+impl<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
+    Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ChainStateProvider>
 where
     ViewProvider: HistoricalView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
     Executor: ports::StorageReadReplayRecorder + 'static,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ChainStateInfoProvider,
+    ChainStateProvider: ChainStateInfoProvider,
 {
     /// Re-executes an old block, getting the storage read events.
     pub async fn storage_read_replay(
@@ -413,12 +414,12 @@ where
 
 pub const NO_NEW_DA_HEIGHT_FOUND: &str = "No new da_height found";
 
-impl<ViewProvider, TxPool, Executor, GP, ConsensusProvider>
-    Producer<ViewProvider, TxPool, Executor, GP, ConsensusProvider>
+impl<ViewProvider, TxPool, Executor, GP, ChainStateProvider>
+    Producer<ViewProvider, TxPool, Executor, GP, ChainStateProvider>
 where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
-    ConsensusProvider: ChainStateInfoProvider,
+    ChainStateProvider: ChainStateInfoProvider,
 {
     /// Create the header for a new block at the provided height
     async fn new_header_with_new_da_height(

--- a/crates/services/producer/src/block_producer.rs
+++ b/crates/services/producer/src/block_producer.rs
@@ -1,6 +1,6 @@
 use crate::{
     block_producer::gas_price::{
-        ConsensusParametersProvider,
+        ChainStateInfoProvider,
         GasPriceProvider as GasPriceProviderConstraint,
     },
     ports::{
@@ -100,7 +100,7 @@ pub struct Producer<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusP
     // execution has completed (which may take a while).
     pub lock: Mutex<()>,
     pub gas_price_provider: GasPriceProvider,
-    pub consensus_parameters_provider: ConsensusProvider,
+    pub chain_state_info_provider: ConsensusProvider,
 }
 
 impl<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
@@ -108,7 +108,7 @@ impl<ViewProvider, TxPool, Executor, GasPriceProvider, ConsensusProvider>
 where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
-    ConsensusProvider: ConsensusParametersProvider,
+    ConsensusProvider: ChainStateInfoProvider,
 {
     pub async fn produce_and_execute_predefined(
         &self,
@@ -180,7 +180,7 @@ where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ConsensusParametersProvider,
+    ConsensusProvider: ChainStateInfoProvider,
 {
     /// Produces and execute block for the specified height.
     async fn produce_and_execute<TxSource, F>(
@@ -267,7 +267,7 @@ where
     TxPool: ports::TxPool<TxSource = TxSource> + 'static,
     Executor: ports::BlockProducer<TxSource> + 'static,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ConsensusParametersProvider,
+    ConsensusProvider: ChainStateInfoProvider,
 {
     /// Produces and execute block for the specified height with transactions from the `TxPool`.
     pub async fn produce_and_execute_block_txpool(
@@ -291,7 +291,7 @@ where
     ViewProvider::LatestView: BlockProducerDatabase,
     Executor: ports::BlockProducer<Vec<Transaction>> + 'static,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ConsensusParametersProvider,
+    ConsensusProvider: ChainStateInfoProvider,
 {
     /// Produces and execute block for the specified height with `transactions`.
     pub async fn produce_and_execute_block_transactions(
@@ -312,7 +312,7 @@ where
     ViewProvider::LatestView: BlockProducerDatabase,
     Executor: ports::DryRunner + 'static,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ConsensusParametersProvider,
+    ConsensusProvider: ChainStateInfoProvider,
 {
     /// Simulates multiple transactions without altering any state. Does not acquire the production lock.
     /// since it is basically a "read only" operation and shouldn't get in the way of normal
@@ -391,7 +391,7 @@ where
     ViewProvider::LatestView: BlockProducerDatabase,
     Executor: ports::StorageReadReplayRecorder + 'static,
     GasPriceProvider: GasPriceProviderConstraint,
-    ConsensusProvider: ConsensusParametersProvider,
+    ConsensusProvider: ChainStateInfoProvider,
 {
     /// Re-executes an old block, getting the storage read events.
     pub async fn storage_read_replay(
@@ -418,7 +418,7 @@ impl<ViewProvider, TxPool, Executor, GP, ConsensusProvider>
 where
     ViewProvider: AtomicView + 'static,
     ViewProvider::LatestView: BlockProducerDatabase,
-    ConsensusProvider: ConsensusParametersProvider,
+    ConsensusProvider: ChainStateInfoProvider,
 {
     /// Create the header for a new block at the provided height
     async fn new_header_with_new_da_height(
@@ -430,7 +430,7 @@ where
         let mut block_header = self.new_header(height, block_time, view)?;
         let previous_da_height = block_header.da_height;
         let gas_limit = self
-            .consensus_parameters_provider
+            .chain_state_info_provider
             .consensus_params_at_version(&block_header.consensus_parameters_version)?
             .block_gas_limit();
         // We have a hard limit of u16::MAX transactions per block, including the final mint transactions.

--- a/crates/services/producer/src/block_producer/gas_price.rs
+++ b/crates/services/producer/src/block_producer/gas_price.rs
@@ -9,9 +9,9 @@ pub trait GasPriceProvider {
     fn dry_run_gas_price(&self) -> anyhow::Result<u64>;
 }
 
-/// Interface for retrieving the consensus parameters.
+/// Interface for retrieving the chain state info.
 #[cfg_attr(feature = "test-helpers", mockall::automock)]
-pub trait ConsensusParametersProvider {
+pub trait ChainStateInfoProvider {
     /// Retrieve the consensus parameters for the `version`.
     fn consensus_params_at_version(
         &self,

--- a/crates/services/producer/src/block_producer/tests.rs
+++ b/crates/services/producer/src/block_producer/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     block_producer::{
         gas_price::{
             GasPriceProvider,
-            MockConsensusParametersProvider,
+            MockChainStateInfoProvider,
         },
         Bytes32,
         Error,
@@ -909,7 +909,7 @@ impl<Executor> TestContext<Executor> {
         MockTxPool,
         Executor,
         MockProducerGasPrice,
-        MockConsensusParametersProvider,
+        MockChainStateInfoProvider,
     > {
         let gas_price = self.gas_price;
         let static_gas_price = MockProducerGasPrice::new(gas_price);
@@ -918,9 +918,8 @@ impl<Executor> TestContext<Executor> {
         consensus_params.set_block_gas_limit(self.block_gas_limit);
         let consensus_params = Arc::new(consensus_params);
 
-        let mut consensus_parameters_provider =
-            MockConsensusParametersProvider::default();
-        consensus_parameters_provider
+        let mut chain_state_info_provider = MockChainStateInfoProvider::default();
+        chain_state_info_provider
             .expect_consensus_params_at_version()
             .returning(move |_| Ok(consensus_params.clone()));
 
@@ -932,7 +931,7 @@ impl<Executor> TestContext<Executor> {
             relayer: Box::new(self.relayer),
             lock: Default::default(),
             gas_price_provider: static_gas_price,
-            consensus_parameters_provider,
+            chain_state_info_provider,
         }
     }
 
@@ -944,7 +943,7 @@ impl<Executor> TestContext<Executor> {
         MockTxPool,
         Executor,
         MockProducerGasPrice,
-        MockConsensusParametersProvider,
+        MockChainStateInfoProvider,
     > {
         self.gas_price = gas_price;
         self.producer()

--- a/crates/services/txpool_v2/src/ports.rs
+++ b/crates/services/txpool_v2/src/ports.rs
@@ -41,8 +41,8 @@ pub trait BlockImporter {
     fn block_events(&self) -> BoxStream<SharedImportResult>;
 }
 
-/// Trait for getting the latest consensus parameters.
-pub trait ConsensusParametersProvider: Send + Sync + 'static {
+/// Trait for getting the latest chain state info.
+pub trait ChainStateInfoProvider: Send + Sync + 'static {
     /// Get latest consensus parameters.
     fn latest_consensus_parameters(
         &self,

--- a/crates/services/txpool_v2/src/service.rs
+++ b/crates/services/txpool_v2/src/service.rs
@@ -39,7 +39,7 @@ use fuel_core_txpool::{
     ports::{
         AtomicView,
         BlockImporter as BlockImporterTrait,
-        ConsensusParametersProvider,
+        ChainStateInfoProvider,
         GasPriceProvider as GasPriceProviderTrait,
         P2PRequests,
         P2PSubscriptions,
@@ -710,7 +710,7 @@ pub fn new_service<
     BlockImporter,
     PSProvider,
     PSView,
-    ConsensusParamsProvider,
+    ChainStateProvider,
     GasPriceProvider,
     WasmChecker,
 >(
@@ -719,7 +719,7 @@ pub fn new_service<
     p2p: P2P,
     block_importer: BlockImporter,
     ps_provider: PSProvider,
-    consensus_parameters_provider: ConsensusParamsProvider,
+    chain_state_info_provider: ChainStateProvider,
     current_height: BlockHeight,
     gas_price_provider: GasPriceProvider,
     wasm_checker: WasmChecker,
@@ -729,7 +729,7 @@ where
     P2P: P2PRequests,
     PSProvider: AtomicView<LatestView = PSView> + 'static,
     PSView: TxPoolPersistentStorage,
-    ConsensusParamsProvider: ConsensusParametersProvider,
+    ChainStateProvider: ChainStateInfoProvider,
     GasPriceProvider: GasPriceProviderTrait,
     WasmChecker: WasmCheckerTrait,
     BlockImporter: BlockImporterTrait,
@@ -768,7 +768,7 @@ where
     let storage_provider = Arc::new(ps_provider);
     let verification = Verification {
         persistent_storage_provider: storage_provider.clone(),
-        consensus_parameters_provider: Arc::new(consensus_parameters_provider),
+        chain_state_info_provider: Arc::new(chain_state_info_provider),
         gas_price_provider: Arc::new(gas_price_provider),
         wasm_checker: Arc::new(wasm_checker),
         memory_pool: MemoryPool::new(),

--- a/crates/services/txpool_v2/src/service/verifications.rs
+++ b/crates/services/txpool_v2/src/service/verifications.rs
@@ -5,7 +5,7 @@ use crate::{
         InputValidationError,
     },
     ports::{
-        ConsensusParametersProvider,
+        ChainStateInfoProvider,
         GasPriceProvider,
         TxPoolPersistentStorage,
         WasmChecker,
@@ -50,7 +50,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub(crate) struct Verification<View> {
     pub persistent_storage_provider: Arc<dyn AtomicView<LatestView = View>>,
-    pub consensus_parameters_provider: Arc<dyn ConsensusParametersProvider>,
+    pub chain_state_info_provider: Arc<dyn ChainStateInfoProvider>,
     pub gas_price_provider: Arc<dyn GasPriceProvider>,
     pub wasm_checker: Arc<dyn WasmChecker>,
     pub memory_pool: MemoryPool,
@@ -67,9 +67,8 @@ where
         current_height: BlockHeight,
         utxo_validation: bool,
     ) -> Result<PoolTransaction, Error> {
-        let (version, consensus_params) = self
-            .consensus_parameters_provider
-            .latest_consensus_parameters();
+        let (version, consensus_params) =
+            self.chain_state_info_provider.latest_consensus_parameters();
 
         let unverified = UnverifiedTx(tx);
 

--- a/crates/services/txpool_v2/src/tests/mocks.rs
+++ b/crates/services/txpool_v2/src/tests/mocks.rs
@@ -2,7 +2,7 @@ use crate::{
     ports::{
         AtomicView,
         BlockImporter as BlockImporterTrait,
-        ConsensusParametersProvider,
+        ChainStateInfoProvider,
         GasPriceProvider,
         NotifyP2P,
         P2PRequests,
@@ -251,9 +251,9 @@ impl WasmChecker for MockWasmChecker {
 }
 
 mockall::mock! {
-    pub ConsensusParametersProvider {}
+    pub ChainStateInfoProvider {}
 
-    impl ConsensusParametersProvider for ConsensusParametersProvider {
+    impl ChainStateInfoProvider for ChainStateInfoProvider {
         fn latest_consensus_parameters(&self) -> (ConsensusParametersVersion, Arc<ConsensusParameters>);
     }
 }

--- a/crates/services/txpool_v2/src/tests/universe.rs
+++ b/crates/services/txpool_v2/src/tests/universe.rs
@@ -89,7 +89,7 @@ use crate::{
 };
 
 use super::mocks::{
-    MockConsensusParametersProvider,
+    MockChainStateInfoProvider,
     MockImporter,
     MockP2P,
     MockTxPoolGasPrice,
@@ -179,9 +179,8 @@ impl TestPoolUniverse {
 
         let importer = importer.unwrap_or_else(|| MockImporter::with_blocks(vec![]));
         let gas_price_provider = MockTxPoolGasPrice::new(gas_price);
-        let mut consensus_parameters_provider =
-            MockConsensusParametersProvider::default();
-        consensus_parameters_provider
+        let mut chain_state_info_provider = MockChainStateInfoProvider::default();
+        chain_state_info_provider
             .expect_latest_consensus_parameters()
             .returning(|| (0, Arc::new(Default::default())));
 
@@ -191,7 +190,7 @@ impl TestPoolUniverse {
             p2p,
             importer,
             MockDBProvider(self.mock_db.clone()),
-            consensus_parameters_provider,
+            chain_state_info_provider,
             Default::default(),
             gas_price_provider,
             MockWasmChecker { result: Ok(()) },
@@ -228,9 +227,9 @@ impl TestPoolUniverse {
         tx: Transaction,
     ) -> Result<(ArcPoolTx, Vec<ArcPoolTx>), Error> {
         if let Some(pool) = &self.pool {
-            let mut mock_consensus_params_provider =
-                MockConsensusParametersProvider::default();
-            mock_consensus_params_provider
+            let mut mock_chain_state_info_provider =
+                MockChainStateInfoProvider::default();
+            mock_chain_state_info_provider
                 .expect_latest_consensus_parameters()
                 .returning(|| (0, Arc::new(ConsensusParameters::standard())));
             let verification = Verification {
@@ -238,7 +237,7 @@ impl TestPoolUniverse {
                     self.mock_db.clone(),
                 )),
                 gas_price_provider: Arc::new(MockTxPoolGasPrice::new(0)),
-                consensus_parameters_provider: Arc::new(mock_consensus_params_provider),
+                chain_state_info_provider: Arc::new(mock_chain_state_info_provider),
                 wasm_checker: Arc::new(MockWasmChecker::new(Ok(()))),
                 memory_pool: MemoryPool::new(),
                 blacklist: BlackList::default(),
@@ -258,9 +257,8 @@ impl TestPoolUniverse {
         gas_price: GasPrice,
     ) -> Result<Vec<ArcPoolTx>, Error> {
         if let Some(pool) = &self.pool {
-            let mut mock_consensus_params_provider =
-                MockConsensusParametersProvider::default();
-            mock_consensus_params_provider
+            let mut mock_chain_state_info = MockChainStateInfoProvider::default();
+            mock_chain_state_info
                 .expect_latest_consensus_parameters()
                 .returning(|| (0, Arc::new(ConsensusParameters::standard())));
             let verification = Verification {
@@ -268,7 +266,7 @@ impl TestPoolUniverse {
                     self.mock_db.clone(),
                 )),
                 gas_price_provider: Arc::new(MockTxPoolGasPrice::new(gas_price)),
-                consensus_parameters_provider: Arc::new(mock_consensus_params_provider),
+                chain_state_info_provider: Arc::new(mock_chain_state_info),
                 wasm_checker: Arc::new(MockWasmChecker::new(Ok(()))),
                 memory_pool: MemoryPool::new(),
                 blacklist: BlackList::default(),
@@ -288,9 +286,9 @@ impl TestPoolUniverse {
         wasm_checker: MockWasmChecker,
     ) -> Result<Vec<ArcPoolTx>, Error> {
         if let Some(pool) = &self.pool {
-            let mut mock_consensus_params_provider =
-                MockConsensusParametersProvider::default();
-            mock_consensus_params_provider
+            let mut mock_chain_state_info_provider =
+                MockChainStateInfoProvider::default();
+            mock_chain_state_info_provider
                 .expect_latest_consensus_parameters()
                 .returning(move || (0, Arc::new(consensus_params.clone())));
             let verification = Verification {
@@ -298,7 +296,7 @@ impl TestPoolUniverse {
                     self.mock_db.clone(),
                 )),
                 gas_price_provider: Arc::new(MockTxPoolGasPrice::new(0)),
-                consensus_parameters_provider: Arc::new(mock_consensus_params_provider),
+                chain_state_info_provider: Arc::new(mock_chain_state_info_provider),
                 wasm_checker: Arc::new(wasm_checker),
                 memory_pool: MemoryPool::new(),
                 blacklist: BlackList::default(),

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -283,6 +283,19 @@ impl BlockHeader {
         }
     }
 
+    /// Set the stf version
+    pub fn set_stf_version(&mut self, version: StateTransitionBytecodeVersion) {
+        match self {
+            BlockHeader::V1(header) => {
+                header.set_stf_version(version);
+            }
+            #[cfg(feature = "fault-proving")]
+            BlockHeader::V2(header) => {
+                header.set_stf_version(version);
+            }
+        }
+    }
+
     /// Set the application hash
     pub fn set_application_hash(&mut self, hash: Bytes32) {
         match self {

--- a/crates/types/src/blockchain/header/v1.rs
+++ b/crates/types/src/blockchain/header/v1.rs
@@ -148,6 +148,14 @@ impl BlockHeaderV1 {
         self.recalculate_metadata();
     }
 
+    pub(crate) fn set_stf_version(
+        &mut self,
+        version: super::StateTransitionBytecodeVersion,
+    ) {
+        self.application_mut().state_transition_bytecode_version = version;
+        self.recalculate_metadata();
+    }
+
     pub(crate) fn set_application_hash(&mut self, hash: Bytes32) {
         self.consensus_mut().generated.application_hash = hash;
     }

--- a/crates/types/src/blockchain/header/v2.rs
+++ b/crates/types/src/blockchain/header/v2.rs
@@ -171,6 +171,14 @@ impl BlockHeaderV2 {
         self.recalculate_metadata();
     }
 
+    pub(crate) fn set_stf_version(
+        &mut self,
+        version: super::StateTransitionBytecodeVersion,
+    ) {
+        self.application_mut().state_transition_bytecode_version = version;
+        self.recalculate_metadata();
+    }
+
     pub(crate) fn set_application_hash(&mut self, hash: Bytes32) {
         self.consensus_mut().generated.application_hash = hash;
     }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/2754

## Description
This is a follow-up PR to the "[new GraphQL extension data](https://github.com/FuelLabs/fuel-core/pull/2715)" PR created to solve some unaddressed comments:
- https://github.com/FuelLabs/fuel-core/pull/2715#discussion_r1967573829
- https://github.com/FuelLabs/fuel-core/pull/2715#discussion_r1967551776

The main change is: _"Renamed `ConsensusParametersProvider` to `ChainStateInfoProvider` because it is now providing more than just info about consensus parameters."_

Apart from that it also contains some other minor renames and a fix to initialization of the state transition function version.

### Before requesting review
- [X] I have reviewed the code myself