### PR TITLE
Reject transactions for already spent coins

### DIFF
--- a/.changes/fixed/2935.md
+++ b/.changes/fixed/2935.md
@@ -1,0 +1,1 @@
+The change rejects transactions immediately, if they use spent coins. `TxPool` has a SpentInputs LRU cache, storing all spent coins.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ dependencies = [
  "fuel-core-txpool",
  "fuel-core-types 0.42.0",
  "futures",
+ "lru 0.13.0",
  "mockall",
  "num-rational",
  "parking_lot",
@@ -5938,7 +5939,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "lru",
+ "lru 0.12.5",
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
@@ -6135,7 +6136,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "lru",
+ "lru 0.12.5",
  "multistream-select",
  "once_cell",
  "rand 0.8.5",
@@ -6460,6 +6461,15 @@ name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
 ]

--- a/benches/src/bin/tps_bench.rs
+++ b/benches/src/bin/tps_bench.rs
@@ -150,7 +150,7 @@ fn main() {
     test_builder.initial_coins.extend(
         transactions
             .iter()
-            .flat_map(|t| t.inputs().unwrap())
+            .flat_map(|t| t.inputs())
             .filter_map(|input| {
                 if let Input::CoinSigned(CoinSigned {
                     amount,

--- a/benches/src/bin/tps_bench.rs
+++ b/benches/src/bin/tps_bench.rs
@@ -150,7 +150,7 @@ fn main() {
     test_builder.initial_coins.extend(
         transactions
             .iter()
-            .flat_map(|t| t.inputs())
+            .flat_map(|t| t.inputs().into_owned())
             .filter_map(|input| {
                 if let Input::CoinSigned(CoinSigned {
                     amount,
@@ -174,9 +174,9 @@ fn main() {
                         output_index: utxo_id.output_index(),
                         tx_pointer_block_height: tx_pointer.block_height(),
                         tx_pointer_tx_idx: tx_pointer.tx_index(),
-                        owner: *owner,
-                        amount: *amount,
-                        asset_id: *asset_id,
+                        owner,
+                        amount,
+                        asset_id,
                     })
                 } else {
                     None

--- a/bin/e2e-test-client/src/lib.rs
+++ b/bin/e2e-test-client/src/lib.rs
@@ -66,7 +66,7 @@ pub fn main_body(config: SuiteConfig, mut args: Arguments) {
             with_cloned(&config, |config| {
                 async_execute(async {
                     let ctx = TestContext::new(config).await;
-                    tests::transfers::transfer_back(&ctx).await
+                    tests::script::receipts(&ctx).await
                 })
             }),
         ),
@@ -121,7 +121,7 @@ pub fn main_body(config: SuiteConfig, mut args: Arguments) {
         ),
     ];
 
-    libtest_mimic::run(&args, tests).exit();
+    libtest_mimic::run(&args, tests).exit_if_failed();
 }
 
 pub fn load_config_env() -> SuiteConfig {

--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -592,6 +592,10 @@ impl Node {
                             || matches!(status, TransactionStatus::Success { .. }) {
                             break
                         }
+
+                        if matches!(status, TransactionStatus::SqueezedOut(_)) {
+                            panic!("Transaction was squeezed out: {:?}", status);
+                        }
                     }
                     _ = self.node.await_shutdown() => {
                         panic!("Got a stop signal")

--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -250,6 +250,7 @@ impl Bootstrap {
 }
 
 // set of nodes with the given setups.
+#[allow(clippy::arithmetic_side_effects)]
 pub async fn make_nodes(
     bootstrap_setup: impl IntoIterator<Item = Option<BootstrapSetup>>,
     producers_setup: impl IntoIterator<Item = Option<ProducerSetup>>,
@@ -268,12 +269,12 @@ pub async fn make_nodes(
             let all: Vec<_> = (0..num_test_txs)
                 .map(|_| {
                     let secret = SecretKey::random(&mut rng);
-                    let initial_coin = CoinConfig {
-                        // set idx to prevent overlapping utxo_ids when
-                        // merging with existing coins from config
-                        output_index: 10,
+                    let mut initial_coin = CoinConfig {
                         ..coin_generator.generate_with(secret, 10000)
                     };
+                    // Shift idx to prevent overlapping utxo_ids when
+                    // merging with existing coins from config
+                    initial_coin.output_index += 100;
                     let tx = TransactionBuilder::script(
                         vec![op::ret(RegId::ONE)].into_iter().collect(),
                         vec![],

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -982,7 +982,7 @@ impl<'a> ContextExt for Context<'a> {
     ) -> anyhow::Result<FuelTx> {
         let mut has_predicates = false;
 
-        for input in tx.inputs()? {
+        for input in tx.inputs().iter() {
             if input.predicate().is_some() {
                 has_predicates = true;
                 break;

--- a/crates/fuel-core/src/service/adapters/txpool.rs
+++ b/crates/fuel-core/src/service/adapters/txpool.rs
@@ -14,6 +14,7 @@ use fuel_core_storage::{
         Coins,
         ContractsRawCode,
         Messages,
+        ProcessedTransactions,
     },
     Result as StorageResult,
     StorageAsRef,
@@ -204,6 +205,10 @@ const _: () = {
 };
 
 impl fuel_core_txpool::ports::TxPoolPersistentStorage for OnChainIterableKeyValueView {
+    fn contains_tx(&self, tx_id: &TxId) -> StorageResult<bool> {
+        self.storage::<ProcessedTransactions>().contains_key(tx_id)
+    }
+
     fn utxo(&self, utxo_id: &UtxoId) -> StorageResult<Option<CompressedCoin>> {
         self.storage::<Coins>()
             .get(utxo_id)

--- a/crates/services/executor/src/ports.rs
+++ b/crates/services/executor/src/ports.rs
@@ -124,7 +124,7 @@ impl MaybeCheckedTransaction {
 }
 
 impl TransactionExt for MaybeCheckedTransaction {
-    fn inputs(&self) -> ExecutorResult<&Vec<Input>> {
+    fn inputs(&self) -> Cow<[Input]> {
         match self {
             MaybeCheckedTransaction::CheckedTransaction(tx, _) => tx.inputs(),
             MaybeCheckedTransaction::Transaction(tx) => tx.inputs(),

--- a/crates/services/txpool_v2/Cargo.toml
+++ b/crates/services/txpool_v2/Cargo.toml
@@ -19,8 +19,8 @@ fuel-core-services = { workspace = true, features = ["sync-processor"] }
 fuel-core-storage = { workspace = true, features = ["std"] }
 fuel-core-types = { workspace = true, features = ["test-helpers"] }
 futures = { workspace = true }
-num-rational = { workspace = true }
 lru = "0.13.0"
+num-rational = { workspace = true }
 parking_lot = { workspace = true }
 petgraph = "0.6.5"
 tokio = { workspace = true, default-features = false, features = ["sync"] }

--- a/crates/services/txpool_v2/Cargo.toml
+++ b/crates/services/txpool_v2/Cargo.toml
@@ -20,6 +20,7 @@ fuel-core-storage = { workspace = true, features = ["std"] }
 fuel-core-types = { workspace = true, features = ["test-helpers"] }
 futures = { workspace = true }
 num-rational = { workspace = true }
+lru = "0.13.0"
 parking_lot = { workspace = true }
 petgraph = "0.6.5"
 tokio = { workspace = true, default-features = false, features = ["sync"] }

--- a/crates/services/txpool_v2/src/error.rs
+++ b/crates/services/txpool_v2/src/error.rs
@@ -59,6 +59,10 @@ pub enum Error {
         /// The minimum gas price required by TxPool.
         minimal_gas_price: Word,
     },
+    #[display(fmt = "The message input {_0:#x} was already spent")]
+    MessageInputWasAlreadySpent(Nonce),
+    #[display(fmt = "The UTXO input {_0:#x} was already spent")]
+    UtxoInputWasAlreadySpent(UtxoId),
 }
 
 impl Error {

--- a/crates/services/txpool_v2/src/lib.rs
+++ b/crates/services/txpool_v2/src/lib.rs
@@ -56,6 +56,7 @@ mod storage;
 
 pub type GasPrice = Word;
 
+mod spent_inputs;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -1,5 +1,6 @@
 mod collisions;
 
+use core::num::NonZeroUsize;
 use std::{
     collections::HashMap,
     iter,
@@ -59,7 +60,10 @@ use crate::{
     },
 };
 
-use crate::error::RemovedReason;
+use crate::{
+    error::RemovedReason,
+    spent_inputs::SpentInputs,
+};
 #[cfg(test)]
 use std::collections::HashSet;
 
@@ -85,6 +89,8 @@ pub struct Pool<S, SI, CM, SA, TxStatusManager> {
     pub(crate) tx_id_to_storage_id: HashMap<TxId, SI>,
     /// All sent outputs when transactions are extracted. Clear when processing a block.
     pub(crate) extracted_outputs: ExtractedOutputs,
+    /// The spent inputs cache.
+    pub(crate) spent_inputs: SpentInputs,
     /// Current pool gas stored.
     pub(crate) current_gas: u64,
     /// Current pool size in bytes.
@@ -108,6 +114,9 @@ impl<S, SI, CM, SA, TxStatusManager> Pool<S, SI, CM, SA, TxStatusManager> {
         new_executable_txs_notifier: tokio::sync::watch::Sender<()>,
         tx_status_manager: Arc<TxStatusManager>,
     ) -> Self {
+        let capacity = NonZeroUsize::new(config.pool_limits.max_txs.saturating_add(1))
+            .expect("Max txs is greater than 0");
+        let spent_inputs = SpentInputs::new(capacity);
         Pool {
             storage,
             collision_manager,
@@ -115,6 +124,7 @@ impl<S, SI, CM, SA, TxStatusManager> Pool<S, SI, CM, SA, TxStatusManager> {
             config,
             tx_id_to_storage_id: HashMap::new(),
             extracted_outputs: ExtractedOutputs::new(),
+            spent_inputs,
             current_gas: 0,
             current_bytes_size: 0,
             pool_stats_sender,
@@ -276,6 +286,7 @@ where
             &tx,
             persistent_storage,
             &self.extracted_outputs,
+            &self.spent_inputs,
             self.config.utxo_validation,
         )?;
 
@@ -376,6 +387,10 @@ where
             .map(|storage_entry| {
                 self.extracted_outputs
                     .new_extracted_transaction(&storage_entry.transaction);
+                self.spent_inputs.maybe_spend_inputs(
+                    storage_entry.transaction.id(),
+                    &storage_entry.transaction.inputs(),
+                );
                 self.update_components_and_caches_on_removal(iter::once(&storage_entry));
                 storage_entry.transaction
             })
@@ -404,6 +419,7 @@ where
     pub fn process_committed_transactions(&mut self, tx_ids: impl Iterator<Item = TxId>) {
         let mut transactions_to_promote = vec![];
         for tx_id in tx_ids {
+            self.spent_inputs.spend_inputs_by_tx_id(tx_id);
             if let Some(storage_id) = self.tx_id_to_storage_id.remove(&tx_id) {
                 let dependents: Vec<S::StorageIndex> =
                     self.storage.get_direct_dependents(storage_id).collect();
@@ -417,6 +433,8 @@ where
                 };
                 self.extracted_outputs
                     .new_extracted_transaction(&transaction.transaction);
+                self.spent_inputs
+                    .spend_inputs(tx_id, &transaction.transaction.inputs());
                 self.update_components_and_caches_on_removal(iter::once(&transaction));
 
                 for dependent in dependents {
@@ -621,7 +639,7 @@ where
         if self.tx_id_to_storage_id.contains_key(&tx_id) {
             let tx_status = statuses::SqueezedOut {
                 reason: Error::SkippedTransaction(format!(
-                    "Parent transaction with id: {tx_id}, was removed because of: {reason}"
+                    "Transaction with id: {tx_id}, was removed because of: {reason}"
                 ))
                 .to_string(),
             };
@@ -629,6 +647,7 @@ where
         }
 
         self.extracted_outputs.new_skipped_transaction(&tx_id);
+        self.spent_inputs.unspend_inputs(tx_id);
 
         let coin_dependents = self.collision_manager.get_coins_spenders(&tx_id);
         if !coin_dependents.is_empty() {

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -155,10 +155,11 @@ where
         persistent_storage: &impl TxPoolPersistentStorage,
     ) -> Result<(), InsertionErrorType> {
         let tx_id = tx.id();
-        let contains = persistent_storage
-            .contains_tx(&tx_id)
-            .map_err(|e| Error::Database(format!("{:?}", e)))?;
-        if contains {
+        if self.spent_inputs.is_spent_tx(&tx_id)
+            || persistent_storage
+                .contains_tx(&tx_id)
+                .map_err(|e| Error::Database(format!("{:?}", e)))?
+        {
             return Err(InsertionErrorType::Error(Error::InputValidation(
                 InputValidationError::DuplicateTxId(tx_id),
             )))

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -154,6 +154,16 @@ where
         tx: ArcPoolTx,
         persistent_storage: &impl TxPoolPersistentStorage,
     ) -> Result<(), InsertionErrorType> {
+        let tx_id = tx.id();
+        let contains = persistent_storage
+            .contains_tx(&tx_id)
+            .map_err(|e| Error::Database(format!("{:?}", e)))?;
+        if contains {
+            return Err(InsertionErrorType::Error(Error::InputValidation(
+                InputValidationError::DuplicateTxId(tx_id),
+            )))
+        }
+
         let insertion_result = self.insert_inner(tx, persistent_storage);
         self.register_transaction_counts();
         insertion_result

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -389,7 +389,7 @@ where
                     .new_extracted_transaction(&storage_entry.transaction);
                 self.spent_inputs.maybe_spend_inputs(
                     storage_entry.transaction.id(),
-                    &storage_entry.transaction.inputs(),
+                    storage_entry.transaction.inputs(),
                 );
                 self.update_components_and_caches_on_removal(iter::once(&storage_entry));
                 storage_entry.transaction
@@ -434,7 +434,7 @@ where
                 self.extracted_outputs
                     .new_extracted_transaction(&transaction.transaction);
                 self.spent_inputs
-                    .spend_inputs(tx_id, &transaction.transaction.inputs());
+                    .spend_inputs(tx_id, transaction.transaction.inputs());
                 self.update_components_and_caches_on_removal(iter::once(&transaction));
 
                 for dependent in dependents {

--- a/crates/services/txpool_v2/src/ports.rs
+++ b/crates/services/txpool_v2/src/ports.rs
@@ -68,6 +68,9 @@ pub trait ChainStateInfoProvider: Send + Sync + 'static {
 pub trait TxPoolPersistentStorage:
     Clone + PredicateStorageRequirements + Send + Sync + 'static
 {
+    /// Returns `true` if the transaction already is inside the storage.
+    fn contains_tx(&self, tx_id: &TxId) -> StorageResult<bool>;
+
     /// Get the UTXO by its ID.
     fn utxo(&self, utxo_id: &UtxoId) -> StorageResult<Option<CompressedCoin>>;
 

--- a/crates/services/txpool_v2/src/spent_inputs.rs
+++ b/crates/services/txpool_v2/src/spent_inputs.rs
@@ -36,6 +36,10 @@ impl SpentInputs {
         }
     }
 
+    /// Marks inputs as spent, by preserves the information about the spender in the case
+    /// if we need to unspend inputs later, see [`unspend_inputs`] for more details.
+    ///
+    /// This function is called when `TxPool` extracts transactions for the block producer.
     pub fn maybe_spend_inputs(&mut self, tx_id: TxId, inputs: &[Input]) {
         let inputs = inputs
             .iter()
@@ -83,6 +87,8 @@ impl SpentInputs {
         }
     }
 
+    /// If transaction is skipped during the block production, this functions
+    /// can be used to unspend inputs, allowing other transactions to spend them.
     pub fn unspend_inputs(&mut self, tx_id: TxId) {
         let inputs = self.spender_of_inputs.remove(&tx_id);
 

--- a/crates/services/txpool_v2/src/spent_inputs.rs
+++ b/crates/services/txpool_v2/src/spent_inputs.rs
@@ -1,0 +1,283 @@
+use fuel_core_types::{
+    fuel_tx::{
+        Input,
+        TxId,
+        UtxoId,
+    },
+    fuel_types::Nonce,
+};
+use lru::LruCache;
+use std::{
+    collections::HashMap,
+    num::NonZeroUsize,
+};
+
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+enum InputKey {
+    Utxo(UtxoId),
+    Message(Nonce),
+}
+
+/// Keeps track of spent inputs.
+pub struct SpentInputs {
+    /// Use LRU to support automatic clean up of old entries.
+    spent_inputs: LruCache<InputKey, ()>,
+    /// When it is unclear whether an input has been spent, we want to store which
+    /// transaction spent it. Later, this information can be used to unspent
+    /// or fully spend the input.
+    spender_of_inputs: HashMap<TxId, Vec<InputKey>>,
+}
+
+impl SpentInputs {
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            spent_inputs: LruCache::new(capacity),
+            spender_of_inputs: HashMap::new(),
+        }
+    }
+
+    pub fn maybe_spend_inputs(&mut self, tx_id: TxId, inputs: &[Input]) {
+        let inputs = inputs
+            .iter()
+            .filter_map(|input| {
+                if input.is_coin() {
+                    input.utxo_id().cloned().map(InputKey::Utxo)
+                } else if input.is_message() {
+                    input.nonce().cloned().map(InputKey::Message)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        for input in inputs.iter() {
+            self.spent_inputs.put(*input, ());
+        }
+        self.spender_of_inputs.insert(tx_id, inputs);
+    }
+
+    pub fn spend_inputs(&mut self, tx_id: TxId, inputs: &[Input]) {
+        let inputs = inputs.iter().filter_map(|input| {
+            if input.is_coin() {
+                input.utxo_id().cloned().map(InputKey::Utxo)
+            } else if input.is_message() {
+                input.nonce().cloned().map(InputKey::Message)
+            } else {
+                None
+            }
+        });
+
+        for input in inputs {
+            self.spent_inputs.put(input, ());
+        }
+        self.spend_inputs_by_tx_id(tx_id);
+    }
+
+    pub fn spend_inputs_by_tx_id(&mut self, tx_id: TxId) {
+        let inputs = self.spender_of_inputs.remove(&tx_id);
+
+        if let Some(inputs) = inputs {
+            for input in inputs {
+                self.spent_inputs.put(input, ());
+            }
+        }
+    }
+
+    pub fn unspend_inputs(&mut self, tx_id: TxId) {
+        let inputs = self.spender_of_inputs.remove(&tx_id);
+
+        if let Some(inputs) = inputs {
+            for input in inputs {
+                self.spent_inputs.pop(&input);
+            }
+        }
+    }
+
+    pub fn is_spent_utxo(&self, input: &UtxoId) -> bool {
+        self.spent_inputs.contains(&InputKey::Utxo(*input))
+    }
+
+    pub fn is_spent_message(&self, input: &Nonce) -> bool {
+        self.spent_inputs.contains(&InputKey::Message(*input))
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use super::*;
+    use fuel_core_types::fuel_tx::Input;
+    use std::num::NonZeroUsize;
+
+    #[test]
+    fn maybe_spend_inputs_works__inputs_marked_as_spent() {
+        let mut spent_inputs = SpentInputs::new(NonZeroUsize::new(10).unwrap());
+
+        let tx_id = TxId::default();
+        let input_1 = Input::coin_signed(
+            UtxoId::new([123; 32].into(), 1),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        let input_2 = Input::message_coin_signed(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            [123; 32].into(),
+            Default::default(),
+        );
+
+        // Given
+        assert!(!spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(!spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+
+        // When
+        spent_inputs.maybe_spend_inputs(tx_id, &[input_1.clone(), input_2.clone()]);
+
+        // Then
+        assert!(spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+    }
+
+    #[test]
+    fn unspend_inputs_works__after_maybe_spend_inputs() {
+        let mut spent_inputs = SpentInputs::new(NonZeroUsize::new(10).unwrap());
+
+        let tx_id = TxId::default();
+        let input_1 = Input::coin_signed(
+            UtxoId::new([123; 32].into(), 1),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        let input_2 = Input::message_coin_signed(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            [123; 32].into(),
+            Default::default(),
+        );
+
+        // Given
+        spent_inputs.maybe_spend_inputs(tx_id, &[input_1.clone(), input_2.clone()]);
+        assert!(spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+
+        // When
+        spent_inputs.unspend_inputs(tx_id);
+
+        // Then
+        assert!(!spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(!spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+    }
+
+    #[test]
+    fn unspend_inputs_do_nothing__after_spend_inputs_by_tx_id() {
+        let mut spent_inputs = SpentInputs::new(NonZeroUsize::new(10).unwrap());
+
+        let tx_id = TxId::default();
+        let input_1 = Input::coin_signed(
+            UtxoId::new([123; 32].into(), 1),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        let input_2 = Input::message_coin_signed(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            [123; 32].into(),
+            Default::default(),
+        );
+
+        // Given
+        spent_inputs.maybe_spend_inputs(tx_id, &[input_1.clone(), input_2.clone()]);
+        assert!(spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+        spent_inputs.spend_inputs_by_tx_id(tx_id);
+
+        // When
+        spent_inputs.unspend_inputs(tx_id);
+
+        // Then
+        assert!(spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+    }
+
+    #[test]
+    fn unspend_inputs_do_nothing__after_spend_inputs__with_valid_inputs() {
+        let mut spent_inputs = SpentInputs::new(NonZeroUsize::new(10).unwrap());
+
+        let tx_id = TxId::default();
+        let input_1 = Input::coin_signed(
+            UtxoId::new([123; 32].into(), 1),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        let input_2 = Input::message_coin_signed(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            [123; 32].into(),
+            Default::default(),
+        );
+
+        // Given
+        spent_inputs.maybe_spend_inputs(tx_id, &[input_1.clone(), input_2.clone()]);
+        assert!(spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+        spent_inputs.spend_inputs(tx_id, &[input_1.clone(), input_2.clone()]);
+
+        // When
+        spent_inputs.unspend_inputs(tx_id);
+
+        // Then
+        assert!(spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+    }
+
+    #[test]
+    fn unspend_inputs_do_nothing__after_spend_inputs__without_valid_inputs() {
+        let mut spent_inputs = SpentInputs::new(NonZeroUsize::new(10).unwrap());
+
+        let tx_id = TxId::default();
+        let input_1 = Input::coin_signed(
+            UtxoId::new([123; 32].into(), 1),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        let input_2 = Input::message_coin_signed(
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            [123; 32].into(),
+            Default::default(),
+        );
+
+        // Given
+        spent_inputs.maybe_spend_inputs(tx_id, &[input_1.clone(), input_2.clone()]);
+        assert!(spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+        spent_inputs.spend_inputs(tx_id, &[]);
+
+        // When
+        spent_inputs.unspend_inputs(tx_id);
+
+        // Then
+        assert!(spent_inputs.is_spent_utxo(input_1.utxo_id().unwrap()));
+        assert!(spent_inputs.is_spent_message(input_2.nonce().unwrap()));
+    }
+}

--- a/crates/services/txpool_v2/src/storage/graph.rs
+++ b/crates/services/txpool_v2/src/storage/graph.rs
@@ -49,6 +49,7 @@ use crate::{
     pending_pool::MissingInput,
     ports::TxPoolPersistentStorage,
     selection_algorithms::ratio_tip_gas::RatioTipGasSelectionAlgorithmStorage,
+    spent_inputs::SpentInputs,
     storage::checked_collision::CheckedTransaction,
 };
 
@@ -618,6 +619,7 @@ impl Storage for GraphStorage {
         transaction: &PoolTransaction,
         persistent_storage: &impl TxPoolPersistentStorage,
         extracted_outputs: &ExtractedOutputs,
+        spent_inputs: &SpentInputs,
         utxo_validation: bool,
     ) -> Result<(), InputValidationErrorType> {
         let mut missing_inputs = Vec::new();
@@ -656,6 +658,12 @@ impl Storage for GraphStorage {
                             return Err(InputValidationErrorType::Inconsistency(e));
                         };
                     } else if utxo_validation {
+                        if spent_inputs.is_spent_utxo(utxo_id) {
+                            return Err(InputValidationErrorType::Inconsistency(
+                                Error::UtxoInputWasAlreadySpent(*utxo_id),
+                            ));
+                        }
+
                         match persistent_storage.utxo(utxo_id) {
                             Ok(Some(coin)) => {
                                 if !coin
@@ -691,6 +699,12 @@ impl Storage for GraphStorage {
                     // since message id is derived, we don't need to double check all the fields
                     // Maybe this should be on an other function as it's not a dependency finder but just a test
                     if utxo_validation {
+                        if spent_inputs.is_spent_message(nonce) {
+                            return Err(InputValidationErrorType::Inconsistency(
+                                Error::MessageInputWasAlreadySpent(*nonce),
+                            ));
+                        }
+
                         match persistent_storage.message(nonce) {
                             Ok(Some(db_message)) => {
                                 // verify message id integrity

--- a/crates/services/txpool_v2/src/storage/mod.rs
+++ b/crates/services/txpool_v2/src/storage/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     extracted_outputs::ExtractedOutputs,
     ports::TxPoolPersistentStorage,
+    spent_inputs::SpentInputs,
 };
 use fuel_core_types::services::txpool::{
     ArcPoolTx,
@@ -94,6 +95,7 @@ pub trait Storage {
         transaction: &PoolTransaction,
         persistent_storage: &impl TxPoolPersistentStorage,
         extracted_outputs: &ExtractedOutputs,
+        spent_inputs: &SpentInputs,
         utxo_validation: bool,
     ) -> Result<(), InputValidationErrorType>;
 

--- a/crates/services/txpool_v2/src/tests/mocks.rs
+++ b/crates/services/txpool_v2/src/tests/mocks.rs
@@ -67,7 +67,10 @@ use fuel_core_types::{
 };
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{
+        HashMap,
+        HashSet,
+    },
     sync::{
         Arc,
         Mutex,
@@ -88,6 +91,7 @@ pub struct Data {
     pub contracts: HashMap<ContractId, Contract>,
     pub blobs: HashMap<BlobId, BlobBytes>,
     pub messages: HashMap<Nonce, Message>,
+    pub transactions: HashSet<TxId>,
 }
 
 #[derive(Clone)]
@@ -157,6 +161,10 @@ impl MockDb {
 }
 
 impl TxPoolPersistentStorage for MockDb {
+    fn contains_tx(&self, tx_id: &TxId) -> StorageResult<bool> {
+        Ok(self.data.lock().unwrap().transactions.contains(tx_id))
+    }
+
     fn utxo(&self, utxo_id: &UtxoId) -> StorageResult<Option<CompressedCoin>> {
         Ok(self.data.lock().unwrap().coins.get(utxo_id).cloned())
     }

--- a/crates/services/txpool_v2/src/tests/tests_service.rs
+++ b/crates/services/txpool_v2/src/tests/tests_service.rs
@@ -532,7 +532,8 @@ async fn pending_pool__returns_error_for_transaction_that_spends_already_spent_u
     let (output_a, unset_input) = universe.create_output_and_input();
     let tx1 = universe.build_script_transaction(None, Some(vec![output_a]), 1);
     let input_a = unset_input.into_input(UtxoId::new(tx1.id(&Default::default()), 0));
-    let tx2 = universe.build_script_transaction(Some(vec![input_a]), None, 20);
+    let tx2 = universe.build_script_transaction(Some(vec![input_a.clone()]), None, 20);
+    let tx_with_input_a = universe.build_script_transaction(Some(vec![input_a]), None, 1);
 
     // When
     service.shared.insert(tx1.clone()).await.unwrap();
@@ -549,7 +550,7 @@ async fn pending_pool__returns_error_for_transaction_that_spends_already_spent_u
 
     // Insert tx2 will land in pending pool because it uses an input that doesn't exist anymore
     // it should be pruned out of the pending pool after the timeout
-    let result = service.shared.insert(tx2.clone()).await;
+    let result = service.shared.insert(tx_with_input_a.clone()).await;
 
     // Then
     assert_eq!(txs_first_extract.len(), 2);

--- a/crates/services/txpool_v2/src/tests/tests_service.rs
+++ b/crates/services/txpool_v2/src/tests/tests_service.rs
@@ -518,8 +518,7 @@ async fn insert__tx_depends_one_extracted_and_one_pool_tx() {
 }
 
 #[tokio::test]
-async fn pending_pool__returns_error_after_timeout_for_transaction_that_spends_already_spent_utxo(
-) {
+async fn pending_pool__returns_error_for_transaction_that_spends_already_spent_utxo() {
     // Given
     const TIMEOUT: u64 = 1;
     let mut universe = TestPoolUniverse::default().config(Config {
@@ -550,17 +549,62 @@ async fn pending_pool__returns_error_after_timeout_for_transaction_that_spends_a
 
     // Insert tx2 will land in pending pool because it uses an input that doesn't exist anymore
     // it should be pruned out of the pending pool after the timeout
-    service.shared.try_insert(vec![tx2.clone()]).unwrap();
+    let result = service.shared.insert(tx2.clone()).await;
 
     // Then
     assert_eq!(txs_first_extract.len(), 2);
     assert_eq!(txs_first_extract[0].id(), tx1.id(&Default::default()));
     assert_eq!(txs_first_extract[1].id(), tx2.id(&Default::default()));
+    let err = result.expect_err("Should be an error");
+    assert_eq!(
+        err.to_string(),
+        "The UTXO input 0xcd590cc7b217fad36bc7e48743d5164cee0415acdcbd4cfa90f464e8c77a57b30000 was already spent"
+    );
+
+    service.stop_and_await().await.unwrap();
+}
+
+#[tokio::test]
+async fn pending_pool__returns_error_after_timeout_for_transaction_that_spends_unknown_utxo(
+) {
+    // Given
+    const TIMEOUT: u64 = 1;
+    let mut universe = TestPoolUniverse::default().config(Config {
+        pending_pool_tx_ttl: Duration::from_secs(TIMEOUT),
+        utxo_validation: true,
+        ..Default::default()
+    });
+    let service = universe.build_service(None, None);
+    service.start_and_await().await.unwrap();
+
+    let (output_a, unset_input) = universe.create_output_and_input();
+    let tx1 = universe.build_script_transaction(None, Some(vec![output_a]), 1);
+    let unknown_input = unset_input.into_input(UtxoId::new([123; 32].into(), 0));
+    let tx2 = universe.build_script_transaction(Some(vec![unknown_input]), None, 20);
+
+    // When
+    service.shared.insert(tx1.clone()).await.unwrap();
+    let txs_first_extract = service
+        .shared
+        .extract_transactions_for_block(Constraints {
+            minimal_gas_price: 0,
+            max_gas: u64::MAX,
+            maximum_txs: u16::MAX,
+            maximum_block_size: u32::MAX,
+        })
+        .unwrap();
+
+    // Insert tx2 will land in pending pool because it uses an input that doesn't exist anymore
+    // it should be pruned out of the pending pool after the timeout
+    service.shared.try_insert(vec![tx2.clone()]).unwrap();
+
+    // Then
+    assert_eq!(txs_first_extract.len(), 1);
+    assert_eq!(txs_first_extract[0].id(), tx1.id(&Default::default()));
     let ids = vec![tx2.id(&Default::default())];
     universe
         .await_expected_tx_statuses(ids, |status| {
-            matches!(status, TransactionStatus::SqueezedOut(s)
-                    if s.reason == "Transaction input validation failed: UTXO (id: cd590cc7b217fad36bc7e48743d5164cee0415acdcbd4cfa90f464e8c77a57b30000) does not exist")
+            matches!(status, TransactionStatus::SqueezedOut(_))
         })
         .await
         .unwrap();

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -1,9 +1,11 @@
 //! Block header types
 
-mod v1;
+/// The V1 version of the header.
+pub mod v1;
 
+/// The V2 version of the header.
 #[cfg(feature = "fault-proving")]
-mod v2;
+pub mod v2;
 
 use super::{
     consensus::ConsensusType,

--- a/crates/types/src/blockchain/transaction.rs
+++ b/crates/types/src/blockchain/transaction.rs
@@ -29,7 +29,7 @@ use alloc::{
 /// Extension trait for transactions.
 pub trait TransactionExt {
     /// Returns the inputs of the transaction.
-    fn inputs(&self) -> ExecutorResult<&Vec<Input>>;
+    fn inputs(&self) -> Cow<[Input]>;
 
     /// Returns the outputs of the transaction.
     fn outputs(&self) -> Cow<[Output]>;
@@ -39,16 +39,14 @@ pub trait TransactionExt {
 }
 
 impl TransactionExt for Transaction {
-    fn inputs(&self) -> ExecutorResult<&Vec<Input>> {
+    fn inputs(&self) -> Cow<[Input]> {
         match self {
-            Transaction::Script(tx) => Ok(tx.inputs()),
-            Transaction::Create(tx) => Ok(tx.inputs()),
-            Transaction::Mint(_) => Err(ExecutorError::Other(
-                "Mint transaction doesn't have inputs".to_string(),
-            )),
-            Transaction::Upgrade(tx) => Ok(tx.inputs()),
-            Transaction::Upload(tx) => Ok(tx.inputs()),
-            Transaction::Blob(tx) => Ok(tx.inputs()),
+            Transaction::Script(tx) => Cow::Borrowed(tx.inputs()),
+            Transaction::Create(tx) => Cow::Borrowed(tx.inputs()),
+            Transaction::Mint(_) => Cow::Owned(Vec::new()),
+            Transaction::Upgrade(tx) => Cow::Borrowed(tx.inputs()),
+            Transaction::Upload(tx) => Cow::Borrowed(tx.inputs()),
+            Transaction::Blob(tx) => Cow::Borrowed(tx.inputs()),
         }
     }
 
@@ -80,16 +78,14 @@ impl TransactionExt for Transaction {
 }
 
 impl TransactionExt for CheckedTransaction {
-    fn inputs(&self) -> ExecutorResult<&Vec<Input>> {
+    fn inputs(&self) -> Cow<[Input]> {
         match self {
-            CheckedTransaction::Script(tx) => Ok(tx.transaction().inputs()),
-            CheckedTransaction::Create(tx) => Ok(tx.transaction().inputs()),
-            CheckedTransaction::Mint(_) => Err(ExecutorError::Other(
-                "Mint transaction doesn't have max_gas".to_string(),
-            )),
-            CheckedTransaction::Upgrade(tx) => Ok(tx.transaction().inputs()),
-            CheckedTransaction::Upload(tx) => Ok(tx.transaction().inputs()),
-            CheckedTransaction::Blob(tx) => Ok(tx.transaction().inputs()),
+            CheckedTransaction::Script(tx) => Cow::Borrowed(tx.transaction().inputs()),
+            CheckedTransaction::Create(tx) => Cow::Borrowed(tx.transaction().inputs()),
+            CheckedTransaction::Mint(_) => Cow::Owned(Vec::new()),
+            CheckedTransaction::Upgrade(tx) => Cow::Borrowed(tx.transaction().inputs()),
+            CheckedTransaction::Upload(tx) => Cow::Borrowed(tx.transaction().inputs()),
+            CheckedTransaction::Blob(tx) => Cow::Borrowed(tx.transaction().inputs()),
         }
     }
 

--- a/tests/tests/blocks.rs
+++ b/tests/tests/blocks.rs
@@ -443,7 +443,7 @@ mod full_block {
         let local_node_config = Config::local_node();
         let txpool = fuel_core_txpool::config::Config {
             pool_limits: PoolLimits {
-                max_txs: usize::MAX,
+                max_txs: 2_000_000,
                 max_gas: u64::MAX,
                 max_bytes_size: usize::MAX,
             },

--- a/tests/tests/tx/txpool.rs
+++ b/tests/tests/tx/txpool.rs
@@ -4,6 +4,11 @@ use crate::helpers::{
     TestContext,
     TestSetupBuilder,
 };
+use fuel_core::service::FuelService;
+use fuel_core_client::client::{
+    types::TransactionStatus,
+    FuelClient,
+};
 use fuel_core_poa::Trigger;
 use fuel_core_types::{
     fuel_asm::*,
@@ -11,11 +16,18 @@ use fuel_core_types::{
     fuel_tx,
     fuel_tx::*,
 };
+use futures::StreamExt;
 use itertools::Itertools;
 use rand::{
     rngs::StdRng,
     Rng,
     SeedableRng,
+};
+use std::time::Duration;
+use test_helpers::{
+    assemble_tx::AssembleAndRunTx,
+    config_with_fee,
+    default_signing_wallet,
 };
 
 #[tokio::test]
@@ -71,4 +83,101 @@ async fn txs_max_script_gas_limit() {
         block.transactions.len(),
         transactions.len() + 1 // coinbase
     )
+}
+
+#[tokio::test]
+async fn informs_immediately_if_the_input_was_spent_during_open_period() {
+    let mut config = config_with_fee();
+    config.block_production = Trigger::Open {
+        period: Duration::from_secs(1_000_000),
+    };
+
+    // Given
+    config.txpool.pending_pool_tx_ttl = Duration::from_secs(1_000_000);
+
+    let srv = FuelService::new_node(config).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    let script = vec![op::ret(RegId::ONE)];
+    let tx = client
+        .assemble_script(script, vec![], default_signing_wallet())
+        .await
+        .unwrap();
+
+    let status = client
+        .submit_and_await_status_opt(&tx, None, Some(true))
+        .await
+        .unwrap()
+        // Skip `Submitted` status
+        .skip(1)
+        .next()
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        status,
+        TransactionStatus::PreconfirmationSuccess { .. }
+    ));
+
+    // When
+    let script = vec![op::ret(RegId::ONE)];
+    let script_data_to_change_tx_id = vec![123];
+    let tx_with_same_input = client
+        .assemble_script(
+            script,
+            script_data_to_change_tx_id,
+            default_signing_wallet(),
+        )
+        .await
+        .unwrap();
+    let status = client.submit_and_await_commit(&tx_with_same_input).await;
+
+    // Then
+    let err = status.expect_err("Should receive error that transaction squeezed out");
+    assert!(err.to_string().contains("was already spent"))
+}
+
+#[tokio::test]
+async fn informs_immediately_if_the_input_was_spent_during_previous_blocks_without_timeout(
+) {
+    let mut config = config_with_fee();
+    config.block_production = Trigger::Open {
+        period: Duration::from_secs(1),
+    };
+
+    // Given
+    config.txpool.pending_pool_tx_ttl = Duration::from_secs(1_000_000);
+
+    let srv = FuelService::new_node(config).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    let script = vec![op::ret(RegId::ONE)];
+    let tx = client
+        .assemble_script(script, vec![], default_signing_wallet())
+        .await
+        .unwrap();
+
+    let status = client
+        .submit_and_await_status_opt(&tx, None, Some(true))
+        .await
+        .unwrap()
+        // Skip `Submitted` and `PreconfirmationSuccess` statuses
+        .skip(2)
+        .next()
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(status, TransactionStatus::Success { .. }));
+
+    // When
+    let status = tokio::time::timeout(
+        Duration::from_secs(10),
+        client.submit_and_await_commit(&tx),
+    )
+    .await;
+
+    // Then
+    let status = status.expect("Should receive response from TxPool immediately");
+    let err = status.expect_err("Should receive error that transaction squeezed out");
+    assert!(err.to_string().contains("was already spent"))
 }

--- a/tests/tests/tx/txpool.rs
+++ b/tests/tests/tx/txpool.rs
@@ -153,7 +153,11 @@ async fn informs_immediately_if_the_input_was_spent_during_previous_blocks_witho
 
     let script = vec![op::ret(RegId::ONE)];
     let tx = client
-        .assemble_script(script, vec![], default_signing_wallet())
+        .assemble_script(script.clone(), vec![], default_signing_wallet())
+        .await
+        .unwrap();
+    let different_tx_with_same_input = client
+        .assemble_script(script, vec![123], default_signing_wallet())
         .await
         .unwrap();
 
@@ -172,7 +176,7 @@ async fn informs_immediately_if_the_input_was_spent_during_previous_blocks_witho
     // When
     let status = tokio::time::timeout(
         Duration::from_secs(10),
-        client.submit_and_await_commit(&tx),
+        client.submit_and_await_commit(&different_tx_with_same_input),
     )
     .await;
 


### PR DESCRIPTION
## Description

Our e2e tests were flaky, example: https://github.com/FuelLabs/fuel-core/actions/runs/14343235447/job/40207476637

The reason was that during transaction reconciliation(after we fixed that), we included transactions that had already been executed and confirmed in the pending pool. After the timeout on the pending pool we will remove all dependent transactions, and in the case of the test, it was a transaction from another test suite that used `Change` output(which already was confirmed and existed on the chain) of the transaction from the first test suite.

So basically, the e2e tests revealed that it was possible to submit transactions with already spent inputs, which will be included in the pending pool and later discarded along with all dependent transactions(even if outputs already were stored on the chain as coins).

This change rejects transactions immediately, if they use spent coins. TxPool has a `SpentInptus` LRU cache, storing all spent coins.

## Checklist
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself