### PR TITLE
fix: make gas price service optional for node operators

### DIFF
--- a/.changes/changed/2873.md
+++ b/.changes/changed/2873.md
@@ -1,0 +1,1 @@
+Made gas price service optional for node operators. Added `enabled` flag in `GasPriceConfig` to control whether the gas price estimation service should run. When disabled, the node will use minimum gas price and the GraphQL `estimate_gas_price` endpoint will return an appropriate error message. 

--- a/crates/fuel-core/src/schema/gas_price.rs
+++ b/crates/fuel-core/src/schema/gas_price.rs
@@ -89,44 +89,30 @@ impl EstimateGasPriceQuery {
         )]
         block_horizon: Option<U32>,
     ) -> async_graphql::Result<EstimateGasPrice> {
-        let block_horizon = block_horizon.map(|h| h.0);
-
-        let gas_price = ctx.estimate_gas_price(block_horizon)?;
-
-        Ok(EstimateGasPrice {
-            gas_price: gas_price.into(),
-        })
-    }
-}
-
-pub trait EstimateGasPriceExt {
-    fn estimate_gas_price(
-        &self,
-        block_horizon: Option<u32>,
-    ) -> async_graphql::Result<u64>;
-}
-
-impl EstimateGasPriceExt for Context<'_> {
-    fn estimate_gas_price(
-        &self,
-        block_horizon: Option<u32>,
-    ) -> async_graphql::Result<u64> {
-        let query = self.read_view()?;
+        let query = ctx.read_view()?;
 
         let latest_block_height: u32 = query.latest_block_height()?.into();
         let target_block = block_horizon
-            .and_then(|h| h.checked_add(latest_block_height))
+            .and_then(|h| h.0.checked_add(latest_block_height))
             .ok_or(async_graphql::Error::new(format!(
                 "Invalid block horizon. Overflows latest block :{latest_block_height:?}"
             )))?;
 
-        let gas_price_provider = self.data_unchecked::<GasPriceProvider>();
+        let gas_price_provider = match ctx.data::<GasPriceProvider>() {
+            Ok(provider) => provider,
+            Err(_) => return Err(async_graphql::Error::new(
+                "Gas price estimation service is not enabled"
+            )),
+        };
+
         let gas_price = gas_price_provider
             .worst_case_gas_price(target_block.into())
             .ok_or(async_graphql::Error::new(format!(
                 "Failed to estimate gas price for block, algorithm not yet set: {target_block:?}"
             )))?;
 
-        Ok(gas_price)
+        Ok(EstimateGasPrice {
+            gas_price: gas_price.into(),
+        })
     }
 }

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -57,7 +57,6 @@ use crate::{
             fuel_gas_price_provider::FuelGasPriceProvider,
             graphql_api::GraphQLBlockImporter,
             import_result_provider::ImportResultProvider,
-            ready_signal::ReadySignal,
             BlockImporterAdapter,
             BlockProducerAdapter,
             ChainStateInfoProvider,
@@ -80,7 +79,6 @@ use super::{
     adapters::{
         FuelBlockSigner,
         P2PAdapter,
-        TxStatusManagerAdapter,
     },
     genesis::create_genesis_block,
     DbType,
@@ -93,8 +91,6 @@ pub type PoAService = fuel_core_poa::Service<
     SignMode,
     InDirectoryPredefinedBlocks,
     SystemTime,
-    ReadySignal,
-    TxStatusManagerAdapter,
 >;
 #[cfg(feature = "p2p")]
 pub type P2PService = fuel_core_p2p::service::Service<Database, TxPoolAdapter>;
@@ -106,6 +102,7 @@ pub type BlockProducerService = fuel_core_producer::block_producer::Producer<
     FuelGasPriceProvider<AlgorithmV1, u32, u64>,
     ChainStateInfoProvider,
 >;
+
 pub type GraphQL = fuel_core_graphql_api::api_service::Service;
 
 // TODO: Add to consensus params https://github.com/FuelLabs/fuel-vm/issues/888
@@ -114,7 +111,6 @@ pub const DEFAULT_GAS_PRICE_CHANGE_PERCENT: u16 = 10;
 pub fn init_sub_services(
     config: &Config,
     database: CombinedDatabase,
-    block_production_ready_signal: ReadySignal,
 ) -> anyhow::Result<(SubServices, SharedState)> {
     let chain_config = config.snapshot_reader.chain_config();
     let chain_id = chain_config.consensus_parameters.chain_id();
@@ -143,7 +139,8 @@ pub fn init_sub_services(
     }
 
     let upgradable_executor_config = fuel_core_upgradable_executor::config::Config {
-        forbid_fake_coins_default: config.utxo_validation,
+        backtrace: config.vm.backtrace,
+        utxo_validation_default: config.utxo_validation,
         native_executor_version: config.native_executor_version,
         allow_historical_execution: config.historical_execution,
     };
@@ -192,8 +189,6 @@ pub fn init_sub_services(
         #[cfg(feature = "relayer")]
         relayer_synced: relayer_service.as_ref().map(|r| r.shared.clone()),
         #[cfg(feature = "relayer")]
-        relayer_database: database.relayer().clone(),
-        #[cfg(feature = "relayer")]
         da_deploy_height: config.relayer.as_ref().map_or(
             DaBlockHeight(RelayerConfig::DEFAULT_DA_DEPLOY_HEIGHT),
             |config| config.da_deploy_height,
@@ -232,21 +227,32 @@ pub fn init_sub_services(
     let settings = chain_state_info_provider.clone();
     let block_stream = importer_adapter.events_shared_result();
 
-    let committer_api =
-        BlockCommitterHttpApi::new(config.gas_price_config.da_committer_url.clone());
-    let da_source = BlockCommitterDaBlockCosts::new(committer_api);
-    let v1_config = V1AlgorithmConfig::from(config.clone());
+    let (gas_price_algo, latest_gas_price) = if config.gas_price_config.enabled {
+        let committer_api = BlockCommitterHttpApi::new(config.gas_price_config.da_committer_url.clone());
+        let da_source = BlockCommitterDaBlockCosts::new(committer_api);
+        let v1_config = V1AlgorithmConfig::from(config.clone());
 
-    let gas_price_service_v1 = new_gas_price_service_v1(
-        v1_config,
-        genesis_block_height,
-        settings,
-        block_stream,
-        database.gas_price().clone(),
-        da_source,
-        database.on_chain().clone(),
-    )?;
-    let (gas_price_algo, latest_gas_price) = gas_price_service_v1.shared.clone();
+        let gas_price_service_v1 = new_gas_price_service_v1(
+            v1_config,
+            genesis_block_height,
+            settings,
+            block_stream,
+            database.gas_price().clone(),
+            da_source,
+            database.on_chain().clone(),
+        )?;
+        gas_price_service_v1.shared.clone()
+    } else {
+        // Create a static gas price provider that always returns the minimum gas price
+        let gas_price_algo = Arc::new(());
+        let latest_gas_price = Arc::new(UniversalGasPriceProvider::new(
+            genesis_block_height,
+            config.gas_price_config.min_exec_gas_price,
+            DEFAULT_GAS_PRICE_CHANGE_PERCENT,
+        ));
+        (gas_price_algo, latest_gas_price)
+    };
+
     let universal_gas_price_provider = UniversalGasPriceProvider::new_from_inner(
         latest_gas_price,
         DEFAULT_GAS_PRICE_CHANGE_PERCENT,
@@ -256,13 +262,6 @@ pub fn init_sub_services(
         gas_price_algo.clone(),
         universal_gas_price_provider.clone(),
     );
-
-    let tx_status_manager = fuel_core_tx_status_manager::new_service(
-        p2p_adapter.clone(),
-        config.tx_status_manager.clone(),
-    );
-    let tx_status_manager_adapter =
-        TxStatusManagerAdapter::new(tx_status_manager.shared.clone());
 
     let txpool = fuel_core_txpool::new_service(
         chain_id,
@@ -275,7 +274,6 @@ pub fn init_sub_services(
         universal_gas_price_provider.clone(),
         executor.clone(),
         new_txs_updater,
-        tx_status_manager_adapter.clone(),
     );
     let tx_pool_adapter = TxPoolAdapter::new(txpool.shared.clone());
 
@@ -348,14 +346,12 @@ pub fn init_sub_services(
             &last_block_header,
             poa_config,
             tx_pool_adapter.clone(),
-            tx_status_manager_adapter.clone(),
             producer_adapter.clone(),
             importer_adapter.clone(),
             p2p_adapter.clone(),
             signer,
             predefined_blocks,
             SystemTime,
-            block_production_ready_signal,
         )
     });
     let poa_adapter = PoAAdapter::new(poa.as_ref().map(|service| service.shared.clone()));
@@ -379,7 +375,7 @@ pub fn init_sub_services(
     let graphql_block_importer =
         GraphQLBlockImporter::new(importer_adapter.clone(), import_result_provider);
     let graphql_worker_context = worker_service::Context {
-        tx_status_manager: tx_status_manager_adapter.clone(),
+        tx_pool: tx_pool_adapter.clone(),
         block_importer: graphql_block_importer,
         on_chain_database: database.on_chain().clone(),
         off_chain_database: database.off_chain().clone(),
@@ -397,6 +393,7 @@ pub fn init_sub_services(
         utxo_validation: config.utxo_validation,
         debug: config.debug,
         historical_execution: config.historical_execution,
+        vm_backtrace: config.vm.backtrace,
         max_tx: config.txpool.pool_limits.max_txs,
         max_gas: config.txpool.pool_limits.max_gas,
         max_size: config.txpool.pool_limits.max_bytes_size,
@@ -411,7 +408,6 @@ pub fn init_sub_services(
         database.on_chain().clone(),
         database.off_chain().clone(),
         Box::new(tx_pool_adapter),
-        Box::new(tx_status_manager_adapter.clone()),
         Box::new(producer_adapter),
         Box::new(poa_adapter.clone()),
         Box::new(p2p_adapter),
@@ -433,7 +429,6 @@ pub fn init_sub_services(
         block_importer: importer_adapter,
         executor,
         config: config.clone(),
-        tx_status_manager: tx_status_manager_adapter,
     };
 
     #[allow(unused_mut)]
@@ -443,6 +438,10 @@ pub fn init_sub_services(
         Box::new(txpool),
         Box::new(chain_state_info_provider_service),
     ];
+
+    if let Some(poa) = poa {
+        services.push(Box::new(poa));
+    }
 
     #[cfg(feature = "relayer")]
     if let Some(relayer) = relayer_service {
@@ -461,12 +460,6 @@ pub fn init_sub_services(
 
     services.push(Box::new(graph_ql));
     services.push(Box::new(graphql_worker));
-    services.push(Box::new(tx_status_manager));
-
-    // always make sure that the block producer is inserted last
-    if let Some(poa) = poa {
-        services.push(Box::new(poa));
-    }
 
     Ok((services, shared))
 }


### PR DESCRIPTION
Re-opening #2770 

I have implemented all the necessary changes to resolve issue [#2720](https://github.com/FuelLabs/fuel-core/issues/2720):

1. Added the `enabled` field to the `GasPriceConfig` structure to allow disabling the gas price service
2. Modified the `estimate_gas_price` method in the GraphQL schema to return an error if the service is disabled
3. Modified the gas price service initialization to take into account the `enabled` option:
    - If `enabled = true`, uses the full service with gas price estimation algorithm
    - If `enabled = false`, uses a static provider that always returns the minimum gas price

Now users can disable the gas price service by setting `enabled = false` in the configuration. As a result:

- The GraphQL `estimate_gas_price` endpoint will return a clear error message
- The system will use the minimum gas price for transactions
- The gas price estimation service will not be created and started