### PR TITLE
refactor: Get rid of `Deref` impl on `ImportResult` by introducing wrapper type.

### DIFF
--- a/.changes/breaking/2900.md
+++ b/.changes/breaking/2900.md
@@ -1,0 +1,1 @@
+Get rid of `Deref` impl on `ImportResult` by introducing wrapper type.

--- a/crates/fuel-core/src/graphql_api/worker_service/tests.rs
+++ b/crates/fuel-core/src/graphql_api/worker_service/tests.rs
@@ -65,7 +65,7 @@ fn block_importer_for_event(event: Event) -> BoxStream<SharedImportResult> {
         tx_status: vec![],
         events: vec![event],
         source: Default::default(),
-    });
+    }.wrap());
     let blocks: Vec<SharedImportResult> = vec![block];
     tokio_stream::iter(blocks).into_boxed()
 }

--- a/crates/fuel-core/src/graphql_api/worker_service/tests.rs
+++ b/crates/fuel-core/src/graphql_api/worker_service/tests.rs
@@ -60,12 +60,15 @@ async fn run__relayed_transaction_events_are_added_to_storage() {
 }
 
 fn block_importer_for_event(event: Event) -> BoxStream<SharedImportResult> {
-    let block = Arc::new(ImportResult {
-        sealed_block: Default::default(),
-        tx_status: vec![],
-        events: vec![event],
-        source: Default::default(),
-    }.wrap());
+    let block = Arc::new(
+        ImportResult {
+            sealed_block: Default::default(),
+            tx_status: vec![],
+            events: vec![event],
+            source: Default::default(),
+        }
+        .wrap(),
+    );
     let blocks: Vec<SharedImportResult> = vec![block];
     tokio_stream::iter(blocks).into_boxed()
 }

--- a/crates/fuel-core/src/service/adapters/chain_state_info_provider.rs
+++ b/crates/fuel-core/src/service/adapters/chain_state_info_provider.rs
@@ -367,7 +367,7 @@ mod tests {
             sealed_block,
             Default::default(),
             Default::default(),
-        ))
+        ).wrap())
     }
 
     #[tokio::test]
@@ -441,7 +441,7 @@ mod tests {
             sealed_block,
             Default::default(),
             Default::default(),
-        ))
+        ).wrap())
     }
 
     #[tokio::test]

--- a/crates/fuel-core/src/service/adapters/chain_state_info_provider.rs
+++ b/crates/fuel-core/src/service/adapters/chain_state_info_provider.rs
@@ -363,11 +363,14 @@ mod tests {
             entity: block,
             consensus: Default::default(),
         };
-        std::sync::Arc::new(ImportResult::new_from_local(
-            sealed_block,
-            Default::default(),
-            Default::default(),
-        ).wrap())
+        std::sync::Arc::new(
+            ImportResult::new_from_local(
+                sealed_block,
+                Default::default(),
+                Default::default(),
+            )
+            .wrap(),
+        )
     }
 
     #[tokio::test]
@@ -437,11 +440,14 @@ mod tests {
             entity: block,
             consensus: Default::default(),
         };
-        std::sync::Arc::new(ImportResult::new_from_local(
-            sealed_block,
-            Default::default(),
-            Default::default(),
-        ).wrap())
+        std::sync::Arc::new(
+            ImportResult::new_from_local(
+                sealed_block,
+                Default::default(),
+                Default::default(),
+            )
+            .wrap(),
+        )
     }
 
     #[tokio::test]

--- a/crates/fuel-core/src/service/adapters/import_result_provider.rs
+++ b/crates/fuel-core/src/service/adapters/import_result_provider.rs
@@ -51,7 +51,7 @@ impl ImportResultProvider {
                     .into_result();
                 let result =
                     ImportResult::new_from_local(sealed_block, tx_status, events);
-                Ok(Arc::new(result))
+                Ok(Arc::new(result.wrap()))
             }
             BlockAt::Genesis => {
                 let genesis_height = self
@@ -69,7 +69,7 @@ impl ImportResultProvider {
                     sealed_block,
                     vec![],
                     vec![],
-                )))
+                ).wrap()))
             }
         }
     }

