### PR TITLE
fix(preconfs): include nonce as part of the sealed delegate key

### DIFF
--- a/.changes/changed/2934.md
+++ b/.changes/changed/2934.md
@@ -1,0 +1,1 @@
+Include the `nonce` in the `PreConfirmationMessage::Delegate` payload broadcasted over p2p.

--- a/crates/services/consensus_module/poa/src/pre_confirmation_signature_service/broadcast.rs
+++ b/crates/services/consensus_module/poa/src/pre_confirmation_signature_service/broadcast.rs
@@ -33,7 +33,6 @@ pub trait Broadcast: Send {
     fn broadcast_delegate_key(
         &mut self,
         delegate: DelegatePreConfirmationKey<PublicKey<Self>>,
-        nonce: u64,
         signature: <Self::ParentKey as ParentSignature>::Signature,
     ) -> impl Future<Output = Result<()>> + Send;
 }

--- a/crates/services/consensus_module/poa/src/pre_confirmation_signature_service/tests.rs
+++ b/crates/services/consensus_module/poa/src/pre_confirmation_signature_service/tests.rs
@@ -72,7 +72,6 @@ impl Broadcast for FakeBroadcast {
     async fn broadcast_delegate_key(
         &mut self,
         data: DelegatePreConfirmationKey<PublicKey<Self>>,
-        _: u64,
         signature: <Self::ParentKey as ParentSignature>::Signature,
     ) -> Result<()> {
         let delegate_key = FakeParentSignedData {
@@ -227,6 +226,7 @@ impl TaskBuilder {
         let entity = DelegatePreConfirmationKey {
             public_key: Bytes32::zeroed(),
             expiration: Tai64::UNIX_EPOCH,
+            nonce: 0,
         };
         let signature = parent_signature.dummy_signature.clone();
         let period = self.period.unwrap_or(Duration::from_secs(60 * 60));
@@ -373,6 +373,7 @@ async fn run__key_rotation_trigger_will_broadcast_generated_key_with_correct_sig
         data: DelegatePreConfirmationKey {
             public_key: Bytes32::zeroed(),
             expiration: expiration_time,
+            nonce: 0,
         },
         dummy_signature: dummy_signature.into(),
     };
@@ -419,6 +420,7 @@ async fn run__will_rebroadcast_generated_key_with_correct_signature_after_1_seco
         data: DelegatePreConfirmationKey {
             public_key: Bytes32::zeroed(),
             expiration: expiration_time,
+            nonce: 0,
         },
         dummy_signature: dummy_signature.into(),
     };

--- a/crates/types/src/services/p2p.rs
+++ b/crates/types/src/services/p2p.rs
@@ -103,6 +103,8 @@ pub struct DelegatePreConfirmationKey<P> {
     /// to use to verify the pre-confirmations--serves the second purpose of being a nonce of
     /// each key
     pub expiration: Tai64,
+    /// The nonce of this Delegate key. Should be Monotonically increasing.
+    pub nonce: u64,
 }
 
 /// A signed key delegation
@@ -116,12 +118,7 @@ pub type SignedPreconfirmationByDelegate<S> = Sealed<Preconfirmations, S>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PreConfirmationMessage<DP, DS, S> {
     /// Notification of key delegation
-    Delegate {
-        /// The sealed key delegation.
-        seal: SignedByBlockProducerDelegation<DP, S>,
-        /// The nonce of the p2p message to make it unique.
-        nonce: u64,
-    },
+    Delegate(SignedByBlockProducerDelegation<DP, S>),
     /// Notification of pre-confirmations
     Preconfirmations(SignedPreconfirmationByDelegate<DS>),
 }


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
Nonce should be included within the data being signed.

## Description
<!-- List of detailed changes -->
This pull request focuses on modifying the `PreConfirmationMessage::Delegate` payload to include the `nonce` and refactoring related code to accommodate this change. The most important changes include updating the `DelegatePreConfirmationKey` structure, modifying the `broadcast_delegate_key` function, and adjusting the corresponding tests.

Key changes:

*Payload Update:*
* [`crates/types/src/services/p2p.rs`](diffhunk://#diff-8b8ff5c89aa703335749640558ba57623f1e8c07b60ca58c4e89687c182fa976R106-R107): Updated the `PreConfirmationMessage::Delegate` to include the `nonce` field. [[1]](diffhunk://#diff-8b8ff5c89aa703335749640558ba57623f1e8c07b60ca58c4e89687c182fa976R106-R107) [[2]](diffhunk://#diff-8b8ff5c89aa703335749640558ba57623f1e8c07b60ca58c4e89687c182fa976L119-R121)

*Function Modifications:*
* [`crates/fuel-core/src/service/adapters/consensus_module/poa/pre_confirmation_signature/broadcast.rs`](diffhunk://#diff-f9218dcdb35fe7e9dffdbffe6a38bd7d8bdef5f020c3d9a02f59b3a06fabcab4L61-R68): Modified the `broadcast_delegate_key` function to remove the `nonce` parameter and use the updated `PreConfirmationMessage::Delegate` structure. [[1]](diffhunk://#diff-f9218dcdb35fe7e9dffdbffe6a38bd7d8bdef5f020c3d9a02f59b3a06fabcab4L61-R68) [[2]](diffhunk://#diff-f9218dcdb35fe7e9dffdbffe6a38bd7d8bdef5f020c3d9a02f59b3a06fabcab4R176-R182) [[3]](diffhunk://#diff-f9218dcdb35fe7e9dffdbffe6a38bd7d8bdef5f020c3d9a02f59b3a06fabcab4R196) [[4]](diffhunk://#diff-f9218dcdb35fe7e9dffdbffe6a38bd7d8bdef5f020c3d9a02f59b3a06fabcab4R206-R215)
* [`crates/services/consensus_module/poa/src/pre_confirmation_signature_service.rs`](diffhunk://#diff-e95200904776b54c384079c8b68c9833f00f484c78093c4d80041491552d8feaR131-R140): Updated the `create_delegate_key` function and related code to handle the `nonce` field. [[1]](diffhunk://#diff-e95200904776b54c384079c8b68c9833f00f484c78093c4d80041491552d8feaR131-R140) [[2]](diffhunk://#diff-e95200904776b54c384079c8b68c9833f00f484c78093c4d80041491552d8feaR165) [[3]](diffhunk://#diff-e95200904776b54c384079c8b68c9833f00f484c78093c4d80041491552d8feaR181) [[4]](diffhunk://#diff-e95200904776b54c384079c8b68c9833f00f484c78093c4d80041491552d8feaR256-R269) [[5]](diffhunk://#diff-e95200904776b54c384079c8b68c9833f00f484c78093c4d80041491552d8feaL280-R280)

*Test Adjustments:*
* [`crates/services/consensus_module/poa/src/pre_confirmation_signature_service/tests.rs`](diffhunk://#diff-91d092dba0da996f7e0fff52177f36ec9a650eb6e7deb19113e47a9d9f6ad4b2L75): Updated tests to reflect changes in the `DelegatePreConfirmationKey` structure and the `broadcast_delegate_key` function. [[1]](diffhunk://#diff-91d092dba0da996f7e0fff52177f36ec9a650eb6e7deb19113e47a9d9f6ad4b2L75) [[2]](diffhunk://#diff-91d092dba0da996f7e0fff52177f36ec9a650eb6e7deb19113e47a9d9f6ad4b2R229) [[3]](diffhunk://#diff-91d092dba0da996f7e0fff52177f36ec9a650eb6e7deb19113e47a9d9f6ad4b2R376) [[4]](diffhunk://#diff-91d092dba0da996f7e0fff52177f36ec9a650eb6e7deb19113e47a9d9f6ad4b2R423)
* [`crates/services/tx_status_manager/src/service.rs`](diffhunk://#diff-13448c44eb7f53d281aa495122d49ead24aa28ced85bc431510e87c7e8da26d9L251-R251): Adjusted tests to include the `nonce` field in the `DelegatePreConfirmationKey` structure. [[1]](diffhunk://#diff-13448c44eb7f53d281aa495122d49ead24aa28ced85bc431510e87c7e8da26d9L251-R251) [[2]](diffhunk://#diff-13448c44eb7f53d281aa495122d49ead24aa28ced85bc431510e87c7e8da26d9R783-R794) [[3]](diffhunk://#diff-13448c44eb7f53d281aa495122d49ead24aa28ced85bc431510e87c7e8da26d9L807-R814) [[4]](diffhunk://#diff-13448c44eb7f53d281aa495122d49ead24aa28ced85bc431510e87c7e8da26d9R1387-R1392) [[5]](diffhunk://#diff-13448c44eb7f53d281aa495122d49ead24aa28ced85bc431510e87c7e8da26d9R1524-R1529) [[6]](diffhunk://#diff-13448c44eb7f53d281aa495122d49ead24aa28ced85bc431510e87c7e8da26d9R1593-R1598) [[7]](diffhunk://#diff-13448c44eb7f53d281aa495122d49ead24aa28ced85bc431510e87c7e8da26d9R1670-R1677)

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
