### PR TITLE
Allow estimation of predicates on submission of the transaction

### DIFF
--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -766,7 +766,7 @@ type Mutation {
 	
 	Returns submitted transaction if the transaction is included in the `TxPool` without problems.
 	"""
-	submit(tx: HexString!): Transaction!
+	submit(tx: HexString!, estimatePredicates: Boolean): Transaction!
 	"""
 	Sequentially produces `blocks_to_produce` blocks. The first block starts with
 	`start_timestamp`. If the block production in the [`crate::service::Config`] is
@@ -1245,13 +1245,13 @@ type Subscription {
 	"""
 	Submits transaction to the `TxPool` and await either confirmation or failure.
 	"""
-	submitAndAwait(tx: HexString!): TransactionStatus!
+	submitAndAwait(tx: HexString!, estimatePredicates: Boolean): TransactionStatus!
 	"""
 	Submits the transaction to the `TxPool` and returns a stream of events.
 	Compared to the `submitAndAwait`, the stream also contains `
 	SubmittedStatus` as an intermediate state.
 	"""
-	submitAndAwaitStatus(tx: HexString!): TransactionStatus!
+	submitAndAwaitStatus(tx: HexString!, estimatePredicates: Boolean): TransactionStatus!
 	contractStorageSlots(contractId: ContractId!): StorageSlot!
 	contractStorageBalances(contractId: ContractId!): ContractBalance!
 }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -12,7 +12,10 @@ use crate::{
             gas_price::EstimateGasPrice,
             message::MessageStatusArgs,
             relayed_tx::RelayedTransactionStatusArgs,
-            tx::DryRunArg,
+            tx::{
+                DryRunArg,
+                TxWithEstimatedPredicatesArg,
+            },
             Tai64Timestamp,
             TransactionId,
         },
@@ -759,30 +762,54 @@ impl FuelClient {
         &self,
         tx: &Transaction,
     ) -> io::Result<types::primitives::TransactionId> {
+        self.submit_opt(tx, None).await
+    }
+
+    pub async fn submit_opt(
+        &self,
+        tx: &Transaction,
+        estimate_predicates: Option<bool>,
+    ) -> io::Result<types::primitives::TransactionId> {
         let tx = tx.clone().to_bytes();
-        let query = schema::tx::Submit::build(TxArg {
+        let query = schema::tx::Submit::build(TxWithEstimatedPredicatesArg {
             tx: HexString(Bytes(tx)),
+            estimate_predicates,
         });
 
         let id = self.query(query).await.map(|r| r.submit)?.id.into();
         Ok(id)
     }
 
-    /// Submit the transaction and wait for it either to be included in
-    /// a block or removed from `TxPool`.
-    ///
-    /// This will wait forever if needed, so consider wrapping this call
-    /// with a `tokio::time::timeout`.
+    /// Similar to [`Self::submit_and_await_commit_opt`], but with default options.
     #[cfg(feature = "subscriptions")]
     pub async fn submit_and_await_commit(
         &self,
         tx: &Transaction,
     ) -> io::Result<TransactionStatus> {
+        self.submit_and_await_commit_opt(tx, None).await
+    }
+
+    /// Submit the transaction and wait for it either to be included in
+    /// a block or removed from `TxPool`.
+    ///
+    /// If `estimate_predicates` is set, the predicates will be estimated before
+    /// the transaction is inserted into transaction pool.
+    ///
+    /// This will wait forever if needed, so consider wrapping this call
+    /// with a `tokio::time::timeout`.
+    #[cfg(feature = "subscriptions")]
+    pub async fn submit_and_await_commit_opt(
+        &self,
+        tx: &Transaction,
+        estimate_predicates: Option<bool>,
+    ) -> io::Result<TransactionStatus> {
         use cynic::SubscriptionBuilder;
         let tx = tx.clone().to_bytes();
-        let s = schema::tx::SubmitAndAwaitSubscription::build(TxArg {
-            tx: HexString(Bytes(tx)),
-        });
+        let s =
+            schema::tx::SubmitAndAwaitSubscription::build(TxWithEstimatedPredicatesArg {
+                tx: HexString(Bytes(tx)),
+                estimate_predicates,
+            });
 
         let mut stream = self.subscribe(s).await?.map(
             |r: io::Result<schema::tx::SubmitAndAwaitSubscription>| {
@@ -805,11 +832,24 @@ impl FuelClient {
         &self,
         tx: &Transaction,
     ) -> io::Result<StatusWithTransaction> {
+        self.submit_and_await_commit_with_tx_opt(tx, None).await
+    }
+
+    /// Similar to [`Self::submit_and_await_commit_opt`], but the status also contains transaction.
+    #[cfg(feature = "subscriptions")]
+    pub async fn submit_and_await_commit_with_tx_opt(
+        &self,
+        tx: &Transaction,
+        estimate_predicates: Option<bool>,
+    ) -> io::Result<StatusWithTransaction> {
         use cynic::SubscriptionBuilder;
         let tx = tx.clone().to_bytes();
-        let s = schema::tx::SubmitAndAwaitSubscriptionWithTransaction::build(TxArg {
-            tx: HexString(Bytes(tx)),
-        });
+        let s = schema::tx::SubmitAndAwaitSubscriptionWithTransaction::build(
+            TxWithEstimatedPredicatesArg {
+                tx: HexString(Bytes(tx)),
+                estimate_predicates,
+            },
+        );
 
         let mut stream = self.subscribe(s).await?.map(
             |r: io::Result<schema::tx::SubmitAndAwaitSubscriptionWithTransaction>| {
@@ -826,19 +866,30 @@ impl FuelClient {
         Ok(status)
     }
 
-    /// Submits the transaction to the `TxPool` and returns a stream of events.
-    /// Compared to the `submit_and_await_commit`, the stream also contains
-    /// `SubmittedStatus` as an intermediate state.
+    /// Similar to [`Self::submit_and_await_commit`], but includes all intermediate states.
     #[cfg(feature = "subscriptions")]
     pub async fn submit_and_await_status<'a>(
         &'a self,
         tx: &'a Transaction,
     ) -> io::Result<impl Stream<Item = io::Result<TransactionStatus>> + 'a> {
+        self.submit_and_await_status_opt(tx, None).await
+    }
+
+    /// Similar to [`Self::submit_and_await_commit_opt`], but includes all intermediate states.
+    #[cfg(feature = "subscriptions")]
+    pub async fn submit_and_await_status_opt<'a>(
+        &'a self,
+        tx: &'a Transaction,
+        estimate_predicates: Option<bool>,
+    ) -> io::Result<impl Stream<Item = io::Result<TransactionStatus>> + 'a> {
         use cynic::SubscriptionBuilder;
         let tx = tx.clone().to_bytes();
-        let s = schema::tx::SubmitAndAwaitStatusSubscription::build(TxArg {
-            tx: HexString(Bytes(tx)),
-        });
+        let s = schema::tx::SubmitAndAwaitStatusSubscription::build(
+            TxWithEstimatedPredicatesArg {
+                tx: HexString(Bytes(tx)),
+                estimate_predicates,
+            },
+        );
 
         let stream = self.subscribe(s).await?.map(
             |r: io::Result<schema::tx::SubmitAndAwaitStatusSubscription>| {

--- a/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__submit_tx_gql_output.snap
+++ b/crates/client/src/client/schema/snapshots/fuel_core_client__client__schema__tx__tests__submit_tx_gql_output.snap
@@ -2,8 +2,8 @@
 source: crates/client/src/client/schema/tx.rs
 expression: query.query
 ---
-mutation Submit($tx: HexString!) {
-  submit(tx: $tx) {
+mutation Submit($tx: HexString!, $estimatePredicates: Boolean) {
+  submit(tx: $tx, estimatePredicates: $estimatePredicates) {
     id
   }
 }

--- a/crates/client/src/client/schema/tx.rs
+++ b/crates/client/src/client/schema/tx.rs
@@ -488,6 +488,13 @@ pub struct TxArg {
     pub tx: HexString,
 }
 
+#[derive(cynic::QueryVariables)]
+pub struct TxWithEstimatedPredicatesArg {
+    pub tx: HexString,
+    #[cynic(skip_serializing_if = "Option::is_none")]
+    pub estimate_predicates: Option<bool>,
+}
+
 #[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
@@ -522,10 +529,10 @@ pub struct DryRun {
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Mutation",
-    variables = "TxArg"
+    variables = "TxWithEstimatedPredicatesArg"
 )]
 pub struct Submit {
-    #[arguments(tx: $tx)]
+    #[arguments(tx: $tx, estimatePredicates: $estimate_predicates)]
     pub submit: TransactionIdFragment,
 }
 
@@ -533,10 +540,10 @@ pub struct Submit {
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Subscription",
-    variables = "TxArg"
+    variables = "TxWithEstimatedPredicatesArg"
 )]
 pub struct SubmitAndAwaitSubscription {
-    #[arguments(tx: $tx)]
+    #[arguments(tx: $tx, estimatePredicates: $estimate_predicates)]
     pub submit_and_await: TransactionStatus,
 }
 
@@ -544,10 +551,10 @@ pub struct SubmitAndAwaitSubscription {
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Subscription",
-    variables = "TxArg"
+    variables = "TxWithEstimatedPredicatesArg"
 )]
 pub struct SubmitAndAwaitSubscriptionWithTransaction {
-    #[arguments(tx: $tx)]
+    #[arguments(tx: $tx, estimatePredicates: $estimate_predicates)]
     pub submit_and_await: StatusWithTransaction,
 }
 
@@ -555,10 +562,10 @@ pub struct SubmitAndAwaitSubscriptionWithTransaction {
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Subscription",
-    variables = "TxArg"
+    variables = "TxWithEstimatedPredicatesArg"
 )]
 pub struct SubmitAndAwaitStatusSubscription {
-    #[arguments(tx: $tx)]
+    #[arguments(tx: $tx, estimatePredicates: $estimate_predicates)]
     pub submit_and_await_status: TransactionStatus,
 }
 
@@ -641,8 +648,9 @@ pub mod tests {
     fn submit_tx_gql_output() {
         use cynic::MutationBuilder;
         let tx = fuel_tx::Transaction::default_test_tx();
-        let query = Submit::build(TxArg {
+        let query = Submit::build(TxWithEstimatedPredicatesArg {
             tx: HexString(Bytes(tx.to_bytes())),
+            estimate_predicates: Some(true),
         });
         insta::assert_snapshot!(query.query)
     }

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -48,6 +48,7 @@ use fuel_core_storage::{
     iter::IterDirection,
     Error as StorageError,
     IsNotFound,
+    PredicateStorageRequirements,
     Result as StorageResult,
 };
 use fuel_core_tx_status_manager::TxStatusMessage;
@@ -75,6 +76,7 @@ use futures::{
 };
 use std::{
     borrow::Cow,
+    future::Future,
     iter,
 };
 use types::{
@@ -252,24 +254,15 @@ impl TxQuery {
     ) -> async_graphql::Result<Transaction> {
         let query = ctx.read_view()?.into_owned();
 
-        let mut tx = FuelTx::from_bytes(&tx.0)?;
+        let tx = FuelTx::from_bytes(&tx.0)?;
 
-        let params = ctx
+        let tx = ctx.estimate_predicates(tx, query).await?;
+        let chain_id = ctx
             .data_unchecked::<ChainInfoProvider>()
-            .current_consensus_params();
+            .current_consensus_params()
+            .chain_id();
 
-        let memory_pool = ctx.data_unchecked::<SharedMemoryPool>();
-        let memory = memory_pool.get_memory().await;
-
-        let parameters = CheckPredicateParams::from(params.as_ref());
-        let tx = tokio_rayon::spawn_fifo(move || {
-            let result = tx.estimate_predicates(&parameters, memory, &query);
-            result.map(|_| tx)
-        })
-        .await
-        .map_err(|err| anyhow::anyhow!("{:?}", err))?;
-
-        Ok(Transaction::from_tx(tx.id(&params.chain_id()), tx))
+        Ok(Transaction::from_tx(tx.id(&chain_id), tx))
     }
 
     #[cfg(feature = "test-helpers")]
@@ -404,18 +397,26 @@ impl TxMutation {
         &self,
         ctx: &Context<'_>,
         tx: HexString,
+        estimate_predicates: Option<bool>,
     ) -> async_graphql::Result<Transaction> {
         let txpool = ctx.data_unchecked::<TxPool>();
-        let params = ctx
-            .data_unchecked::<ChainInfoProvider>()
-            .current_consensus_params();
-        let tx = FuelTx::from_bytes(&tx.0)?;
+        let mut tx = FuelTx::from_bytes(&tx.0)?;
+
+        if estimate_predicates.unwrap_or(false) {
+            let query = ctx.read_view()?.into_owned();
+            tx = ctx.estimate_predicates(tx, query).await?;
+        }
 
         txpool
             .insert(tx.clone())
             .await
             .map_err(|e| anyhow::anyhow!(e))?;
-        let id = tx.id(&params.chain_id());
+
+        let chain_id = ctx
+            .data_unchecked::<ChainInfoProvider>()
+            .current_consensus_params()
+            .chain_id();
+        let id = tx.id(&chain_id);
 
         let tx = Transaction(tx, id);
         Ok(tx)
@@ -467,11 +468,14 @@ impl TxStatusSubscription {
         &self,
         ctx: &'a Context<'a>,
         tx: HexString,
+        estimate_predicates: Option<bool>,
     ) -> async_graphql::Result<
         impl Stream<Item = async_graphql::Result<TransactionStatus>> + 'a,
     > {
         use tokio_stream::StreamExt;
-        let subscription = submit_and_await_status(ctx, tx).await?;
+        let subscription =
+            submit_and_await_status(ctx, tx, estimate_predicates.unwrap_or(false))
+                .await?;
 
         Ok(subscription
             .skip_while(|event| matches!(event, Ok(TransactionStatus::Submitted(..))))
@@ -486,16 +490,18 @@ impl TxStatusSubscription {
         &self,
         ctx: &'a Context<'a>,
         tx: HexString,
+        estimate_predicates: Option<bool>,
     ) -> async_graphql::Result<
         impl Stream<Item = async_graphql::Result<TransactionStatus>> + 'a,
     > {
-        submit_and_await_status(ctx, tx).await
+        submit_and_await_status(ctx, tx, estimate_predicates.unwrap_or(false)).await
     }
 }
 
 async fn submit_and_await_status<'a>(
     ctx: &'a Context<'a>,
     tx: HexString,
+    estimate_predicates: bool,
 ) -> async_graphql::Result<
     impl Stream<Item = async_graphql::Result<TransactionStatus>> + 'a,
 > {
@@ -505,8 +511,14 @@ async fn submit_and_await_status<'a>(
     let params = ctx
         .data_unchecked::<ChainInfoProvider>()
         .current_consensus_params();
-    let tx = FuelTx::from_bytes(&tx.0)?;
+    let mut tx = FuelTx::from_bytes(&tx.0)?;
     let tx_id = tx.id(&params.chain_id());
+
+    if estimate_predicates {
+        let query = ctx.read_view()?.into_owned();
+        tx = ctx.estimate_predicates(tx, query).await?;
+    }
+
     let subscription = tx_status_manager.tx_update_subscribe(tx_id).await?;
 
     txpool.insert(tx).await?;
@@ -548,7 +560,13 @@ pub trait ContextExt {
     fn try_find_tx(
         &self,
         id: Bytes32,
-    ) -> impl std::future::Future<Output = StorageResult<Option<FuelTx>>> + Send;
+    ) -> impl Future<Output = StorageResult<Option<FuelTx>>> + Send;
+
+    fn estimate_predicates(
+        &self,
+        tx: FuelTx,
+        query: impl PredicateStorageRequirements + Send + Sync + 'static,
+    ) -> impl Future<Output = anyhow::Result<FuelTx>> + Send;
 }
 
 impl<'a> ContextExt for Context<'a> {
@@ -567,5 +585,28 @@ impl<'a> ContextExt for Context<'a> {
                 result.map(Some)
             }
         }
+    }
+
+    async fn estimate_predicates(
+        &self,
+        mut tx: FuelTx,
+        query: impl PredicateStorageRequirements + Send + Sync + 'static,
+    ) -> anyhow::Result<FuelTx> {
+        let params = self
+            .data_unchecked::<ChainInfoProvider>()
+            .current_consensus_params();
+
+        let memory_pool = self.data_unchecked::<SharedMemoryPool>();
+        let memory = memory_pool.get_memory().await;
+
+        let parameters = CheckPredicateParams::from(params.as_ref());
+        let tx = tokio_rayon::spawn_fifo(move || {
+            let result = tx.estimate_predicates(&parameters, memory, &query);
+            result.map(|_| tx)
+        })
+        .await
+        .map_err(|err| anyhow::anyhow!("{:?}", err))?;
+
+        Ok(tx)
     }
 }

--- a/tests/tests/graphql_extensions.rs
+++ b/tests/tests/graphql_extensions.rs
@@ -97,9 +97,12 @@ async fn upgrade_consensus_parameters(
     )
     .unwrap();
 
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    client.submit_and_await_commit(&tx).await.unwrap();
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await
+        .unwrap();
     client
         .produce_blocks(1, None)
         .await
@@ -160,12 +163,11 @@ async fn upgrade_stf(
     root: Bytes32,
 ) {
     for upload in transactions {
-        let mut tx = upload.into();
-        client
-            .estimate_predicates(&mut tx)
-            .await
-            .expect("Should estimate transaction");
-        let result = client.submit_and_await_commit(&tx).await;
+        let tx = upload.into();
+        let estimate_predicates = true;
+        let result = client
+            .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+            .await;
         let result = result.expect("We should be able to upload the bytecode subsection");
         assert!(matches!(result, TransactionStatus::Success { .. }))
     }
@@ -186,9 +188,11 @@ async fn upgrade_stf(
         vec![],
         vec![],
     );
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    let result = client.submit_and_await_commit(&tx).await;
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    let result = client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await;
     let result = result.expect("We should be able to upgrade to the uploaded bytecode");
     assert!(matches!(result, TransactionStatus::Success { .. }));
     client

--- a/tests/tests/messages.rs
+++ b/tests/tests/messages.rs
@@ -353,7 +353,7 @@ async fn can_get_message_proof() {
         let output = Output::contract_created(id, state_root);
 
         // Create the contract deploy transaction.
-        let mut contract_deploy = TransactionBuilder::create(bytecode, salt, vec![])
+        let contract_deploy = TransactionBuilder::create(bytecode, salt, vec![])
             .add_fee_input()
             .add_output(output)
             .finalize_as_transaction();
@@ -441,25 +441,22 @@ async fn can_get_message_proof() {
         let srv = FuelService::new_node(config).await.unwrap();
         let client = FuelClient::from(srv.bound_address);
 
-        client
-            .estimate_predicates(&mut contract_deploy)
-            .await
-            .expect("Should be able to estimate deploy tx");
-
         // Deploy the contract.
+        let estimate_predicates = true;
         matches!(
-            client.submit_and_await_commit(&contract_deploy).await,
+            client
+                .submit_and_await_commit_opt(&contract_deploy, Some(estimate_predicates))
+                .await,
             Ok(TransactionStatus::Success { .. })
         );
 
-        let mut script = script.into();
-        client
-            .estimate_predicates(&mut script)
-            .await
-            .expect("Should be able to estimate script tx");
+        let script = script.into();
         // Call the contract.
+        let estimate_predicates = true;
         matches!(
-            client.submit_and_await_commit(&script).await,
+            client
+                .submit_and_await_commit_opt(&script, Some(estimate_predicates))
+                .await,
             Ok(TransactionStatus::Success { .. })
         );
 

--- a/tests/tests/tx/upgrade.rs
+++ b/tests/tests/tx/upgrade.rs
@@ -49,12 +49,11 @@ async fn can_upload_current_state_transition_function() {
 
     for upload in transactions {
         // When
-        let mut tx = upload.into();
-        client
-            .estimate_predicates(&mut tx)
-            .await
-            .expect("Should estimate transaction");
-        let result = client.submit_and_await_commit(&tx).await;
+        let tx = upload.into();
+        let estimate_predicates = true;
+        let result = client
+            .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+            .await;
 
         // Then
         let result = result.expect("We should be able to upload the bytecode subsection");
@@ -81,9 +80,12 @@ async fn can_upgrade_to_uploaded_state_transition() {
 
     let transactions = transactions_from_subsections(&mut rng, subsections, amount);
     for upload in transactions {
-        let mut tx = upload.into();
-        client.estimate_predicates(&mut tx).await.unwrap();
-        client.submit_and_await_commit(&tx).await.unwrap();
+        let tx = upload.into();
+        let estimate_predicates = true;
+        client
+            .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+            .await
+            .unwrap();
     }
 
     // Given
@@ -105,9 +107,11 @@ async fn can_upgrade_to_uploaded_state_transition() {
     );
 
     // When
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    let result = client.submit_and_await_commit(&tx).await;
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    let result = client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await;
 
     // Then
     let TransactionStatus::Success { block_height, .. } =
@@ -158,9 +162,12 @@ async fn upgrading_to_invalid_state_transition_fails() {
 
     let transactions = transactions_from_subsections(&mut rng, subsections, amount);
     for upload in transactions {
-        let mut tx = upload.into();
-        client.estimate_predicates(&mut tx).await.unwrap();
-        client.submit_and_await_commit(&tx).await.unwrap();
+        let tx = upload.into();
+        let estimate_predicates = true;
+        client
+            .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+            .await
+            .unwrap();
     }
 
     // Given
@@ -182,9 +189,11 @@ async fn upgrading_to_invalid_state_transition_fails() {
     );
 
     // When
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    let result = client.submit_and_await_commit(&tx).await;
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    let result = client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await;
 
     // Then
     let result_str = format!("{:?}", result); // io::Result forces string handling
@@ -231,9 +240,11 @@ async fn upgrading_to_missing_state_transition_fails() {
     );
 
     // When
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    let result = client.submit_and_await_commit(&tx).await;
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    let result = client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await;
 
     // Then
     let result_str = format!("{:?}", result); // io::Result forces string handling
@@ -266,9 +277,12 @@ async fn upgrade_to_a_partially_uploaded_state_transition_fails() {
     assert!(transactions.len() > 1);
     let _ = transactions.pop(); // Don't upload the last subsection
     for upload in transactions {
-        let mut tx = upload.into();
-        client.estimate_predicates(&mut tx).await.unwrap();
-        client.submit_and_await_commit(&tx).await.unwrap();
+        let tx = upload.into();
+        let estimate_predicates = true;
+        client
+            .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+            .await
+            .unwrap();
     }
 
     // Given
@@ -290,9 +304,11 @@ async fn upgrade_to_a_partially_uploaded_state_transition_fails() {
     );
 
     // When
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    let result = client.submit_and_await_commit(&tx).await;
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    let result = client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await;
 
     // Then
     let result_str = format!("{:?}", result); // io::Result forces string handling
@@ -343,9 +359,12 @@ async fn upgrade_of_consensus_parameters_affects_used_gas_of_next_tx() {
     } = test_builder.finalize().await;
 
     // Given
-    let mut tx = valid_transaction(&mut rng, amount);
-    client.estimate_predicates(&mut tx).await.unwrap();
-    let result = client.submit_and_await_commit(&tx).await.unwrap();
+    let tx = valid_transaction(&mut rng, amount);
+    let estimate_predicates = true;
+    let result = client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await
+        .unwrap();
     let TransactionStatus::Success { receipts, .. } = result else {
         panic!("{result:?}")
     };
@@ -372,14 +391,20 @@ async fn upgrade_of_consensus_parameters_affects_used_gas_of_next_tx() {
         vec![],
     )
     .unwrap();
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    client.submit_and_await_commit(&tx).await.unwrap();
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await
+        .unwrap();
 
     // Then
-    let mut tx = valid_transaction(&mut rng, amount);
-    client.estimate_predicates(&mut tx).await.unwrap();
-    let result = client.submit_and_await_commit(&tx).await.unwrap();
+    let tx = valid_transaction(&mut rng, amount);
+    let estimate_predicates = true;
+    let result = client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await
+        .unwrap();
     let TransactionStatus::Success { receipts, .. } = result else {
         panic!("{result:?}")
     };
@@ -424,9 +449,12 @@ async fn old_consensus_parameters_should_be_queryable_after_upgrade() {
     .unwrap();
 
     // When
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    client.submit_and_await_commit(&tx).await.unwrap();
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await
+        .unwrap();
     let next_block_height = client.produce_blocks(1, None).await.unwrap();
 
     let latest_consensus_parameters_version = client
@@ -476,9 +504,12 @@ async fn state_transition_bytecode_should_be_queryable_by_its_root_and_version()
 
     let transactions = transactions_from_subsections(&mut rng, subsections, amount);
     for upload in transactions {
-        let mut tx = upload.into();
-        client.estimate_predicates(&mut tx).await.unwrap();
-        client.submit_and_await_commit(&tx).await.unwrap();
+        let tx = upload.into();
+        let estimate_predicates = true;
+        client
+            .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+            .await
+            .unwrap();
     }
 
     // Given
@@ -500,9 +531,12 @@ async fn state_transition_bytecode_should_be_queryable_by_its_root_and_version()
     );
 
     // When
-    let mut tx = upgrade.into();
-    client.estimate_predicates(&mut tx).await.unwrap();
-    client.submit_and_await_commit(&tx).await.unwrap();
+    let tx = upgrade.into();
+    let estimate_predicates = true;
+    client
+        .submit_and_await_commit_opt(&tx, Some(estimate_predicates))
+        .await
+        .unwrap();
 
     let next_block_height = client.produce_blocks(1, None).await.unwrap();
 


### PR DESCRIPTION
Allow estimation of predicates on submission of the transaction.
It affects the following endpoints:
- `submit`
- `submit_and_await`
- `submit_and_await_status`

This behavior is controlled via an optional `estimatePredicates` argument. The change is backward compatible with SDK. The change is not forward-compatible with Rust SDK in the case of the `estiamte_predicates` flag being used.