### PR TITLE
fix(ci): explicitly push before creating PR

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -70,7 +70,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - run: |
+      - name: Parse benchmark results and create PR
+        run: |
           jq --argjson benchmark_results "$benchmark_results" \
             '.consensus_parameters.${{ env.CONSENSUS_PARAMETERS_VERSION }}.gas_costs = $benchmark_results' \
             bin/fuel-core/chainspec/local-testnet/chain_config.json > \
@@ -83,6 +84,9 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git commit -m "Update benchmark results"
+
+          git push origin "$branch_name"
+
           # create a new PR
           gh pr create \
             --title "chore(gas_costs): update local chain config with nightly benchmark results" \

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -94,6 +94,7 @@ jobs:
             --body "Updated benchmark results" \
             --base master \
             --head "$branch_name"
+            --label "no changelog"
         env:
           benchmark_results: ${{ needs.benchmark.outputs.benchmark_results }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -63,6 +63,7 @@ jobs:
     needs: benchmark
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
 
     if: ${{ github.event.inputs.create_pr == 'true' || github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
none, fixes related to nightly benchmark

> [!NOTE]
> nightly benchmark CI has passed on this branch

## Description
<!-- List of detailed changes -->
- name the parsing / pr step
- explicitly push before creating PR using gh cli. there are some defaults which aren't set.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
