### PR TITLE
fix(relayer): ensure local state is updated after logs downloaded

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2024-0421" # https://github.com/FuelLabs/fuel-core/issues/2488
+    "RUSTSEC-2024-0421", # https://github.com/FuelLabs/fuel-core/issues/2488
+    "RUSTSEC-2025-0009", # https://github.com/FuelLabs/fuel-core/issues/2814
 ]

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -74,11 +74,7 @@ pub struct SharedState {
     pub network: Option<fuel_core_p2p::service::SharedState>,
     #[cfg(feature = "relayer")]
     /// The Relayer shared state.
-    pub relayer: Option<
-        fuel_core_relayer::SharedState<
-            Database<crate::database::database_description::relayer::Relayer>,
-        >,
-    >,
+    pub relayer: Option<fuel_core_relayer::SharedState>,
     /// The GraphQL shared state.
     pub graph_ql: crate::fuel_core_graphql_api::api_service::SharedState,
     /// The underlying database.

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -409,6 +409,8 @@ pub struct MaybeRelayerAdapter {
     #[cfg(feature = "relayer")]
     pub relayer_synced: Option<fuel_core_relayer::SharedState>,
     #[cfg(feature = "relayer")]
+    pub relayer_database: Database<Relayer>,
+    #[cfg(feature = "relayer")]
     pub da_deploy_height: fuel_core_types::blockchain::primitives::DaBlockHeight,
 }
 

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -74,6 +74,8 @@ pub mod shared_sequencer;
 pub mod sync;
 pub mod txpool;
 
+pub mod block_production_trigger;
+
 #[derive(Debug, Clone)]
 pub struct ConsensusParametersProvider {
     shared_state: consensus_parameters_provider::SharedState,

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -407,7 +407,7 @@ impl ConsensusAdapter {
 #[derive(Clone)]
 pub struct MaybeRelayerAdapter {
     #[cfg(feature = "relayer")]
-    pub relayer_synced: Option<fuel_core_relayer::SharedState<Database<Relayer>>>,
+    pub relayer_synced: Option<fuel_core_relayer::SharedState>,
     #[cfg(feature = "relayer")]
     pub da_deploy_height: fuel_core_types::blockchain::primitives::DaBlockHeight,
 }

--- a/crates/fuel-core/src/service/adapters/block_production_trigger.rs
+++ b/crates/fuel-core/src/service/adapters/block_production_trigger.rs
@@ -1,0 +1,31 @@
+use fuel_core_poa::ports::TriggerBlockProduction;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct BlockProductionTrigger {
+    notifier: Arc<tokio::sync::Notify>,
+}
+
+impl TriggerBlockProduction for BlockProductionTrigger {
+    async fn wait_for_trigger(&self) {
+        self.notifier.notified().await;
+    }
+}
+
+impl BlockProductionTrigger {
+    pub fn new() -> Self {
+        Self {
+            notifier: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    pub fn send_trigger(&self) {
+        self.notifier.notify_one();
+    }
+}
+
+impl Default for BlockProductionTrigger {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/fuel-core/src/service/adapters/consensus_module.rs
+++ b/crates/fuel-core/src/service/adapters/consensus_module.rs
@@ -67,7 +67,7 @@ impl RelayerPort for MaybeRelayerAdapter {
     ) -> anyhow::Result<()> {
         #[cfg(feature = "relayer")]
         {
-            if let Some(sync) = self.relayer_synced.as_ref() {
+            if let Some(sync) = &self.relayer_synced {
                 let current_height = sync.get_finalized_da_height();
                 anyhow::ensure!(
                     da_height.saturating_sub(*current_height) <= **_max_da_lag,

--- a/crates/fuel-core/src/service/adapters/producer.rs
+++ b/crates/fuel-core/src/service/adapters/producer.rs
@@ -157,14 +157,21 @@ impl fuel_core_producer::ports::Relayer for MaybeRelayerAdapter {
     ) -> anyhow::Result<RelayerBlockInfo> {
         #[cfg(feature = "relayer")]
         {
-            if let Some(sync) = self.relayer_synced.as_ref() {
-                get_gas_cost_and_transactions_number_for_height(**height, sync)
-            } else {
-                Ok(RelayerBlockInfo {
-                    gas_cost: 0,
-                    tx_count: 0,
-                })
-            }
+            let (gas_cost, tx_count) = self
+                .relayer_database
+                .get_events(height)?
+                .iter()
+                .fold((0u64, 0u64), |(gas_cost, tx_count), event| {
+                    let gas_cost = gas_cost.saturating_add(event.cost());
+                    let tx_count = match event {
+                        fuel_core_types::services::relayer::Event::Message(_) => tx_count,
+                        fuel_core_types::services::relayer::Event::Transaction(_) => {
+                            tx_count.saturating_add(1)
+                        }
+                    };
+                    (gas_cost, tx_count)
+                });
+            Ok(RelayerBlockInfo { gas_cost, tx_count })
         }
         #[cfg(not(feature = "relayer"))]
         {
@@ -179,28 +186,6 @@ impl fuel_core_producer::ports::Relayer for MaybeRelayerAdapter {
             })
         }
     }
-}
-
-#[cfg(feature = "relayer")]
-fn get_gas_cost_and_transactions_number_for_height(
-    height: u64,
-    sync: &fuel_core_relayer::SharedState,
-) -> anyhow::Result<RelayerBlockInfo> {
-    let da_height = DaBlockHeight(height);
-    let (gas_cost, tx_count) = sync.get_events(&da_height)?.iter().fold(
-        (0u64, 0u64),
-        |(gas_cost, tx_count), event| {
-            let gas_cost = gas_cost.saturating_add(event.cost());
-            let tx_count = match event {
-                fuel_core_types::services::relayer::Event::Message(_) => tx_count,
-                fuel_core_types::services::relayer::Event::Transaction(_) => {
-                    tx_count.saturating_add(1)
-                }
-            };
-            (gas_cost, tx_count)
-        },
-    );
-    Ok(RelayerBlockInfo { gas_cost, tx_count })
 }
 
 impl fuel_core_producer::ports::BlockProducerDatabase for OnChainIterableKeyValueView {

--- a/crates/fuel-core/src/service/adapters/relayer.rs
+++ b/crates/fuel-core/src/service/adapters/relayer.rs
@@ -2,16 +2,30 @@ use crate::database::{
     database_description::relayer::Relayer,
     Database,
 };
-use fuel_core_relayer::ports::Transactional;
-use fuel_core_storage::transactional::{
-    HistoricalView,
-    IntoTransaction,
-    StorageTransaction,
+use fuel_core_relayer::ports::{
+    EventProvider,
+    Transactional,
 };
-use fuel_core_types::blockchain::primitives::DaBlockHeight;
+use fuel_core_storage::{
+    transactional::{
+        AtomicView,
+        HistoricalView,
+        IntoTransaction,
+        StorageTransaction,
+    },
+    Result as StorageResult,
+    StorageAsRef,
+};
+use fuel_core_types::{
+    blockchain::primitives::DaBlockHeight,
+    services::relayer::Event,
+};
 
 impl Transactional for Database<Relayer> {
-    type Transaction<'a> = StorageTransaction<&'a mut Self> where Self: 'a;
+    type Transaction<'a>
+        = StorageTransaction<&'a mut Self>
+    where
+        Self: 'a;
 
     fn transaction(&mut self) -> Self::Transaction<'_> {
         self.into_transaction()
@@ -19,5 +33,18 @@ impl Transactional for Database<Relayer> {
 
     fn latest_da_height(&self) -> Option<DaBlockHeight> {
         HistoricalView::latest_height(self)
+    }
+}
+
+impl EventProvider for Database<Relayer> {
+    fn get_events(&self, da_height: &DaBlockHeight) -> StorageResult<Vec<Event>> {
+        let events = self
+            .latest_view()?
+            .storage_as_ref::<fuel_core_relayer::storage::EventsHistory>()
+            .get(da_height)?
+            .unwrap_or_default()
+            .into_owned();
+
+        Ok(events)
     }
 }

--- a/crates/fuel-core/src/service/adapters/relayer.rs
+++ b/crates/fuel-core/src/service/adapters/relayer.rs
@@ -2,10 +2,7 @@ use crate::database::{
     database_description::relayer::Relayer,
     Database,
 };
-use fuel_core_relayer::ports::{
-    EventProvider,
-    Transactional,
-};
+use fuel_core_relayer::ports::Transactional;
 use fuel_core_storage::{
     transactional::{
         AtomicView,
@@ -36,8 +33,8 @@ impl Transactional for Database<Relayer> {
     }
 }
 
-impl EventProvider for Database<Relayer> {
-    fn get_events(&self, da_height: &DaBlockHeight) -> StorageResult<Vec<Event>> {
+impl Database<Relayer> {
+    pub fn get_events(&self, da_height: &DaBlockHeight) -> StorageResult<Vec<Event>> {
         let events = self
             .latest_view()?
             .storage_as_ref::<fuel_core_relayer::storage::EventsHistory>()

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -17,6 +17,7 @@ use crate::{
     schema::build_schema,
     service::{
         adapters::{
+            block_production_trigger::BlockProductionTrigger,
             consensus_module::poa::InDirectoryPredefinedBlocks,
             consensus_parameters_provider,
             fuel_gas_price_provider::FuelGasPriceProvider,
@@ -66,6 +67,7 @@ pub type PoAService = fuel_core_poa::Service<
     SignMode,
     InDirectoryPredefinedBlocks,
     SystemTime,
+    BlockProductionTrigger,
 >;
 #[cfg(feature = "p2p")]
 pub type P2PService = fuel_core_p2p::service::Service<Database, TxPoolAdapter>;
@@ -86,6 +88,7 @@ pub const DEFAULT_GAS_PRICE_CHANGE_PERCENT: u16 = 10;
 pub fn init_sub_services(
     config: &Config,
     database: CombinedDatabase,
+    block_production_trigger: BlockProductionTrigger,
 ) -> anyhow::Result<(SubServices, SharedState)> {
     let chain_config = config.snapshot_reader.chain_config();
     let chain_id = chain_config.consensus_parameters.chain_id();
@@ -297,6 +300,7 @@ pub fn init_sub_services(
             signer,
             predefined_blocks,
             SystemTime,
+            block_production_trigger,
         )
     });
     let poa_adapter = PoAAdapter::new(poa.as_ref().map(|service| service.shared.clone()));
@@ -378,10 +382,6 @@ pub fn init_sub_services(
         Box::new(consensus_parameters_provider_service),
     ];
 
-    if let Some(poa) = poa {
-        services.push(Box::new(poa));
-    }
-
     #[cfg(feature = "relayer")]
     if let Some(relayer) = relayer_service {
         services.push(Box::new(relayer));
@@ -399,6 +399,11 @@ pub fn init_sub_services(
 
     services.push(Box::new(graph_ql));
     services.push(Box::new(graphql_worker));
+
+    // always make sure that the block producer is inserted last
+    if let Some(poa) = poa {
+        services.push(Box::new(poa));
+    }
 
     Ok((services, shared))
 }

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -157,6 +157,7 @@ pub fn init_sub_services(
     let relayer_adapter = MaybeRelayerAdapter {
         #[cfg(feature = "relayer")]
         relayer_synced: relayer_service.as_ref().map(|r| r.shared.clone()),
+        #[cfg(feature = "relayer")]
         relayer_database: database.relayer().clone(),
         #[cfg(feature = "relayer")]
         da_deploy_height: config.relayer.as_ref().map_or(

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -157,6 +157,7 @@ pub fn init_sub_services(
     let relayer_adapter = MaybeRelayerAdapter {
         #[cfg(feature = "relayer")]
         relayer_synced: relayer_service.as_ref().map(|r| r.shared.clone()),
+        relayer_database: database.relayer().clone(),
         #[cfg(feature = "relayer")]
         da_deploy_height: config.relayer.as_ref().map_or(
             DaBlockHeight(RelayerConfig::DEFAULT_DA_DEPLOY_HEIGHT),

--- a/crates/services/consensus_module/poa/src/ports.rs
+++ b/crates/services/consensus_module/poa/src/ports.rs
@@ -140,3 +140,42 @@ impl PredefinedBlocks for InMemoryPredefinedBlocks {
 pub trait GetTime: Send + Sync {
     fn now(&self) -> Tai64;
 }
+
+pub trait TriggerBlockProduction: Send + Sync {
+    fn wait_for_trigger(&self) -> impl core::future::Future<Output = ()> + Send;
+}
+
+pub(crate) struct BlockProductionTrigger<TBP> {
+    notifier: TBP,
+    notified: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl<TBP> TriggerBlockProduction for BlockProductionTrigger<TBP>
+where
+    TBP: TriggerBlockProduction,
+{
+    /// Cache the notification to avoid waiting for the trigger multiple times.
+    async fn wait_for_trigger(&self) {
+        if self.notified.load(std::sync::atomic::Ordering::Acquire) {
+            return;
+        }
+        self.notifier.wait_for_trigger().await;
+        // this is the first and only time we are notified
+        tracing::info!("Block Production has been triggered.");
+
+        self.notified
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
+impl<TBP> BlockProductionTrigger<TBP>
+where
+    TBP: TriggerBlockProduction,
+{
+    pub(crate) fn new(notifier: TBP) -> Self {
+        Self {
+            notifier,
+            notified: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
+}

--- a/crates/services/consensus_module/poa/src/service.rs
+++ b/crates/services/consensus_module/poa/src/service.rs
@@ -21,12 +21,14 @@ use crate::{
     ports::{
         BlockImporter,
         BlockProducer,
+        BlockProductionTrigger,
         BlockSigner,
         GetTime,
         P2pPort,
         PredefinedBlocks,
         TransactionPool,
         TransactionsSource,
+        TriggerBlockProduction,
     },
     sync::{
         SyncState,
@@ -69,7 +71,8 @@ use fuel_core_types::{
 };
 use serde::Serialize;
 
-pub type Service<T, B, I, S, PB, C> = ServiceRunner<MainTask<T, B, I, S, PB, C>>;
+pub type Service<T, B, I, S, PB, C, TBP> =
+    ServiceRunner<MainTask<T, B, I, S, PB, C, TBP>>;
 
 #[derive(Clone)]
 pub struct SharedState {
@@ -123,7 +126,7 @@ pub(crate) enum RequestType {
     Manual,
     Trigger,
 }
-pub struct MainTask<T, B, I, S, PB, C> {
+pub struct MainTask<T, B, I, S, PB, C, TBP> {
     signer: Arc<S>,
     block_producer: B,
     block_importer: I,
@@ -139,14 +142,17 @@ pub struct MainTask<T, B, I, S, PB, C> {
     clock: C,
     /// Deadline clock, used by the triggers
     sync_task_handle: ServiceRunner<SyncTask>,
+    /// externally controlled start of block production
+    block_production_trigger: BlockProductionTrigger<TBP>,
 }
 
-impl<T, B, I, S, PB, C> MainTask<T, B, I, S, PB, C>
+impl<T, B, I, S, PB, C, TBP> MainTask<T, B, I, S, PB, C, TBP>
 where
     T: TransactionPool,
     I: BlockImporter,
     PB: PredefinedBlocks,
     C: GetTime,
+    TBP: TriggerBlockProduction,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new<P: P2pPort>(
@@ -159,6 +165,7 @@ where
         signer: Arc<S>,
         predefined_blocks: PB,
         clock: C,
+        block_production_trigger: TBP,
     ) -> Self {
         let new_txs_watcher = txpool.new_txs_watcher();
         let (request_sender, request_receiver) = mpsc::channel(1024);
@@ -185,6 +192,9 @@ where
 
         let sync_task_handle = ServiceRunner::new(sync_task);
 
+        let block_production_trigger =
+            BlockProductionTrigger::new(block_production_trigger);
+
         Self {
             signer,
             txpool,
@@ -200,6 +210,7 @@ where
             trigger,
             sync_task_handle,
             clock,
+            block_production_trigger,
         }
     }
 
@@ -246,7 +257,7 @@ where
     }
 }
 
-impl<T, B, I, S, PB, C> MainTask<T, B, I, S, PB, C>
+impl<T, B, I, S, PB, C, TBP> MainTask<T, B, I, S, PB, C, TBP>
 where
     T: TransactionPool,
     B: BlockProducer,
@@ -254,6 +265,7 @@ where
     S: BlockSigner,
     PB: PredefinedBlocks,
     C: GetTime,
+    TBP: TriggerBlockProduction,
 {
     // Request the block producer to make a new block, and return it when ready
     async fn signal_produce_block(
@@ -471,14 +483,15 @@ struct PredefinedBlockWithSkippedTransactions {
 }
 
 #[async_trait::async_trait]
-impl<T, B, I, S, PB, C> RunnableService for MainTask<T, B, I, S, PB, C>
+impl<T, B, I, S, PB, C, TBP> RunnableService for MainTask<T, B, I, S, PB, C, TBP>
 where
     Self: RunnableTask,
+    TBP: TriggerBlockProduction,
 {
     const NAME: &'static str = "PoA";
 
     type SharedData = SharedState;
-    type Task = MainTask<T, B, I, S, PB, C>;
+    type Task = MainTask<T, B, I, S, PB, C, TBP>;
     type TaskParams = ();
 
     fn shared_data(&self) -> Self::SharedData {
@@ -506,7 +519,7 @@ where
     }
 }
 
-impl<T, B, I, S, PB, C> RunnableTask for MainTask<T, B, I, S, PB, C>
+impl<T, B, I, S, PB, C, TBP> RunnableTask for MainTask<T, B, I, S, PB, C, TBP>
 where
     T: TransactionPool,
     B: BlockProducer,
@@ -514,8 +527,17 @@ where
     S: BlockSigner,
     PB: PredefinedBlocks,
     C: GetTime,
+    TBP: TriggerBlockProduction,
 {
     async fn run(&mut self, watcher: &mut StateWatcher) -> TaskNextAction {
+        tokio::select! {
+            biased;
+            _ = watcher.while_started() => {
+                return TaskNextAction::Stop
+            }
+            _ = self.block_production_trigger.wait_for_trigger() => {}
+        }
+
         let mut sync_state = self.sync_task_handle.shared.clone();
         // make sure we're synced first
         if *sync_state.borrow_and_update() == SyncState::NotSynced {
@@ -604,7 +626,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn new_service<T, B, I, P, S, PB, C>(
+pub fn new_service<T, B, I, P, S, PB, C, TBP>(
     last_block: &BlockHeader,
     config: Config,
     txpool: T,
@@ -614,7 +636,8 @@ pub fn new_service<T, B, I, P, S, PB, C>(
     block_signer: Arc<S>,
     predefined_blocks: PB,
     clock: C,
-) -> Service<T, B, I, S, PB, C>
+    block_production_trigger: TBP,
+) -> Service<T, B, I, S, PB, C, TBP>
 where
     T: TransactionPool + 'static,
     B: BlockProducer + 'static,
@@ -623,6 +646,7 @@ where
     PB: PredefinedBlocks + 'static,
     P: P2pPort,
     C: GetTime,
+    TBP: TriggerBlockProduction,
 {
     Service::new(MainTask::new(
         last_block,
@@ -634,6 +658,7 @@ where
         block_signer,
         predefined_blocks,
         clock,
+        block_production_trigger,
     ))
 }
 

--- a/crates/services/consensus_module/poa/src/service_test.rs
+++ b/crates/services/consensus_module/poa/src/service_test.rs
@@ -13,6 +13,7 @@ use crate::{
         MockP2pPort,
         MockTransactionPool,
         TransactionsSource,
+        TriggerBlockProduction,
     },
     service::MainTask,
     Config,
@@ -180,6 +181,8 @@ impl TestContextBuilder {
 
         let watch = time.watch();
 
+        let block_production_trigger = FakeBlockProductionTrigger;
+
         let service = new_service(
             &BlockHeader::new_block(BlockHeight::from(1u32), watch.now()),
             config.clone(),
@@ -190,7 +193,9 @@ impl TestContextBuilder {
             FakeBlockSigner { succeeds: true }.into(),
             predefined_blocks,
             watch,
+            block_production_trigger.clone(),
         );
+
         service.start_and_await().await.unwrap();
         TestContext { service, time }
     }
@@ -220,6 +225,13 @@ impl BlockSigner for FakeBlockSigner {
     }
 }
 
+#[derive(Clone)]
+struct FakeBlockProductionTrigger;
+
+impl TriggerBlockProduction for FakeBlockProductionTrigger {
+    async fn wait_for_trigger(&self) {}
+}
+
 struct TestContext {
     service: Service<
         MockTransactionPool,
@@ -228,6 +240,7 @@ struct TestContext {
         FakeBlockSigner,
         InMemoryPredefinedBlocks,
         test_time::Watch,
+        FakeBlockProductionTrigger,
     >,
     time: TestTime,
 }
@@ -367,6 +380,8 @@ async fn remove_skipped_transactions() {
 
     let time = TestTime::at_unix_epoch();
 
+    let block_production_trigger = FakeBlockProductionTrigger;
+
     let mut task = MainTask::new(
         &BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now()),
         config,
@@ -377,6 +392,7 @@ async fn remove_skipped_transactions() {
         FakeBlockSigner { succeeds: true }.into(),
         predefined_blocks,
         time.watch(),
+        block_production_trigger.clone(),
     );
 
     assert!(task.produce_next_block().await.is_ok());
@@ -486,6 +502,7 @@ async fn consensus_service__run__will_include_sequential_predefined_blocks_befor
     let tx = make_tx(&mut rng);
     let TxPoolContext { txpool, .. } = MockTransactionPool::new_with_txs(vec![tx]);
     let time = TestTime::at_unix_epoch();
+    let block_production_trigger = FakeBlockProductionTrigger;
     let task = MainTask::new(
         &last_block,
         config,
@@ -496,6 +513,7 @@ async fn consensus_service__run__will_include_sequential_predefined_blocks_befor
         FakeBlockSigner { succeeds: true }.into(),
         InMemoryPredefinedBlocks::new(blocks_map),
         time.watch(),
+        block_production_trigger.clone(),
     );
 
     // when
@@ -550,6 +568,8 @@ async fn consensus_service__run__will_insert_predefined_blocks_in_correct_order(
     let tx = make_tx(&mut rng);
     let TxPoolContext { txpool, .. } = MockTransactionPool::new_with_txs(vec![tx]);
     let time = TestTime::at_unix_epoch();
+    let block_production_trigger = FakeBlockProductionTrigger;
+
     let task = MainTask::new(
         &last_block,
         config,
@@ -560,6 +580,7 @@ async fn consensus_service__run__will_insert_predefined_blocks_in_correct_order(
         FakeBlockSigner { succeeds: true }.into(),
         InMemoryPredefinedBlocks::new(predefined_blocks_map),
         time.watch(),
+        block_production_trigger.clone(),
     );
 
     // when
@@ -579,4 +600,122 @@ async fn consensus_service__run__will_insert_predefined_blocks_in_correct_order(
             });
         }
     }
+}
+
+#[derive(Clone)]
+struct MockBlockProductionTrigger(std::sync::Arc<tokio::sync::Notify>);
+
+impl TriggerBlockProduction for MockBlockProductionTrigger {
+    async fn wait_for_trigger(&self) {
+        self.0.notified().await;
+    }
+}
+
+impl Default for MockBlockProductionTrigger {
+    fn default() -> Self {
+        Self(std::sync::Arc::new(tokio::sync::Notify::new()))
+    }
+}
+
+impl MockBlockProductionTrigger {
+    fn send_trigger(&self) {
+        self.0.notify_one();
+    }
+}
+
+#[tokio::test]
+async fn consensus_service__run__will_not_produce_blocks_without_trigger() {
+    // this test basically checks that the block production trigger is working
+    // no blocks should be produced if the trigger is not set
+
+    // given
+    let (block_producer, mut block_receiver) = FakeBlockProducer::new();
+    let last_block = BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now());
+    let config = Config {
+        trigger: Trigger::Interval {
+            block_time: std::time::Duration::from_millis(10),
+        },
+        signer: SignMode::Key(test_signing_key()),
+        metrics: false,
+        ..Default::default()
+    };
+    let mut block_importer = MockBlockImporter::default();
+    block_importer.expect_commit_result().returning(|_| Ok(()));
+    block_importer
+        .expect_block_stream()
+        .returning(|| Box::pin(tokio_stream::empty()));
+    let mut rng = StdRng::seed_from_u64(0);
+    let tx = make_tx(&mut rng);
+    let TxPoolContext { txpool, .. } = MockTransactionPool::new_with_txs(vec![tx]);
+    let time = TestTime::at_unix_epoch();
+    let block_production_trigger = MockBlockProductionTrigger::default();
+
+    let task = MainTask::new(
+        &last_block,
+        config,
+        txpool,
+        block_producer,
+        block_importer,
+        generate_p2p_port(),
+        FakeBlockSigner { succeeds: true }.into(),
+        InMemoryPredefinedBlocks::new(HashMap::new()),
+        time.watch(),
+        block_production_trigger.clone(),
+    );
+
+    // when
+    let service = ServiceRunner::new(task);
+    service.start_and_await().await.unwrap();
+    // we don't send the trigger
+
+    // then
+    time::sleep(Duration::from_millis(200)).await;
+    assert!(block_receiver.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn consensus_service__run__will_produce_blocks_with_trigger() {
+    // given
+    let (block_producer, mut block_receiver) = FakeBlockProducer::new();
+    let last_block = BlockHeader::new_block(BlockHeight::from(1u32), Tai64::now());
+    let config = Config {
+        trigger: Trigger::Interval {
+            block_time: std::time::Duration::from_millis(10),
+        },
+        signer: SignMode::Key(test_signing_key()),
+        metrics: false,
+        ..Default::default()
+    };
+    let mut block_importer = MockBlockImporter::default();
+    block_importer.expect_commit_result().returning(|_| Ok(()));
+    block_importer
+        .expect_block_stream()
+        .returning(|| Box::pin(tokio_stream::empty()));
+    let mut rng = StdRng::seed_from_u64(0);
+    let tx = make_tx(&mut rng);
+    let TxPoolContext { txpool, .. } = MockTransactionPool::new_with_txs(vec![tx]);
+    let time = TestTime::at_unix_epoch();
+    let block_production_trigger = MockBlockProductionTrigger::default();
+
+    let task = MainTask::new(
+        &last_block,
+        config,
+        txpool,
+        block_producer,
+        block_importer,
+        generate_p2p_port(),
+        FakeBlockSigner { succeeds: true }.into(),
+        InMemoryPredefinedBlocks::new(HashMap::new()),
+        time.watch(),
+        block_production_trigger.clone(),
+    );
+
+    // when
+    let service = ServiceRunner::new(task);
+    service.start_and_await().await.unwrap();
+    block_production_trigger.send_trigger();
+
+    // then
+    let produced_block = block_receiver.recv().await.unwrap();
+    assert!(matches!(produced_block, FakeProducedBlock::New(_, _)));
 }

--- a/crates/services/relayer/src/mock_db.rs
+++ b/crates/services/relayer/src/mock_db.rs
@@ -1,9 +1,6 @@
 #![allow(missing_docs)]
 
-use crate::ports::{
-    EventProvider,
-    RelayerDb,
-};
+use crate::ports::RelayerDb;
 use fuel_core_storage::Result as StorageResult;
 use fuel_core_types::{
     blockchain::primitives::DaBlockHeight,
@@ -135,24 +132,5 @@ impl RelayerDb for MockDb {
 
     fn get_finalized_da_height(&self) -> Option<DaBlockHeight> {
         self.data.lock().unwrap().finalized_da_height
-    }
-}
-
-impl EventProvider for MockDb {
-    fn get_events(&self, da_height: &DaBlockHeight) -> StorageResult<Vec<Event>> {
-        let m = self.data.lock().unwrap();
-        let mut events = Vec::new();
-        if let Some(messages) = m.messages.get(da_height) {
-            for (_, message) in messages {
-                events.push(Event::Message(message.clone()));
-            }
-        }
-        if let Some(transactions) = m.transactions.get(da_height) {
-            for (_, transaction) in transactions {
-                events.push(Event::Transaction(transaction.clone()));
-            }
-        }
-
-        Ok(events)
     }
 }

--- a/crates/services/relayer/src/ports.rs
+++ b/crates/services/relayer/src/ports.rs
@@ -24,12 +24,6 @@ pub trait RelayerDb: Send + Sync {
     fn get_finalized_da_height(&self) -> Option<DaBlockHeight>;
 }
 
-/// Provides the list of relayer events.
-pub trait EventProvider: Send + Sync {
-    /// Returns the list of relayer events.
-    fn get_events(&self, da_height: &DaBlockHeight) -> StorageResult<Vec<Event>>;
-}
-
 /// The trait that should be implemented by the database transaction returned by the database.
 #[cfg_attr(test, mockall::automock)]
 pub trait DatabaseTransaction {

--- a/crates/services/relayer/src/ports.rs
+++ b/crates/services/relayer/src/ports.rs
@@ -1,6 +1,5 @@
 //! Ports used by the relayer to access the outside world
 
-use async_trait::async_trait;
 use fuel_core_storage::Result as StorageResult;
 use fuel_core_types::{
     blockchain::primitives::DaBlockHeight,
@@ -11,7 +10,6 @@ use fuel_core_types::{
 mod tests;
 
 /// Manages state related to supported external chains.
-#[async_trait]
 pub trait RelayerDb: Send + Sync {
     /// Add bridge events to database. Events are not revertible.
     /// Must only set a new da height if it is greater than the current.
@@ -24,6 +22,12 @@ pub trait RelayerDb: Send + Sync {
     /// Get finalized da height that represent last block from da layer that got finalized.
     /// Panics if height is not set as of initialization of database.
     fn get_finalized_da_height(&self) -> Option<DaBlockHeight>;
+}
+
+/// Provides the list of relayer events.
+pub trait EventProvider: Send + Sync {
+    /// Returns the list of relayer events.
+    fn get_events(&self, da_height: &DaBlockHeight) -> StorageResult<Vec<Event>>;
 }
 
 /// The trait that should be implemented by the database transaction returned by the database.

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -167,7 +167,7 @@ where
     async fn download_logs(
         &mut self,
         eth_sync_gap: &state::EthSyncGap,
-    ) -> anyhow::Result<Option<u64>> {
+    ) -> anyhow::Result<()> {
         let logs = download_logs(
             eth_sync_gap,
             self.config.eth_v2_listening_contracts.clone(),
@@ -176,9 +176,7 @@ where
         );
         let logs = logs.take_until(self.shutdown.while_started());
 
-        let last_written_height = write_logs(&mut self.database, logs).await?;
-
-        Ok(last_written_height)
+        write_logs(&mut self.database, logs).await
     }
 
     fn update_synced(&self, state: &state::EthState) {

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -115,7 +115,6 @@ impl<P, D> NotInitializedTask<P, D> {
     }
 }
 
-#[async_trait]
 impl<P, D> RelayerData for Task<P, D>
 where
     P: Middleware<Error = ProviderError> + 'static,

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -140,7 +140,7 @@ where
     async fn download_logs(
         &mut self,
         eth_sync_gap: &state::EthSyncGap,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Option<u64>> {
         let logs = download_logs(
             eth_sync_gap,
             self.config.eth_v2_listening_contracts.clone(),
@@ -149,7 +149,9 @@ where
         );
         let logs = logs.take_until(self.shutdown.while_started());
 
-        write_logs(&mut self.database, logs).await
+        let last_written_height = write_logs(&mut self.database, logs).await?;
+
+        Ok(last_written_height)
     }
 
     fn update_synced(&self, state: &state::EthState) {

--- a/crates/services/relayer/src/service.rs
+++ b/crates/services/relayer/src/service.rs
@@ -302,7 +302,6 @@ impl<D> SharedState<D> {
     }
 }
 
-#[async_trait]
 impl<P, D> state::EthRemote for Task<P, D>
 where
     P: Middleware<Error = ProviderError>,
@@ -326,7 +325,6 @@ where
     }
 }
 
-#[async_trait]
 impl<P, D> EthLocal for Task<P, D>
 where
     P: Middleware<Error = ProviderError>,

--- a/crates/services/relayer/src/service/get_logs.rs
+++ b/crates/services/relayer/src/service/get_logs.rs
@@ -79,14 +79,12 @@ where
 }
 
 /// Write the logs to the database.
-/// returns the last height written.
 pub(crate) async fn write_logs<D, S>(database: &mut D, logs: S) -> anyhow::Result<()>
 where
     D: RelayerDb,
     S: futures::Stream<Item = Result<DownloadedLogs, ProviderError>>,
 {
     tokio::pin!(logs);
-
     while let Some(DownloadedLogs {
         start_height,
         last_height,

--- a/crates/services/relayer/src/service/get_logs.rs
+++ b/crates/services/relayer/src/service/get_logs.rs
@@ -80,17 +80,12 @@ where
 
 /// Write the logs to the database.
 /// returns the last height written.
-pub(crate) async fn write_logs<D, S>(
-    database: &mut D,
-    logs: S,
-) -> anyhow::Result<Option<u64>>
+pub(crate) async fn write_logs<D, S>(database: &mut D, logs: S) -> anyhow::Result<()>
 where
     D: RelayerDb,
     S: futures::Stream<Item = Result<DownloadedLogs, ProviderError>>,
 {
     tokio::pin!(logs);
-
-    let mut last_written_height = None;
 
     while let Some(DownloadedLogs {
         start_height,
@@ -130,10 +125,8 @@ where
             let events = unordered_events.get(&height).unwrap_or(&empty_events);
             database.insert_events(&height, events)?;
         }
-
-        last_written_height = Some(last_height);
     }
-    Ok(last_written_height)
+    Ok(())
 }
 
 fn sort_events_by_log_index(events: Vec<Log>) -> anyhow::Result<Vec<Log>> {

--- a/crates/services/relayer/src/service/run.rs
+++ b/crates/services/relayer/src/service/run.rs
@@ -49,16 +49,15 @@ where
     if let Some(eth_sync_gap) = state.needs_to_sync_eth() {
         // Download events and write them to the database.
         let result = relayer.download_logs(&eth_sync_gap).await;
-        // update the local state, only if we have written something.
 
         let local_height = relayer.storage_da_block_height();
 
+        // Update the local state, only if we have written something.
         if let Some(latest_written_height) = local_height {
             state.set_local(latest_written_height);
+            // Update the synced state.
+            relayer.update_synced(&state);
         }
-
-        // Update the synced state.
-        relayer.update_synced(&state);
 
         result
     } else {

--- a/crates/services/relayer/src/service/run/test.rs
+++ b/crates/services/relayer/src/service/run/test.rs
@@ -7,7 +7,7 @@ async fn can_set_da_height() {
     let mut relayer = MockRelayerData::default();
     relayer.expect_wait_if_eth_syncing().returning(|| Ok(()));
     relayer.expect_update_synced().return_const(());
-    relayer.expect_download_logs().returning(|_| Ok(()));
+    relayer.expect_download_logs().returning(|_| Ok(None));
     test_data_source(
         &mut relayer,
         TestDataSource {
@@ -26,7 +26,7 @@ async fn logs_are_downloaded_and_written() {
     relayer
         .expect_download_logs()
         .withf(|gap| gap.oldest() == 0 && gap.latest() == 200)
-        .returning(|_| Ok(()));
+        .returning(|_| Ok(None));
     test_data_source(
         &mut relayer,
         TestDataSource {
@@ -54,7 +54,7 @@ mockall::mock! {
         async fn download_logs(
             &mut self,
             eth_sync_gap: &state::EthSyncGap,
-        ) -> anyhow::Result<()>;
+        ) -> anyhow::Result<Option<u64>>;
 
         fn update_synced(&self, state: &EthState);
     }

--- a/crates/services/relayer/src/service/run/test.rs
+++ b/crates/services/relayer/src/service/run/test.rs
@@ -40,7 +40,7 @@ async fn logs_are_downloaded_and_written() {
 mockall::mock! {
     RelayerData {}
 
-    #[async_trait]
+    #[async_trait::async_trait]
     impl EthRemote for RelayerData {
         async fn finalized(&self) -> anyhow::Result<u64>;
     }
@@ -49,7 +49,6 @@ mockall::mock! {
         fn observed(&self) -> Option<u64>;
     }
 
-    #[async_trait]
     impl RelayerData for RelayerData{
         async fn wait_if_eth_syncing(&self) -> anyhow::Result<()>;
 

--- a/crates/services/relayer/src/service/run/test.rs
+++ b/crates/services/relayer/src/service/run/test.rs
@@ -40,7 +40,6 @@ async fn logs_are_downloaded_and_written() {
 mockall::mock! {
     RelayerData {}
 
-    #[async_trait::async_trait]
     impl EthRemote for RelayerData {
         async fn finalized(&self) -> anyhow::Result<u64>;
     }

--- a/crates/services/relayer/src/service/state.rs
+++ b/crates/services/relayer/src/service/state.rs
@@ -1,6 +1,7 @@
 //! # State
 //! Tracks all state that determines the actions of the relayer.
 
+use crate::service::SyncState;
 use core::ops::RangeInclusive;
 pub use state_builder::*;
 
@@ -9,16 +10,23 @@ mod state_builder;
 #[cfg(test)]
 mod test;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 /// The state of the Ethereum node.
 pub struct EthState {
     /// The state that the relayer thinks the remote Ethereum node is in.
     remote: EthHeight,
     /// State related to the Ethereum node that is tracked by the relayer.
-    local: Option<EthHeight>,
+    local: EthHeight,
 }
 
 type EthHeight = u64;
+
+impl EthState {
+    #[cfg(test)]
+    pub fn new(remote: EthHeight, local: EthHeight) -> Self {
+        Self { remote, local }
+    }
+}
 
 #[derive(Clone, Debug)]
 /// The gap between the eth block height on
@@ -38,21 +46,25 @@ pub struct EthSyncPage {
 }
 
 impl EthState {
-    /// Is the relayer in sync with the Ethereum node?
-    pub fn is_synced(&self) -> bool {
-        self.is_synced_at().is_some()
+    /// Returns the `SyncState` of the relayer.
+    pub fn sync_state(&self) -> SyncState {
+        if self.is_synced() {
+            SyncState::Synced(self.local.into())
+        } else {
+            SyncState::PartiallySynced(self.local.into())
+        }
     }
 
-    /// If synced to the remote Ethereum node, return the block height.
-    pub fn is_synced_at(&self) -> Option<u64> {
-        self.local.filter(|local| *local >= self.remote)
+    /// Is the relayer in sync with the Ethereum node?
+    pub fn is_synced(&self) -> bool {
+        self.local >= self.remote
     }
 
     /// Get the gap between the relayer and the Ethereum node if
     /// a sync is required.
     pub fn needs_to_sync_eth(&self) -> Option<EthSyncGap> {
         (!self.is_synced()).then(|| {
-            let local = self.local.map(|l| l.saturating_add(1)).unwrap_or(0);
+            let local = self.local.saturating_add(1);
             let remote = self.remote;
             EthSyncGap::new(local, remote)
         })
@@ -60,7 +72,7 @@ impl EthState {
 
     /// Set the local state of the Ethereum node.
     pub fn set_local(&mut self, local: EthHeight) {
-        self.local = Some(local);
+        self.local = local;
     }
 }
 

--- a/crates/services/relayer/src/service/state.rs
+++ b/crates/services/relayer/src/service/state.rs
@@ -57,6 +57,11 @@ impl EthState {
             EthSyncGap::new(local, remote)
         })
     }
+
+    /// Set the local state of the Ethereum node.
+    pub fn set_local(&mut self, local: EthHeight) {
+        self.local = Some(local);
+    }
 }
 
 impl EthSyncGap {

--- a/crates/services/relayer/src/service/state/state_builder.rs
+++ b/crates/services/relayer/src/service/state/state_builder.rs
@@ -10,7 +10,7 @@ pub trait EthRemote {
 
 pub trait EthLocal {
     /// The current finalized eth block that the relayer has seen.
-    fn observed(&self) -> Option<u64>;
+    fn observed(&self) -> u64;
 }
 
 /// Build the Ethereum state.
@@ -33,7 +33,7 @@ pub mod test_builder {
     #[derive(Debug, Default, Clone)]
     pub struct TestDataSource {
         pub eth_remote_finalized: u64,
-        pub eth_local_finalized: Option<u64>,
+        pub eth_local_finalized: u64,
     }
 
     impl EthRemote for TestDataSource {
@@ -43,7 +43,7 @@ pub mod test_builder {
     }
 
     impl EthLocal for TestDataSource {
-        fn observed(&self) -> Option<u64> {
+        fn observed(&self) -> u64 {
             self.eth_local_finalized
         }
     }

--- a/crates/services/relayer/src/service/state/state_builder.rs
+++ b/crates/services/relayer/src/service/state/state_builder.rs
@@ -1,15 +1,13 @@
 //! Type safe state building
 
 use super::*;
-use async_trait::async_trait;
 
-#[async_trait]
 pub trait EthRemote {
     /// The most recently finalized height on the Ethereum node.
-    async fn finalized(&self) -> anyhow::Result<u64>;
+    fn finalized(&self)
+        -> impl core::future::Future<Output = anyhow::Result<u64>> + Send;
 }
 
-#[async_trait]
 pub trait EthLocal {
     /// The current finalized eth block that the relayer has seen.
     fn observed(&self) -> Option<u64>;
@@ -38,7 +36,6 @@ pub mod test_builder {
         pub eth_local_finalized: Option<u64>,
     }
 
-    #[async_trait]
     impl EthRemote for TestDataSource {
         async fn finalized(&self) -> anyhow::Result<u64> {
             Ok(self.eth_remote_finalized)

--- a/crates/services/relayer/src/service/state/test.rs
+++ b/crates/services/relayer/src/service/state/test.rs
@@ -8,31 +8,25 @@ use test_case::test_case;
 #[test_case(
     TestDataSource {
         eth_remote_finalized: 200,
-        eth_local_finalized: None,
-    } => Some(0..=200); "empty so needs to sync"
-)]
-#[test_case(
-    TestDataSource {
-        eth_remote_finalized: 200,
-        eth_local_finalized: Some(0),
+        eth_local_finalized: 0,
     } => Some(1..=200); "behind so needs to sync"
 )]
 #[test_case(
     TestDataSource {
         eth_remote_finalized: 200,
-        eth_local_finalized: Some(200),
+        eth_local_finalized: 200,
     } => None; "same so doesn't need to sync"
 )]
 #[test_case(
     TestDataSource {
         eth_remote_finalized: 200,
-        eth_local_finalized: Some(201),
+        eth_local_finalized: 201,
     } => None; "ahead so doesn't need to sync"
 )]
 #[test_case(
     TestDataSource {
         eth_remote_finalized: 200,
-        eth_local_finalized: Some(50),
+        eth_local_finalized: 50,
     } => Some(51..=200); "behind by less so needs to sync"
 )]
 #[tokio::test]

--- a/crates/services/relayer/src/service/test.rs
+++ b/crates/services/relayer/src/service/test.rs
@@ -27,7 +27,7 @@ async fn can_download_logs() {
 
     let eth_state = super::state::test_builder::TestDataSource {
         eth_remote_finalized: 5,
-        eth_local_finalized: Some(1),
+        eth_local_finalized: 1,
     };
     let eth_state = state::build_eth(&eth_state).await.unwrap();
 
@@ -64,7 +64,7 @@ async fn quorum_agrees_on_logs() {
 
     let eth_state = super::state::test_builder::TestDataSource {
         eth_remote_finalized: 5,
-        eth_local_finalized: Some(1),
+        eth_local_finalized: 1,
     };
     let eth_state = state::build_eth(&eth_state).await.unwrap();
 
@@ -115,7 +115,7 @@ async fn quorum__disagree_on_logs() {
 
     let eth_state = super::state::test_builder::TestDataSource {
         eth_remote_finalized: 5,
-        eth_local_finalized: Some(1),
+        eth_local_finalized: 1,
     };
     let eth_state = state::build_eth(&eth_state).await.unwrap();
 
@@ -173,20 +173,22 @@ async fn deploy_height_does_not_override() {
     assert_eq!(*mock_db.get_finalized_da_height().unwrap(), 50);
 }
 
-#[test_case(6, Some(6), Some(6); "if local is up to date with remote, then update sync")]
-#[test_case(6, Some(100), Some(100); "if local is somehow ahead of remote, then update sync")]
-#[test_case(6, Some(5), None; "if local is behind remote, then nothing sent to sync")]
-#[test_case(6, None, None; "if local is not set, then nothing sent to sync")]
+const STATING_HEIGHT: u64 = 2;
+
+#[test_case(6, 6, SyncState::Synced(6u64.into()); "if local is up to date with remote, then fully synced state")]
+#[test_case(6, 100, SyncState::Synced(100u64.into()); "if local is somehow ahead of remote, then fully synced state")]
+#[test_case(6, 5, SyncState::PartiallySynced(5u64.into()); "if local is behind remote, then partially synced state")]
+#[test_case(6, 0, SyncState::PartiallySynced(0u64.into()); "if local is set to starting height, then partially synced state")]
 #[tokio::test]
 async fn update_sync__changes_latest_eth_state(
     remote: u64,
-    local: Option<u64>,
-    expected: Option<u64>,
+    local: u64,
+    expected: SyncState,
 ) {
     // given
     let mock_db = crate::mock_db::MockDb::default();
     let config = Config {
-        da_deploy_height: 20u64.into(),
+        da_deploy_height: STATING_HEIGHT.into(),
         ..Default::default()
     };
     let eth_node = MockMiddleware::default();
@@ -203,7 +205,6 @@ async fn update_sync__changes_latest_eth_state(
     task.update_synced(&eth_state);
 
     // then
-    let expected = expected.map(DaBlockHeight);
-    let actual = *shared.synced.borrow().deref();
+    let actual = *shared.synced.borrow();
     assert_eq!(expected, actual);
 }

--- a/crates/services/relayer/tests/integration.rs
+++ b/crates/services/relayer/tests/integration.rs
@@ -30,13 +30,18 @@ async fn can_set_da_height() {
     let eth_node = MockMiddleware::default();
     // Setup the eth node with a block high enough that there
     // will be some finalized blocks.
-    eth_node.update_data(|data| data.best_block.number = Some(100.into()));
+    let da_block_height = 100u64;
+    eth_node.update_data(|data| data.best_block.number = Some(da_block_height.into()));
     let relayer = new_service_test(eth_node, mock_db.clone(), Default::default());
     relayer.start_and_await().await.unwrap();
 
-    relayer.shared.await_synced().await.unwrap();
+    relayer
+        .shared
+        .await_at_least_synced(&da_block_height.into())
+        .await
+        .unwrap();
 
-    assert_eq!(*mock_db.get_finalized_da_height().unwrap(), 100);
+    assert_eq!(*mock_db.get_finalized_da_height().unwrap(), da_block_height);
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/services/relayer/tests/integration.rs
+++ b/crates/services/relayer/tests/integration.rs
@@ -91,7 +91,6 @@ async fn stop_service_at_the_middle() {
     }
     relayer.stop();
 
-    assert!(relayer.shared.await_synced().await.is_err());
     // During each iteration we sync 5 blocks, so the final 5 * `NUMBER_OF_SYNC_ITERATIONS`
     assert_eq!(
         *mock_db.get_finalized_da_height().unwrap(),

--- a/crates/services/src/service.rs
+++ b/crates/services/src/service.rs
@@ -359,7 +359,7 @@ async fn run<S>(
     let mut task = service
         .into_task(&state, params)
         .await
-        .expect("The initialization of the service failed");
+        .expect(&format!("The initialization of {} failed", S::NAME));
 
     sender.send_if_modified(|s| {
         if s.starting() {

--- a/crates/services/src/service.rs
+++ b/crates/services/src/service.rs
@@ -359,7 +359,7 @@ async fn run<S>(
     let mut task = service
         .into_task(&state, params)
         .await
-        .expect(&format!("The initialization of {} failed", S::NAME));
+        .unwrap_or_else(|_| panic!("The initialization of {} failed", S::NAME));
 
     sender.send_if_modified(|s| {
         if s.starting() {


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->
delayed block production. includes deterministic start of block production

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
