### PR TITLE
chore(1.85): 1.85.0 readiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,6 +3403,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "serde_with",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "tempfile",

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -57,6 +57,7 @@ rocksdb = { version = "0.21", default-features = false, features = [
 ], optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["raw_value"] }
+serde_with = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
 tempfile = { workspace = true, optional = true }
@@ -93,7 +94,8 @@ tokio-test = "0.4.4"
 tracing-subscriber = { workspace = true }
 
 [features]
-default = ["rocksdb"]
+default = ["rocksdb", "serde"]
+serde = ["dep:serde_with"]
 smt = [
   "fuel-core-storage/smt",
   "fuel-core-executor/smt",

--- a/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
+++ b/crates/fuel-core/src/service/adapters/graphql_api/off_chain.rs
@@ -333,7 +333,7 @@ impl OffChainIterableKeyValueView {
         start: Option<CoinBalancesKey>,
         direction: IterDirection,
         base_asset_id: &'a AssetId,
-    ) -> BoxedIter<'_, Result<(AssetId, u128), StorageError>> {
+    ) -> BoxedIter<'a, Result<(AssetId, u128), StorageError>> {
         self.iter_all_filtered_keys::<CoinBalances, _>(
             Some(owner),
             start.as_ref(),
@@ -364,7 +364,7 @@ impl OffChainIterableKeyValueView {
         owner: &Address,
         base_asset_id: &'a AssetId,
         direction: IterDirection,
-    ) -> BoxedIter<'_, Result<(AssetId, u128), StorageError>> {
+    ) -> BoxedIter<'a, Result<(AssetId, u128), StorageError>> {
         let start = start.map(|asset_id| CoinBalancesKey::new(owner, &asset_id));
         let base_asset_balance = self.base_asset_balance(base_asset_id, owner);
         let non_base_asset_balance =
@@ -379,7 +379,7 @@ impl OffChainIterableKeyValueView {
         owner: &Address,
         base_asset_id: &'a AssetId,
         direction: IterDirection,
-    ) -> BoxedIter<'_, Result<(AssetId, u128), StorageError>> {
+    ) -> BoxedIter<'a, Result<(AssetId, u128), StorageError>> {
         let base_asset_balance = self.base_asset_balance(base_asset_id, owner);
         let non_base_asset_balances =
             self.non_base_asset_balances(owner, None, direction, base_asset_id);


### PR DESCRIPTION
see passing action here: https://github.com/FuelLabs/fuels-rs/actions/runs/14362772711/job/40268264149?pr=1639



This pull request includes several updates to the `Cargo.toml` file and modifications to the `OffChainIterableKeyValueView` implementation in the `graphql_api` adapter. The most important changes are summarized below:

### Dependency Updates:
* Added `serde_with` as an optional workspace dependency in `Cargo.toml`.
* Updated the default features to include `serde` and added a new feature `serde` that depends on `serde_with` in `Cargo.toml`.

### Code Enhancements:
* Changed the lifetime annotation for return type in three methods of `OffChainIterableKeyValueView` from `BoxedIter<'_, Result<(AssetId, u128), StorageError>>` to `BoxedIter<'a, Result<(AssetId, u128), StorageError>>` to ensure consistency in the `graphql_api` adapter. [[1]](diffhunk://#diff-a2c13bbe4fe3673e734fec61faaa1cf60dbd59a45b6567cd13f596b36e090f6cL336-R336) [[2]](diffhunk://#diff-a2c13bbe4fe3673e734fec61faaa1cf60dbd59a45b6567cd13f596b36e090f6cL367-R367) [[3]](diffhunk://#diff-a2c13bbe4fe3673e734fec61faaa1cf60dbd59a45b6567cd13f596b36e090f6cL382-R382)