### PR TITLE
Release v0.43.0

### DIFF
--- a/.changes/added/2848.md
+++ b/.changes/added/2848.md
@@ -1,1 +1,0 @@
-Link all components of preconfirmations and add E2E tests.

--- a/.changes/added/2882.md
+++ b/.changes/added/2882.md
@@ -1,1 +1,0 @@
-Listen to tx status update from `TxStatusManager` in `TxPool`. Added logic to clean up transactions from the pool if received squeezed out pre confirmations. Added logic to promote transactions on sentry nodes when receive pre-confirmation.

--- a/.changes/added/2885.md
+++ b/.changes/added/2885.md
@@ -1,1 +1,0 @@
-Notify P2P from `TxStatusManager` in case of bad preconfirmation message.

--- a/.changes/added/2901.md
+++ b/.changes/added/2901.md
@@ -1,1 +1,0 @@
-New query `dryRunRecordStorageReads` which works like `dryRun` but also returns storage reads, allowing use of execution tracer or local debugger

--- a/.changes/added/2912.md
+++ b/.changes/added/2912.md
@@ -1,1 +1,0 @@
-Add the `allow_partial` parameter to the `coinsToSpend` query. The default value of this parameters is `false` to preserve the old behavior. If set to `true`, the query returns available coins instead of failing when the requested amount is unavailable.

--- a/.changes/added/2914.md
+++ b/.changes/added/2914.md
@@ -1,1 +1,0 @@
-Tests ensuring the proof generation and validation of tables with sparse and merklized blueprints work.

--- a/.changes/breaking/2882.md
+++ b/.changes/breaking/2882.md
@@ -1,1 +1,0 @@
-Changed the type of the `resolved_outputs` for pre-confirmations. Now it also includes `Utxoid`. `resolved_outputs` field contains only `Change` and `Variable` outputs, so the `UtxoId` for them could be hard to derive, if transaction has known inputs. This information should help to create dependent transactions more easily.

--- a/.changes/breaking/2900.md
+++ b/.changes/breaking/2900.md
@@ -1,1 +1,0 @@
-Get rid of `Deref` impl on `ImportResult` by introducing wrapper type.

--- a/.changes/breaking/2909.md
+++ b/.changes/breaking/2909.md
@@ -1,1 +1,0 @@
-Compressed block headers now include a merkle root of the temporal registry after compression was performed.

--- a/.changes/breaking/2931.md
+++ b/.changes/breaking/2931.md
@@ -1,1 +1,0 @@
-In `fuel-core-compression`, the `compress` function now takes a reference to `Config` instead of the value.

--- a/.changes/changed/2859.md
+++ b/.changes/changed/2859.md
@@ -1,1 +1,0 @@
-Swap out off-chain worker compression for dedicated compression service in `fuel-core-bin`.

--- a/.changes/changed/2914.md
+++ b/.changes/changed/2914.md
@@ -1,1 +1,0 @@
-Break out test logic to trait methods for `root_storage_tests` and `basic_merkleized_storage_tests` test macros.

--- a/.changes/changed/2925.md
+++ b/.changes/changed/2925.md
@@ -1,1 +1,0 @@
-Make preconfirmation optional on API endpoints.

--- a/.changes/fixed/2918.md
+++ b/.changes/fixed/2918.md
@@ -1,1 +1,0 @@
-Only cancel background work if primary RocksDB instance is dropped

--- a/.changes/fixed/2935.md
+++ b/.changes/fixed/2935.md
@@ -1,1 +1,0 @@
-The change rejects transactions immediately, if they use spent coins. `TxPool` has a SpentInputs LRU cache, storing all spent coins.

