### PR TITLE
Add expiration check on pending pool and refactor extracted outputs cache

### DIFF
--- a/.changes/added/2855.md
+++ b/.changes/added/2855.md
@@ -1,0 +1,1 @@
+Add an expiration interval check for pending pool and add deletion of Ouputs in saved_ouputs when a transaction that use the coin UTXO is extracted.

--- a/.changes/added/2855.md
+++ b/.changes/added/2855.md
@@ -1,1 +1,1 @@
-Add an expiration interval check for pending pool and add deletion of Ouputs in saved_ouputs when a transaction that use the coin UTXO is extracted.
+Add an expiration interval check for pending pool and refactor extracted_outputs to not rely on block creation/process sequence.

--- a/crates/services/txpool_v2/src/extracted_outputs.rs
+++ b/crates/services/txpool_v2/src/extracted_outputs.rs
@@ -1,0 +1,127 @@
+//! Temporary module to extract outputs until we know that they have been settled in database or skipped.
+
+use std::collections::{
+    HashMap,
+    HashSet,
+};
+
+use fuel_core_types::{
+    fuel_tx::{
+        input::coin::{
+            CoinPredicate,
+            CoinSigned,
+        },
+        Address,
+        AssetId,
+        ContractId,
+        Input,
+        Output,
+        UtxoId,
+    },
+    services::txpool::ArcPoolTx,
+};
+
+pub struct ExtractedOutputs {
+    contract_created: HashSet<ContractId>,
+    coins_created: HashMap<UtxoId, (Address, u64, AssetId)>,
+}
+
+impl ExtractedOutputs {
+    pub fn new() -> Self {
+        Self {
+            contract_created: HashSet::new(),
+            coins_created: HashMap::new(),
+        }
+    }
+}
+
+impl Default for ExtractedOutputs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExtractedOutputs {
+    pub fn new_extracted_transaction(&mut self, tx: &ArcPoolTx) {
+        for (idx, output) in tx.outputs().iter().enumerate() {
+            match output {
+                Output::ContractCreated { contract_id, .. } => {
+                    self.contract_created.insert(*contract_id);
+                }
+                Output::Coin {
+                    to,
+                    amount,
+                    asset_id,
+                } => {
+                    self.coins_created.insert(
+                        UtxoId::new(
+                            tx.id(),
+                            u16::try_from(idx)
+                                .expect("Outputs count is less than u16::MAX"),
+                        ),
+                        (*to, *amount, *asset_id),
+                    );
+                }
+                Output::Contract { .. }
+                | Output::Change { .. }
+                | Output::Variable { .. } => {
+                    continue;
+                }
+            }
+        }
+        for input in tx.inputs() {
+            match input {
+                Input::CoinSigned(CoinSigned { utxo_id, .. })
+                | Input::CoinPredicate(CoinPredicate { utxo_id, .. }) => {
+                    self.coins_created.remove(utxo_id);
+                }
+                Input::Contract(_)
+                | Input::MessageCoinPredicate(_)
+                | Input::MessageCoinSigned(_)
+                | Input::MessageDataPredicate(_)
+                | Input::MessageDataSigned(_) => {
+                    continue;
+                }
+            }
+        }
+    }
+
+    pub fn new_executed_transaction(&mut self, tx: &ArcPoolTx) {
+        for (idx, output) in tx.outputs().iter().enumerate() {
+            match output {
+                Output::ContractCreated { contract_id, .. } => {
+                    self.contract_created.remove(contract_id);
+                }
+                Output::Coin { .. } => {
+                    self.coins_created.remove(&UtxoId::new(
+                        tx.id(),
+                        u16::try_from(idx).expect("Outputs count is less than u16::MAX"),
+                    ));
+                }
+                Output::Contract { .. }
+                | Output::Change { .. }
+                | Output::Variable { .. } => {
+                    continue;
+                }
+            }
+        }
+    }
+
+    pub fn contract_exists(&self, contract_id: &ContractId) -> bool {
+        self.contract_created.contains(contract_id)
+    }
+
+    pub fn coin_exists(
+        &self,
+        utxo_id: &UtxoId,
+        address: &Address,
+        amount: &u64,
+        asset_id: &AssetId,
+    ) -> bool {
+        self.coins_created
+            .get(utxo_id)
+            .map_or(false, |(addr, amt, asset)| {
+                addr == address && amt == amount && asset == asset_id
+            })
+    }
+}

