### PR TITLE
chore(compression): include registry root in compressed block header

### DIFF
--- a/.changes/breaking/2909.md
+++ b/.changes/breaking/2909.md
@@ -1,0 +1,1 @@
+Compressed block headers now include a merkle root of the temporal registry after compression was performed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
             args: run -p fuel-core-client --no-default-features
           - command: nextest
             args: run -p fuel-core-chain-config --no-default-features
+          - command: nextest
+            args: run --workspace --features fault-proving --test integration_tests
           # Don't split this command; this is a workaround.
           # We need to run `cargo check` first to fetch the locked dependencies
           # for `fuel-core 0.26.0`(because of the bug with `--offline`

--- a/crates/compression/src/compressed_block_payload/v1.rs
+++ b/crates/compression/src/compressed_block_payload/v1.rs
@@ -19,6 +19,9 @@ use fuel_core_types::{
     fuel_types::BlockHeight,
 };
 
+/// The root of the registry.
+pub type RegistryRoot = fuel_core_types::fuel_tx::Bytes32;
+
 /// A partially complete fuel block header that does not
 /// have any generated fields because it has not been executed yet.
 #[derive(
@@ -29,12 +32,14 @@ pub struct CompressedBlockHeader {
     pub application: ApplicationHeader<Empty>,
     /// The consensus header.
     pub consensus: ConsensusHeader<Empty>,
-    // The block id.
+    /// The block id.
     pub block_id: BlockId,
+    // The registry root
+    pub registry_root: RegistryRoot,
 }
 
