### PR TITLE
Change the number of write buffers in RocksDB to be more than 3.

### DIFF
--- a/.changes/fixed/2916.md
+++ b/.changes/fixed/2916.md
@@ -1,0 +1,1 @@
+Change `max_write_buffer_number` to not experience write stalls under high loads.

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -331,6 +331,7 @@ where
             opts.set_row_cache(&cache);
         }
         opts.set_max_background_jobs(6);
+        opts.set_max_write_buffer_number(4);
         opts.set_bytes_per_sync(1048576);
         opts.set_max_open_files(database_config.max_fds);
 
@@ -516,6 +517,7 @@ where
         opts.create_if_missing(true);
         opts.set_compression_type(DBCompressionType::Lz4);
         opts.set_block_based_table_factory(block_opts);
+        opts.set_max_write_buffer_number(4);
 
         opts
     }


### PR DESCRIPTION
## Description
When trying high load of transactions on the node we experienced some errors from RocksDB about write stalls. I tried differents things that I detailed just below to end up to this PR : 

- Tried to increase `set_max_total_wal_size` was just making the problem happens afterwards
- Tried to increase `set_max_background_jobs` didn't change much.
- Verifies that `no_slowdown` option on write options is already `false`, so slowdown is already activated by default.
- Final used solution : increase `set_max_write_buffer_number` to be more than `3` to activate this slowndown explained in the doc : `If max_write_buffer_number > 3, writing will be slowed down to options.delayed_write_rate if we are writing to the last write buffer allowed.`. Default value was 2. We only experience a lag of few dozens of milliseconds which is not a problem given our block time.

### Before requesting review
- [x] I have reviewed the code myself