### PR TITLE
Revert fix version of symbolic-common dependency

### DIFF
--- a/version-compatibility/forkless-upgrade/Cargo.toml
+++ b/version-compatibility/forkless-upgrade/Cargo.toml
@@ -14,8 +14,6 @@ hex = "0.4.3"
 rand = "0.8"
 tempfile = "3.4"
 tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
-# TODO: Remove after https://github.com/FuelLabs/fuel-core/issues/2607
-symbolic-common = "=12.13.0"
 
 # Neutral deps
 fuel-core = { path = "../../crates/fuel-core", features = ["test-helpers"] }

--- a/version-compatibility/forkless-upgrade/src/lib.rs
+++ b/version-compatibility/forkless-upgrade/src/lib.rs
@@ -1,10 +1,6 @@
 #![deny(unused_crate_dependencies)]
 #![deny(warnings)]
 
-// TODO: Remove after https://github.com/FuelLabs/fuel-core/issues/2607
-#[cfg(test)]
-use symbolic_common as _;
-
 #[cfg(test)]
 use fuel_core::{
     chain_config::{


### PR DESCRIPTION
## Description
`symbolic-common` reverted their change and now has a MSRV set to 1.73.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