--- a/crates/fuel-core/src/service/adapters/import_result_provider.rs
+++ b/crates/fuel-core/src/service/adapters/import_result_provider.rs
@@ -65,11 +65,9 @@ impl ImportResultProvider {
                     .get_sealed_block_by_height(&genesis_height)?
                     .ok_or(not_found!("SealedBlock"))?;
 
-                Ok(Arc::new(ImportResult::new_from_local(
-                    sealed_block,
-                    vec![],
-                    vec![],
-                ).wrap()))
+                Ok(Arc::new(
+                    ImportResult::new_from_local(sealed_block, vec![], vec![]).wrap(),
+                ))
             }
         }
     }

--- a/crates/services/gas_price_service/src/common/l2_block_source/tests.rs
+++ b/crates/services/gas_price_service/src/common/l2_block_source/tests.rs
@@ -107,7 +107,7 @@ fn block_to_import_result(block: Block) -> SharedImportResult {
         events: vec![],
         source: Default::default(),
     };
-    Arc::new(result)
+    Arc::new(result.wrap())
 }
 
 #[tokio::test]

--- a/crates/services/txpool_v2/src/tests/mocks.rs
+++ b/crates/services/txpool_v2/src/tests/mocks.rs
@@ -360,7 +360,7 @@ impl MockImporter {
                 let block = blocks.pop();
                 if let Some(sealed_block) = block {
                     let result: SharedImportResult = Arc::new(
-                        ImportResult::new_from_local(sealed_block, vec![], vec![]),
+                        ImportResult::new_from_local(sealed_block, vec![], vec![]).wrap(),
                     );
 
                     Some((result, blocks))

--- a/crates/services/txpool_v2/src/tests/tests_service.rs
+++ b/crates/services/txpool_v2/src/tests/tests_service.rs
@@ -304,7 +304,7 @@ async fn prune_expired_transactions() {
             expiration_block,
             vec![],
             vec![],
-        )))
+        ).wrap()))
         .await
         .unwrap();
 
@@ -400,7 +400,7 @@ async fn prune_expired_does_not_trigger_twice() {
             expiration_block,
             vec![],
             vec![],
-        )))
+        ).wrap()))
         .await
         .unwrap();
 

--- a/crates/services/txpool_v2/src/tests/tests_service.rs
+++ b/crates/services/txpool_v2/src/tests/tests_service.rs
@@ -300,11 +300,9 @@ async fn prune_expired_transactions() {
 
     // When
     sender
-        .send(Arc::new(ImportResult::new_from_local(
-            expiration_block,
-            vec![],
-            vec![],
-        ).wrap()))
+        .send(Arc::new(
+            ImportResult::new_from_local(expiration_block, vec![], vec![]).wrap(),
+        ))
         .await
         .unwrap();
 
@@ -396,11 +394,9 @@ async fn prune_expired_does_not_trigger_twice() {
 
     // When
     sender
-        .send(Arc::new(ImportResult::new_from_local(
-            expiration_block,
-            vec![],
-            vec![],
-        ).wrap()))
+        .send(Arc::new(
+            ImportResult::new_from_local(expiration_block, vec![], vec![]).wrap(),
+        ))
         .await
         .unwrap();
 

--- a/crates/types/src/services/block_importer.rs
+++ b/crates/types/src/services/block_importer.rs
@@ -29,6 +29,19 @@ pub type UncommittedResult<DatabaseTransaction> =
 /// The alias for the `ImportResult` that can be shared between threads.
 pub type SharedImportResult = Arc<dyn Deref<Target = ImportResult> + Send + Sync>;
 
+/// Thin wrapper over `ImportResult` that implements `Deref` and
+/// thus can be used in the SharedImportResult.
+#[derive(Debug)]
+pub struct WrappedImportResult(ImportResult);
+
+impl Deref for WrappedImportResult {
+    type Target = ImportResult;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// The result of the block import.
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "test-helpers"), derive(Default))]
@@ -43,11 +56,10 @@ pub struct ImportResult {
     pub source: Source,
 }
 
-impl Deref for ImportResult {
-    type Target = Self;
-
-    fn deref(&self) -> &Self::Target {
-        self
+impl ImportResult {
+    /// Wrap this result into a `WrappedImportResult`.
+    pub fn wrap(self) -> WrappedImportResult {
+        WrappedImportResult(self)
     }
 }
 


### PR DESCRIPTION
closes #2899 

See `crates/types/src/services/block_importer.rs` for the main change. The rest of the PR is just adapting the code to use explicit dereferencing to access the relevant fields.