-impl From<&BlockHeader> for CompressedBlockHeader {
-    fn from(header: &BlockHeader) -> Self {
+impl CompressedBlockHeader {
+    fn new(header: &BlockHeader, registry_root: RegistryRoot) -> Self {
         let ConsensusHeader {
             prev_root,
             height,
@@ -56,6 +61,7 @@ impl From<&BlockHeader> for CompressedBlockHeader {
                 generated: Empty {},
             },
             block_id: header.id(),
+            registry_root,
         }
     }
 }
@@ -112,9 +118,10 @@ impl CompressedBlockPayloadV1 {
         header: &BlockHeader,
         registrations: RegistrationsPerTable,
         transactions: Vec<CompressedTransaction>,
+        registry_root: RegistryRoot,
     ) -> Self {
         Self {
-            header: CompressedBlockHeader::from(header),
+            header: CompressedBlockHeader::new(header, registry_root),
             registrations,
             transactions,
         }

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -60,6 +60,8 @@ impl VersionedCompressedBlock {
         header: &BlockHeader,
         registrations: RegistrationsPerTable,
         transactions: Vec<CompressedTransaction>,
+        #[cfg(feature = "fault-proving")]
+        registry_root: crate::compressed_block_payload::v1::RegistryRoot,
     ) -> Self {
         #[cfg(not(feature = "fault-proving"))]
         return Self::V0(CompressedBlockPayloadV0::new(
@@ -72,6 +74,7 @@ impl VersionedCompressedBlock {
             header,
             registrations,
             transactions,
+            registry_root,
         ))
     }
 }
@@ -250,6 +253,8 @@ mod tests {
         use fuel_core_types::blockchain::primitives::BlockId;
         use std::str::FromStr;
 
+        use crate::compressed_block_payload::v1::RegistryRoot;
+
         proptest!(|(strategy in postcard_roundtrip_strategy())| {
             let PostcardRoundtripStrategy {
                 da_height,
@@ -274,6 +279,7 @@ mod tests {
                     generated: Empty,
                 },
                 block_id: BlockId::from_str("0xecea85c17070bc2e65f911310dbd01198f4436052ebba96cded9ddf30c58dd1a").unwrap(),
+                registry_root: RegistryRoot::from_str("0xecea85c17070bc2e65f911310dbd01198f4436052ebba96cded9ddf30c58dd1b").unwrap(),
             };
 
 
@@ -302,6 +308,7 @@ mod tests {
 
             if let VersionedCompressedBlock::V1(block) = decompressed {
                 assert_eq!(block.header.block_id, header.block_id);
+                assert_eq!(block.header.registry_root, header.registry_root);
             } else {
                 panic!("Expected V1 block, got {:?}", decompressed);
             }

--- a/crates/compression/src/ports.rs
+++ b/crates/compression/src/ports.rs
@@ -119,3 +119,29 @@ where
         <D as EvictorDb<T>>::set_latest_assigned_key(self, key)
     }
 }
+
+#[cfg(feature = "fault-proving")]
+pub mod fault_proving {
+    pub trait GetRegistryRoot {
+        type Error: core::fmt::Display;
+        fn registry_root(
+            &self,
+        ) -> Result<crate::compressed_block_payload::v1::RegistryRoot, Self::Error>;
+    }
+
+    impl<D> GetRegistryRoot for &mut D
+    where
+        D: GetRegistryRoot,
+    {
+        type Error = D::Error;
+        fn registry_root(
+            &self,
+        ) -> Result<crate::compressed_block_payload::v1::RegistryRoot, Self::Error>
+        {
+            D::registry_root(self)
+        }
+    }
+}
+
+#[cfg(feature = "fault-proving")]
+pub use fault_proving::*;

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -130,4 +130,5 @@ fault-proving = [
   "fuel-core-sync?/fault-proving",
   "fuel-core-importer/fault-proving",
   "fuel-core-poa/fault-proving",
+  "fuel-core-compression-service/fault-proving",
 ]

--- a/crates/services/compression/Cargo.toml
+++ b/crates/services/compression/Cargo.toml
@@ -42,3 +42,9 @@ test-helpers = [
   "dep:rand",
   "dep:fuel-core-chain-config",
 ]
+fault-proving = [
+  "fuel-core-compression/fault-proving",
+  "fuel-core-chain-config?/fault-proving",
+  "fuel-core-types/fault-proving",
+  "fuel-core-storage/fault-proving",
+]

--- a/crates/services/compression/src/errors.rs
+++ b/crates/services/compression/src/errors.rs
@@ -29,6 +29,9 @@ pub enum CompressionError {
     /// Failed to compress block
     #[error("failed to compress block: `{0}`")]
     FailedToCompressBlock(anyhow::Error),
+    /// Failed to compute registry root
+    #[error("failed to compute registry root: `{0}`")]
+    FailedToComputeRegistryRoot(StorageError),
     /// Failed to handle new block
     #[error("failed to handle new block: `{0}`")]
     FailedToHandleNewBlock(String),

--- a/crates/services/compression/src/ports/compression_storage.rs
+++ b/crates/services/compression/src/ports/compression_storage.rs
@@ -1,4 +1,6 @@
-use crate::storage;
+use crate::storage::{
+    self,
+};
 use fuel_core_storage::{
     kv_store::KeyValueInspect,
     merkle::column::MerkleizedColumn,

--- a/crates/services/compression/src/ports/compression_storage.rs
+++ b/crates/services/compression/src/ports/compression_storage.rs
@@ -1,6 +1,4 @@
-use crate::storage::{
-    self,
-};
+use crate::storage;
 use fuel_core_storage::{
     kv_store::KeyValueInspect,
     merkle::column::MerkleizedColumn,

--- a/crates/services/compression/src/temporal_registry.rs
+++ b/crates/services/compression/src/temporal_registry.rs
@@ -1,6 +1,7 @@
 //! This module contains implementations of `TemporalRegistry` for the merkleized indexing tables
 use crate::{
     ports::compression_storage::CompressionStorage as CompressionStoragePort,
+    storage,
     storage::{
         evictor_cache::MetadataKey,
         timestamps::{
@@ -23,9 +24,11 @@ use fuel_core_storage::{
         Messages,
     },
     transactional::StorageTransaction,
+    Error as StorageError,
     StorageAsMut,
     StorageAsRef,
     StorageInspect,
+    StorageMutate,
 };
 use fuel_core_types::{
     fuel_tx::{
@@ -61,12 +64,6 @@ pub struct DecompressionContext<'a, CS, Onchain> {
     /// The mutable reference to the onchain database
     pub onchain_db: Onchain,
 }
-
-use crate::storage;
-use fuel_core_storage::{
-    Error as StorageError,
-    StorageMutate,
-};
 
 macro_rules! impl_temporal_registry {
     ($type:ty) => { paste::paste! {
@@ -358,4 +355,137 @@ where
             data: message.data().clone(),
         })
     }
+}
+
+#[cfg(feature = "fault-proving")]
+mod fault_proving {
+    use super::*;
+    use crate::storage::{
+        column::CompressionColumn,
+        {
+            self,
+        },
+    };
+    use fuel_core_storage::{
+        blueprint::BlueprintInspect,
+        kv_store::{
+            KeyValueInspect,
+            StorageColumn,
+        },
+        merkle::{
+            column::MerkleizedColumn,
+            sparse::{
+                DummyStorage,
+                Merkleized,
+                MerkleizedTableColumn,
+            },
+        },
+        structured_storage::TableWithBlueprint,
+        transactional::StorageTransaction,
+        Mappable,
+        MerkleRoot,
+        MerkleRootStorage,
+    };
+
+    trait ComputeRegistryRoot {
+        fn registry_root(&self) -> crate::Result<fuel_core_types::fuel_tx::Bytes32>;
+        fn root_of_table<Table>(&self) -> Result<MerkleRoot, fuel_core_storage::Error>
+        where
+            Table: Mappable + MerkleizedTableColumn<TableColumn = CompressionColumn>,
+            Table: TableWithBlueprint,
+            Table::Blueprint: BlueprintInspect<
+                Table,
+                DummyStorage<MerkleizedColumn<CompressionColumn>>,
+            >;
+    }
+
+    impl<Storage> ComputeRegistryRoot for StorageTransaction<Storage>
+    where
+        Storage: KeyValueInspect<
+            Column = MerkleizedColumn<storage::column::CompressionColumn>,
+        >,
+    {
+        fn registry_root(&self) -> crate::Result<fuel_core_types::fuel_tx::Bytes32> {
+            macro_rules! compute_registry_root {
+                ($ty:ty) => {
+                    self.root_of_table::<$ty>().map_err(
+                        crate::errors::CompressionError::FailedToComputeRegistryRoot,
+                    )?
+                };
+            }
+
+            // don't change the order. it is important for backward compatibility.
+            let roots = [
+                compute_registry_root!(storage::address::Address),
+                compute_registry_root!(storage::asset_id::AssetId),
+                compute_registry_root!(storage::contract_id::ContractId),
+                compute_registry_root!(storage::evictor_cache::EvictorCache),
+                compute_registry_root!(storage::predicate_code::PredicateCode),
+                compute_registry_root!(storage::script_code::ScriptCode),
+                compute_registry_root!(storage::registry_index::RegistryIndex),
+            ];
+
+            let mut hasher = fuel_core_types::fuel_crypto::Hasher::default();
+
+            for root in roots {
+                hasher.input(root);
+            }
+
+            Ok(hasher.finalize())
+        }
+
+        fn root_of_table<Table>(&self) -> Result<MerkleRoot, fuel_core_storage::Error>
+        where
+            Table: Mappable + MerkleizedTableColumn<TableColumn = CompressionColumn>,
+            Table: TableWithBlueprint,
+            Table::Blueprint: BlueprintInspect<
+                Table,
+                DummyStorage<MerkleizedColumn<CompressionColumn>>,
+            >,
+        {
+            <Self as MerkleRootStorage<u32, Merkleized<Table>>>::root(
+                self,
+                &Table::column().id(),
+            )
+        }
+    }
+
+    macro_rules! impl_compute_registry_root {
+        ($type:ty $(, $extra_generic:ident)?) => {
+            impl<'a, CS $(, $extra_generic)?> ComputeRegistryRoot for $type
+            where
+                CS: CompressionStoragePort,
+            {
+                fn registry_root(&self) -> crate::Result<fuel_core_types::fuel_tx::Bytes32> {
+                    self.compression_storage.storage_tx.registry_root()
+                }
+
+                fn root_of_table<Table>(&self) -> Result<MerkleRoot, fuel_core_storage::Error>
+                where
+                    Table: Mappable + MerkleizedTableColumn<TableColumn = CompressionColumn>,
+                    Table: TableWithBlueprint,
+                    Table::Blueprint: BlueprintInspect<
+                        Table,
+                        DummyStorage<MerkleizedColumn<CompressionColumn>>,
+                    >,
+                {
+                    self.compression_storage.storage_tx.root_of_table::<Table>()
+                }
+            }
+
+            impl<'a, CS $(, $extra_generic)?> fuel_core_compression::ports::GetRegistryRoot for $type
+            where
+                Self: ComputeRegistryRoot,
+            {
+                type Error = crate::errors::CompressionError;
+
+                fn registry_root(&self) -> crate::Result<fuel_core_types::fuel_tx::Bytes32> {
+                    <Self as ComputeRegistryRoot>::registry_root(self)
+                }
+            }
+        };
+    }
+
+    impl_compute_registry_root!(CompressionContext<'a, CS>);
+    impl_compute_registry_root!(DecompressionContext<'a, CS, Onchain>, Onchain);
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -92,3 +92,13 @@ tracing = { workspace = true }
 default = ["fuel-core/default"]
 only-p2p = ["fuel-core-p2p"]
 aws-kms = ["dep:aws-config", "dep:aws-sdk-kms", "fuel-core-bin/aws-kms"]
+fault-proving = [
+  "fuel-core/fault-proving",
+  "fuel-core-types/fault-proving",
+  "fuel-core-storage/fault-proving",
+  "fuel-core-upgradable-executor/fault-proving",
+  "fuel-core-poa/fault-proving",
+  "fuel-core-compression/fault-proving",
+  "fuel-core-compression-service/fault-proving",
+  "fuel-core-benches/fault-proving",
+]


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
part of https://github.com/FuelLabs/fuel-core/issues/2232
closes https://github.com/FuelLabs/fuel-core/issues/2568

## Description
<!-- List of detailed changes -->
enhances the compression and decompression processes to handle a new `registry_root` field.

### Feature flag `fault-proving` support:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR152-R153): Added a new `nextest` command to run integration tests with the `fault-proving` feature enabled.

### Compression and decompression updates:

* [`crates/compression/src/compress.rs`](diffhunk://#diff-6d3f24703843ef40147c63bb3cd0f1fa8d6277ce298cc704d21514bdd480d552R44-R69): Introduced conditional modules and traits for `CompressDb` based on the `fault-proving` feature, and included `registry_root` in the compression process. [[1]](diffhunk://#diff-6d3f24703843ef40147c63bb3cd0f1fa8d6277ce298cc704d21514bdd480d552R44-R69) [[2]](diffhunk://#diff-6d3f24703843ef40147c63bb3cd0f1fa8d6277ce298cc704d21514bdd480d552R96-R106)
* [`crates/compression/src/decompress.rs`](diffhunk://#diff-d0b271dacdbc77c5808aab48fee0fa85f338d593e1adc25e8bd0205c370dd824R49-R71): Added conditional modules and traits for `DecompressDb` and included `registry_root` verification in the decompression process. [[1]](diffhunk://#diff-d0b271dacdbc77c5808aab48fee0fa85f338d593e1adc25e8bd0205c370dd824R49-R71) [[2]](diffhunk://#diff-d0b271dacdbc77c5808aab48fee0fa85f338d593e1adc25e8bd0205c370dd824R115-R131)

### Registry root handling:

* [`crates/compression/src/compressed_block_payload/v1.rs`](diffhunk://#diff-d8d7fa8cb497931632674d904112a5bbea802757e71df7d92e06474a71463307R22-R24): Added `RegistryRoot` type and included it in `CompressedBlockHeader` and `CompressedBlockPayloadV1`. [[1]](diffhunk://#diff-d8d7fa8cb497931632674d904112a5bbea802757e71df7d92e06474a71463307R22-R24) [[2]](diffhunk://#diff-d8d7fa8cb497931632674d904112a5bbea802757e71df7d92e06474a71463307L32-R42) [[3]](diffhunk://#diff-d8d7fa8cb497931632674d904112a5bbea802757e71df7d92e06474a71463307R64) [[4]](diffhunk://#diff-d8d7fa8cb497931632674d904112a5bbea802757e71df7d92e06474a71463307R121-R124)
* [`crates/compression/src/lib.rs`](diffhunk://#diff-be21606b619b01dffba7556a2716b7083b03ab1525dd249f6a517e92d16d27baR63-R64): Updated `VersionedCompressedBlock` to handle `registry_root`. [[1]](diffhunk://#diff-be21606b619b01dffba7556a2716b7083b03ab1525dd249f6a517e92d16d27baR63-R64) [[2]](diffhunk://#diff-be21606b619b01dffba7556a2716b7083b03ab1525dd249f6a517e92d16d27baR77)

### Error handling and trait implementations:

* [`crates/services/compression/src/errors.rs`](diffhunk://#diff-4e1e8a438c26f0ee9cde7ff8e033cb1ab58ffd3f5fad9dd5f39a74269a4a971cR32-R34): Added a new error variant `FailedToComputeRegistryRoot`.
* [`crates/services/compression/src/temporal_registry.rs`](diffhunk://#diff-390e459c3eb588077c8f7a95ae572fcf01a144a449ce1fbccf2d3dc61b489546R359-R517): Implemented `ComputeRegistryRoot` trait and related methods for computing and verifying `registry_root`.

### Configuration updates:

* [`crates/services/compression/Cargo.toml`](diffhunk://#diff-3b348e1ded89f349afd45656ad5c57ebbab5e690f2bf64e059dd5d7c32de228dR45-R50): Added `fault-proving` feature dependencies.
* [`tests/Cargo.toml`](diffhunk://#diff-9abb8310fe65807f370f136db9528106606118c7e98654141b0bbd87b07639f7R95-R103): Added `fault-proving` feature dependencies for testing.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
