### PR TITLE
fix: clean up Docker chain config

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -46,7 +46,12 @@ RUN \
 # all layers should be cached.
 COPY . .
 # download latest chain-configuration repo after cache to ensure most recent version
-RUN git clone --depth=1 https://github.com/FuelLabs/chain-configuration.git /chain-config
+# also delete large directories to avoid size bloat
+RUN \
+    git clone --depth=1 https://github.com/FuelLabs/chain-configuration.git /chain-config \
+    && rm -fr /chain-config/.git \
+    && rm -fr /chain-config/.github \
+    && rm -fr /chain-config/upgradelog
 # build application
 # note this puts the builds outside of the cache dirs so the run image can copy them
 RUN \


### PR DESCRIPTION
## Description

Our chain-configuration repository contains a full upgrade history, which currently is sitting around 150MB of data & growing. We don't need the history in the final Docker image, only the current/active configuration.

This change removes the upgrade log directory, as well as the `.git` directory so we don't bloat the image.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [X] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
