### PR TITLE
Refactor: Move ClampedPercentage type to common folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4201,6 +4201,7 @@ dependencies = [
 name = "fuel-gas-price-algorithm"
 version = "0.41.7"
 dependencies = [
+ "fuel-core-types 0.41.7",
  "proptest",
  "rand",
  "serde",

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -51,6 +51,7 @@ use fuel_core_types::{
     signer::SignMode,
     tai64::Tai64,
 };
+use fuel_core_types::clamped_percentage::ClampedPercentage;
 //#[cfg(not(feature = "parallel-executor"))]
 use fuel_core_upgradable_executor::executor::Executor;
 use std::sync::Arc;
@@ -102,12 +103,13 @@ mod universal_gas_price_provider_tests {
 
     use super::*;
     use proptest::proptest;
+    use fuel_core_types::clamped_percentage::ClampedPercentage;
 
     fn _worst_case__correctly_calculates_value(
         gas_price: u64,
         starting_height: u32,
         block_horizon: u32,
-        percentage: u16,
+        percentage: ClampedPercentage,
     ) {
         // given
         let subject =
@@ -122,7 +124,7 @@ mod universal_gas_price_provider_tests {
 
         for _ in 0..block_horizon {
             let change_amount =
-                actual.saturating_mul(percentage as u64).saturating_div(100);
+                actual.saturating_mul(*percentage as u64).saturating_div(100);
             actual = actual.saturating_add(change_amount);
         }
 
@@ -137,6 +139,7 @@ mod universal_gas_price_provider_tests {
             block_horizon in 0..10_000u32,
             percentage: u16,
         ) {
+            let percentage = ClampedPercentage::new(percentage as u8);
             _worst_case__correctly_calculates_value(
                 gas_price,
                 starting_height,
@@ -154,6 +157,8 @@ mod universal_gas_price_provider_tests {
             block_horizon in 0..10_000u32,
             percentage: u16
         ) {
+            // Convert u16 to ClampedPercentage
+            let percentage = ClampedPercentage::new(percentage as u8);
             // given
             let subject = UniversalGasPriceProvider::new(starting_height, gas_price, percentage);
 
@@ -170,7 +175,7 @@ mod universal_gas_price_provider_tests {
     fn _next_gas_price__correctly_calculates_value(
         gas_price: u64,
         starting_height: u32,
-        percentage: u16,
+        percentage: ClampedPercentage,
     ) {
         // given
         let subject =
@@ -181,7 +186,7 @@ mod universal_gas_price_provider_tests {
 
         // then
         let change_amount = gas_price
-            .saturating_mul(percentage as u64)
+            .saturating_mul(*percentage as u64)
             .saturating_div(100);
         let actual = gas_price.saturating_add(change_amount);
 
@@ -195,6 +200,7 @@ mod universal_gas_price_provider_tests {
             starting_height: u32,
             percentage: u16,
         ) {
+            let percentage = ClampedPercentage::new(percentage as u8);
             _next_gas_price__correctly_calculates_value(
                 gas_price,
                 starting_height,
@@ -212,7 +218,7 @@ pub struct UniversalGasPriceProvider<Height, GasPrice> {
     /// Shared state of latest gas price data
     latest_gas_price: LatestGasPrice<Height, GasPrice>,
     /// The max percentage the gas price can increase per block
-    percentage: u16,
+    percentage: ClampedPercentage,
 }
 
 impl<Height, GasPrice> Clone for UniversalGasPriceProvider<Height, GasPrice> {
@@ -226,7 +232,7 @@ impl<Height, GasPrice> Clone for UniversalGasPriceProvider<Height, GasPrice> {
 
 impl<Height, GasPrice> UniversalGasPriceProvider<Height, GasPrice> {
     #[cfg(test)]
-    pub fn new(height: Height, price: GasPrice, percentage: u16) -> Self {
+    pub fn new(height: Height, price: GasPrice, percentage: ClampedPercentage) -> Self {
         let latest_gas_price = LatestGasPrice::new(height, price);
         Self {
             latest_gas_price,
@@ -236,7 +242,7 @@ impl<Height, GasPrice> UniversalGasPriceProvider<Height, GasPrice> {
 
     pub fn new_from_inner(
         inner: LatestGasPrice<Height, GasPrice>,
-        percentage: u16,
+        percentage: ClampedPercentage,
     ) -> Self {
         Self {
             latest_gas_price: inner,
@@ -257,7 +263,7 @@ impl UniversalGasPriceProvider<u32, u64> {
         let percentage = self.percentage;
 
         let change = latest_price
-            .saturating_mul(percentage as u64)
+            .saturating_mul(*percentage as u64)
             .saturating_div(100);
 
         latest_price.saturating_add(change)
@@ -278,7 +284,7 @@ impl GasPriceEstimate for UniversalGasPriceProvider<u32, u64> {
         let worst = cumulative_percentage_change(
             best_gas_price,
             best_height,
-            percentage as u64,
+            *percentage as u64,
             height.into(),
         );
         Some(worst)

--- a/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests.rs
+++ b/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 
 use super::*;
+use fuel_core_types::clamped_percentage::ClampedPercentage;
 
 #[cfg(test)]
 mod producer_gas_price_tests;
@@ -9,12 +10,13 @@ fn build_provider<A>(
     algorithm: A,
     height: u32,
     price: u64,
-    percentage: u16,
+    percentage: ClampedPercentage,
 ) -> FuelGasPriceProvider<A, u32, u64>
 where
     A: Send + Sync,
 {
     let algorithm = SharedGasPriceAlgo::new_with_algorithm(algorithm);
+    // let clamped_percentage = ClampedPercentage::new(percentage as u8);
     let latest_gas_price = UniversalGasPriceProvider::new(height, price, percentage);
     FuelGasPriceProvider::new(algorithm, latest_gas_price)
 }

--- a/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests/producer_gas_price_tests.rs
+++ b/crates/fuel-core/src/service/adapters/fuel_gas_price_provider/tests/producer_gas_price_tests.rs
@@ -4,13 +4,14 @@ use fuel_core_gas_price_service::{
     static_updater::StaticAlgorithm,
 };
 use fuel_core_producer::block_producer::gas_price::GasPriceProvider;
+use fuel_core_types::clamped_percentage::ClampedPercentage;
 
 #[test]
 fn production_gas_price__if_requested_block_height_is_latest_return_gas_price() {
     // given
     let price = 33;
     let algo = StaticAlgorithm::new(price);
-    let gas_price_provider = build_provider(algo.clone(), 0, price, 10);
+    let gas_price_provider = build_provider(algo.clone(), 0, price, ClampedPercentage::new(10));
 
     // when
     let expected_price = algo.next_gas_price();
@@ -25,7 +26,7 @@ fn dry_run_gas_price__calculates_correctly_based_on_percentage() {
     // given
     let height = 123;
     let price = 33;
-    let percentage = 10;
+    let percentage = ClampedPercentage::new(10);
     let algo = StaticAlgorithm::new(price);
     let gas_price_provider = build_provider(algo.clone(), height, price, percentage);
 
@@ -33,7 +34,7 @@ fn dry_run_gas_price__calculates_correctly_based_on_percentage() {
     let actual = gas_price_provider.dry_run_gas_price().unwrap();
 
     // then
-    let change_amount = price.saturating_mul(percentage as u64).saturating_div(100);
+    let change_amount = price.saturating_mul(*percentage as u64).saturating_div(100);
     let expected = price + change_amount;
     assert_eq!(expected, actual);
 }

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -60,6 +60,7 @@ use fuel_core_storage::{
 #[cfg(feature = "relayer")]
 use fuel_core_types::blockchain::primitives::DaBlockHeight;
 use fuel_core_types::signer::SignMode;
+use fuel_core_types::clamped_percentage::ClampedPercentage;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -222,9 +223,10 @@ pub fn init_sub_services(
         database.on_chain().clone(),
     )?;
     let (gas_price_algo, latest_gas_price) = gas_price_service_v1.shared.clone();
+    let clamped_percentage = ClampedPercentage::new(DEFAULT_GAS_PRICE_CHANGE_PERCENT as u8);
     let universal_gas_price_provider = UniversalGasPriceProvider::new_from_inner(
         latest_gas_price,
-        DEFAULT_GAS_PRICE_CHANGE_PERCENT,
+        clamped_percentage,
     );
 
     let producer_gas_price_provider = FuelGasPriceProvider::new(

--- a/crates/fuel-gas-price-algorithm/Cargo.toml
+++ b/crates/fuel-gas-price-algorithm/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+fuel-core-types = { path = "../types" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/fuel-gas-price-algorithm/src/v1.rs
+++ b/crates/fuel-gas-price-algorithm/src/v1.rs
@@ -1,4 +1,5 @@
 use crate::utils::cumulative_percentage_change;
+use fuel_core_types::clamped_percentage::ClampedPercentage;
 use std::{
     cmp::{
         max,
@@ -318,36 +319,6 @@ impl L2ActivityTracker {
 
     pub fn block_activity_threshold(&self) -> ClampedPercentage {
         self.block_activity_threshold
-    }
-}
-
-/// A value that represents a value between 0 and 100. Higher values are clamped to 100
-#[derive(
-    serde::Serialize, serde::Deserialize, Debug, Copy, Clone, PartialEq, PartialOrd,
-)]
-pub struct ClampedPercentage {
-    value: u8,
-}
-
-impl ClampedPercentage {
-    pub fn new(maybe_value: u8) -> Self {
-        Self {
-            value: maybe_value.min(100),
-        }
-    }
-}
-
-impl From<u8> for ClampedPercentage {
-    fn from(value: u8) -> Self {
-        Self::new(value)
-    }
-}
-
-impl core::ops::Deref for ClampedPercentage {
-    type Target = u8;
-
-    fn deref(&self) -> &Self::Target {
-        &self.value
     }
 }
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -38,7 +38,7 @@ aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 tokio = { workspace = true, features = ["macros"] }
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 alloc = ["fuel-vm-private/alloc", "educe"]
 serde = ["dep:serde", "fuel-vm-private/serde"]
 da-compression = ["fuel-vm-private/da-compression"]

--- a/crates/types/src/clamped_percentage.rs
+++ b/crates/types/src/clamped_percentage.rs
@@ -1,0 +1,30 @@
+/// A value that represents a value between 0 and 100. Higher values are clamped to 100
+#[derive(
+    serde::Serialize, serde::Deserialize, Debug, Copy, Clone, PartialEq, PartialOrd,
+)]
+pub struct ClampedPercentage {
+    value: u8,
+}
+
+impl ClampedPercentage {
+     /// Creates a new `ClampedPercentage` by clamping the given value to the range [0, 100].
+    pub fn new(maybe_value: u8) -> Self {
+        Self {
+            value: maybe_value.min(100),
+        }
+    }
+}
+
+impl From<u8> for ClampedPercentage {
+    fn from(value: u8) -> Self {
+        Self::new(value)
+    }
+}
+
+impl core::ops::Deref for ClampedPercentage {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -32,6 +32,8 @@ pub mod blockchain;
 pub mod entities;
 pub mod services;
 pub mod signer;
+/// A module that provides functionality for working with clamped percentages.
+pub mod clamped_percentage;
 
 /// Re-export of some fuel-vm types
 pub mod fuel_vm {


### PR DESCRIPTION
## Description:

• Moved ClampedPercentage from `fuel-gas-price-algorithm` to `crates/types/src/` for better modularity and reuse.
• Updated references in `fuel_gas_price_provider` and `genesis` adapters.
• No functional changes, just refactoring.

## Testing:

 Ran `cargo test --all-targets`, and all tests passed.
 
 ## Linked Issue:
• close #2773

Let me know if any further adjustments are needed! 