### PR TITLE
Change CODEOWNERS to use team instead of users

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,6 @@ docs/ @xgreenx @Dentosal @MitchTurner @netrome
 crates/fraud_proofs @xgreenx @netrome @acerone85 @rymnc
 
 # Code owners for common files
-CHANGELOG.md @xgreenx @Dentosal @MitchTurner @netrome @acerone85 @rafal-ch @rymnc @AurelienFT
-.changes/ @xgreenx @Dentosal @MitchTurner @netrome @acerone85 @rafal-ch @rymnc @AurelienFT
-Cargo.lock @xgreenx @Dentosal @MitchTurner @netrome @acerone85 @rafal-ch @rymnc @AurelienFT
+CHANGELOG.md @FuelLabs/client
+.changes/ @FuelLabs/client
+Cargo.lock @FuelLabs/client


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

* [Classic PR](?expand=1&template=default.md)
* [Bump version](?expand=1&template=bump_version.md)
