### PR TITLE
chore(compression): make registry mod public

### DIFF
--- a/.changes/added/2954.md
+++ b/.changes/added/2954.md
@@ -1,0 +1,1 @@
+Made `registry` mod public in `fuel-core-compression`

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -9,7 +9,7 @@ pub mod config;
 pub mod decompress;
 mod eviction_policy;
 pub mod ports;
-mod registry;
+pub mod registry;
 
 pub use config::Config;
 use enum_dispatch::enum_dispatch;


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- we need the `RegistrationsPerTable` struct accessible in the decompression proving game 

## Description
<!-- List of detailed changes -->


## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
