### PR TITLE
fix(version-compatibility): pin async-graphql to 7.0.15

### DIFF
--- a/version-compatibility/forkless-upgrade/Cargo.toml
+++ b/version-compatibility/forkless-upgrade/Cargo.toml
@@ -53,3 +53,5 @@ version-36-fuel-core-client = { version = "0.36.0", package = "fuel-core-client"
 version-36-fuel-core-services = { version = "0.36.0", package = "fuel-core-services" }
 version-36-fuel-core-gas-price-service = { version = "0.36.0", package = "fuel-core-gas-price-service" }
 version-36-fuel-core-storage = { version = "0.36.0", package = "fuel-core-storage" }
+# pin async-graphql because they bumped msrv in a patch release
+async-graphql = "=7.0.15"

--- a/version-compatibility/forkless-upgrade/src/lib.rs
+++ b/version-compatibility/forkless-upgrade/src/lib.rs
@@ -12,6 +12,9 @@ use fuel_core::{
 };
 
 #[cfg(test)]
+use async_graphql as _;
+
+#[cfg(test)]
 mod backward_compatibility;
 #[cfg(test)]
 mod forward_compatibility;


### PR DESCRIPTION
they bumped msrv between patch releases.