### PR TITLE
Add `Try`-like macros for `TaskNextAction`, use in the pre-conf task

### DIFF
--- a/.changes/added/2824.md
+++ b/.changes/added/2824.md
@@ -1,0 +1,1 @@
+Introduce new `Try`-like methods for the `TaskNextAction`

--- a/.changes/changed/2824.md
+++ b/.changes/changed/2824.md
@@ -1,0 +1,1 @@
+Improve conditions where `Error`s in the `PreConfirmationSignatureTask` stop the service

--- a/crates/services/consensus_module/poa/src/pre_confirmation_signature_service.rs
+++ b/crates/services/consensus_module/poa/src/pre_confirmation_signature_service.rs
@@ -1,6 +1,7 @@
 use error::Result;
 use fuel_core_services::{
     try_or_continue,
+    try_or_stop,
     EmptyShared,
     RunnableService,
     RunnableTask,
@@ -96,66 +97,6 @@ where
     }
 }
 
-impl<Preconfirmations, Parent, DelegateKey, TxRcv, Brdcst, Gen, Trigger>
-    PreConfirmationSignatureTask<TxRcv, Brdcst, Parent, Gen, DelegateKey, Trigger>
-where
-    TxRcv: TxReceiver<Txs = Preconfirmations>,
-    Brdcst: Broadcast<
-        DelegateKey = DelegateKey,
-        ParentKey = Parent,
-        Preconfirmations = Preconfirmations,
-    >,
-    Gen: KeyGenerator<Key = DelegateKey>,
-    Trigger: KeyRotationTrigger,
-    DelegateKey: SigningKey,
-    Parent: ParentSignature,
-    Preconfirmations: serde::Serialize + Send,
-{
-    pub async fn _run(&mut self) -> TaskNextAction {
-        tracing::debug!("Running pre-confirmation task");
-        tokio::select! {
-            res = self.tx_receiver.receive() => {
-                tracing::debug!("Received transactions");
-                let pre_confirmations = try_or_continue!(res);
-                let signature = try_or_continue!(self.current_delegate_key.sign(&pre_confirmations));
-                let expiration = self.current_delegate_key.expiration();
-                try_or_continue!(
-                    self.broadcast.broadcast_preconfirmations(pre_confirmations, signature, expiration).await,
-                    |err| tracing::error!("Failed to broadcast pre-confirmations: {:?}", err)
-                );
-            }
-            res = self.key_rotation_trigger.next_rotation() => {
-                tracing::debug!("Key rotation triggered");
-                let expiration = try_or_continue!(res);
-
-                let (new_delegate_key, sealed) = try_or_continue!(create_delegate_key(
-                    &mut self.key_generator,
-                    &self.parent_signature,
-                    expiration,
-                ).await);
-
-                self.current_delegate_key = new_delegate_key;
-                self.sealed_delegate_message = sealed.clone();
-
-                try_or_continue!(
-                    self.broadcast.broadcast_delegate_key(sealed.entity, sealed.signature).await,
-                    |err| tracing::error!("Failed to broadcast newly generated delegate key: {:?}", err)
-                );
-            }
-            _ = self.echo_delegation_trigger.tick() => {
-                tracing::debug!("Echo delegation trigger");
-                let sealed = self.sealed_delegate_message.clone();
-
-                try_or_continue!(
-                    self.broadcast.broadcast_delegate_key(sealed.entity, sealed.signature).await,
-                    |err| tracing::error!("Failed to re-broadcast delegate key: {:?}", err)
-                );
-            }
-        }
-        TaskNextAction::Continue
-    }
-}
-
 async fn create_delegate_key<Gen, DelegateKey, Parent>(
     key_generator: &mut Gen,
     parent_signature: &Parent,
@@ -226,12 +167,50 @@ where
     Preconfirmations: serde::Serialize + Send,
 {
     async fn run(&mut self, watcher: &mut StateWatcher) -> TaskNextAction {
+        tracing::debug!("Running pre-confirmation task");
         tokio::select! {
             _ = watcher.while_started() => {
                 TaskNextAction::Stop
             }
-            action = self._run() => {
-                action
+            res = self.tx_receiver.receive() => {
+                tracing::debug!("Received transactions");
+                let pre_confirmations = try_or_stop!(res);
+                let signature = try_or_stop!(self.current_delegate_key.sign(&pre_confirmations));
+                let expiration = self.current_delegate_key.expiration();
+                try_or_continue!(
+                    self.broadcast.broadcast_preconfirmations(pre_confirmations, signature, expiration).await,
+                    |err| tracing::error!("Failed to broadcast pre-confirmations: {:?}", err)
+                );
+                TaskNextAction::Continue
+            }
+            res = self.key_rotation_trigger.next_rotation() => {
+                tracing::debug!("Key rotation triggered");
+                let expiration = try_or_stop!(res);
+
+                let (new_delegate_key, sealed) = try_or_stop!(create_delegate_key(
+                    &mut self.key_generator,
+                    &self.parent_signature,
+                    expiration,
+                ).await);
+
+                self.current_delegate_key = new_delegate_key;
+                self.sealed_delegate_message = sealed.clone();
+
+                try_or_continue!(
+                    self.broadcast.broadcast_delegate_key(sealed.entity, sealed.signature).await,
+                    |err| tracing::error!("Failed to broadcast newly generated delegate key: {:?}", err)
+                );
+                TaskNextAction::Continue
+            }
+            _ = self.echo_delegation_trigger.tick() => {
+                tracing::debug!("Echo delegation trigger");
+                let sealed = self.sealed_delegate_message.clone();
+
+                try_or_continue!(
+                    self.broadcast.broadcast_delegate_key(sealed.entity, sealed.signature).await,
+                    |err| tracing::error!("Failed to re-broadcast delegate key: {:?}", err)
+                );
+                TaskNextAction::Continue
             }
         }
     }


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->
Before, the task would always continue after an error. Now we have a more fine-grained approach to it.

Because tasks return `TaskNextAction`, the ergonomics aren't as great as something that supports the `?` operator. To deal with this common problem, I've introduced some new macros to imitate that behavior. 


## Checklist
- [ ] New behavior is reflected in tests

### Before requesting review
- [ ] I have reviewed the code myself
