### PR TITLE
Rafal/2835/pruning updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,6 +4072,7 @@ dependencies = [
  "mockall",
  "parking_lot",
  "proptest",
+ "test-case",
  "test-strategy",
  "tokio",
  "tokio-stream",

--- a/crates/services/tx_status_manager/Cargo.toml
+++ b/crates/services/tx_status_manager/Cargo.toml
@@ -26,6 +26,7 @@ fuel-core-tx-status-manager = { path = ".", features = ["test-helpers"] }
 fuel-core-types = { path = "./../../types", features = ["test-helpers"] }
 mockall = { workspace = true }
 proptest = { workspace = true }
+test-case = { workspace = true }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tracing = { workspace = true }

--- a/crates/services/tx_status_manager/src/lib.rs
+++ b/crates/services/tx_status_manager/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::cast_possible_truncation)]
 #![deny(unused_crate_dependencies)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
 pub mod config;
 mod error;

--- a/crates/services/tx_status_manager/src/lib.rs
+++ b/crates/services/tx_status_manager/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 #![deny(clippy::cast_possible_truncation)]
 #![deny(unused_crate_dependencies)]
-//#![deny(warnings)]
+#![deny(warnings)]
 
 pub mod config;
 mod error;

--- a/crates/services/tx_status_manager/src/manager.rs
+++ b/crates/services/tx_status_manager/src/manager.rs
@@ -174,7 +174,7 @@ impl TxStatusManager {
             .get(tx_id)
             .map(|(_, status)| status)
             .or_else(|| self.data.non_prunable_statuses.get(tx_id))
-            .map(|status| status.clone())
+            .cloned()
     }
 
     /// Subscribe to status updates for a transaction.
@@ -259,10 +259,10 @@ mod tests {
         ]
     }
 
-    fn random_prunable_status(rng: &mut StdRng) -> TransactionStatus {
+    fn random_prunable_tx_status(rng: &mut StdRng) -> TransactionStatus {
         all_statuses()
             .into_iter()
-            .filter(|tx| TxStatusManager::is_prunable(tx))
+            .filter(TxStatusManager::is_prunable)
             .collect::<Vec<_>>()
             .choose(rng)
             .unwrap()
@@ -794,7 +794,7 @@ mod tests {
                     // Make sure we'll never update back to submitted
                     let current_tx_status = tx_status_manager.status(&tx_id.into());
                     let new_tx_status = match current_tx_status {
-                        Some(_) => random_prunable_status(&mut rng),
+                        Some(_) => random_prunable_tx_status(&mut rng),
                         None => random_tx_status(&mut rng),
                     };
 

--- a/crates/services/tx_status_manager/src/manager.rs
+++ b/crates/services/tx_status_manager/src/manager.rs
@@ -112,7 +112,8 @@ impl TxStatusManager {
                     // We only need to remove status from the cache if it is the last status
                     // for the transaction(in other words timestamp from queue matches
                     // timestamp from the cache).
-                    if entry.get().0 == past {
+                    let (timestamp, _) = entry.get();
+                    if *timestamp == past {
                         entry.remove();
                     }
                 }


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuel-core/issues/2835

## Description
This PR changes the TxStatusManager so that it'll never prune the "Submitted" statuses using TTL. They are now removed only when the transaction switches to some other status.

## Checklist
- [X] New behavior is reflected in tests

### Before requesting review
- [X] I have reviewed the code myself
- [X] I have created follow-up issues caused by this PR and linked them here

### List of follow-up issues
- https://github.com/FuelLabs/fuel-core/issues/2851
- https://github.com/FuelLabs/fuel-core/issues/2852