### PR TITLE
Fix version of symbolic common

### DIFF
--- a/version-compatibility/forkless-upgrade/Cargo.toml
+++ b/version-compatibility/forkless-upgrade/Cargo.toml
@@ -14,6 +14,8 @@ hex = "0.4.3"
 rand = "0.8"
 tempfile = "3.4"
 tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
+# TODO: Remove after https://github.com/FuelLabs/fuel-core/issues/2607
+symbolic-common = "=12.13.0"
 
 # Neutral deps
 fuel-core = { path = "../../crates/fuel-core", features = ["test-helpers"] }

--- a/version-compatibility/forkless-upgrade/src/lib.rs
+++ b/version-compatibility/forkless-upgrade/src/lib.rs
@@ -1,6 +1,10 @@
 #![deny(unused_crate_dependencies)]
 #![deny(warnings)]
 
+// TODO: Remove after https://github.com/FuelLabs/fuel-core/issues/2607
+#[cfg(test)]
+use symbolic_common as _;
+
 #[cfg(test)]
 use fuel_core::{
     chain_config::{


### PR DESCRIPTION
## Description
Latest minor release of `symbolic-common` has bumped their MSRV version to something we don't support (https://github.com/getsentry/symbolic/commit/0ba5f9cef6904da0e48d26b685f66f0dcc880b8e#diff-afd9b4dda3be108e72706e331af2db47183abf528db1e1ca470e616648fc67e7R57). As it's a minor and it get automatically updated we need to pin it to avoid automatic updates to avoid CI error (https://github.com/FuelLabs/fuel-core/actions/runs/13678878856/job/38245904554).

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
