### PR TITLE
fix: Mark (temporarily) dead code with `#[allow(dead_code)]`

### DIFF
--- a/crates/fuel-core/src/service/adapters/consensus_module/poa/pre_confirmation_signature/tx_receiver.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module/poa/pre_confirmation_signature/tx_receiver.rs
@@ -11,6 +11,9 @@ use fuel_core_types::{
     services::p2p::PreconfirmationStatus,
 };
 
+// TODO(#2739): Remove when integrated
+// link: https://github.com/FuelLabs/fuel-core/issues/2739
+#[allow(dead_code)]
 pub struct MPSCTxReceiver<T> {
     receiver: tokio::sync::mpsc::Receiver<T>,
 }

--- a/crates/services/consensus_module/poa/src/pre_confirmation_signature_service.rs
+++ b/crates/services/consensus_module/poa/src/pre_confirmation_signature_service.rs
@@ -27,6 +27,9 @@ pub type Signed<K, T> = <K as SigningKey>::Signature<T>;
 #[cfg(test)]
 pub mod tests;
 
+// TODO(#2739): Remove when integrated
+// link: https://github.com/FuelLabs/fuel-core/issues/2739
+#[allow(dead_code)]
 pub struct PreConfirmationSignatureTask<
     TxReceiver,
     Broadcast,

--- a/crates/services/consensus_module/poa/src/pre_confirmation_signature_service/parent_signature.rs
+++ b/crates/services/consensus_module/poa/src/pre_confirmation_signature_service/parent_signature.rs
@@ -1,6 +1,9 @@
 use super::*;
 use std::future::Future;
 
+// TODO(#2739): Remove when integrated
+// link: https://github.com/FuelLabs/fuel-core/issues/2739
+#[allow(dead_code)]
 /// Used to sign the delegate keys, proving that the parent key approves of the delegation
 pub trait ParentSignature<T: Send>: Send {
     type SignedData: Send;


### PR DESCRIPTION
Currently `master` fails to build on some toolchains (e.g. `cargo 1.81.0-nightly (a515d4634 2024-07-02)`) due to some temporary dead code. This PR adds a few `#[allow(dead_code)]` to resolve this until https://github.com/FuelLabs/fuel-core/issues/2739 is done.