### PR TITLE
chore(tx|gas_price): add test to ensure heap memory is cleared, add gm opcode integ test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,24 +3331,24 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4702e63db53a308a4bb57ba21e8f7dcb08f1146a9b34fce06d964306ed3e1497"
+checksum = "3da0b560abd7105b17c363d4c7eb7113c5d012c80ee37548b27909acd1b18d1c"
 dependencies = [
  "bitflags 2.9.0",
- "fuel-types 0.60.0",
+ "fuel-types 0.60.2",
  "serde",
  "strum 0.24.1",
 ]
 
 [[package]]
 name = "fuel-compression"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad1694f1c4f53309056d5343aae7f1944408b5c426d52d34027f4005778e54c"
+checksum = "6b56ceef5e2ea5f63e61fb890c732c80676ae53878019145b49344f31c38d950"
 dependencies = [
- "fuel-derive 0.60.0",
- "fuel-types 0.60.0",
+ "fuel-derive 0.60.2",
+ "fuel-types 0.60.2",
  "serde",
 ]
 
@@ -3924,7 +3924,7 @@ dependencies = [
  "enum-iterator",
  "fuel-core-storage",
  "fuel-core-types 0.43.0",
- "fuel-vm 0.60.0",
+ "fuel-vm 0.60.2",
  "impl-tools",
  "itertools 0.12.1",
  "mockall",
@@ -4095,7 +4095,7 @@ dependencies = [
  "ed25519-dalek",
  "educe",
  "fuel-core-types 0.43.0",
- "fuel-vm 0.60.0",
+ "fuel-vm 0.60.2",
  "k256",
  "postcard",
  "rand 0.8.5",
@@ -4157,16 +4157,16 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b478d21160fa528667ca477b82e2426efa5ac226a7b6fce67987d62f1b041cac"
+checksum = "0bbb6ef7a5451f4e73b6a4811ed176e902af141d1b7006f5132ffee5fde86883"
 dependencies = [
  "base64ct",
  "coins-bip32",
  "coins-bip39",
  "ecdsa",
  "ed25519-dalek",
- "fuel-types 0.60.0",
+ "fuel-types 0.60.2",
  "k256",
  "p256",
  "rand 0.8.5",
@@ -4190,9 +4190,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0b24c724f47a73f021dae315e5d2b5aec03ba6b9ef9d66377106a20a5fdcde"
+checksum = "982cdb2e97a5831621b47562a4ed88fecb9797605b2077c7f30d1ffbb63d4958"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4228,13 +4228,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3a023169ea7231b6bd107c513b8b9a7ff849df5ca023c120b348da234ec20a"
+checksum = "3848d4c7d0485554eb8280b3b3da67e56dc01fb6f31af1a994f9e453989117cf"
 dependencies = [
  "derive_more 0.99.19",
  "digest 0.10.7",
- "fuel-storage 0.60.0",
+ "fuel-storage 0.60.2",
  "hashbrown 0.13.2",
  "hex",
  "serde",
@@ -4261,9 +4261,9 @@ checksum = "4c1b711f28553ddc5f3546711bd220e144ce4c1af7d9e9a1f70b2f20d9f5b791"
 
 [[package]]
 name = "fuel-storage"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8425dc32f86e2d6082126ee34998a9556306c6a79d95b85a62a05b439ff9bb19"
+checksum = "0d874d57e5ccaa1ad80f39304a9e50dcc0ced5aad3710730fcb629a55ab478f5"
 
 [[package]]
 name = "fuel-tx"
@@ -4289,18 +4289,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db32cb7845a7462b02a8406303bfc5387589387418b5f4817a01bd5d3d16b287"
+checksum = "50239ffd36450fe7a520a13ed23e26cc9caedb7ac24fa65f5b02e1af8074da09"
 dependencies = [
  "bitflags 2.9.0",
  "derive_more 1.0.0",
  "educe",
- "fuel-asm 0.60.0",
+ "fuel-asm 0.60.2",
  "fuel-compression",
- "fuel-crypto 0.60.0",
- "fuel-merkle 0.60.0",
- "fuel-types 0.60.0",
+ "fuel-crypto 0.60.2",
+ "fuel-merkle 0.60.2",
+ "fuel-types 0.60.2",
  "hashbrown 0.14.5",
  "itertools 0.10.5",
  "postcard",
@@ -4323,11 +4323,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f4e00bb184c4d24e7fe12f5a698612c384f2b9354eba4478bb022b4fb0a33"
+checksum = "da2d9bc4981b2ecf6896577dd569ce1d9a86bf88352f8c3f7618fe5c910c5176"
 dependencies = [
- "fuel-derive 0.60.0",
+ "fuel-derive 0.60.2",
  "hex",
  "rand 0.8.5",
  "serde",
@@ -4366,9 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07bfdb498244dc1e82de4e396a6c1f4183fd05355454e4847a727c9b5fb3331"
+checksum = "676037dcbf91d010288c6c75eca649cb0064673aa81341a3d3c6f8198e45776b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4377,13 +4377,13 @@ dependencies = [
  "derive_more 0.99.19",
  "educe",
  "ethnum",
- "fuel-asm 0.60.0",
+ "fuel-asm 0.60.2",
  "fuel-compression",
- "fuel-crypto 0.60.0",
- "fuel-merkle 0.60.0",
- "fuel-storage 0.60.0",
- "fuel-tx 0.60.0",
- "fuel-types 0.60.0",
+ "fuel-crypto 0.60.2",
+ "fuel-merkle 0.60.2",
+ "fuel-storage 0.60.2",
+ "fuel-tx 0.60.2",
+ "fuel-types 0.60.2",
  "hashbrown 0.14.5",
  "itertools 0.10.5",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 fuel-gas-price-algorithm = { version = "0.43.0", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.60.0", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.60.2", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"

--- a/tests/tests/tx.rs
+++ b/tests/tests/tx.rs
@@ -64,6 +64,7 @@ mod txn_status_subscription;
 mod txpool;
 mod upgrade;
 mod utxo_validation;
+mod vm_memory;
 
 #[test]
 fn basic_script_snapshot() {

--- a/tests/tests/tx/vm_memory.rs
+++ b/tests/tests/tx/vm_memory.rs
@@ -1,0 +1,124 @@
+//! Tests related to vm memory usage
+
+use fuel_core_types::{
+    fuel_asm::{
+        op,
+        GTFArgs,
+        RegId,
+    },
+    fuel_tx::{
+        Finalizable,
+        Input,
+        TransactionBuilder,
+    },
+    fuel_types::AssetId,
+};
+use rand::{
+    rngs::StdRng,
+    Rng,
+    SeedableRng,
+};
+use test_helpers::builder::TestSetupBuilder;
+
+#[tokio::test]
+async fn predicate_that_uses_heap_does_not_leave_dirty_memory_for_next_predicate() {
+    // This test checks that a first predicate that uses the heap does not leave
+    // dirty memory for the next predicate.
+    // First predicate:
+    // 1. Allocates memory on the heap 10_000.
+    // 2. Copies data from predicate input where it is [1; 10_000]
+    // 3. Compares data from the predicate input with copied data on the heap.
+    //
+    // Second predicate:
+    // 1. Allocates memory on the heap 100_000.
+    // 2. Compares data from the predicate input(it is [0; 100_000]) with the heap.
+    let mut rng = StdRng::seed_from_u64(121210);
+
+    const AMOUNT: u64 = 1_000;
+
+    let size_reg = 0x10;
+    let data_start_reg = 0x11;
+    let result_reg = 0x12;
+    let first_data_size = 10_000;
+    let first_predicate_index = 0;
+
+    let first_predicate = vec![
+        op::movi(size_reg, first_data_size),
+        op::aloc(size_reg),
+        op::gtf_args(
+            data_start_reg,
+            first_predicate_index,
+            GTFArgs::InputCoinPredicateData,
+        ),
+        op::mcp(RegId::HP, data_start_reg, size_reg),
+        op::meq(result_reg, RegId::HP, data_start_reg, size_reg),
+        op::ret(result_reg),
+    ];
+    let first_predicate_data = vec![1u8; first_data_size as usize];
+    let first_predicate: Vec<u8> = first_predicate.into_iter().collect();
+    let first_predicate_owner = Input::predicate_owner(&first_predicate);
+
+    let second_data_size = 100_000;
+    let second_predicate_index = 1;
+
+    let second_predicate = vec![
+        op::movi(size_reg, second_data_size),
+        op::aloc(size_reg),
+        op::gtf_args(
+            data_start_reg,
+            second_predicate_index,
+            GTFArgs::InputCoinPredicateData,
+        ),
+        op::meq(result_reg, RegId::HP, data_start_reg, size_reg),
+        op::ret(result_reg),
+    ];
+    let second_predicate_data = vec![0u8; second_data_size as usize];
+    let second_predicate: Vec<u8> = second_predicate.into_iter().collect();
+    let second_predicate_owner = Input::predicate_owner(&second_predicate);
+
+    // Given
+    let transaction_with_predicates =
+        TransactionBuilder::script(Default::default(), Default::default())
+            .add_input(Input::coin_predicate(
+                rng.gen(),
+                first_predicate_owner,
+                AMOUNT,
+                AssetId::BASE,
+                Default::default(),
+                Default::default(),
+                first_predicate,
+                first_predicate_data,
+            ))
+            .add_input(Input::coin_predicate(
+                rng.gen(),
+                second_predicate_owner,
+                AMOUNT,
+                AssetId::BASE,
+                Default::default(),
+                Default::default(),
+                second_predicate,
+                second_predicate_data,
+            ))
+            .finalize();
+
+    let mut context = TestSetupBuilder::default();
+    context.utxo_validation = true;
+    context.config_coin_inputs_from_transactions(&[&transaction_with_predicates]);
+    let context = context.finalize().await;
+
+    let mut transaction_with_predicates = transaction_with_predicates.into();
+    context
+        .client
+        .estimate_predicates(&mut transaction_with_predicates)
+        .await
+        .unwrap();
+
+    // When
+    let result = context
+        .client
+        .submit_and_await_commit(&transaction_with_predicates)
+        .await;
+
+    // Then
+    result.expect("Transaction should be executed successfully");
+}


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
upcoming v0.43.1 release

vm pr: https://github.com/fuellabs/fuel-vm/pull/942

## Description
<!-- List of detailed changes -->
the fuel-vm 0.60.1+0.60.2 releases include 2 changes -
1. patched heap reallocation bug
2. `GM::GetGasPrice` opcode

this PR adds integ tests for both.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
