### PR TITLE
Fix publishing by using `async-graphql 7.0.15`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ fuel-vm-private = { version = "0.60.0", package = "fuel-vm", default-features = 
 
 # Common dependencies
 anyhow = "1.0"
-async-graphql = { version = "7.0.15", features = [
+async-graphql = { version = "=7.0.15", features = [
   "graphiql",
   "tracing",
 ], default-features = false }


### PR DESCRIPTION
Again one of dependencies bumped rust version as a minor release... https://github.com/async-graphql/async-graphql/commit/75a9d14e8f45176a32bac7f458534c05cabd10cc