### PR TITLE
test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Define the order of sections
+sections_order=("breaking" "added" "changed" "fixed" "removed")
+
+# Process each section in the specified order
+for section in "${sections_order[@]}"; do
+    dir_path=".changes/${section}"
+    if [ -d "$dir_path" ]; then
+        # Collect .md files sorted numerically using version sort
+        files=()
+        while IFS= read -r -d $'\0' file; do
+            files+=("$file")
+        done < <(find "$dir_path" -maxdepth 1 -type f -name '*.md' -print0 | sort -V -z)
+              
+        if [ ${#files[@]} -gt 0 ]; then
+            # Capitalize the first letter of the section name
+            section_name="$(tr '[:lower:]' '[:upper:]' <<< "${section:0:1}")${section:1}"
+            VERSION_TEXT+="\n### $section_name\n"
+            for file in "${files[@]}"; do
+                filename=$(basename "$file" .md)
+                content=$(cat "$file")
+                VERSION_TEXT+="- [${filename}](https://github.com/FuelLabs/fuel-core/pull/${filename}): ${content}\n"
+            done
+        fi
+    fi
+done
+{
+    echo 'VERSION_TEXT<<EOF'
+    echo -e ${VERSION_TEXT}
+    echo EOF
+} >> debug.txt


### PR DESCRIPTION
## Version 0.42.0

### Breaking
- [2648](https://github.com/FuelLabs/fuel-core/pull/2648): Add feature-flagged field to block header  that contains a commitment to all transaction ids.
- [2678](https://github.com/FuelLabs/fuel-core/pull/2678): Removed public accessors for  fields and replaced with methods instead, moved  to the application header of .
- [2746](https://github.com/FuelLabs/fuel-core/pull/2746): Breaking changes to the CLI arguments: - To disable  just don't specify it. Before it required to use . - Next CLI arguments were renamed: -  ->  -  ->  -  ->  - Default value for the  was changed from  to . So information about new block will be propagated faster by default. - All CLI arguments below use time(like , , , etc.) use as a flag argument instead of number of seconds: -  -  -  -  -  -  -  -  -  -  -  -  -  - 
- [2840](https://github.com/FuelLabs/fuel-core/pull/2840): CLI argument  is deprecated and does nothing. It will be removed in a future version of . The  field was renamed into  that affects JSON based serialization/deserialization. Renamed  field into .

### Added
- [2150](https://github.com/FuelLabs/fuel-core/pull/2150): Upgraded  to  and introduced  to limit pending incoming/outgoing connections.
- [2491](https://github.com/FuelLabs/fuel-core/pull/2491): Storage read replays of historical blocks for execution tracing. Only available behind  flag.
- [2619](https://github.com/FuelLabs/fuel-core/pull/2619): Add possibility to submit list of changes to rocksdb.
- [2666](https://github.com/FuelLabs/fuel-core/pull/2666): Added two new CLI arguments to control the GraphQL queries consistency:  (default: ) and  (default: ). If a request requires a specific block height and the node is slightly behind, it will wait instead of failing.
- [2682](https://github.com/FuelLabs/fuel-core/pull/2682): Added GraphQL APIs to get contract storage and balances for current and past blocks.
- [2719](https://github.com/FuelLabs/fuel-core/pull/2719): Merklized DA compression temporal registry tables.
- [2722](https://github.com/FuelLabs/fuel-core/pull/2722): Service definition for state root service.
- [2724](https://github.com/FuelLabs/fuel-core/pull/2724): Explicit error type for merkleized storage.
- [2726](https://github.com/FuelLabs/fuel-core/pull/2726): Add a new gossip-sub message for transaction preconfirmations
- [2731](https://github.com/FuelLabs/fuel-core/pull/2731): Include  trait implementations for v2 tables.
- [2733](https://github.com/FuelLabs/fuel-core/pull/2733): Add a pending pool transaction that allow transaction to wait a bit of time if an input is missing instead of direct delete.
- [2742](https://github.com/FuelLabs/fuel-core/pull/2742): Added API crate for merkle root service.
- [2756](https://github.com/FuelLabs/fuel-core/pull/2756): Add new service for managing pre-confirmations
- [2769](https://github.com/FuelLabs/fuel-core/pull/2769): Added a new  GraphQL endpoint. The endpoint can be used to assemble the transaction based on the provided requirements. The returned transaction contains: - Input coins to cover  - Input coins to cover the fee of the transaction based on the gas price from  -  or  outputs for all assets from the inputs -  outputs in the case they are required during the execution -  inputs and outputs in the case they are required during the execution - Reserved witness slots for signed coins filled with  zeroes - Set script gas limit(unless Script started, output log file is 'typescript'.
$ 
Script done. is empty) - Estimated predicates, if  Returns an error if: - The number of required balances exceeds the maximum number of inputs allowed. - The fee address index is out of bounds. - The same asset has multiple change policies(either the receiver of the change is different, or one of the policies states about the destruction of the token while the other does not). The  output from the transaction also count as a . - The number of excluded coin IDs exceeds the maximum number of inputs allowed. - Required assets have multiple entries. - If accounts don't have sufficient amounts to cover the transaction requirements in assets. - If a constructed transaction breaks the rules defined by consensus parameters.
- [2780](https://github.com/FuelLabs/fuel-core/pull/2780): Add implementations for the pre-confirmation signing task
- [2784](https://github.com/FuelLabs/fuel-core/pull/2784): Integrate the pre conf signature task into the main consensus task
- [2788](https://github.com/FuelLabs/fuel-core/pull/2788): Scaffold dedicated compression service.
- [2799](https://github.com/FuelLabs/fuel-core/pull/2799): Add a transaction waiter to the executor to wait for potential new transactions inside the block production window. Add a channel to send preconfirmation created by executor to the other modules Added a new CLI arguments: -  to control the block production timeout in the case if block producer stuck. -  set the block production mode to . The  mode starts the production of the next block immediately after the previous block. The block is open until the  passed. The period is a duration represented by , , , etc. The manual block production is disabled if this production mode is used.
- [2802](https://github.com/FuelLabs/fuel-core/pull/2802): Add a new cache with outputs extracted from the pool for the duration of the block.
- [2824](https://github.com/FuelLabs/fuel-core/pull/2824): Introduce new -like methods for the 
- [2840](https://github.com/FuelLabs/fuel-core/pull/2840): Added a new CLI arguments: -  - The max number how many times script can be executed during  GraphQL request. Default value is  times. -  - The max number how many times predicates can be estimated during  GraphQL request. Default values is  times.
- [2841](https://github.com/FuelLabs/fuel-core/pull/2841): Following endpoints allow estimation of predicates on submission of the transaction via new  argument: -  -  -  The change is backward compatible with all SDKs. The change is not forward-compatible with Rust SDK in the case of the  flag set.
- [2844](https://github.com/FuelLabs/fuel-core/pull/2844): Implement DA compression in .
- [2845](https://github.com/FuelLabs/fuel-core/pull/2845): New status to manage the pre confirmation status send in .
- [2855](https://github.com/FuelLabs/fuel-core/pull/2855): Add an expiration interval check for pending pool and refactor extracted_outputs to not rely on block creation/process sequence.
- [2856](https://github.com/FuelLabs/fuel-core/pull/2856): Add generic logic for managing the signatures and delegate keys for pre-confirmations signatures
- [2862](https://github.com/FuelLabs/fuel-core/pull/2862): Derive  and  for MerkleizedColumn.

### Changed
- [2388](https://github.com/FuelLabs/fuel-core/pull/2388): Rework the P2P service codecs to avoid unnecessary coupling between components. The refactoring makes it explicit that the Gossipsub and RequestResponse codecs only share encoding/decoding functionalities from the Postcard codec. It also makes handling Gossipsub and RequestResponse messages completely independent of each other.
- [2460](https://github.com/FuelLabs/fuel-core/pull/2460): The type of the for the postcard codec used in  protocols has been changed from  to .
- [2473](https://github.com/FuelLabs/fuel-core/pull/2473): Graphql requests and responses make use of a new  object to specify request/response metadata. A request  object can contain an integer-valued  field. When specified, the request will return an error unless the node's current fuel block height is at least the value specified in the  field. All graphql responses now contain an integer-valued  field in the  object, which contains the block height of the last block processed by the node.
- [2618](https://github.com/FuelLabs/fuel-core/pull/2618): Parallelize block/transaction changes creation in Importer
- [2653](https://github.com/FuelLabs/fuel-core/pull/2653): Added cleaner error for wasm-executor upon failed deserialization.
- [2656](https://github.com/FuelLabs/fuel-core/pull/2656): Migrate test helper function  to , and refactor test in proof_system/global_merkle_root crate to use this function.
- [2659](https://github.com/FuelLabs/fuel-core/pull/2659): Replace  crate with  crate.
- [2705](https://github.com/FuelLabs/fuel-core/pull/2705): Update the default value for  and  to 50 MB
- [2715](https://github.com/FuelLabs/fuel-core/pull/2715): Each GraphQL response contains  and  in the  section.
- [2723](https://github.com/FuelLabs/fuel-core/pull/2723): Change the way we are building the changelog to avoids conflicts.
- [2725](https://github.com/FuelLabs/fuel-core/pull/2725): New txpool worker to remove lock contention
- [2752](https://github.com/FuelLabs/fuel-core/pull/2752): Extended the  to support pre-confirmations.
- [2761](https://github.com/FuelLabs/fuel-core/pull/2761): Renamed  to  because it is now providing more than just info about consensus parameters.
- [2767](https://github.com/FuelLabs/fuel-core/pull/2767): Updated fuel-vm to v0.60.0, see [release notes](https://github.com/FuelLabs/fuel-vm/releases/tag/v0.60.0).
- [2781](https://github.com/FuelLabs/fuel-core/pull/2781): Deprecate  mutation. Use  query instead.
- [2791](https://github.com/FuelLabs/fuel-core/pull/2791): Added  service which serves as a single source of truth regarding the current statuses of transactions
- [2793](https://github.com/FuelLabs/fuel-core/pull/2793): Moved common merkle storage trait implementations to  and made it easier to setup a set of columns that need merkleization.
- [2799](https://github.com/FuelLabs/fuel-core/pull/2799): Change the block production to not be trigger after an interval but directly after the creation of last block and let the executor run for the block time window.
- [2800](https://github.com/FuelLabs/fuel-core/pull/2800): Implement P2P adapter for preconfirmation broadcasting
- [2802](https://github.com/FuelLabs/fuel-core/pull/2802): Change new txs notifier to be notified only on executable transactions
- [2811](https://github.com/FuelLabs/fuel-core/pull/2811): When the state rewind window of 7d was triggered, the  was repeatedly called, resulting in multiple iterations over the empty ModificationsHistoryV1 table. Iteration was slow because compaction didn't have a chance to clean up V1 table. We removed iteration from the migration process.
- [2824](https://github.com/FuelLabs/fuel-core/pull/2824): Improve conditions where s in the  stop the service
- [2840](https://github.com/FuelLabs/fuel-core/pull/2840): Removed  logic from the executor. It is not needed anymore with the existence of the local debugger for the transactions.
- [2865](https://github.com/FuelLabs/fuel-core/pull/2865): Consider the following transaction statuses as final: , , , . All other statuses will be considered transient.

### Fixed
- [2646](https://github.com/FuelLabs/fuel-core/pull/2646): Improved performance of fetching block height by caching it when the view is created.
- [2682](https://github.com/FuelLabs/fuel-core/pull/2682): Fixed the issue with RPC consistency feature for the subscriptions(without the fix first we perform the logic of the query, and only after verify the required height).
- [2730](https://github.com/FuelLabs/fuel-core/pull/2730): Fixed RocksDB closing issue that potentially could panic.
- [2743](https://github.com/FuelLabs/fuel-core/pull/2743): Allow discovery of the peers when slots for functional connections are consumed. Reserved nodes are not affected by the limitation on connections anymore.
- [2746](https://github.com/FuelLabs/fuel-core/pull/2746): Fixed flaky part in the e2e tests and version compatibility tests. Speed up compatibility tests execution time. Decreased the default time between block height propagation throw the network.
- [2758](https://github.com/FuelLabs/fuel-core/pull/2758): Made  feature flagged in .
- [2832](https://github.com/FuelLabs/fuel-core/pull/2832): - Trigger block production only when all other sub services are started. - Fix relayer syncing issue causing block production to slow down occasionally.
- [2840](https://github.com/FuelLabs/fuel-core/pull/2840): Fixed  receipt deserialization in the case if the  is zero.

### Removed
- [2863](https://github.com/FuelLabs/fuel-core/pull/2863): Removed everything related to the state root service, as it has been moved to another repo.
