### PR TITLE
Make preconfirmation optional on API endpoints

### DIFF
--- a/.changes/changed/2925.md
+++ b/.changes/changed/2925.md
@@ -1,0 +1,1 @@
+Make preconfirmation optional on API endpoints.

--- a/bin/e2e-test-client/src/test_context.rs
+++ b/bin/e2e-test-client/src/test_context.rs
@@ -186,6 +186,7 @@ impl Wallet {
         let tx_id = tx.id(&self.consensus_params.chain_id());
         println!("submitting tx... {:?}", tx_id);
         let status = self.client.submit_and_await_commit(&tx).await?;
+        println!("Status for {:?} is {:?}", tx_id, status);
 
         // we know the transferred coin should be output 0 from above
         let transferred_utxo = UtxoId::new(tx_id, 0);

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -1342,7 +1342,7 @@ type Subscription {
 		"""
 		If true, accept to receive the preconfirmation status
 		"""
-		allowPreconfirmation: Boolean
+		includePreconfirmation: Boolean
 	): TransactionStatus!
 	"""
 	Submits transaction to the `TxPool` and await either success or failure.
@@ -1353,7 +1353,7 @@ type Subscription {
 	Compared to the `submitAndAwait`, the stream also contains
 	`SubmittedStatus` and potentially preconfirmation as an intermediate state.
 	"""
-	submitAndAwaitStatus(tx: HexString!, estimatePredicates: Boolean, allowPreconfirmation: Boolean): TransactionStatus!
+	submitAndAwaitStatus(tx: HexString!, estimatePredicates: Boolean, includePreconfirmation: Boolean): TransactionStatus!
 	contractStorageSlots(contractId: ContractId!): StorageSlot!
 	contractStorageBalances(contractId: ContractId!): ContractBalance!
 }
