### PR TITLE
chore(compression): pass compression config by reference

### DIFF
--- a/.changes/breaking/2931.md
+++ b/.changes/breaking/2931.md
@@ -1,0 +1,1 @@
+In `fuel-core-compression`, the `compress` function now takes a reference to `Config` instead of the value.

--- a/crates/services/compression/src/config.rs
+++ b/crates/services/compression/src/config.rs
@@ -27,8 +27,8 @@ impl CompressionConfig {
     }
 }
 
-impl From<CompressionConfig> for fuel_core_compression::Config {
-    fn from(config: CompressionConfig) -> Self {
+impl From<&CompressionConfig> for fuel_core_compression::Config {
+    fn from(config: &CompressionConfig) -> Self {
         Self {
             temporal_registry_retention: config.temporal_registry_retention(),
         }

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -125,7 +125,7 @@ where
 fn compress_block<S>(
     storage: &mut S,
     block_with_metadata: &BlockWithMetadata,
-    config: CompressionConfig,
+    config: &CompressionConfig,
 ) -> crate::Result<usize>
 where
     S: CompressionStorage,
@@ -140,7 +140,7 @@ where
         block_events: block_with_metadata.events(),
     };
     let compressed_block = compress(
-        config.into(),
+        &config.into(),
         compression_context,
         block_with_metadata.block(),
     )
@@ -161,7 +161,7 @@ where
 fn handle_new_block<S>(
     storage: &mut S,
     block_with_metadata: &BlockWithMetadata,
-    config: CompressionConfig,
+    config: &CompressionConfig,
     sync_notifier: &SyncStateNotifier,
     metrics_manager: &Option<CompressionMetricsManager>,
 ) -> crate::Result<()>
@@ -208,7 +208,7 @@ where
         handle_new_block(
             &mut self.storage,
             block_with_metadata,
-            self.config,
+            &self.config,
             &self.sync_notifier,
             &self.metrics_manager,
         )
@@ -252,7 +252,7 @@ where
             handle_new_block(
                 &mut self.storage,
                 &block_with_metadata,
-                self.config,
+                &self.config,
                 &self.sync_notifier,
                 &self.metrics_manager,
             )?;


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->
simple PR, `Config` is 16 bytes, `&Config` is 8 bytes. 77x faster measured with microbenchmark.


## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
