### PR TITLE
fault_proving(storage_traits): refactor to allow usage of arbitrary `TableColumn`

### DIFF
--- a/.changes/changed/2793.md
+++ b/.changes/changed/2793.md
@@ -1,0 +1,1 @@
+Moved common merkle storage trait implementations to `fuel-core-storage` and made it easier to setup a set of columns that need merkleization.

--- a/crates/proof_system/global_merkle_root/service/src/ports.rs
+++ b/crates/proof_system/global_merkle_root/service/src/ports.rs
@@ -1,8 +1,9 @@
 use std::future::Future;
 
-use fuel_core_global_merkle_root_storage::column::Column;
+use fuel_core_global_merkle_root_storage::column::TableColumn;
 use fuel_core_storage::{
     kv_store::KeyValueInspect,
+    merkle::column::MerkleizedColumn,
     transactional::Modifiable,
 };
 use fuel_core_types::blockchain::block::Block;
@@ -17,6 +18,12 @@ pub trait BlockStream {
 }
 
 /// The storage requirements for the merkle root service
-pub trait ServiceStorage: KeyValueInspect<Column = Column> + Modifiable {}
+pub trait ServiceStorage:
+    KeyValueInspect<Column = MerkleizedColumn<TableColumn>> + Modifiable
+{
+}
 
-impl<T> ServiceStorage for T where T: KeyValueInspect<Column = Column> + Modifiable {}
+impl<T> ServiceStorage for T where
+    T: KeyValueInspect<Column = MerkleizedColumn<TableColumn>> + Modifiable
+{
+}

--- a/crates/proof_system/global_merkle_root/storage/src/column.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/column.rs
@@ -1,12 +1,3 @@
-use alloc::{
-    format,
-    string::{
-        String,
-        ToString,
-    },
-};
-use fuel_core_storage::kv_store::StorageColumn;
-
 /// Almost in the case of all tables we need to prove exclusion of entries,
 /// in the case of malicious block.
 #[repr(u32)]
