### PR TITLE
Chore/backport rocksdb fix

### DIFF
--- a/.changes/fixed/2917.md
+++ b/.changes/fixed/2917.md
@@ -1,0 +1,1 @@
+Change `max_write_buffer_number` to not experience write stalls under high loads.

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -331,6 +331,7 @@ where
             opts.set_row_cache(&cache);
         }
         opts.set_max_background_jobs(6);
+        opts.set_max_write_buffer_number(4);
         opts.set_bytes_per_sync(1048576);
         opts.set_max_open_files(database_config.max_fds);
 
@@ -516,6 +517,7 @@ where
         opts.create_if_missing(true);
         opts.set_compression_type(DBCompressionType::Lz4);
         opts.set_block_based_table_factory(block_opts);
+        opts.set_max_write_buffer_number(4);
 
         opts
     }

--- a/version-compatibility/forkless-upgrade/Cargo.toml
+++ b/version-compatibility/forkless-upgrade/Cargo.toml
@@ -53,3 +53,6 @@ version-36-fuel-core-client = { version = "0.36.0", package = "fuel-core-client"
 version-36-fuel-core-services = { version = "0.36.0", package = "fuel-core-services" }
 version-36-fuel-core-gas-price-service = { version = "0.36.0", package = "fuel-core-gas-price-service" }
 version-36-fuel-core-storage = { version = "0.36.0", package = "fuel-core-storage" }
+
+# pin async-graphql because they bumped msrv in a patch release
+async-graphql = "=7.0.15"


### PR DESCRIPTION
Backport fix from https://github.com/FuelLabs/fuel-core/pull/2916 to `0.42`