--- a/.changes/removed/2859.md
+++ b/.changes/removed/2859.md
@@ -1,1 +1,0 @@
-Removed DA compression from off-chain worker in favor of dedicated compression service in `fuel-core-bin`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+## [Version 0.43.0]
+
+### Breaking
+- [2882](https://github.com/FuelLabs/fuel-core/pull/2882): Changed the type of the `resolved_outputs` for pre-confirmations. Now it also includes `Utxoid`. `resolved_outputs` field contains only `Change` and `Variable` outputs, so the `UtxoId` for them could be hard to derive, if transaction has known inputs. This information should help to create dependent transactions more easily.
+- [2900](https://github.com/FuelLabs/fuel-core/pull/2900): Get rid of `Deref` impl on `ImportResult` by introducing wrapper type.
+- [2909](https://github.com/FuelLabs/fuel-core/pull/2909): Compressed block headers now include a merkle root of the temporal registry after compression was performed.
+- [2931](https://github.com/FuelLabs/fuel-core/pull/2931): In `fuel-core-compression`, the `compress` function now takes a reference to `Config` instead of the value.
+
+### Added
+- [2848](https://github.com/FuelLabs/fuel-core/pull/2848): Link all components of preconfirmations and add E2E tests.
+- [2882](https://github.com/FuelLabs/fuel-core/pull/2882): Listen to tx status update from `TxStatusManager` in `TxPool`. Added logic to clean up transactions from the pool if received squeezed out pre confirmations. Added logic to promote transactions on sentry nodes when receive pre-confirmation.
+- [2885](https://github.com/FuelLabs/fuel-core/pull/2885): Notify P2P from `TxStatusManager` in case of bad preconfirmation message.
+- [2901](https://github.com/FuelLabs/fuel-core/pull/2901): New query `dryRunRecordStorageReads` which works like `dryRun` but also returns storage reads, allowing use of execution tracer or local debugger
+- [2912](https://github.com/FuelLabs/fuel-core/pull/2912): Add the `allow_partial` parameter to the `coinsToSpend` query. The default value of this parameters is `false` to preserve the old behavior. If set to `true`, the query returns available coins instead of failing when the requested amount is unavailable.
+- [2914](https://github.com/FuelLabs/fuel-core/pull/2914): Tests ensuring the proof generation and validation of tables with sparse and merklized blueprints work.
+
+### Changed
+- [2859](https://github.com/FuelLabs/fuel-core/pull/2859): Swap out off-chain worker compression for dedicated compression service in `fuel-core-bin`.
+- [2914](https://github.com/FuelLabs/fuel-core/pull/2914): Break out test logic to trait methods for `root_storage_tests` and `basic_merkleized_storage_tests` test macros.
+- [2925](https://github.com/FuelLabs/fuel-core/pull/2925): Make preconfirmation optional on API endpoints.
+
+### Fixed
+- [2918](https://github.com/FuelLabs/fuel-core/pull/2918): Only cancel background work if primary RocksDB instance is dropped
+- [2935](https://github.com/FuelLabs/fuel-core/pull/2935): The change rejects transactions immediately, if they use spent coins. `TxPool` has a SpentInputs LRU cache, storing all spent coins.
+
+### Removed
+- [2859](https://github.com/FuelLabs/fuel-core/pull/2859): Removed DA compression from off-chain worker in favor of dedicated compression service in `fuel-core-bin`.
+
 ## [Version 0.42.0]
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3387,7 +3387,7 @@ dependencies = [
  "fuel-core-trace",
  "fuel-core-tx-status-manager",
  "fuel-core-txpool",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3442,7 +3442,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-sync",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "hex",
  "itertools 0.12.1",
@@ -3465,11 +3465,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.42.0"
+version = "0.43.0"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3484,7 +3484,7 @@ dependencies = [
  "fuel-core-poa",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3515,7 +3515,7 @@ dependencies = [
  "educe",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3533,14 +3533,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more 0.99.19",
  "eventsource-client",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -3557,23 +3557,23 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "clap",
  "fuel-core-client",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fuel-core-compression",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "paste",
  "postcard",
  "proptest",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-compression-service"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3597,7 +3597,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "paste",
  "rand 0.8.5",
@@ -3612,30 +3612,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3643,7 +3643,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "hex",
  "humantime-serde",
@@ -3661,12 +3661,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "parking_lot",
  "serde",
  "tracing",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3682,7 +3682,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "fuel-gas-price-algorithm",
  "futures",
  "mockito",
@@ -3702,14 +3702,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "mockall",
  "rayon",
  "test-case",
@@ -3719,18 +3719,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "clap",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3768,7 +3768,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3791,17 +3791,17 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-parallel-executor"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "fuel-core-storage",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "fuel-core-upgradable-executor",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3810,7 +3810,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "mockall",
  "rand 0.8.5",
  "serde",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "mockall",
  "proptest",
  "rand 0.8.5",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3857,7 +3857,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "mockall",
  "once_cell",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3901,7 +3901,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -3917,13 +3917,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "fuel-vm 0.60.0",
  "impl-tools",
  "itertools 0.12.1",
@@ -3941,13 +3941,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "mockall",
  "rand 0.8.5",
@@ -3983,7 +3983,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "ctor",
  "tracing",
@@ -4021,14 +4021,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-tx-status-manager"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-tx-status-manager",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "mockall",
  "parking_lot",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "lru 0.13.0",
  "mockall",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4094,7 +4094,7 @@ dependencies = [
  "ed25519",
  "ed25519-dalek",
  "educe",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "fuel-vm 0.60.0",
  "k256",
  "postcard",
@@ -4108,13 +4108,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "fuel-core-wasm-executor",
  "futures",
  "parking_lot",
@@ -4125,13 +4125,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "postcard",
  "proptest",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "proptest",
  "rand 0.8.5",
@@ -9830,7 +9830,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.42.0",
+ "fuel-core-types 0.43.0",
  "futures",
  "itertools 0.12.1",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,44 +60,44 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.42.0"
+version = "0.43.0"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.42.0", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.42.0", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.42.0", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.42.0", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.42.0", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.42.0", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.42.0", path = "./crates/client" }
-fuel-core-compression = { version = "0.42.0", path = "./crates/compression" }
-fuel-core-compression-service = { version = "0.42.0", path = "./crates/services/compression" }
-fuel-core-database = { version = "0.42.0", path = "./crates/database" }
-fuel-core-metrics = { version = "0.42.0", path = "./crates/metrics" }
-fuel-core-services = { version = "0.42.0", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.42.0", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.42.0", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.42.0", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.42.0", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.42.0", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.42.0", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.42.0", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.42.0", path = "./crates/services/p2p" }
-fuel-core-parallel-executor = { version = "0.42.0", path = "./crates/services/parallel-executor" }
-fuel-core-producer = { version = "0.42.0", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.42.0", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.42.0", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.42.0", path = "./crates/services/txpool_v2" }
-fuel-core-tx-status-manager = { version = "0.42.0", path = "./crates/services/tx_status_manager" }
-fuel-core-storage = { version = "0.42.0", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.42.0", path = "./crates/trace" }
-fuel-core-types = { version = "0.42.0", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.43.0", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.43.0", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.43.0", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.43.0", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.43.0", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.43.0", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.43.0", path = "./crates/client" }
+fuel-core-compression = { version = "0.43.0", path = "./crates/compression" }
+fuel-core-compression-service = { version = "0.43.0", path = "./crates/services/compression" }
+fuel-core-database = { version = "0.43.0", path = "./crates/database" }
+fuel-core-metrics = { version = "0.43.0", path = "./crates/metrics" }
+fuel-core-services = { version = "0.43.0", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.43.0", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.43.0", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.43.0", path = "./crates/services/consensus_module/poa" }
+fuel-core-shared-sequencer = { version = "0.43.0", path = "crates/services/shared-sequencer" }
+fuel-core-executor = { version = "0.43.0", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.43.0", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.43.0", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.43.0", path = "./crates/services/p2p" }
+fuel-core-parallel-executor = { version = "0.43.0", path = "./crates/services/parallel-executor" }
+fuel-core-producer = { version = "0.43.0", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.43.0", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.43.0", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.43.0", path = "./crates/services/txpool_v2" }
+fuel-core-tx-status-manager = { version = "0.43.0", path = "./crates/services/tx_status_manager" }
+fuel-core-storage = { version = "0.43.0", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.43.0", path = "./crates/trace" }
+fuel-core-types = { version = "0.43.0", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.42.0", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.42.0", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.43.0", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.43.0", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.42.0", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.43.0", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.60.0", package = "fuel-vm", default-features = false }

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -304,7 +304,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 25,
+  "genesis_state_transition_version": 26,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -308,7 +308,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 25,
+  "genesis_state_transition_version": 26,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -234,7 +234,8 @@ impl<S, R> Executor<S, R> {
         // This update has been performed on the branch release/v0.41.9 which
         // is on top of the branch release/v0.41.8 not on master.
         ("0-41-9", 24),
-        ("0-42-0", LATEST_STATE_TRANSITION_VERSION),
+        ("0-42-0", 25),
+        ("0-43-0", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -330,7 +330,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 25;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 26;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Version 0.43.0

### Breaking
- [2882](https://github.com/FuelLabs/fuel-core/pull/2882): Changed the type of the `resolved_outputs` for pre-confirmations. Now it also includes `Utxoid`. `resolved_outputs` field contains only `Change` and `Variable` outputs, so the `UtxoId` for them could be hard to derive, if transaction has known inputs. This information should help to create dependent transactions more easily.
- [2900](https://github.com/FuelLabs/fuel-core/pull/2900): Get rid of `Deref` impl on `ImportResult` by introducing wrapper type.
- [2909](https://github.com/FuelLabs/fuel-core/pull/2909): Compressed block headers now include a merkle root of the temporal registry after compression was performed.
- [2931](https://github.com/FuelLabs/fuel-core/pull/2931): In `fuel-core-compression`, the `compress` function now takes a reference to `Config` instead of the value.

### Added
- [2848](https://github.com/FuelLabs/fuel-core/pull/2848): Link all components of preconfirmations and add E2E tests.
- [2882](https://github.com/FuelLabs/fuel-core/pull/2882): Listen to tx status update from `TxStatusManager` in `TxPool`. Added logic to clean up transactions from the pool if received squeezed out pre confirmations. Added logic to promote transactions on sentry nodes when receive pre-confirmation.
- [2885](https://github.com/FuelLabs/fuel-core/pull/2885): Notify P2P from `TxStatusManager` in case of bad preconfirmation message.
- [2901](https://github.com/FuelLabs/fuel-core/pull/2901): New query `dryRunRecordStorageReads` which works like `dryRun` but also returns storage reads, allowing use of execution tracer or local debugger
- [2912](https://github.com/FuelLabs/fuel-core/pull/2912): Add the `allow_partial` parameter to the `coinsToSpend` query. The default value of this parameters is `false` to preserve the old behavior. If set to `true`, the query returns available coins instead of failing when the requested amount is unavailable.
- [2914](https://github.com/FuelLabs/fuel-core/pull/2914): Tests ensuring the proof generation and validation of tables with sparse and merklized blueprints work.

### Changed
- [2859](https://github.com/FuelLabs/fuel-core/pull/2859): Swap out off-chain worker compression for dedicated compression service in `fuel-core-bin`.
- [2914](https://github.com/FuelLabs/fuel-core/pull/2914): Break out test logic to trait methods for `root_storage_tests` and `basic_merkleized_storage_tests` test macros.
- [2925](https://github.com/FuelLabs/fuel-core/pull/2925): Make preconfirmation optional on API endpoints.

### Fixed
- [2918](https://github.com/FuelLabs/fuel-core/pull/2918): Only cancel background work if primary RocksDB instance is dropped
- [2935](https://github.com/FuelLabs/fuel-core/pull/2935): The change rejects transactions immediately, if they use spent coins. `TxPool` has a SpentInputs LRU cache, storing all spent coins.

### Removed
- [2859](https://github.com/FuelLabs/fuel-core/pull/2859): Removed DA compression from off-chain worker in favor of dedicated compression service in `fuel-core-bin`.

## What's Changed
* Rework `TxStatusManager` tests by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2871
* fix(storage): custom impl of EnumCount for MerkleizedColumn by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2875
* Update network versions on README by @github-actions in https://github.com/FuelLabs/fuel-core/pull/2889
* fix(version-compatibility): pin async-graphql to 7.0.15 by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2891
* Fix proptest for tx status manager by @rafal-ch in https://github.com/FuelLabs/fuel-core/pull/2893
* fault_proving(compression): glue code for integ into fuel-core by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2859
* Link and activate preconfirmations and add integrations tests by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2848
* refactor: Get rid of `Deref` impl on `ImportResult` by introducing wrapper type. by @netrome in https://github.com/FuelLabs/fuel-core/pull/2900
* fix(compression_service): post merge reviews by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2895
* Listen status updates from in TxStatusManager in TxPool by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2882
* chore(compression): include registry root in compressed block header by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2909
* Improve TxStatusManager tests coverage by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2911
* ci(benchmarks): run nightly benchmark and create PR by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2915
* fix: Only cancel background work if primary RocksDB instance is dropped by @netrome in https://github.com/FuelLabs/fuel-core/pull/2918
* fix(ci): nightly benchmark by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2922
* fix(ci): explicitly push before creating PR by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2926
* Add allow_partial parameter to the "coins to spend" query by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2912
* fix(compression): improve robustness on startup and shutdown by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2923
* chore(compression): metrics for compression service by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2920
* chore(compression): pass compression config by reference by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2931
* Dry run execution tracing by @Dentosal in https://github.com/FuelLabs/fuel-core/pull/2901
* Make preconfirmation optional on API endpoints by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2925
* Notify P2P in case of bad preconfirmation message by @AurelienFT in https://github.com/FuelLabs/fuel-core/pull/2885
* chore(1.85): 1.85.0 readiness by @rymnc in https://github.com/FuelLabs/fuel-core/pull/2937
* Reject transactions for already spent coins by @xgreenx in https://github.com/FuelLabs/fuel-core/pull/2935
* feat: add tests for sparse and merkleized blueprint proof generation by @netrome in https://github.com/FuelLabs/fuel-core/pull/2914


**Full Changelog**: https://github.com/FuelLabs/fuel-core/compare/v0.42.0...v0.43.0