### PR TITLE
fix(ci): only run changelog job if triggering event is a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,17 +33,13 @@ jobs:
   check-changelog:
     name: Check Changelog
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Check for a file with the PR number in a sub-directory of the .changes directory" or "no changelog" label.
         run: |
-          # Check if we are on master
-          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
-            echo "On master branch, skipping changelog check."
-            exit 0
-          fi
           pr_number_file=$(echo $GITHUB_REF | cut -d'/' -f3).md
           if [[ $(find .changes/ -type f -name $pr_number_file -print -quit) ]]; then
             echo "File $pr_number_file exists."


### PR DESCRIPTION
This check runs against all tags, we prevent it from doing so