@@ -47,62 +38,11 @@ pub enum TableColumn {
 
 impl TableColumn {
     /// The total count of variants in the enum.
-    const COUNT: usize = <Self as strum::EnumCount>::COUNT;
+    pub const COUNT: usize = <Self as strum::EnumCount>::COUNT;
+}
 
-    /// Returns the `usize` representation of the `Column`.
-    pub fn as_u32(&self) -> u32 {
+impl fuel_core_storage::merkle::column::AsU32 for TableColumn {
+    fn as_u32(&self) -> u32 {
         *self as u32
-    }
-}
-
-/// Almost in the case of all tables we need to prove exclusion of entries,
-/// in the case of malicious block.
-#[repr(u32)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Column {
-    /// The column with the specific data.
-    TableColumn(TableColumn),
-    /// The column with the merkle tree nodes.
-    MerkleDataColumn(TableColumn),
-    /// The merkle metadata column.
-    MerkleMetadataColumn,
-}
-
-impl Column {
-    /// The total count of variants in the enum.
-    pub const COUNT: usize = TableColumn::COUNT + TableColumn::COUNT + 1;
-
-    /// The start of the merkle data columns.
-    pub const MERKLE_DATA_COLUMNS_START: u32 = u16::MAX as u32;
-
-    /// Returns the `usize` representation of the `Column`.
-    pub fn as_u32(&self) -> u32 {
-        match self {
-            Self::TableColumn(column) => column.as_u32(),
-            Self::MerkleDataColumn(column) => {
-                Self::MERKLE_DATA_COLUMNS_START.wrapping_add(column.as_u32())
-            }
-            Self::MerkleMetadataColumn => u32::MAX,
-        }
-    }
-}
-
-impl StorageColumn for Column {
-    fn name(&self) -> String {
-        match self {
-            Self::TableColumn(column) => {
-                let str: &str = column.into();
-                str.to_string()
-            }
-            Self::MerkleDataColumn(column) => {
-                let str: &str = column.into();
-                format!("Merkle{}", str)
-            }
-            Column::MerkleMetadataColumn => "MerkleMetadata".to_string(),
-        }
-    }
-
-    fn id(&self) -> u32 {
-        self.as_u32()
     }
 }

--- a/crates/proof_system/global_merkle_root/storage/src/compute.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/compute.rs
@@ -4,6 +4,7 @@ use fuel_core_storage::{
         KeyValueInspect,
         StorageColumn,
     },
+    merkle::column::MerkleizedColumn,
     structured_storage::TableWithBlueprint,
     tables::{
         BlobData,
@@ -28,7 +29,7 @@ use fuel_core_types::{
 };
 
 use crate::{
-    column::Column,
+    column::TableColumn,
     merkle::{
         DummyStorage,
         Merkleized,
@@ -44,14 +45,15 @@ pub trait ComputeStateRoot {
     /// Compute the merkle root of the specific table
     fn merkle_root<Table>(&self) -> Result<MerkleRoot, StorageError>
     where
-        Table: Mappable + MerkleizedTableColumn,
+        Table: Mappable + MerkleizedTableColumn<TableColumn = TableColumn>,
         Table: TableWithBlueprint,
-        Table::Blueprint: BlueprintInspect<Table, DummyStorage<Column>>;
+        Table::Blueprint:
+            BlueprintInspect<Table, DummyStorage<MerkleizedColumn<TableColumn>>>;
 }
 
 impl<Storage> ComputeStateRoot for StorageTransaction<Storage>
 where
-    Storage: KeyValueInspect<Column = Column>,
+    Storage: KeyValueInspect<Column = MerkleizedColumn<TableColumn>>,
 {
     fn state_root(&self) -> Result<Bytes32, StorageError> {
         let roots = [
@@ -77,9 +79,10 @@ where
 
     fn merkle_root<Table>(&self) -> Result<MerkleRoot, StorageError>
     where
-        Table: Mappable + MerkleizedTableColumn,
+        Table: Mappable + MerkleizedTableColumn<TableColumn = TableColumn>,
         Table: TableWithBlueprint,
-        Table::Blueprint: BlueprintInspect<Table, DummyStorage<Column>>,
+        Table::Blueprint:
+            BlueprintInspect<Table, DummyStorage<MerkleizedColumn<TableColumn>>>,
     {
         <Self as MerkleRootStorage<u32, Merkleized<Table>>>::root(
             self,

--- a/crates/proof_system/global_merkle_root/storage/src/merkle/smt.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/merkle/smt.rs
@@ -1,5 +1,5 @@
 use crate::{
-    column::Column,
+    column::TableColumn,
     merkle::MerkleizedTableColumn,
 };
 use fuel_core_storage::{
@@ -8,6 +8,10 @@ use fuel_core_storage::{
         postcard::Postcard,
         primitive::Primitive,
         raw::Raw,
+    },
+    merkle::column::{
+        AsU32,
+        MerkleizedColumn,
     },
     structured_storage::TableWithBlueprint,
     tables::merkle::SparseMerkleMetadata,
@@ -25,15 +29,16 @@ impl<Table> Mappable for MerkleData<Table> {
     type OwnedValue = Self::Value;
 }
 
-impl<Table> TableWithBlueprint for MerkleData<Table>
+impl<Table, TC> TableWithBlueprint for MerkleData<Table>
 where
-    Table: MerkleizedTableColumn,
+    Table: MerkleizedTableColumn<TableColumn = TC>,
+    TC: core::fmt::Debug + Copy + strum::EnumCount + AsU32,
 {
     type Blueprint = Plain<Raw, Postcard>;
-    type Column = Column;
+    type Column = MerkleizedColumn<TC>;
 
-    fn column() -> Column {
-        Column::MerkleDataColumn(Table::table_column())
+    fn column() -> Self::Column {
+        Self::Column::MerkleDataColumn(Table::table_column())
     }
 }
 
@@ -49,9 +54,9 @@ impl Mappable for MerkleMetadata {
 
 impl TableWithBlueprint for MerkleMetadata {
     type Blueprint = Plain<Primitive<4>, Postcard>;
-    type Column = Column;
+    type Column = MerkleizedColumn<TableColumn>;
 
-    fn column() -> Column {
-        Column::MerkleMetadataColumn
+    fn column() -> Self::Column {
+        Self::Column::MerkleMetadataColumn
     }
 }

--- a/crates/proof_system/global_merkle_root/storage/src/structured_storage/blobs.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/structured_storage/blobs.rs
@@ -5,6 +5,8 @@ use crate::{
 use fuel_core_storage::tables::BlobData;
 
 impl MerkleizedTableColumn for BlobData {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::Blobs
     }

--- a/crates/proof_system/global_merkle_root/storage/src/structured_storage/coins.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/structured_storage/coins.rs
@@ -5,6 +5,8 @@ use crate::{
 use fuel_core_storage::tables::Coins;
 
 impl MerkleizedTableColumn for Coins {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::Coins
     }

--- a/crates/proof_system/global_merkle_root/storage/src/structured_storage/contracts.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/structured_storage/contracts.rs
@@ -8,12 +8,16 @@ use fuel_core_storage::tables::{
 };
 
 impl MerkleizedTableColumn for ContractsRawCode {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::ContractsRawCode
     }
 }
 
 impl MerkleizedTableColumn for ContractsLatestUtxo {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::ContractsLatestUtxo
     }

--- a/crates/proof_system/global_merkle_root/storage/src/structured_storage/messages.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/structured_storage/messages.rs
@@ -5,6 +5,8 @@ use crate::{
 use fuel_core_storage::tables::Messages;
 
 impl MerkleizedTableColumn for Messages {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::Messages
     }

--- a/crates/proof_system/global_merkle_root/storage/src/structured_storage/transactions.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/structured_storage/transactions.rs
@@ -5,6 +5,8 @@ use crate::{
 use fuel_core_storage::tables::ProcessedTransactions;
 
 impl MerkleizedTableColumn for ProcessedTransactions {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::ProcessedTransactions
     }

--- a/crates/proof_system/global_merkle_root/storage/src/structured_storage/upgrades.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/structured_storage/upgrades.rs
@@ -9,18 +9,24 @@ use fuel_core_storage::tables::{
 };
 
 impl MerkleizedTableColumn for ConsensusParametersVersions {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::ConsensusParametersVersions
     }
 }
 
 impl MerkleizedTableColumn for StateTransitionBytecodeVersions {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::StateTransitionBytecodeVersions
     }
 }
 
 impl MerkleizedTableColumn for UploadedBytecodes {
+    type TableColumn = TableColumn;
+
     fn table_column() -> TableColumn {
         TableColumn::UploadedBytecodes
     }

--- a/crates/proof_system/global_merkle_root/storage/src/update.rs
+++ b/crates/proof_system/global_merkle_root/storage/src/update.rs
@@ -1,5 +1,5 @@
 use crate::{
-    column::Column,
+    column::TableColumn,
     error::{
         InvalidBlock,
         InvariantViolation,
@@ -21,6 +21,7 @@ use alloc::{
 };
 use fuel_core_storage::{
     kv_store::KeyValueInspect,
+    merkle::column::MerkleizedColumn,
     transactional::StorageTransaction,
     StorageAsMut,
     StorageAsRef,
@@ -100,7 +101,7 @@ pub trait UpdateMerkleizedTables {
 
 impl<Storage> UpdateMerkleizedTables for StorageTransaction<Storage>
 where
-    Storage: KeyValueInspect<Column = Column>,
+    Storage: KeyValueInspect<Column = MerkleizedColumn<TableColumn>>,
 {
     #[tracing::instrument(skip(self, block))]
     fn update_merkleized_tables(
@@ -134,7 +135,7 @@ struct UpdateMerkleizedTablesTransaction<'a, Storage> {
 
 impl<'a, Storage> UpdateMerkleizedTablesTransaction<'a, Storage>
 where
-    Storage: KeyValueInspect<Column = Column>,
+    Storage: KeyValueInspect<Column = MerkleizedColumn<TableColumn>>,
 {
     #[tracing::instrument(skip(self, block))]
     pub fn process_block(&mut self, block: &Block) -> crate::Result<()> {
@@ -585,6 +586,9 @@ mod tests {
         Rng,
         SeedableRng,
     };
+
+    /// type alias for the tests using `Column`
+    type Column = super::MerkleizedColumn<TableColumn>;
 
     #[test]
     /// When encountering a transaction with a coin output,

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -38,6 +38,7 @@ pub mod codec;
 pub mod column;
 pub mod iter;
 pub mod kv_store;
+pub mod merkle;
 pub mod structured_storage;
 pub mod tables;
 #[cfg(feature = "test-helpers")]

--- a/crates/storage/src/merkle.rs
+++ b/crates/storage/src/merkle.rs
@@ -1,0 +1,7 @@
+//! This module provides helpers to work with merkle trees
+//! You just need to provide a set of columns and the rest of the merkle* traits
+//! will be implemented for you.
+
+pub mod column;
+
+pub mod sparse;

--- a/crates/storage/src/merkle/column.rs
+++ b/crates/storage/src/merkle/column.rs
@@ -1,0 +1,73 @@
+//! This module defines a `MerklizedColumn` type which defines data, merkledata and merkle metadata for it
+use crate::kv_store::StorageColumn;
+use alloc::{
+    format,
+    string::{
+        String,
+        ToString,
+    },
+};
+
+/// Almost in the case of all tables we need to prove exclusion of entries,
+/// in the case of malicious block.
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum MerkleizedColumn<TC> {
+    /// The column with the specific data.
+    TableColumn(TC),
+    /// The column with the merkle tree nodes.
+    MerkleDataColumn(TC),
+    /// The merkle metadata column.
+    MerkleMetadataColumn,
+}
+
+/// The trait to convert the column to the `u32`.
+pub trait AsU32 {
+    /// Returns the `u32` representation of the `Column`.
+    fn as_u32(&self) -> u32;
+}
+
+impl<TC> MerkleizedColumn<TC>
+where
+    TC: strum::EnumCount + AsU32,
+{
+    /// The total count of variants in the enum.
+    /// Since we have two columns for each table column and one for the merkle data,
+    /// we have to multiply the count of the table columns by 2 and add one for the merkle metadata.
+    pub const COUNT: usize = TC::COUNT * 2 + 1;
+
+    /// The start of the merkle data columns.
+    pub const MERKLE_DATA_COLUMNS_START: u32 = u16::MAX as u32;
+
+    /// Returns the `u32` representation of the `Column`.
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::TableColumn(column) => column.as_u32(),
+            Self::MerkleDataColumn(column) => {
+                Self::MERKLE_DATA_COLUMNS_START.wrapping_add(column.as_u32())
+            }
+            Self::MerkleMetadataColumn => u32::MAX,
+        }
+    }
+}
+
+impl<TC> StorageColumn for MerkleizedColumn<TC>
+where
+    TC: core::fmt::Debug + Copy + strum::EnumCount + AsU32,
+{
+    fn name(&self) -> String {
+        match self {
+            Self::TableColumn(column) => {
+                format!("{:?}", column)
+            }
+            Self::MerkleDataColumn(column) => {
+                format!("Merkle{:?}", column)
+            }
+            MerkleizedColumn::MerkleMetadataColumn => "MerkleMetadata".to_string(),
+        }
+    }
+
+    fn id(&self) -> u32 {
+        self.as_u32()
+    }
+}


### PR DESCRIPTION


## Linked Issues/PRs
<!-- List of related issues/PRs -->
- part of https://github.com/FuelLabs/fuel-core/issues/2775

## Description
<!-- List of detailed changes -->
- instead of tying `MerkleizedTableColumn` to the `TableColumn` variant only in use by the global state root service, this refactors the trait to accept an arbitrary `TableColumn` that is returned when `table_column` is called.

we've copied all the common functionality required by both destinations (`fuel-core-global-merkle-root-storage` and `fuel-core-compression-service`), you may see that we haven't deleted the implementations from the `fuel-core-global-merkle-root-storage` crate yet, because that crate doesn't use newtypes and we have an orphan rule error. will be addressed in follow up. For the person implementing the follow up, you can remove -

- `fuel-core-global-merkle-root/src/merkle.rs`
- `fuel-core-global-merkle-root/src/merkle/smt.rs`

and reuse the traits & types from `fuel-core-storage` instead

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