--- a/crates/services/txpool_v2/src/extracted_outputs.rs
+++ b/crates/services/txpool_v2/src/extracted_outputs.rs
@@ -54,14 +54,14 @@ impl ExtractedOutputs {
                 } => {
                     self.coins_created
                         .entry(tx_id)
-                        .or_insert_with(HashMap::new)
+                        .or_default()
                         .insert(
                             UtxoId::new(
                                 tx_id,
                                 u16::try_from(idx)
                                     .expect("Outputs count is less than u16::MAX"),
                             ),
-                            (to.clone(), *amount, *asset_id),
+                            (*to, *amount, *asset_id),
                         );
                 }
                 Output::Contract { .. }
@@ -77,7 +77,7 @@ impl ExtractedOutputs {
                 | Input::CoinPredicate(CoinPredicate { utxo_id, .. }) => {
                     self.coins_created
                         .entry(*utxo_id.tx_id())
-                        .or_insert_with(HashMap::new)
+                        .or_default()
                         .remove(utxo_id);
                 }
                 Input::Contract(_)

--- a/crates/services/txpool_v2/src/extracted_outputs.rs
+++ b/crates/services/txpool_v2/src/extracted_outputs.rs
@@ -52,17 +52,14 @@ impl ExtractedOutputs {
                     amount,
                     asset_id,
                 } => {
-                    self.coins_created
-                        .entry(tx_id)
-                        .or_default()
-                        .insert(
-                            UtxoId::new(
-                                tx_id,
-                                u16::try_from(idx)
-                                    .expect("Outputs count is less than u16::MAX"),
-                            ),
-                            (*to, *amount, *asset_id),
-                        );
+                    self.coins_created.entry(tx_id).or_default().insert(
+                        UtxoId::new(
+                            tx_id,
+                            u16::try_from(idx)
+                                .expect("Outputs count is less than u16::MAX"),
+                        ),
+                        (*to, *amount, *asset_id),
+                    );
                 }
                 Output::Contract { .. }
                 | Output::Change { .. }

--- a/crates/services/txpool_v2/src/lib.rs
+++ b/crates/services/txpool_v2/src/lib.rs
@@ -44,6 +44,7 @@
 mod collision_manager;
 pub mod config;
 pub mod error;
+mod extracted_outputs;
 mod pending_pool;
 mod pool;
 mod pool_worker;

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -1,10 +1,7 @@
 mod collisions;
 
 use std::{
-    collections::{
-        HashMap,
-        HashSet,
-    },
+    collections::HashMap,
     iter,
     time::{
         Instant,
@@ -17,18 +14,7 @@ use fuel_core_metrics::txpool_metrics::txpool_metrics;
 use fuel_core_types::{
     fuel_tx::{
         field::BlobId,
-        input::coin::{
-            CoinPredicate,
-            CoinSigned,
-        },
-        Address,
-        AssetId,
-        ContractId,
-        Input,
-        Output,
         TxId,
-        UtxoId,
-        Word,
     },
     services::txpool::{
         ArcPoolTx,
@@ -49,6 +35,7 @@ use crate::{
         InputValidationError,
         InsertionErrorType,
     },
+    extracted_outputs::ExtractedOutputs,
     ports::TxPoolPersistentStorage,
     selection_algorithms::{
         Constraints,
@@ -61,25 +48,14 @@ use crate::{
     },
 };
 
+#[cfg(test)]
+use std::collections::HashSet;
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TxPoolStats {
     pub tx_count: u64,
     pub total_size: u64,
     pub total_gas: u64,
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, PartialOrd, Eq, Ord)]
-pub(crate) struct SavedCoinOutput {
-    pub utxo_id: UtxoId,
-    pub to: Address,
-    pub amount: Word,
-    pub asset_id: AssetId,
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, PartialOrd, Eq, Ord)]
-pub(crate) enum SavedOutput {
-    Coin(SavedCoinOutput),
-    Contract(ContractId),
 }
 
 /// The pool is the main component of the txpool service. It is responsible for storing transactions
@@ -96,7 +72,7 @@ pub struct Pool<S, SI, CM, SA> {
     /// Mapping from tx_id to storage_id.
     pub(crate) tx_id_to_storage_id: HashMap<TxId, SI>,
     /// All sent outputs when transactions are extracted. Clear when processing a block.
-    pub(crate) extracted_outputs: HashSet<SavedOutput>,
+    pub(crate) extracted_outputs: ExtractedOutputs,
     /// Current pool gas stored.
     pub(crate) current_gas: u64,
     /// Current pool size in bytes.
@@ -123,7 +99,7 @@ impl<S, SI, CM, SA> Pool<S, SI, CM, SA> {
             selection_algorithm,
             config,
             tx_id_to_storage_id: HashMap::new(),
-            extracted_outputs: HashSet::new(),
+            extracted_outputs: ExtractedOutputs::new(),
             current_gas: 0,
             current_bytes_size: 0,
             pool_stats_sender,
@@ -334,76 +310,6 @@ where
         }
     }
 
-    fn populate_saved_outputs_cache(&mut self, best_txs: &[StorageData]) {
-        for tx in best_txs {
-            for (idx, output) in tx.transaction.outputs().iter().enumerate() {
-                match output {
-                    Output::Coin {
-                        to,
-                        amount,
-                        asset_id,
-                    } => {
-                        self.extracted_outputs.insert(SavedOutput::Coin(
-                            SavedCoinOutput {
-                                utxo_id: UtxoId::new(
-                                    tx.transaction.id(),
-                                    u16::try_from(idx)
-                                        .expect("Outputs count is less than u16::MAX"),
-                                ),
-                                to: *to,
-                                amount: *amount,
-                                asset_id: *asset_id,
-                            },
-                        ));
-                    }
-                    Output::ContractCreated { contract_id, .. } => {
-                        self.extracted_outputs
-                            .insert(SavedOutput::Contract(*contract_id));
-                    }
-                    Output::Contract { .. }
-                    | Output::Change { .. }
-                    | Output::Variable { .. } => {
-                        continue;
-                    }
-                }
-            }
-            for input in tx.transaction.inputs() {
-                match input {
-                    Input::CoinSigned(CoinSigned {
-                        utxo_id,
-                        owner,
-                        amount,
-                        asset_id,
-                        ..
-                    })
-                    | Input::CoinPredicate(CoinPredicate {
-                        utxo_id,
-                        owner,
-                        amount,
-                        asset_id,
-                        ..
-                    }) => {
-                        self.extracted_outputs.remove(&SavedOutput::Coin(
-                            SavedCoinOutput {
-                                utxo_id: *utxo_id,
-                                to: *owner,
-                                amount: *amount,
-                                asset_id: *asset_id,
-                            },
-                        ));
-                    }
-                    Input::Contract(_)
-                    | Input::MessageCoinPredicate(_)
-                    | Input::MessageCoinSigned(_)
-                    | Input::MessageDataPredicate(_)
-                    | Input::MessageDataSigned(_) => {
-                        continue;
-                    }
-                }
-            }
-        }
-    }
-
     /// Extract transactions for a block.
     /// Returns a list of transactions that were selected for the block
     /// based on the constraints given in the configuration and the selection algorithm used.
@@ -416,8 +322,6 @@ where
         let best_txs = self
             .selection_algorithm
             .gather_best_txs(constraints, &mut self.storage);
-
-        self.populate_saved_outputs_cache(&best_txs);
 
         if let Some(start) = maybe_start {
             Self::record_select_transaction_time(start)
@@ -432,6 +336,8 @@ where
         let txs = best_txs
             .into_iter()
             .map(|storage_entry| {
+                self.extracted_outputs
+                    .new_extracted_transaction(&storage_entry.transaction);
                 self.update_components_and_caches_on_removal(iter::once(&storage_entry));
                 storage_entry.transaction
             })
@@ -458,7 +364,6 @@ where
     /// - Remove transaction but keep its dependents and the dependents become executables.
     /// - Notify about possible new executable transactions.
     pub fn process_block(&mut self, tx_ids: impl Iterator<Item = TxId>) {
-        self.extracted_outputs.clear();
         let mut transactions_to_promote = vec![];
         for tx_id in tx_ids {
             if let Some(storage_id) = self.tx_id_to_storage_id.remove(&tx_id) {
@@ -472,6 +377,8 @@ where
                     );
                     continue
                 };
+                self.extracted_outputs
+                    .new_executed_transaction(&transaction.transaction);
                 self.update_components_and_caches_on_removal(iter::once(&transaction));
 
                 for dependent in dependents {

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -366,6 +366,7 @@ where
     pub fn process_block(&mut self, tx_ids: impl Iterator<Item = TxId>) {
         let mut transactions_to_promote = vec![];
         for tx_id in tx_ids {
+            self.extracted_outputs.new_executed_transaction(&tx_id);
             if let Some(storage_id) = self.tx_id_to_storage_id.remove(&tx_id) {
                 let dependents: Vec<S::StorageIndex> =
                     self.storage.get_direct_dependents(storage_id).collect();
@@ -377,8 +378,6 @@ where
                     );
                     continue
                 };
-                self.extracted_outputs
-                    .new_executed_transaction(&transaction.transaction);
                 self.update_components_and_caches_on_removal(iter::once(&transaction));
 
                 for dependent in dependents {
@@ -570,7 +569,8 @@ where
         removed_transactions
     }
 
-    pub fn remove_coin_dependents(&mut self, tx_id: TxId) -> Vec<ArcPoolTx> {
+    pub fn remove_skipped_transaction(&mut self, tx_id: TxId) -> Vec<ArcPoolTx> {
+        self.extracted_outputs.new_skipped_transaction(&tx_id);
         let mut txs_removed = vec![];
         let coin_dependents = self.collision_manager.get_coins_spenders(&tx_id);
         for dependent in coin_dependents {

--- a/crates/services/txpool_v2/src/pool_worker.rs
+++ b/crates/services/txpool_v2/src/pool_worker.rs
@@ -470,8 +470,6 @@ where
                 }
             }
         }
-        self.pending_pool
-            .expire_transactions(self.notification_sender.clone());
     }
 
     fn extract_block_transactions(
@@ -499,9 +497,6 @@ where
         for (tx, source) in resolved_txs {
             self.insert(tx, source);
         }
-
-        self.pending_pool
-            .expire_transactions(self.notification_sender.clone());
     }
 
     fn remove_skipped_transactions(&mut self, parent_txs: Vec<(TxId, Error)>) {

--- a/crates/services/txpool_v2/src/pool_worker.rs
+++ b/crates/services/txpool_v2/src/pool_worker.rs
@@ -201,7 +201,7 @@ pub(super) enum PoolRemoveRequest {
     ProcessBlock {
         block_result: SharedImportResult,
     },
-    CoinDependents {
+    SkippedTransactions {
         dependents_ids: Vec<(TxId, Error)>,
     },
     TxAndCoinDependents {
@@ -300,8 +300,8 @@ where
                         PoolRemoveRequest::ProcessBlock { block_result } => {
                             self.process_block(block_result);
                         }
-                        PoolRemoveRequest::CoinDependents { dependents_ids } => {
-                            self.remove_coin_dependents(dependents_ids);
+                        PoolRemoveRequest::SkippedTransactions { dependents_ids } => {
+                            self.remove_skipped_transactions(dependents_ids);
                         }
                         PoolRemoveRequest::TxAndCoinDependents { tx_and_dependents_ids } => {
                             self.remove_and_coin_dependents(tx_and_dependents_ids);
@@ -504,9 +504,9 @@ where
             .expire_transactions(self.notification_sender.clone());
     }
 
-    fn remove_coin_dependents(&mut self, parent_txs: Vec<(TxId, Error)>) {
+    fn remove_skipped_transactions(&mut self, parent_txs: Vec<(TxId, Error)>) {
         for (tx_id, reason) in parent_txs {
-            let removed = self.pool.remove_coin_dependents(tx_id);
+            let removed = self.pool.remove_skipped_transaction(tx_id);
             for tx in removed {
                 let tx_id = tx.id();
                 if let Err(e) = self.notification_sender.try_send(PoolNotification::Removed {

--- a/crates/services/txpool_v2/src/shared_state.rs
+++ b/crates/services/txpool_v2/src/shared_state.rs
@@ -158,7 +158,7 @@ impl SharedState {
 
         if let Err(e) = self
             .request_remove_sender
-            .try_send(PoolRemoveRequest::CoinDependents { dependents_ids })
+            .try_send(PoolRemoveRequest::SkippedTransactions { dependents_ids })
         {
             tracing::error!("Failed to send remove coin dependents request: {}", e);
         }

--- a/crates/services/txpool_v2/src/storage/mod.rs
+++ b/crates/services/txpool_v2/src/storage/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         Error,
         InputValidationErrorType,
     },
-    pool::SavedOutput,
+    extracted_outputs::ExtractedOutputs,
     ports::TxPoolPersistentStorage,
 };
 use fuel_core_types::services::txpool::{
@@ -93,7 +93,7 @@ pub trait Storage {
         &self,
         transaction: &PoolTransaction,
         persistent_storage: &impl TxPoolPersistentStorage,
-        saved_outputs: &HashSet<SavedOutput>,
+        extracted_outputs: &ExtractedOutputs,
         utxo_validation: bool,
     ) -> Result<(), InputValidationErrorType>;
 

--- a/crates/services/txpool_v2/src/tests/tests_pending_pool.rs
+++ b/crates/services/txpool_v2/src/tests/tests_pending_pool.rs
@@ -13,7 +13,7 @@ use crate::tests::universe::TestPoolUniverse;
 async fn test_tx__keep_missing_input_and_resolved_when_input_submitted() {
     let mut universe = TestPoolUniverse::default();
     universe.config.utxo_validation = true;
-    let timeout = tokio::time::Duration::from_millis(500);
+    let timeout = tokio::time::Duration::from_millis(10000);
     universe.config.pending_pool_tx_ttl = timeout;
 
     let (output, unset_input) = universe.create_output_and_input();

--- a/crates/services/txpool_v2/src/tests/tests_pending_pool.rs
+++ b/crates/services/txpool_v2/src/tests/tests_pending_pool.rs
@@ -55,6 +55,7 @@ async fn test_tx__return_error_expired() {
     let timeout = tokio::time::Duration::from_millis(100);
     universe.config.pending_pool_tx_ttl = timeout;
 
+    // Given
     let (_, unset_input) = universe.create_output_and_input();
     let tx1 = universe.build_script_transaction(None, None, 10);
     let tx1_id = tx1.id(&Default::default());
@@ -66,19 +67,8 @@ async fn test_tx__return_error_expired() {
     let service = universe.build_service(None, None);
     service.start_and_await().await.unwrap();
 
-    // Given
-    service.shared.try_insert(vec![tx2.clone()]).unwrap();
-
     // When
-    let ids = vec![tx2_id];
-    universe
-        .await_expected_tx_statuses(ids, |status| {
-            matches!(status, TransactionStatus::Submitted { .. })
-        })
-        .await
-        .unwrap_err()
-        .is_timeout();
-    service.shared.try_insert(vec![tx1.clone()]).unwrap();
+    service.shared.try_insert(vec![tx2.clone()]).unwrap();
 
     // Then
     // The error returned is the error that the transaction was squeezed out for.

--- a/crates/services/txpool_v2/src/tests/tests_pending_pool.rs
+++ b/crates/services/txpool_v2/src/tests/tests_pending_pool.rs
@@ -13,7 +13,7 @@ use crate::tests::universe::TestPoolUniverse;
 async fn test_tx__keep_missing_input_and_resolved_when_input_submitted() {
     let mut universe = TestPoolUniverse::default();
     universe.config.utxo_validation = true;
-    let timeout = tokio::time::Duration::from_secs(1);
+    let timeout = tokio::time::Duration::from_millis(500);
     universe.config.pending_pool_tx_ttl = timeout;
 
     let (output, unset_input) = universe.create_output_and_input();

--- a/crates/services/txpool_v2/src/tests/tests_service.rs
+++ b/crates/services/txpool_v2/src/tests/tests_service.rs
@@ -520,3 +520,54 @@ async fn insert__tx_depends_one_extracted_and_one_pool_tx() {
     assert_eq!(txs_second_extract[0].id(), tx2.id(&Default::default()));
     assert_eq!(txs_second_extract[1].id(), tx3.id(&Default::default()));
 }
+
+#[tokio::test]
+async fn pending_pool__returns_error_after_timeout_for_transaction_that_spends_already_spent_utxo(
+) {
+    // Given
+    const TIMEOUT: u64 = 1;
+    let mut universe = TestPoolUniverse::default().config(Config {
+        pending_pool_tx_ttl: Duration::from_secs(TIMEOUT),
+        utxo_validation: true,
+        ..Default::default()
+    });
+    let service = universe.build_service(None, None);
+    service.start_and_await().await.unwrap();
+
+    let (output_a, unset_input) = universe.create_output_and_input();
+    let tx1 = universe.build_script_transaction(None, Some(vec![output_a]), 1);
+    let input_a = unset_input.into_input(UtxoId::new(tx1.id(&Default::default()), 0));
+    let tx2 = universe.build_script_transaction(Some(vec![input_a]), None, 20);
+
+    // When
+    service.shared.insert(tx1.clone()).await.unwrap();
+    service.shared.insert(tx2.clone()).await.unwrap();
+    let txs_first_extract = service
+        .shared
+        .extract_transactions_for_block(Constraints {
+            minimal_gas_price: 0,
+            max_gas: u64::MAX,
+            maximum_txs: u16::MAX,
+            maximum_block_size: u32::MAX,
+        })
+        .unwrap();
+
+    // Insert tx2 will land in pending pool because it uses an input that doesn't exist anymore
+    // it should be pruned out of the pending pool after the timeout
+    service.shared.try_insert(vec![tx2.clone()]).unwrap();
+
+    // Then
+    assert_eq!(txs_first_extract.len(), 2);
+    assert_eq!(txs_first_extract[0].id(), tx1.id(&Default::default()));
+    assert_eq!(txs_first_extract[1].id(), tx2.id(&Default::default()));
+    let ids = vec![tx2.id(&Default::default())];
+    universe
+        .await_expected_tx_statuses(ids, |status| {
+            matches!(status, TransactionStatus::SqueezedOut(s)
+                    if s.reason == "Transaction input validation failed: UTXO (id: cd590cc7b217fad36bc7e48743d5164cee0415acdcbd4cfa90f464e8c77a57b30000) does not exist")
+        })
+        .await
+        .unwrap();
+
+    service.stop_and_await().await.unwrap();
+}

--- a/crates/services/txpool_v2/src/tests/universe.rs
+++ b/crates/services/txpool_v2/src/tests/universe.rs
@@ -481,7 +481,7 @@ impl TestPoolUniverse {
         tx_ids: Vec<TxId>,
         predicate: impl Fn(&TransactionStatus) -> bool,
     ) -> Result<(), TxStatusWaitError> {
-        const TIMEOUT: Duration = Duration::from_secs(5);
+        const TIMEOUT: Duration = Duration::from_secs(3);
         const POLL_TIMEOUT: Duration = Duration::from_millis(5);
 
         let mut values = Vec::with_capacity(tx_ids.len());

--- a/crates/services/txpool_v2/src/tests/universe.rs
+++ b/crates/services/txpool_v2/src/tests/universe.rs
@@ -481,7 +481,7 @@ impl TestPoolUniverse {
         tx_ids: Vec<TxId>,
         predicate: impl Fn(&TransactionStatus) -> bool,
     ) -> Result<(), TxStatusWaitError> {
-        const TIMEOUT: Duration = Duration::from_secs(3);
+        const TIMEOUT: Duration = Duration::from_secs(5);
         const POLL_TIMEOUT: Duration = Duration::from_millis(5);
 
         let mut values = Vec::with_capacity(tx_ids.len());


### PR DESCRIPTION
## Description

Add an expiration interval check for pending pool and refactor `extracted_ouputs`.

### Changes in extracted outputs
- 2 data structures one for coins one for contracts
- Now it's not fully clear when receiving a block but only clear when received skipped or executed transactions
- Now clears also when the outputs are used in inputs of another extracted transaction

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
