### PR TITLE
Increase the timeout for the p2p tests

### DIFF
--- a/crates/fuel-core/src/p2p_test_helpers.rs
+++ b/crates/fuel-core/src/p2p_test_helpers.rs
@@ -606,18 +606,18 @@ impl Node {
         }
     }
 
-    /// Wait for the node to reach consistency with the given transactions within 10 seconds.
-    pub async fn consistency_10s(&mut self, txs: &HashMap<Bytes32, Transaction>) {
-        tokio::time::timeout(Duration::from_secs(10), self.consistency(txs))
+    /// Wait for the node to reach consistency with the given transactions within 30 seconds.
+    pub async fn consistency_30s(&mut self, txs: &HashMap<Bytes32, Transaction>) {
+        tokio::time::timeout(Duration::from_secs(30), self.consistency(txs))
             .await
             .unwrap_or_else(|_| {
                 panic!("Failed to reach consistency for {:?}", self.config.name)
             });
     }
 
-    /// Wait for the node to reach consistency with the given transactions within 20 seconds.
-    pub async fn consistency_20s(&mut self, txs: &HashMap<Bytes32, Transaction>) {
-        tokio::time::timeout(Duration::from_secs(20), self.consistency(txs))
+    /// Wait for the node to reach consistency with the given transactions within 60 seconds.
+    pub async fn consistency_60s(&mut self, txs: &HashMap<Bytes32, Transaction>) {
+        tokio::time::timeout(Duration::from_secs(60), self.consistency(txs))
             .await
             .unwrap_or_else(|_| {
                 panic!("Failed to reach consistency for {:?}", self.config.name)

--- a/tests/tests/da_compression.rs
+++ b/tests/tests/da_compression.rs
@@ -177,7 +177,7 @@ async fn da_compressed_blocks_are_available_from_non_block_producing_nodes() {
 
     // Insert some txs
     let expected = producer.insert_txs().await;
-    validator.consistency_20s(&expected).await;
+    validator.consistency_60s(&expected).await;
     validator.node.await_compression_synced().await.unwrap();
 
     let block_height = 1u32.into();

--- a/tests/tests/node_info.rs
+++ b/tests/tests/node_info.rs
@@ -108,7 +108,7 @@ async fn test_peer_info() {
 
     // Wait up to 10 seconds for the validator to sync with the producer.
     // This indicates we have a successful P2P connection.
-    validator.consistency_10s(&expected).await;
+    validator.consistency_30s(&expected).await;
 
     let validator_peer_id = validator
         .node

--- a/tests/tests/sync.rs
+++ b/tests/tests/sync.rs
@@ -52,13 +52,13 @@ async fn test_producer_getting_own_blocks_back() {
     let expected = producer.insert_txs().await;
 
     // Wait up to 10 seconds for the producer to commit their own blocks.
-    producer.consistency_10s(&expected).await;
+    producer.consistency_30s(&expected).await;
 
     // Start the validator.
     validator.start().await;
 
     // Wait up to 10 seconds for the validator to sync with the producer.
-    validator.consistency_10s(&expected).await;
+    validator.consistency_30s(&expected).await;
 }
 
 #[test_case(1; "partition with 1 tx")]
@@ -105,10 +105,10 @@ async fn test_partition_single(num_txs: usize) {
     let expected = producer.insert_txs().await;
 
     // Wait up to 10 seconds for the producer to commit their own blocks.
-    producer.consistency_10s(&expected).await;
+    producer.consistency_30s(&expected).await;
 
     // Wait up to 20 seconds for Bob to sync with the producer.
-    validators["Bob"].consistency_20s(&expected).await;
+    validators["Bob"].consistency_60s(&expected).await;
 
     // Shutdown the producer.
     producer.shutdown().await;
@@ -117,7 +117,7 @@ async fn test_partition_single(num_txs: usize) {
     validators["Carol"].start().await;
 
     // Wait up to 20 seconds for Carol to sync with Bob.
-    validators["Carol"].consistency_20s(&expected).await;
+    validators["Carol"].consistency_60s(&expected).await;
 }
 
 #[test_case(1, 3, 3; "partition with 1 tx 3 validators 3 partitions")]
@@ -175,7 +175,7 @@ async fn test_partitions_larger_groups(
 
     // Insert the transactions into the tx pool.
     let expected = producer.insert_txs().await;
-    producer.consistency_20s(&expected).await;
+    producer.consistency_60s(&expected).await;
 
     // The overlap between two groups.
     let mut overlap: VecDeque<Vec<Node>> = VecDeque::with_capacity(2);
@@ -203,7 +203,7 @@ async fn test_partitions_larger_groups(
 
         // Wait up to 10 seconds validators to sync with the overlapping group.
         for v in &mut validators {
-            v.consistency_20s(&expected).await;
+            v.consistency_60s(&expected).await;
         }
 
         // Shutdown the overlapping group.
@@ -278,7 +278,7 @@ async fn test_multiple_producers_different_keys() {
 
     // Wait producers to produce all blocks.
     for (expected, producer) in expected.iter().zip(producers.iter_mut()) {
-        producer.consistency_10s(expected).await;
+        producer.consistency_30s(expected).await;
     }
 
     // Partition the validators into groups.
@@ -294,7 +294,7 @@ async fn test_multiple_producers_different_keys() {
     for (expected, mut validators) in expected.iter().zip(groups) {
         assert_eq!(group_size, validators.len());
         for v in &mut validators {
-            v.consistency_20s(expected).await;
+            v.consistency_60s(expected).await;
         }
     }
 }
@@ -329,6 +329,6 @@ async fn test_multiple_producers_same_key() {
     }
 
     for v in &mut validators {
-        v.consistency_10s(&expected).await;
+        v.consistency_30s(&expected).await;
     }
 }


### PR DESCRIPTION
It should remove flakiness from the CI. Because of the parallel execution of the tests, we have many tokio tasks that consume CPU and block each other. We can see on the screenshot that tests around flaky tests also take a lot of time. 

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/f6573460-7b3c-488d-aaee-7ee0724541a9" />

https://github.com/FuelLabs/fuel-core/actions/runs/14376950958/job/40311599037?pr=2913

So increasing the timeout should help.