@@ -1395,7 +1395,7 @@ type Transaction {
 	outputContract: ContractOutput
 	witnesses: [HexString!]
 	receiptsRoot: Bytes32
-	status(allowPreconfirmation: Boolean): TransactionStatus
+	status(includePreconfirmation: Boolean): TransactionStatus
 	script: HexString
 	scriptData: HexString
 	bytecodeWitnessIndex: U16

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -1334,7 +1334,11 @@ type Subscription {
 		"""
 		The ID of the transaction
 		"""
-		id: TransactionId!
+		id: TransactionId!,
+		"""
+		If true, accept to receive the preconfirmation status
+		"""
+		allowPreconfirmation: Boolean
 	): TransactionStatus!
 	"""
 	Submits transaction to the `TxPool` and await either success or failure.
@@ -1343,9 +1347,9 @@ type Subscription {
 	"""
 	Submits the transaction to the `TxPool` and returns a stream of events.
 	Compared to the `submitAndAwait`, the stream also contains
-	`SubmittedStatus` as an intermediate state.
+	`SubmittedStatus` and potentially preconfirmation as an intermediate state.
 	"""
-	submitAndAwaitStatus(tx: HexString!, estimatePredicates: Boolean): TransactionStatus!
+	submitAndAwaitStatus(tx: HexString!, estimatePredicates: Boolean, allowPreconfirmation: Boolean): TransactionStatus!
 	contractStorageSlots(contractId: ContractId!): StorageSlot!
 	contractStorageBalances(contractId: ContractId!): ContractBalance!
 }
@@ -1387,7 +1391,7 @@ type Transaction {
 	outputContract: ContractOutput
 	witnesses: [HexString!]
 	receiptsRoot: Bytes32
-	status: TransactionStatus
+	status(allowPreconfirmation: Boolean): TransactionStatus
 	script: HexString
 	scriptData: HexString
 	bytecodeWitnessIndex: U16

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -938,8 +938,10 @@ impl FuelClient {
     pub async fn submit_and_await_status<'a>(
         &'a self,
         tx: &'a Transaction,
+        allow_preconfirmation: bool,
     ) -> io::Result<impl Stream<Item = io::Result<TransactionStatus>> + 'a> {
-        self.submit_and_await_status_opt(tx, None).await
+        self.submit_and_await_status_opt(tx, None, Some(allow_preconfirmation))
+            .await
     }
 
     /// Similar to [`Self::submit_and_await_commit_opt`], but includes all intermediate states.
@@ -948,13 +950,16 @@ impl FuelClient {
         &'a self,
         tx: &'a Transaction,
         estimate_predicates: Option<bool>,
+        allow_preconfirmation: Option<bool>,
     ) -> io::Result<impl Stream<Item = io::Result<TransactionStatus>> + 'a> {
         use cynic::SubscriptionBuilder;
+        use schema::tx::SubmitAndAwaitStatusArg;
         let tx = tx.clone().to_bytes();
         let s = schema::tx::SubmitAndAwaitStatusSubscription::build(
-            TxWithEstimatedPredicatesArg {
+            SubmitAndAwaitStatusArg {
                 tx: HexString(Bytes(tx)),
                 estimate_predicates,
+                allow_preconfirmation,
             },
         );
 

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -938,10 +938,8 @@ impl FuelClient {
     pub async fn submit_and_await_status<'a>(
         &'a self,
         tx: &'a Transaction,
-        allow_preconfirmation: bool,
     ) -> io::Result<impl Stream<Item = io::Result<TransactionStatus>> + 'a> {
-        self.submit_and_await_status_opt(tx, None, Some(allow_preconfirmation))
-            .await
+        self.submit_and_await_status_opt(tx, None, None).await
     }
 
     /// Similar to [`Self::submit_and_await_commit_opt`], but includes all intermediate states.

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -948,7 +948,7 @@ impl FuelClient {
         &'a self,
         tx: &'a Transaction,
         estimate_predicates: Option<bool>,
-        allow_preconfirmation: Option<bool>,
+        include_preconfirmation: Option<bool>,
     ) -> io::Result<impl Stream<Item = io::Result<TransactionStatus>> + 'a> {
         use cynic::SubscriptionBuilder;
         use schema::tx::SubmitAndAwaitStatusArg;
@@ -957,7 +957,7 @@ impl FuelClient {
             SubmitAndAwaitStatusArg {
                 tx: HexString(Bytes(tx)),
                 estimate_predicates,
-                allow_preconfirmation,
+                include_preconfirmation,
             },
         );
 
@@ -1222,7 +1222,7 @@ impl FuelClient {
     pub async fn subscribe_transaction_status_opt<'a>(
         &'a self,
         id: &'a TxId,
-        allow_preconfirmation: Option<bool>,
+        include_preconfirmation: Option<bool>,
     ) -> io::Result<impl Stream<Item = io::Result<TransactionStatus>> + 'a> {
         use cynic::SubscriptionBuilder;
         use schema::tx::StatusChangeSubscriptionArgs;
@@ -1230,7 +1230,7 @@ impl FuelClient {
         let s =
             schema::tx::StatusChangeSubscription::build(StatusChangeSubscriptionArgs {
                 id: tx_id,
-                allow_preconfirmation,
+                include_preconfirmation,
             });
 
         tracing::debug!("subscribing");

--- a/crates/client/src/client/schema/tx.rs
+++ b/crates/client/src/client/schema/tx.rs
@@ -472,14 +472,21 @@ pub struct TransactionsByOwnerQuery {
     pub transactions_by_owner: TransactionConnection,
 }
 
+#[derive(cynic::QueryVariables, Debug)]
+pub struct StatusChangeSubscriptionArgs {
+    pub id: TransactionId,
+    #[cynic(skip_serializing_if = "Option::is_none")]
+    pub allow_preconfirmation: Option<bool>,
+}
+
 #[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Subscription",
-    variables = "TxIdArgs"
+    variables = "StatusChangeSubscriptionArgs"
 )]
 pub struct StatusChangeSubscription {
-    #[arguments(id: $id)]
+    #[arguments(id: $id, allowPreconfirmation: $allow_preconfirmation)]
     pub status_change: TransactionStatus,
 }
 

--- a/crates/client/src/client/schema/tx.rs
+++ b/crates/client/src/client/schema/tx.rs
@@ -476,7 +476,7 @@ pub struct TransactionsByOwnerQuery {
 pub struct StatusChangeSubscriptionArgs {
     pub id: TransactionId,
     #[cynic(skip_serializing_if = "Option::is_none")]
-    pub allow_preconfirmation: Option<bool>,
+    pub include_preconfirmation: Option<bool>,
 }
 
 #[derive(cynic::QueryFragment, Clone, Debug)]
@@ -486,7 +486,7 @@ pub struct StatusChangeSubscriptionArgs {
     variables = "StatusChangeSubscriptionArgs"
 )]
 pub struct StatusChangeSubscription {
-    #[arguments(id: $id, allowPreconfirmation: $allow_preconfirmation)]
+    #[arguments(id: $id, includePreconfirmation: $include_preconfirmation)]
     pub status_change: TransactionStatus,
 }
 
@@ -510,7 +510,7 @@ pub struct SubmitAndAwaitStatusArg {
     #[cynic(skip_serializing_if = "Option::is_none")]
     pub estimate_predicates: Option<bool>,
     #[cynic(skip_serializing_if = "Option::is_none")]
-    pub allow_preconfirmation: Option<bool>,
+    pub include_preconfirmation: Option<bool>,
 }
 
 #[derive(cynic::QueryFragment, Clone, Debug)]
@@ -662,7 +662,7 @@ pub struct SubmitAndAwaitSubscriptionWithTransaction {
     variables = "SubmitAndAwaitStatusArg"
 )]
 pub struct SubmitAndAwaitStatusSubscription {
-    #[arguments(tx: $tx, estimatePredicates: $estimate_predicates, allowPreconfirmation: $allow_preconfirmation)]
+    #[arguments(tx: $tx, estimatePredicates: $estimate_predicates, includePreconfirmation: $include_preconfirmation)]
     pub submit_and_await_status: TransactionStatus,
 }
 

--- a/crates/client/src/client/schema/tx.rs
+++ b/crates/client/src/client/schema/tx.rs
@@ -497,6 +497,15 @@ pub struct TxWithEstimatedPredicatesArg {
     pub estimate_predicates: Option<bool>,
 }
 
+#[derive(cynic::QueryVariables)]
+pub struct SubmitAndAwaitStatusArg {
+    pub tx: HexString,
+    #[cynic(skip_serializing_if = "Option::is_none")]
+    pub estimate_predicates: Option<bool>,
+    #[cynic(skip_serializing_if = "Option::is_none")]
+    pub allow_preconfirmation: Option<bool>,
+}
+
 #[derive(cynic::QueryFragment, Clone, Debug)]
 #[cynic(
     schema_path = "./assets/schema.sdl",
@@ -643,10 +652,10 @@ pub struct SubmitAndAwaitSubscriptionWithTransaction {
 #[cynic(
     schema_path = "./assets/schema.sdl",
     graphql_type = "Subscription",
-    variables = "TxWithEstimatedPredicatesArg"
+    variables = "SubmitAndAwaitStatusArg"
 )]
 pub struct SubmitAndAwaitStatusSubscription {
-    #[arguments(tx: $tx, estimatePredicates: $estimate_predicates)]
+    #[arguments(tx: $tx, estimatePredicates: $estimate_predicates, allowPreconfirmation: $allow_preconfirmation)]
     pub submit_and_await_status: TransactionStatus,
 }
 

--- a/crates/fuel-core/src/combined_database.rs
+++ b/crates/fuel-core/src/combined_database.rs
@@ -523,6 +523,14 @@ impl CombinedDatabase {
 
         Ok(())
     }
+
+    pub fn shutdown(self) {
+        self.on_chain.shutdown();
+        self.off_chain.shutdown();
+        self.relayer.shutdown();
+        self.gas_price.shutdown();
+        self.compression.shutdown();
+    }
 }
 
 /// A trait for listening to shutdown signals.

--- a/crates/fuel-core/src/database.rs
+++ b/crates/fuel-core/src/database.rs
@@ -181,6 +181,12 @@ where
         self.iter_all_filtered::<T, _>(prefix, None, Some(direction))
             .map_ok(|(key, value)| TableEntry { key, value })
     }
+
+    pub fn shutdown(self) {
+        let (storage, _) = self.into_inner();
+
+        storage.data.shutdown()
+    }
 }
 
 impl<Description> GenesisDatabase<Description>

--- a/crates/fuel-core/src/query/subscriptions.rs
+++ b/crates/fuel-core/src/query/subscriptions.rs
@@ -61,7 +61,7 @@ where
             match status {
                 TxStatusMessage::Status(status) => {
                     let status = ApiTxStatus::new(transaction_id, status);
-                    if !allow_preconfirmation && (matches!(status, ApiTxStatus::PreconfirmationFailure(_)) || matches!(status, ApiTxStatus::PreconfirmationSuccess(_))) {
+                    if !allow_preconfirmation && status.is_preconfirmation() {
                         futures::future::ready(None)
                     } else {
                         futures::future::ready(Some(Ok(status)))

--- a/crates/fuel-core/src/query/subscriptions.rs
+++ b/crates/fuel-core/src/query/subscriptions.rs
@@ -28,6 +28,7 @@ pub(crate) async fn transaction_status_change<'a, State>(
     state: State,
     stream: BoxStream<'a, TxStatusMessage>,
     transaction_id: Bytes32,
+    _allow_preconfirmation: bool,
 ) -> impl Stream<Item = anyhow::Result<ApiTxStatus>> + 'a
 where
     State: TxnStatusChangeState + Send + Sync + 'a,

--- a/crates/fuel-core/src/query/subscriptions.rs
+++ b/crates/fuel-core/src/query/subscriptions.rs
@@ -20,6 +20,7 @@ pub(crate) trait TxnStatusChangeState {
     async fn get_tx_status(
         &self,
         id: Bytes32,
+        allow_preconfirmation: bool,
     ) -> StorageResult<Option<TransactionStatus>>;
 }
 
@@ -36,7 +37,7 @@ where
     // Check the database first to see if the transaction already
     // has a status.
     let maybe_db_status = state
-        .get_tx_status(transaction_id)
+        .get_tx_status(transaction_id, allow_preconfirmation)
         .await
         .transpose()
         .map(TxStatusMessage::from);

--- a/crates/fuel-core/src/query/subscriptions/test.rs
+++ b/crates/fuel-core/src/query/subscriptions/test.rs
@@ -265,13 +265,13 @@ fn test_tsc_inner(
     let out = RT.with(|rt| {
         rt.block_on(async {
             let mut mock_state = super::MockTxnStatusChangeState::new();
-            mock_state
-                .expect_get_tx_status()
-                .returning(move |_| match state.clone() {
+            mock_state.expect_get_tx_status().returning(move |_, _| {
+                match state.clone() {
                     Ok(Some(t)) => Ok(Some(t)),
                     Ok(None) => Ok(None),
                     Err(_) => Err(StorageError::NotFound("", "")),
-                });
+                }
+            });
 
             let stream = futures::stream::iter(stream).boxed();
             super::transaction_status_change(mock_state, stream, txn_id(0), true)

--- a/crates/fuel-core/src/query/subscriptions/test.rs
+++ b/crates/fuel-core/src/query/subscriptions/test.rs
@@ -274,7 +274,7 @@ fn test_tsc_inner(
                 });
 
             let stream = futures::stream::iter(stream).boxed();
-            super::transaction_status_change(mock_state, stream, txn_id(0))
+            super::transaction_status_change(mock_state, stream, txn_id(0), false)
                 .await
                 .collect::<Vec<_>>()
                 .await

--- a/crates/fuel-core/src/query/subscriptions/test.rs
+++ b/crates/fuel-core/src/query/subscriptions/test.rs
@@ -274,7 +274,7 @@ fn test_tsc_inner(
                 });
 
             let stream = futures::stream::iter(stream).boxed();
-            super::transaction_status_change(mock_state, stream, txn_id(0), false)
+            super::transaction_status_change(mock_state, stream, txn_id(0), true)
                 .await
                 .collect::<Vec<_>>()
                 .await

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -42,6 +42,7 @@ use crate::{
                 AssembleTx,
             },
             types::{
+                get_tx_status,
                 AssembleTransactionResult,
                 TransactionStatus,
             },
@@ -745,14 +746,15 @@ impl<'a> TxnStatusChangeState for StatusChangeState<'a> {
     async fn get_tx_status(
         &self,
         id: Bytes32,
+        allow_preconfirmation: bool,
     ) -> StorageResult<Option<transaction_status::TransactionStatus>> {
-        match self.query.tx_status(&id) {
-            Ok(status) => Ok(Some(status.into())),
-            Err(StorageError::NotFound(_, _)) => {
-                Ok(self.tx_status_manager.status(id).await?)
-            }
-            Err(err) => Err(err),
-        }
+        get_tx_status(
+            &id,
+            self.query.as_ref(),
+            self.tx_status_manager,
+            allow_preconfirmation,
+        )
+        .await
     }
 }
 

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -720,16 +720,25 @@ async fn submit_and_await_status<'a>(
             match status {
                 TxStatusMessage::Status(status) => {
                     let status = TransactionStatus::new(tx_id, status);
-                    if !allow_preconfirmation && (matches!(status, TransactionStatus::PreconfirmationFailure(_)) || matches!(status, TransactionStatus::PreconfirmationSuccess(_))) {
+                    if !allow_preconfirmation
+                        && (matches!(
+                            status,
+                            TransactionStatus::PreconfirmationFailure(_)
+                        ) || matches!(
+                            status,
+                            TransactionStatus::PreconfirmationSuccess(_)
+                        ))
+                    {
                         None
                     } else {
                         Some(Ok(status))
                     }
-                },
-                // Map a failed status to an error for the api.
-                TxStatusMessage::FailedStatus => {
-                    Some(Err(anyhow::anyhow!("Failed to get transaction status").into()))
                 }
+                // Map a failed status to an error for the api.
+                TxStatusMessage::FailedStatus => Some(Err(anyhow::anyhow!(
+                    "Failed to get transaction status"
+                )
+                .into())),
             }
         })
         .take(3))

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -720,15 +720,7 @@ async fn submit_and_await_status<'a>(
             match status {
                 TxStatusMessage::Status(status) => {
                     let status = TransactionStatus::new(tx_id, status);
-                    if !allow_preconfirmation
-                        && (matches!(
-                            status,
-                            TransactionStatus::PreconfirmationFailure(_)
-                        ) || matches!(
-                            status,
-                            TransactionStatus::PreconfirmationSuccess(_)
-                        ))
-                    {
+                    if !allow_preconfirmation && status.is_preconfirmation() {
                         None
                     } else {
                         Some(Ok(status))

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -785,12 +785,13 @@ impl Transaction {
         let tx_status_manager = ctx.data_unchecked::<DynTxStatusManager>();
 
         get_tx_status(
-            id,
+            &id,
             query.as_ref(),
             tx_status_manager,
             allow_preconfirmation.unwrap_or(false),
         )
         .await
+        .map(|status| status.map(|status| TransactionStatus::new(id, status)))
         .map_err(Into::into)
     }
 
@@ -1108,32 +1109,30 @@ impl StorageReadReplayEvent {
 
 #[tracing::instrument(level = "debug", skip(query, tx_status_manager), ret, err)]
 pub(crate) async fn get_tx_status(
-    id: fuel_core_types::fuel_types::Bytes32,
+    id: &fuel_core_types::fuel_types::Bytes32,
     query: &ReadView,
     tx_status_manager: &DynTxStatusManager,
     allow_preconfirmation: bool,
-) -> Result<Option<TransactionStatus>, StorageError> {
+) -> Result<Option<transaction_status::TransactionStatus>, StorageError> {
     let api_result = query
-        .tx_status(&id)
+        .tx_status(id)
         .into_api_result::<transaction_status::TransactionStatus, StorageError>()?;
     match api_result {
-        Some(status) => {
-            let status = TransactionStatus::new(id, status);
-            Ok(Some(status))
-        }
+        Some(status) => Ok(Some(status)),
         None => {
-            let status = tx_status_manager.status(id).await?;
+            let status = tx_status_manager.status(*id).await?;
             match status {
                 Some(status) => {
-                    let status = TransactionStatus::new(id, status);
-
                     // Filter out preconfirmation statuses if not allowed. Converting to submitted status
                     // because it's the closest to the preconfirmation status.
                     // Having `now()` as timestamp isn't ideal but shouldn't cause much inconsistency.
-                    if !allow_preconfirmation && status.is_preconfirmation() {
-                        Ok(Some(TransactionStatus::Submitted(SubmittedStatus(
+                    if !allow_preconfirmation
+                        && status.is_preconfirmation()
+                        && !status.is_final()
+                    {
+                        Ok(Some(transaction_status::TransactionStatus::submitted(
                             Tai64::now(),
-                        ))))
+                        )))
                     } else {
                         Ok(Some(status))
                     }

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -771,6 +771,7 @@ impl Transaction {
         ctx: &Context<'_>,
         allow_preconfirmation: Option<bool>,
     ) -> async_graphql::Result<Option<TransactionStatus>> {
+        dbg!(allow_preconfirmation);
         let id = self.1;
         let query = ctx.read_view()?;
 

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -769,6 +769,7 @@ impl Transaction {
     async fn status(
         &self,
         ctx: &Context<'_>,
+        _allow_preconfirmation: Option<bool>,
     ) -> async_graphql::Result<Option<TransactionStatus>> {
         let id = self.1;
         let query = ctx.read_view()?;

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -777,7 +777,7 @@ impl Transaction {
     async fn status(
         &self,
         ctx: &Context<'_>,
-        allow_preconfirmation: Option<bool>,
+        include_preconfirmation: Option<bool>,
     ) -> async_graphql::Result<Option<TransactionStatus>> {
         let id = self.1;
         let query = ctx.read_view()?;
@@ -788,7 +788,7 @@ impl Transaction {
             &id,
             query.as_ref(),
             tx_status_manager,
-            allow_preconfirmation.unwrap_or(false),
+            include_preconfirmation.unwrap_or(false),
         )
         .await
         .map(|status| status.map(|status| TransactionStatus::new(id, status)))
@@ -1112,7 +1112,7 @@ pub(crate) async fn get_tx_status(
     id: &fuel_core_types::fuel_types::Bytes32,
     query: &ReadView,
     tx_status_manager: &DynTxStatusManager,
-    allow_preconfirmation: bool,
+    include_preconfirmation: bool,
 ) -> Result<Option<transaction_status::TransactionStatus>, StorageError> {
     let api_result = query
         .tx_status(id)
@@ -1126,7 +1126,7 @@ pub(crate) async fn get_tx_status(
                     // Filter out preconfirmation statuses if not allowed. Converting to submitted status
                     // because it's the closest to the preconfirmation status.
                     // Having `now()` as timestamp isn't ideal but shouldn't cause much inconsistency.
-                    if !allow_preconfirmation
+                    if !include_preconfirmation
                         && status.is_preconfirmation()
                         && !status.is_final()
                     {

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -451,11 +451,11 @@ impl TransactionStatus {
     }
 
     pub fn is_preconfirmation(&self) -> bool {
-        match self {
+        matches!(
+            self,
             TransactionStatus::PreconfirmationSuccess(_)
-            | TransactionStatus::PreconfirmationFailure(_) => true,
-            _ => false,
-        }
+                | TransactionStatus::PreconfirmationFailure(_)
+        )
     }
 }
 

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -776,9 +776,14 @@ impl Transaction {
 
         let tx_status_manager = ctx.data_unchecked::<DynTxStatusManager>();
 
-        get_tx_status(id, query.as_ref(), tx_status_manager, allow_preconfirmation.unwrap_or(false))
-            .await
-            .map_err(Into::into)
+        get_tx_status(
+            id,
+            query.as_ref(),
+            tx_status_manager,
+            allow_preconfirmation.unwrap_or(false),
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn script(&self) -> Option<HexString> {
@@ -1117,12 +1122,22 @@ pub(crate) async fn get_tx_status(
                     // Filter out preconfirmation statuses if not allowed. Converting to submitted status
                     // because it's the closest to the preconfirmation status.
                     // Having `now()` as timestamp isn't ideal but shouldn't cause much inconsistency.
-                    if !allow_preconfirmation && (matches!(status, TransactionStatus::PreconfirmationSuccess(_)) || matches!(status, TransactionStatus::PreconfirmationFailure(_))) {
-                        Ok(Some(TransactionStatus::Submitted(SubmittedStatus(Tai64::now()))))
+                    if !allow_preconfirmation
+                        && (matches!(
+                            status,
+                            TransactionStatus::PreconfirmationSuccess(_)
+                        ) || matches!(
+                            status,
+                            TransactionStatus::PreconfirmationFailure(_)
+                        ))
+                    {
+                        Ok(Some(TransactionStatus::Submitted(SubmittedStatus(
+                            Tai64::now(),
+                        ))))
                     } else {
                         Ok(Some(status))
                     }
-                },
+                }
                 None => Ok(None),
             }
         }

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -771,7 +771,6 @@ impl Transaction {
         ctx: &Context<'_>,
         allow_preconfirmation: Option<bool>,
     ) -> async_graphql::Result<Option<TransactionStatus>> {
-        dbg!(allow_preconfirmation);
         let id = self.1;
         let query = ctx.read_view()?;
 

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -449,6 +449,14 @@ impl TransactionStatus {
             | TransactionStatus::PreconfirmationFailure(_) => false,
         }
     }
+
+    pub fn is_preconfirmation(&self) -> bool {
+        match self {
+            TransactionStatus::PreconfirmationSuccess(_)
+            | TransactionStatus::PreconfirmationFailure(_) => true,
+            _ => false,
+        }
+    }
 }
 
 pub struct Policies(fuel_tx::policies::Policies);
@@ -1122,15 +1130,7 @@ pub(crate) async fn get_tx_status(
                     // Filter out preconfirmation statuses if not allowed. Converting to submitted status
                     // because it's the closest to the preconfirmation status.
                     // Having `now()` as timestamp isn't ideal but shouldn't cause much inconsistency.
-                    if !allow_preconfirmation
-                        && (matches!(
-                            status,
-                            TransactionStatus::PreconfirmationSuccess(_)
-                        ) || matches!(
-                            status,
-                            TransactionStatus::PreconfirmationFailure(_)
-                        ))
-                    {
+                    if !allow_preconfirmation && status.is_preconfirmation() {
                         Ok(Some(TransactionStatus::Submitted(SubmittedStatus(
                             Tai64::now(),
                         ))))

--- a/crates/fuel-core/src/service/query.rs
+++ b/crates/fuel-core/src/service/query.rs
@@ -103,7 +103,7 @@ impl<'a> TxnStatusChangeState for StatusChangeState<'a> {
     async fn get_tx_status(
         &self,
         id: Bytes32,
-        allow_preconfirmation: bool,
+        include_preconfirmation: bool,
     ) -> StorageResult<Option<TxPoolTxStatus>> {
         match self.db.get_tx_status(&id)? {
             Some(status) => Ok(Some(status.into())),
@@ -113,7 +113,7 @@ impl<'a> TxnStatusChangeState for StatusChangeState<'a> {
                     // Filter out preconfirmation statuses if not allowed. Converting to submitted status
                     // because it's the closest to the preconfirmation status.
                     // Having `now()` as timestamp isn't ideal but shouldn't cause much inconsistency.
-                    if !allow_preconfirmation
+                    if !include_preconfirmation
                         && status.is_preconfirmation()
                         && !status.is_final()
                     {

--- a/crates/fuel-core/src/service/query.rs
+++ b/crates/fuel-core/src/service/query.rs
@@ -89,7 +89,7 @@ impl FuelService {
             db,
             tx_status_manager,
         };
-        Ok(transaction_status_change(state, rx, id, false).await)
+        Ok(transaction_status_change(state, rx, id, true).await)
     }
 }
 

--- a/crates/fuel-core/src/service/query.rs
+++ b/crates/fuel-core/src/service/query.rs
@@ -8,6 +8,7 @@ use fuel_core_types::{
     },
     fuel_types::Bytes32,
     services::transaction_status::TransactionStatus as TxPoolTxStatus,
+    tai64::Tai64,
 };
 use futures::{
     Stream,
@@ -99,11 +100,28 @@ struct StatusChangeState<'a> {
 }
 
 impl<'a> TxnStatusChangeState for StatusChangeState<'a> {
-    async fn get_tx_status(&self, id: Bytes32) -> StorageResult<Option<TxPoolTxStatus>> {
+    async fn get_tx_status(
+        &self,
+        id: Bytes32,
+        allow_preconfirmation: bool,
+    ) -> StorageResult<Option<TxPoolTxStatus>> {
         match self.db.get_tx_status(&id)? {
             Some(status) => Ok(Some(status.into())),
             None => {
                 let status = self.tx_status_manager.status(id).await?;
+                let status = status.map(|status| {
+                    // Filter out preconfirmation statuses if not allowed. Converting to submitted status
+                    // because it's the closest to the preconfirmation status.
+                    // Having `now()` as timestamp isn't ideal but shouldn't cause much inconsistency.
+                    if !allow_preconfirmation
+                        && status.is_preconfirmation()
+                        && !status.is_final()
+                    {
+                        TxPoolTxStatus::submitted(Tai64::now())
+                    } else {
+                        status
+                    }
+                });
                 Ok(status)
             }
         }

--- a/crates/fuel-core/src/service/query.rs
+++ b/crates/fuel-core/src/service/query.rs
@@ -89,7 +89,7 @@ impl FuelService {
             db,
             tx_status_manager,
         };
-        Ok(transaction_status_change(state, rx, id).await)
+        Ok(transaction_status_change(state, rx, id, false).await)
     }
 }
 

--- a/crates/fuel-core/src/state.rs
+++ b/crates/fuel-core/src/state.rs
@@ -68,6 +68,10 @@ pub trait TransactableStorage<Height>: IterableStore + Debug + Send + Sync {
     fn latest_view(&self) -> StorageResult<IterableKeyValueView<Self::Column, Height>>;
 
     fn rollback_block_to(&self, height: &Height) -> StorageResult<()>;
+
+    fn shutdown(&self) {
+        // Do nothing by default
+    }
 }
 
 // It is used only to allow conversion of the `StorageTransaction` into the `DataSource`.

--- a/crates/fuel-core/src/state/historical_rocksdb.rs
+++ b/crates/fuel-core/src/state/historical_rocksdb.rs
@@ -621,6 +621,10 @@ where
     fn rollback_block_to(&self, height: &Description::Height) -> StorageResult<()> {
         self.rollback_block_to(height.as_u64())
     }
+
+    fn shutdown(&self) {
+        self.db.shutdown()
+    }
 }
 
 pub fn height_key(key: &[u8], height: &u64) -> Vec<u8> {

--- a/crates/fuel-core/src/state/rocks_db.rs
+++ b/crates/fuel-core/src/state/rocks_db.rs
@@ -855,6 +855,10 @@ where
 
         Ok(())
     }
+
+    pub fn shutdown(&self) {
+        while Arc::strong_count(&self.db) > 1 {}
+    }
 }
 
 pub(crate) struct KeyOnly;

--- a/crates/services/src/async_processor.rs
+++ b/crates/services/src/async_processor.rs
@@ -203,8 +203,8 @@ mod tests {
         assert_eq!(err, OutOfCapacity);
     }
 
-    #[test]
-    fn second_spawn_works_when_first_is_finished() {
+    #[tokio::test]
+    async fn second_spawn_works_when_first_is_finished() {
         const NUMBER_OF_PENDING_TASKS: usize = 1;
         let heavy_task_processor =
             AsyncProcessor::new("Test", 1, NUMBER_OF_PENDING_TASKS).unwrap();
@@ -215,10 +215,8 @@ mod tests {
             sleep(Duration::from_secs(1));
             sender.send(()).unwrap();
         });
-        first_spawn.expect("Expected Ok result");
-        futures::executor::block_on(async move {
-            receiver.await.unwrap();
-        });
+        first_spawn.expect("Expected Ok result").await.unwrap();
+        receiver.await.unwrap();
 
         // When
         let second_spawn = heavy_task_processor.try_spawn(async move {

--- a/crates/services/txpool_v2/src/service.rs
+++ b/crates/services/txpool_v2/src/service.rs
@@ -283,8 +283,7 @@ where
         }
     }
 
-    async fn shutdown(mut self) -> anyhow::Result<()> {
-        self.pool_worker.stop();
+    async fn shutdown(self) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/crates/types/src/services/transaction_status.rs
+++ b/crates/types/src/services/transaction_status.rs
@@ -171,6 +171,19 @@ impl TransactionStatus {
         }
     }
 
+    /// Returns `true` if the status is pre confirmation.
+    pub fn is_preconfirmation(&self) -> bool {
+        match self {
+            TransactionStatus::Submitted(_)
+            | TransactionStatus::Success(_)
+            | TransactionStatus::Failure(_)
+            | TransactionStatus::SqueezedOut(_) => false,
+            TransactionStatus::PreConfirmationSuccess(_)
+            | TransactionStatus::PreConfirmationFailure(_)
+            | TransactionStatus::PreConfirmationSqueezedOut(_) => true,
+        }
+    }
+
     /// Returns `true` if the status is `Submitted`.
     pub fn is_submitted(&self) -> bool {
         matches!(self, Self::Submitted { .. })

--- a/tests/test-helpers/src/counter_contract.rs
+++ b/tests/test-helpers/src/counter_contract.rs
@@ -84,11 +84,6 @@ pub async fn deploy(
         intermediate_status,
         TransactionStatus::Submitted { .. }
     ));
-    let preconfirmation_status = status_stream.next().await.unwrap().unwrap();
-    match preconfirmation_status {
-        TransactionStatus::PreconfirmationSuccess { .. } => {}
-        _ => panic!("Tx wasn't preconfirmed: {:?}", preconfirmation_status),
-    };
     let final_status = status_stream.next().await.unwrap().unwrap();
     let TransactionStatus::Success { block_height, .. } = final_status else {
         panic!("Tx wasn't included in a block: {:?}", final_status);

--- a/tests/test-helpers/src/counter_contract.rs
+++ b/tests/test-helpers/src/counter_contract.rs
@@ -78,7 +78,7 @@ pub async fn deploy(
     let contract_id = CreateMetadata::compute(&tx).unwrap().contract_id;
 
     let tx = tx.into();
-    let mut status_stream = client.submit_and_await_status(&tx, true).await.unwrap();
+    let mut status_stream = client.submit_and_await_status(&tx).await.unwrap();
     let intermediate_status = status_stream.next().await.unwrap().unwrap();
     assert!(matches!(
         intermediate_status,

--- a/tests/test-helpers/src/counter_contract.rs
+++ b/tests/test-helpers/src/counter_contract.rs
@@ -78,7 +78,7 @@ pub async fn deploy(
     let contract_id = CreateMetadata::compute(&tx).unwrap().contract_id;
 
     let tx = tx.into();
-    let mut status_stream = client.submit_and_await_status(&tx).await.unwrap();
+    let mut status_stream = client.submit_and_await_status(&tx, true).await.unwrap();
     let intermediate_status = status_stream.next().await.unwrap().unwrap();
     assert!(matches!(
         intermediate_status,

--- a/tests/tests/gas_price.rs
+++ b/tests/tests/gas_price.rs
@@ -542,6 +542,7 @@ async fn startup__can_override_gas_price_values_by_changing_config() {
         l2_block_height, ..
     } = new_metadata.try_into().unwrap();
     assert_eq!(l2_block_height, new_height);
+    drop(recovered_view);
     recovered_driver.kill().await;
 }
 

--- a/tests/tests/poa.rs
+++ b/tests/tests/poa.rs
@@ -106,12 +106,13 @@ async fn starting_node_with_predefined_nodes_produces_these_predefined_blocks(
     for _ in 0..BLOCK_TO_PRODUCE {
         produce_block_with_tx(&mut rng, &core.client).await;
     }
-    let on_chain_view = core.node.shared.database.on_chain().latest_view()?;
 
     // Given
     let predefined_blocks: Vec<_> = (1..=BLOCK_TO_PRODUCE)
         .map(|block_height| {
             let block_height = block_height as u32;
+            let on_chain_view =
+                core.node.shared.database.on_chain().latest_view().unwrap();
             on_chain_view
                 .get_full_block(&block_height.into())
                 .unwrap()
@@ -145,6 +146,13 @@ async fn starting_node_with_predefined_nodes_produces_these_predefined_blocks(
     let blocks_from_new_node: Vec<_> = (1..=BLOCK_TO_PRODUCE)
         .map(|block_height| {
             let block_height = block_height as u32;
+            let on_chain_view = new_core
+                .node
+                .shared
+                .database
+                .on_chain()
+                .latest_view()
+                .unwrap();
             on_chain_view
                 .get_full_block(&block_height.into())
                 .unwrap()

--- a/tests/tests/preconfirmations.rs
+++ b/tests/tests/preconfirmations.rs
@@ -67,8 +67,7 @@ async fn preconfirmation__received_after_successful_execution() {
         .finalize_as_transaction();
 
     let tx_id = tx.id(&Default::default());
-    let mut tx_statuses_subscriber =
-        client.submit_and_await_status(&tx, true).await.unwrap();
+    let mut tx_statuses_subscriber = client.submit_and_await_status(&tx).await.unwrap();
 
     // When
     assert!(matches!(
@@ -120,6 +119,67 @@ async fn preconfirmation__received_after_successful_execution() {
 }
 
 #[tokio::test]
+async fn preconfirmation__received_when_asked() {
+    let mut rng = rand::thread_rng();
+    let mut config = Config::local_node();
+    config.block_production = Trigger::Never;
+    let address = Address::new([0; 32]);
+    let amount = 10;
+
+    let srv = FuelService::new_node(config).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    let gas_limit = 1_000_000;
+    let maturity = Default::default();
+
+    // Given
+    let script = [
+        op::addi(0x10, RegId::ZERO, 0xca),
+        op::addi(0x11, RegId::ZERO, 0xba),
+        op::log(0x10, 0x11, RegId::ZERO, RegId::ZERO),
+        op::ret(RegId::ONE),
+    ];
+    let script: Vec<u8> = script
+        .iter()
+        .flat_map(|op| u32::from(*op).to_be_bytes())
+        .collect();
+
+    let tx = TransactionBuilder::script(script, vec![])
+        .script_gas_limit(gas_limit)
+        .maturity(maturity)
+        .add_unsigned_coin_input(
+            SecretKey::random(&mut rng),
+            rng.gen(),
+            amount,
+            AssetId::default(),
+            Default::default(),
+        )
+        .add_output(Output::change(address, 0, AssetId::default()))
+        .finalize_as_transaction();
+
+    // When
+    let mut tx_statuses_subscriber = client
+        .submit_and_await_status_opt(&tx, None, Some(true))
+        .await
+        .unwrap();
+
+    // Then
+    assert!(matches!(
+        tx_statuses_subscriber.next().await.unwrap().unwrap(),
+        TransactionStatus::Submitted { .. }
+    ));
+    client.produce_blocks(1, None).await.unwrap();
+    assert!(matches!(
+        tx_statuses_subscriber.next().await.unwrap().unwrap(),
+        TransactionStatus::PreconfirmationSuccess { .. }
+    ));
+    assert!(matches!(
+        tx_statuses_subscriber.next().await.unwrap().unwrap(),
+        TransactionStatus::Success { block_height, .. } if block_height == BlockHeight::new(1)
+    ));
+}
+
+#[tokio::test]
 async fn preconfirmation__not_received_when_not_asked() {
     let mut rng = rand::thread_rng();
     let mut config = Config::local_node();
@@ -162,8 +222,10 @@ async fn preconfirmation__not_received_when_not_asked() {
     // When
     let mut tx_statuses_update_subscriber =
         client.subscribe_transaction_status(&tx_id).await.unwrap();
-    let mut tx_statuses_subscriber =
-        client.submit_and_await_status(&tx, false).await.unwrap();
+    let mut tx_statuses_subscriber = client
+        .submit_and_await_status_opt(&tx, None, None)
+        .await
+        .unwrap();
 
     // Then
     assert!(matches!(
@@ -226,8 +288,7 @@ async fn preconfirmation__received_after_failed_execution() {
         .finalize_as_transaction();
 
     let tx_id = tx.id(&Default::default());
-    let mut tx_statuses_subscriber =
-        client.submit_and_await_status(&tx, true).await.unwrap();
+    let mut tx_statuses_subscriber = client.submit_and_await_status(&tx).await.unwrap();
 
     // When
     assert!(matches!(
@@ -304,7 +365,7 @@ async fn preconfirmation__received_tx_inserted_end_block_open_period() {
 
     // When
     client
-        .submit_and_await_status(&tx, true)
+        .submit_and_await_status(&tx)
         .await
         .unwrap()
         .enumerate()
@@ -371,10 +432,8 @@ async fn preconfirmation__received_after_execution__multiple_txs() {
     .finalize_as_transaction();
 
     // Given
-    let mut tx_statuses_subscriber1 =
-        client.submit_and_await_status(&tx1, true).await.unwrap();
-    let mut tx_statuses_subscriber2 =
-        client.submit_and_await_status(&tx2, true).await.unwrap();
+    let mut tx_statuses_subscriber1 = client.submit_and_await_status(&tx1).await.unwrap();
+    let mut tx_statuses_subscriber2 = client.submit_and_await_status(&tx2).await.unwrap();
 
     // When
     assert!(matches!(

--- a/tests/tests/preconfirmations.rs
+++ b/tests/tests/preconfirmations.rs
@@ -67,7 +67,10 @@ async fn preconfirmation__received_after_successful_execution() {
         .finalize_as_transaction();
 
     let tx_id = tx.id(&Default::default());
-    let mut tx_statuses_subscriber = client.submit_and_await_status(&tx).await.unwrap();
+    let mut tx_statuses_subscriber = client
+        .submit_and_await_status_opt(&tx, None, Some(true))
+        .await
+        .unwrap();
 
     // When
     assert!(matches!(
@@ -288,7 +291,10 @@ async fn preconfirmation__received_after_failed_execution() {
         .finalize_as_transaction();
 
     let tx_id = tx.id(&Default::default());
-    let mut tx_statuses_subscriber = client.submit_and_await_status(&tx).await.unwrap();
+    let mut tx_statuses_subscriber = client
+        .submit_and_await_status_opt(&tx, None, Some(true))
+        .await
+        .unwrap();
 
     // When
     assert!(matches!(
@@ -365,7 +371,7 @@ async fn preconfirmation__received_tx_inserted_end_block_open_period() {
 
     // When
     client
-        .submit_and_await_status(&tx)
+        .submit_and_await_status_opt(&tx, None, Some(true))
         .await
         .unwrap()
         .enumerate()
@@ -432,8 +438,14 @@ async fn preconfirmation__received_after_execution__multiple_txs() {
     .finalize_as_transaction();
 
     // Given
-    let mut tx_statuses_subscriber1 = client.submit_and_await_status(&tx1).await.unwrap();
-    let mut tx_statuses_subscriber2 = client.submit_and_await_status(&tx2).await.unwrap();
+    let mut tx_statuses_subscriber1 = client
+        .submit_and_await_status_opt(&tx1, None, Some(true))
+        .await
+        .unwrap();
+    let mut tx_statuses_subscriber2 = client
+        .submit_and_await_status_opt(&tx2, None, Some(true))
+        .await
+        .unwrap();
 
     // When
     assert!(matches!(

--- a/tests/tests/preconfirmations_gossip.rs
+++ b/tests/tests/preconfirmations_gossip.rs
@@ -162,7 +162,7 @@ async fn preconfirmation__propagate_p2p_after_successful_execution() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx)
+        .submit_and_await_status_opt(&tx, None, Some(true))
         .await
         .expect("Should be able to subscribe for events");
 
@@ -308,7 +308,7 @@ async fn preconfirmation__propagate_p2p_after_failed_execution() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx)
+        .submit_and_await_status_opt(&tx, None, Some(true))
         .await
         .expect("Should be able to subscribe for events");
 
@@ -452,7 +452,7 @@ async fn preconfirmation__propagate_p2p_after_squeezed_out_on_producer() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx)
+        .submit_and_await_status_opt(&tx, None, Some(true))
         .await
         .expect("Should be able to subscribe for events");
 
@@ -605,7 +605,7 @@ async fn preconfirmation__sentry_allows_usage_of_dynamic_outputs() {
         .unwrap();
 
     let tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&final_script_with_transfers)
+        .submit_and_await_status_opt(&final_script_with_transfers, None, Some(true))
         .await
         .expect("Should be able to subscribe for events");
 
@@ -675,7 +675,11 @@ async fn preconfirmation__sentry_allows_usage_of_dynamic_outputs() {
 
     // When
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&transaction_that_rely_on_variable_inputs)
+        .submit_and_await_status_opt(
+            &transaction_that_rely_on_variable_inputs,
+            None,
+            Some(true),
+        )
         .await
         .expect("Should be able to subscribe for events");
 

--- a/tests/tests/preconfirmations_gossip.rs
+++ b/tests/tests/preconfirmations_gossip.rs
@@ -162,7 +162,7 @@ async fn preconfirmation__propagate_p2p_after_successful_execution() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx, true)
+        .submit_and_await_status(&tx)
         .await
         .expect("Should be able to subscribe for events");
 
@@ -308,7 +308,7 @@ async fn preconfirmation__propagate_p2p_after_failed_execution() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx, true)
+        .submit_and_await_status(&tx)
         .await
         .expect("Should be able to subscribe for events");
 
@@ -452,7 +452,7 @@ async fn preconfirmation__propagate_p2p_after_squeezed_out_on_producer() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx, true)
+        .submit_and_await_status(&tx)
         .await
         .expect("Should be able to subscribe for events");
 
@@ -605,7 +605,7 @@ async fn preconfirmation__sentry_allows_usage_of_dynamic_outputs() {
         .unwrap();
 
     let tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&final_script_with_transfers, true)
+        .submit_and_await_status(&final_script_with_transfers)
         .await
         .expect("Should be able to subscribe for events");
 
@@ -675,7 +675,7 @@ async fn preconfirmation__sentry_allows_usage_of_dynamic_outputs() {
 
     // When
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&transaction_that_rely_on_variable_inputs, true)
+        .submit_and_await_status(&transaction_that_rely_on_variable_inputs)
         .await
         .expect("Should be able to subscribe for events");
 

--- a/tests/tests/preconfirmations_gossip.rs
+++ b/tests/tests/preconfirmations_gossip.rs
@@ -162,7 +162,7 @@ async fn preconfirmation__propagate_p2p_after_successful_execution() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx)
+        .submit_and_await_status(&tx, true)
         .await
         .expect("Should be able to subscribe for events");
 
@@ -308,7 +308,7 @@ async fn preconfirmation__propagate_p2p_after_failed_execution() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx)
+        .submit_and_await_status(&tx, true)
         .await
         .expect("Should be able to subscribe for events");
 
@@ -452,7 +452,7 @@ async fn preconfirmation__propagate_p2p_after_squeezed_out_on_producer() {
     // When
     let client_sentry = FuelClient::from(sentry.node.bound_address);
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&tx)
+        .submit_and_await_status(&tx, true)
         .await
         .expect("Should be able to subscribe for events");
 
@@ -605,7 +605,7 @@ async fn preconfirmation__sentry_allows_usage_of_dynamic_outputs() {
         .unwrap();
 
     let tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&final_script_with_transfers)
+        .submit_and_await_status(&final_script_with_transfers, true)
         .await
         .expect("Should be able to subscribe for events");
 
@@ -675,7 +675,7 @@ async fn preconfirmation__sentry_allows_usage_of_dynamic_outputs() {
 
     // When
     let mut tx_statuses_subscriber = client_sentry
-        .submit_and_await_status(&transaction_that_rely_on_variable_inputs)
+        .submit_and_await_status(&transaction_that_rely_on_variable_inputs, true)
         .await
         .expect("Should be able to subscribe for events");
 

--- a/tests/tests/state_rewind.rs
+++ b/tests/tests/state_rewind.rs
@@ -116,10 +116,10 @@ async fn validate_block_at_any_height__only_transfers() -> anyhow::Result<()> {
         database_modifications.insert(last_block_height, block.changes.as_ref().clone());
     }
 
-    let view = node.shared.database.on_chain().latest_view().unwrap();
     for i in 0..TOTAL_BLOCKS {
         let height_to_execute = rng.gen_range(1..last_block_height);
 
+        let view = node.shared.database.on_chain().latest_view().unwrap();
         let block = view
             .get_full_block(&height_to_execute.into())
             .unwrap()
@@ -376,11 +376,10 @@ async fn backup_and_restore__should_work_with_state_rewind() -> anyhow::Result<(
     .unwrap();
     let node = &driver.node;
 
-    let view = node.shared.database.on_chain().latest_view().unwrap();
-
     for i in 0..TOTAL_BLOCKS {
         let height_to_execute = rng.gen_range(1..last_block_height);
 
+        let view = node.shared.database.on_chain().latest_view().unwrap();
         let block = view
             .get_full_block(&height_to_execute.into())
             .unwrap()

--- a/tests/tests/tx.rs
+++ b/tests/tests/tx.rs
@@ -390,11 +390,6 @@ async fn submit_and_await_status() {
         intermediate_status,
         TransactionStatus::Submitted { .. }
     ));
-    let preconfirmation_status = status_stream.next().await.unwrap().unwrap();
-    assert!(matches!(
-        preconfirmation_status,
-        TransactionStatus::PreconfirmationSuccess { .. }
-    ));
     let final_status = status_stream.next().await.unwrap().unwrap();
     assert!(matches!(final_status, TransactionStatus::Success { .. }));
 }

--- a/tests/tests/tx.rs
+++ b/tests/tests/tx.rs
@@ -384,7 +384,7 @@ async fn submit_and_await_status() {
         .await
         .unwrap();
 
-    let mut status_stream = client.submit_and_await_status(&tx, true).await.unwrap();
+    let mut status_stream = client.submit_and_await_status(&tx).await.unwrap();
     let intermediate_status = status_stream.next().await.unwrap().unwrap();
     assert!(matches!(
         intermediate_status,

--- a/tests/tests/tx.rs
+++ b/tests/tests/tx.rs
@@ -384,7 +384,7 @@ async fn submit_and_await_status() {
         .await
         .unwrap();
 
-    let mut status_stream = client.submit_and_await_status(&tx).await.unwrap();
+    let mut status_stream = client.submit_and_await_status(&tx, true).await.unwrap();
     let intermediate_status = status_stream.next().await.unwrap().unwrap();
     assert!(matches!(
         intermediate_status,

--- a/tests/tests/tx/txn_status_subscription.rs
+++ b/tests/tests/tx/txn_status_subscription.rs
@@ -140,7 +140,7 @@ async fn subscribe_txn_status() {
             let client = client.clone();
             async move {
                 client
-                    .subscribe_transaction_status(&id)
+                    .subscribe_transaction_status_opt(&id, Some(true))
                     .await
                     .unwrap()
                     .enumerate()


### PR DESCRIPTION
## Linked Issues/PRs
Closes https://github.com/FuelLabs/fuel-core/issues/2924

## Description

| Endpoint affected | Changes realised | Tested where? | 
|-|-|-|
| statusChange  |  Filter the preconfirmations depending on the boolean values after conversion of the transaction status to the API one. | In preconfirmation integration tests |
| submitAndAwaitStatus | Filter the preconfirmations depending on the boolean values after conversion of the transaction status to the API one. | In preconfirmation integration tests |
| `status` field of `Transaction` object | Filter the preconfirmations depending on the boolean values after conversion of the transaction status to the API one. For preconfirmation we still want to send a status that will be Submitted. | Client doesn't support this feature so no explicit tests |

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here