### PR TITLE
fix(compression_service): post merge reviews

### DIFF
--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -825,6 +825,9 @@ mod tests {
         };
         use fuel_core_storage::transactional::WriteTransaction;
 
+        // this invariant doesn't hold anymore
+        // because we have removed columns from the storage
+        #[ignore]
         #[test]
         fn column_keys_not_exceed_count_test() {
             column_keys_not_exceed_count::<OffChain>();

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -825,14 +825,6 @@ mod tests {
         };
         use fuel_core_storage::transactional::WriteTransaction;
 
-        // this invariant doesn't hold anymore
-        // because we have removed columns from the storage
-        #[ignore]
-        #[test]
-        fn column_keys_not_exceed_count_test() {
-            column_keys_not_exceed_count::<OffChain>();
-        }
-
         #[test]
         fn database_advances_with_a_new_block() {
             // Given

--- a/crates/fuel-core/src/database/database_description/compression.rs
+++ b/crates/fuel-core/src/database/database_description/compression.rs
@@ -19,7 +19,7 @@ impl DatabaseDescription for CompressionDatabase {
     }
 
     fn metadata_column() -> Self::Column {
-        Self::Column::MerkleMetadataColumn
+        Self::Column::Metadata
     }
 
     fn prefix(_column: &Self::Column) -> Option<usize> {

--- a/crates/fuel-core/src/graphql_api/storage.rs
+++ b/crates/fuel-core/src/graphql_api/storage.rs
@@ -96,13 +96,13 @@ pub enum Column {
     /// See [`SpentMessages`](messages::SpentMessages)
     SpentMessages = 13,
     /// Coin balances per account and asset.
-    CoinBalances = 14,
+    CoinBalances = 23,
     /// Message balances per account.
-    MessageBalances = 15,
+    MessageBalances = 24,
     /// See [`AssetsInfo`](assets::AssetsInfo)
-    AssetsInfo = 16,
+    AssetsInfo = 25,
     /// Index of the coins that are available to spend.
-    CoinsToSpend = 17,
+    CoinsToSpend = 26,
 }
 
 impl Column {

--- a/crates/fuel-core/src/service/adapters/compression_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/compression_adapters.rs
@@ -12,20 +12,11 @@ use fuel_core_compression_service::{
         configuration,
     },
 };
-use fuel_core_services::stream::IntoBoxStream;
+use fuel_core_types::services::block_importer::SharedImportResult;
 
 impl block_source::BlockSource for BlockImporterAdapter {
-    fn subscribe(
-        &self,
-    ) -> fuel_core_services::stream::BoxStream<block_source::BlockWithMetadata> {
-        use futures::StreamExt;
+    fn subscribe(&self) -> fuel_core_services::stream::BoxStream<SharedImportResult> {
         self.events_shared_result()
-            .map(|result| {
-                let sealed_block = result.sealed_block.clone();
-                let events = result.events.clone();
-                block_source::BlockWithMetadata::new(sealed_block.entity, events)
-            })
-            .into_boxed()
     }
 }
 

--- a/crates/fuel-core/src/state/in_memory/memory_store.rs
+++ b/crates/fuel-core/src/state/in_memory/memory_store.rs
@@ -63,9 +63,15 @@ where
     Description: DatabaseDescription,
 {
     fn default() -> Self {
-        use strum::EnumCount;
+        use enum_iterator::all;
+
+        let largest_column_idx = all::<Description::Column>()
+            .map(|column| column.as_usize())
+            .max()
+            .expect("there should be atleast 1 column in the storage");
+
         Self {
-            inner: (0..Description::Column::COUNT)
+            inner: (0..=largest_column_idx)
                 .map(|_| Mutex::new(BTreeMap::new()))
                 .collect(),
             _marker: Default::default(),

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -17,9 +17,7 @@ impl BlockWithMetadataExt for BlockWithMetadata {
     }
 
     fn height(&self) -> &BlockHeight {
-        <Self as BlockWithMetadataExt>::block(self)
-            .header()
-            .height()
+        self.block().header().height()
     }
 
     fn block(&self) -> &fuel_core_types::blockchain::block::Block {

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -3,35 +3,34 @@ pub(crate) use fuel_core_types::services::block_importer::SharedImportResult as 
 
 pub(crate) type BlockHeight = u32;
 
-// we can't define a newtype that wraps over SharedImportResult because its `dyn Deref`
-pub(crate) mod block_helpers {
-    use super::*;
-
-    /// Get events from BlockWithMetadata
-    pub(crate) fn events(
-        block_with_metadata: &BlockWithMetadata,
-    ) -> &[fuel_core_types::services::executor::Event] {
-        block_with_metadata.events.as_ref()
-    }
-
-    /// Get sealed block from BlockWithMetadata
-    pub(crate) fn block(
-        block_with_metadata: &BlockWithMetadata,
-    ) -> &fuel_core_types::blockchain::block::Block {
-        &block_with_metadata.sealed_block.entity
-    }
-
-    /// Get block height from BlockWithMetadata
-    pub(crate) fn height(block_with_metadata: &BlockWithMetadata) -> &BlockHeight {
-        block(block_with_metadata).header().height()
-    }
-
-    /// Get the default BlockWithMetadata
+pub(crate) trait BlockWithMetadataExt {
+    fn height(&self) -> &BlockHeight;
+    fn events(&self) -> &[fuel_core_types::services::executor::Event];
+    fn block(&self) -> &fuel_core_types::blockchain::block::Block;
     #[cfg(test)]
-    pub fn default() -> BlockWithMetadata {
-        std::sync::Arc::new(
-            fuel_core_types::services::block_importer::ImportResult::default(),
-        )
+    fn default() -> Self;
+}
+
+impl BlockWithMetadataExt for BlockWithMetadata {
+    fn events(&self) -> &[fuel_core_types::services::executor::Event] {
+        self.events.as_ref()
+    }
+
+    fn height(&self) -> &BlockHeight {
+        <Self as BlockWithMetadataExt>::block(&self)
+            .header()
+            .height()
+    }
+
+    fn block(&self) -> &fuel_core_types::blockchain::block::Block {
+        &self.sealed_block.entity
+    }
+
+    #[cfg(test)]
+    fn default() -> Self {
+        use fuel_core_types::services::block_importer::ImportResult;
+
+        std::sync::Arc::new(ImportResult::default().wrap())
     }
 }
 

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -17,7 +17,7 @@ impl BlockWithMetadataExt for BlockWithMetadata {
     }
 
     fn height(&self) -> &BlockHeight {
-        <Self as BlockWithMetadataExt>::block(&self)
+        <Self as BlockWithMetadataExt>::block(self)
             .header()
             .height()
     }

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -3,32 +3,31 @@ pub(crate) use fuel_core_types::services::block_importer::SharedImportResult as 
 
 pub(crate) type BlockHeight = u32;
 
-// we can't define a newtype that wraps over SharedImportResult because its `dyn Deref`
-pub(crate) mod block_helpers {
-    use super::*;
-
-    /// Get events from BlockWithMetadata
-    pub(crate) fn events(
-        block_with_metadata: &BlockWithMetadata,
-    ) -> &[fuel_core_types::services::executor::Event] {
-        block_with_metadata.events.as_ref()
-    }
-
-    /// Get sealed block from BlockWithMetadata
-    pub(crate) fn block(
-        block_with_metadata: &BlockWithMetadata,
-    ) -> &fuel_core_types::blockchain::block::Block {
-        &block_with_metadata.sealed_block.entity
-    }
-
-    /// Get block height from BlockWithMetadata
-    pub(crate) fn height(block_with_metadata: &BlockWithMetadata) -> &BlockHeight {
-        block(block_with_metadata).header().height()
-    }
-
-    /// Get the default BlockWithMetadata
+pub(crate) trait BlockWithMetadataExt {
+    fn height(&self) -> &BlockHeight;
+    fn block(&self) -> &fuel_core_types::blockchain::block::Block;
+    fn events(&self) -> &[fuel_core_types::services::executor::Event];
     #[cfg(test)]
-    pub fn default() -> BlockWithMetadata {
+    fn default() -> BlockWithMetadata;
+}
+
+impl BlockWithMetadataExt for BlockWithMetadata {
+    fn height(&self) -> &BlockHeight {
+        <Self as BlockWithMetadataExt>::block(self)
+            .header()
+            .height()
+    }
+
+    fn block(&self) -> &fuel_core_types::blockchain::block::Block {
+        &self.sealed_block.entity
+    }
+
+    fn events(&self) -> &[fuel_core_types::services::executor::Event] {
+        self.events.as_ref()
+    }
+
+    #[cfg(test)]
+    fn default() -> BlockWithMetadata {
         std::sync::Arc::new(
             fuel_core_types::services::block_importer::ImportResult::default(),
         )

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -3,31 +3,32 @@ pub(crate) use fuel_core_types::services::block_importer::SharedImportResult as 
 
 pub(crate) type BlockHeight = u32;
 
-pub(crate) trait BlockWithMetadataExt {
-    fn height(&self) -> &BlockHeight;
-    fn block(&self) -> &fuel_core_types::blockchain::block::Block;
-    fn events(&self) -> &[fuel_core_types::services::executor::Event];
+// we can't define a newtype that wraps over SharedImportResult because its `dyn Deref`
+pub(crate) mod block_helpers {
+    use super::*;
+
+    /// Get events from BlockWithMetadata
+    pub(crate) fn events(
+        block_with_metadata: &BlockWithMetadata,
+    ) -> &[fuel_core_types::services::executor::Event] {
+        block_with_metadata.events.as_ref()
+    }
+
+    /// Get sealed block from BlockWithMetadata
+    pub(crate) fn block(
+        block_with_metadata: &BlockWithMetadata,
+    ) -> &fuel_core_types::blockchain::block::Block {
+        &block_with_metadata.sealed_block.entity
+    }
+
+    /// Get block height from BlockWithMetadata
+    pub(crate) fn height(block_with_metadata: &BlockWithMetadata) -> &BlockHeight {
+        block(block_with_metadata).header().height()
+    }
+
+    /// Get the default BlockWithMetadata
     #[cfg(test)]
-    fn default() -> BlockWithMetadata;
-}
-
-impl BlockWithMetadataExt for BlockWithMetadata {
-    fn height(&self) -> &BlockHeight {
-        <Self as BlockWithMetadataExt>::block(self)
-            .header()
-            .height()
-    }
-
-    fn block(&self) -> &fuel_core_types::blockchain::block::Block {
-        &self.sealed_block.entity
-    }
-
-    fn events(&self) -> &[fuel_core_types::services::executor::Event] {
-        self.events.as_ref()
-    }
-
-    #[cfg(test)]
-    fn default() -> BlockWithMetadata {
+    pub fn default() -> BlockWithMetadata {
         std::sync::Arc::new(
             fuel_core_types::services::block_importer::ImportResult::default(),
         )

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -2,9 +2,9 @@ use crate::{
     config::CompressionConfig,
     ports::{
         block_source::{
-            block_helpers,
             BlockSource,
             BlockWithMetadata,
+            BlockWithMetadataExt,
         },
         compression_storage::{
             CompressionStorage,
@@ -84,21 +84,19 @@ where
             compression_storage: CompressionStorageWrapper {
                 storage_tx: &mut storage_tx,
             },
-            block_events: block_helpers::events(block_with_metadata),
+            block_events: &block_with_metadata.events(),
         };
         let compressed_block = compress(
             self.config.into(),
             compression_context,
-            block_helpers::block(block_with_metadata),
+            block_with_metadata.block(),
         )
         .now_or_never()
         .expect("The current implementation should resolve all futures instantly")
         .map_err(crate::errors::CompressionError::FailedToCompressBlock)?;
 
-        storage_tx.write_compressed_block(
-            block_helpers::height(block_with_metadata),
-            &compressed_block,
-        )?;
+        storage_tx
+            .write_compressed_block(block_with_metadata.height(), &compressed_block)?;
 
         storage_tx
             .commit()
@@ -120,7 +118,7 @@ where
         // set the status to synced
         self.sync_notifier
             .send(crate::sync_state::SyncState::Synced(
-                *block_helpers::height(block_with_metadata),
+                *block_with_metadata.height(),
             ))
             .ok();
         Ok(())
@@ -203,7 +201,7 @@ where
                         fuel_core_services::TaskNextAction::Stop
                     }
                     Some(block_with_metadata) => {
-                        tracing::debug!("Got new block: {:?}", block_helpers::height(&block_with_metadata));
+                        tracing::debug!("Got new block: {:?}", &block_with_metadata.height());
                         if let Err(e) = self.handle_new_block(&block_with_metadata) {
                             tracing::error!("Error handling new block: {:?}", e);
                             return fuel_core_services::TaskNextAction::ErrorContinue(anyhow::anyhow!(e));
@@ -246,8 +244,8 @@ mod tests {
     use super::*;
     use crate::{
         ports::block_source::{
-            block_helpers,
             BlockWithMetadata,
+            BlockWithMetadataExt,
         },
         storage,
     };
@@ -361,7 +359,7 @@ mod tests {
     async fn compression_service__run__compresses_blocks() {
         // given
         // we provide a block source that will return a block upon calling .next()
-        let block_with_metadata = block_helpers::default();
+        let block_with_metadata = BlockWithMetadata::default();
         let block_source = MockBlockSource::new(vec![block_with_metadata]);
         let storage = test_storage();
         let config_provider = MockConfigProvider::default();

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -84,7 +84,7 @@ where
             compression_storage: CompressionStorageWrapper {
                 storage_tx: &mut storage_tx,
             },
-            block_events: &block_with_metadata.events(),
+            block_events: block_with_metadata.events(),
         };
         let compressed_block = compress(
             self.config.into(),

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -2,9 +2,9 @@ use crate::{
     config::CompressionConfig,
     ports::{
         block_source::{
-            block_helpers,
             BlockSource,
             BlockWithMetadata,
+            BlockWithMetadataExt,
         },
         compression_storage::{
             CompressionStorage,
@@ -84,21 +84,19 @@ where
             compression_storage: CompressionStorageWrapper {
                 storage_tx: &mut storage_tx,
             },
-            block_events: block_helpers::events(block_with_metadata),
+            block_events: block_with_metadata.events(),
         };
         let compressed_block = compress(
             self.config.into(),
             compression_context,
-            block_helpers::block(block_with_metadata),
+            block_with_metadata.block(),
         )
         .now_or_never()
         .expect("The current implementation should resolve all futures instantly")
         .map_err(crate::errors::CompressionError::FailedToCompressBlock)?;
 
-        storage_tx.write_compressed_block(
-            block_helpers::height(block_with_metadata),
-            &compressed_block,
-        )?;
+        storage_tx
+            .write_compressed_block(block_with_metadata.height(), &compressed_block)?;
 
         storage_tx
             .commit()
@@ -120,7 +118,7 @@ where
         // set the status to synced
         self.sync_notifier
             .send(crate::sync_state::SyncState::Synced(
-                *block_helpers::height(block_with_metadata),
+                *block_with_metadata.height(),
             ))
             .ok();
         Ok(())
@@ -203,7 +201,7 @@ where
                         fuel_core_services::TaskNextAction::Stop
                     }
                     Some(block_with_metadata) => {
-                        tracing::debug!("Got new block: {:?}", block_helpers::height(&block_with_metadata));
+                        tracing::debug!("Got new block: {:?}", &block_with_metadata.height());
                         if let Err(e) = self.handle_new_block(&block_with_metadata) {
                             tracing::error!("Error handling new block: {:?}", e);
                             return fuel_core_services::TaskNextAction::ErrorContinue(anyhow::anyhow!(e));


### PR DESCRIPTION
The most important changes include modifying column definitions, updating block metadata handling, and improving the storage structure.

### Metadata Column Changes:

* [`crates/fuel-core/src/database/database_description/compression.rs`](diffhunk://#diff-22b43c4fb523cd21910e54ffa4f2cae736cb2336021463029ccd5d79b16d9536L22-R22): Renamed `MerkleMetadataColumn` to `Metadata` in the `metadata_column` method.
* [`crates/storage/src/merkle/column.rs`](diffhunk://#diff-93ae578b8b551daca9f2c8317dcb963c8791f9bca0ca716eff2d8e6099d671faR25-L30): Added a new `Metadata` variant to the `MerkleizedColumn` enum and updated the count and column constants accordingly. [[1]](diffhunk://#diff-93ae578b8b551daca9f2c8317dcb963c8791f9bca0ca716eff2d8e6099d671faR25-L30) [[2]](diffhunk://#diff-93ae578b8b551daca9f2c8317dcb963c8791f9bca0ca716eff2d8e6099d671faL39-R42) [[3]](diffhunk://#diff-93ae578b8b551daca9f2c8317dcb963c8791f9bca0ca716eff2d8e6099d671faR61-R66) [[4]](diffhunk://#diff-93ae578b8b551daca9f2c8317dcb963c8791f9bca0ca716eff2d8e6099d671faR76-L75) [[5]](diffhunk://#diff-93ae578b8b551daca9f2c8317dcb963c8791f9bca0ca716eff2d8e6099d671faR92-L92)

### Block Metadata Handling:

* [`crates/services/compression/src/ports/block_source.rs`](diffhunk://#diff-b35ece6e136e2fe3793da56f4456d50692646e9d371946e26024ada643151182L2-R34): Replaced the `BlockWithMetadata` struct with `SharedImportResult` and added helper functions to access block metadata. [[1]](diffhunk://#diff-b35ece6e136e2fe3793da56f4456d50692646e9d371946e26024ada643151182L2-R34) [[2]](diffhunk://#diff-b35ece6e136e2fe3793da56f4456d50692646e9d371946e26024ada643151182L42-R44)
* [`crates/services/compression/src/service.rs`](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L74-R78): Updated the `compress_block` and `handle_new_block` methods to use the new block metadata helper functions. [[1]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L74-R78) [[2]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L83-R101) [[3]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L106-R125) [[4]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L206-R206) [[5]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L248-R251)

### Column Index Updates:

* [`crates/fuel-core/src/graphql_api/storage.rs`](diffhunk://#diff-f40129b7382c84ff5de9ccbc254350dbdb9cd62c5e23e0f653cdb49d32f2e5e7L99-R105): Updated the indices of several columns in the `Column` enum back to old values to prevent breaking change in db.

### Test Modifications:

* [`crates/fuel-core/src/database.rs`](diffhunk://#diff-c95a3d57a39feac7c8c2f3b193a24eec39e794413adc741df36450f9a4539898R828-R830): Ignored the `column_keys_not_exceed_count_test` as the invariant no longer holds due to column removal.
* [`crates/services/compression/src/service.rs`](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L361-R364): Updated tests to use the new block metadata helper functions.

### Stream Subscription Updates:

* [`crates/fuel-core/src/service/adapters/compression_adapters.rs`](diffhunk://#diff-9e66cb09255fa99a40c07b24f3002b040d023c09b9469521b2c8ad8736bf33bfL15-L28): Modified the `subscribe` method to use `SharedImportResult` instead of `BlockWithMetadata`.
