### PR TITLE
chore(v0.41.10): bump versions, release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [Version 0.41.10]
+
+### Fixed 
+
+- [2963](https://github.com/FuelLabs/fuel-core/pull/2963): Ensure that vm heap memory is zeroed out on rellocation after `reset`. Bumps `fuel-vm` to `0.59.3`.
+
 ## [Version 0.41.9]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3402,7 +3402,7 @@ dependencies = [
  "fuel-core-sync",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3453,7 +3453,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-sync",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "futures",
  "hex",
  "itertools 0.12.1",
@@ -3475,11 +3475,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.41.9"
+version = "0.41.10"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3494,7 +3494,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3525,7 +3525,7 @@ dependencies = [
  "derivative",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3543,14 +3543,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more 0.99.19",
  "eventsource-client",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -3567,23 +3567,23 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "clap",
  "fuel-core-client",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fuel-core-compression",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "paste",
  "postcard",
  "proptest",
@@ -3596,30 +3596,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3627,7 +3627,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "futures",
  "hex",
  "humantime-serde",
@@ -3644,12 +3644,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "hex",
  "parking_lot",
  "serde",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3666,7 +3666,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "fuel-gas-price-algorithm",
  "futures",
  "mockito",
@@ -3686,12 +3686,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-global-merkle-root-storage"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "num_enum",
  "postcard",
  "rand",
@@ -3701,14 +3701,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "mockall",
  "parking_lot",
  "rayon",
@@ -3719,18 +3719,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "clap",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "atty",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3769,7 +3769,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3799,17 +3799,17 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-parallel-executor"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "fuel-core-storage",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "fuel-core-upgradable-executor",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3818,7 +3818,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "mockall",
  "rand",
  "serde",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "mockall",
  "proptest",
  "rand",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3864,7 +3864,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "futures",
  "mockall",
  "once_cell",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3908,7 +3908,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -3924,13 +3924,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "fuel-vm 0.59.3",
  "impl-tools",
  "itertools 0.12.1",
@@ -3948,13 +3948,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "futures",
  "mockall",
  "rand",
@@ -3989,7 +3989,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "ctor",
  "tracing",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4037,7 +4037,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "futures",
  "mockall",
  "num-rational",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4089,13 +4089,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "fuel-core-wasm-executor",
  "parking_lot",
  "postcard",
@@ -4105,13 +4105,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "postcard",
  "proptest",
  "serde",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.41.9"
+version = "0.41.10"
 dependencies = [
  "proptest",
  "rand",
@@ -9853,7 +9853,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.41.9",
+ "fuel-core-types 0.41.10",
  "futures",
  "itertools 0.12.1",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,42 +59,42 @@ homepage = "https://fuel.network/"
 keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
-version = "0.41.9"
+version = "0.41.10"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.41.9", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.41.9", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.41.9", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.41.9", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.41.9", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.41.9", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.41.9", path = "./crates/client" }
-fuel-core-compression = { version = "0.41.9", path = "./crates/compression" }
-fuel-core-database = { version = "0.41.9", path = "./crates/database" }
-fuel-core-metrics = { version = "0.41.9", path = "./crates/metrics" }
-fuel-core-services = { version = "0.41.9", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.41.9", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.41.9", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.41.9", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.41.9", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.41.9", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.41.9", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.41.9", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.41.9", path = "./crates/services/p2p" }
-fuel-core-parallel-executor = { version = "0.41.9", path = "./crates/services/parallel-executor" }
-fuel-core-producer = { version = "0.41.9", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.41.9", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.41.9", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.41.9", path = "./crates/services/txpool_v2" }
-fuel-core-storage = { version = "0.41.9", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.41.9", path = "./crates/trace" }
-fuel-core-types = { version = "0.41.9", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.41.10", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.41.10", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.41.10", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.41.10", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.41.10", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.41.10", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.41.10", path = "./crates/client" }
+fuel-core-compression = { version = "0.41.10", path = "./crates/compression" }
+fuel-core-database = { version = "0.41.10", path = "./crates/database" }
+fuel-core-metrics = { version = "0.41.10", path = "./crates/metrics" }
+fuel-core-services = { version = "0.41.10", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.41.10", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.41.10", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.41.10", path = "./crates/services/consensus_module/poa" }
+fuel-core-shared-sequencer = { version = "0.41.10", path = "crates/services/shared-sequencer" }
+fuel-core-executor = { version = "0.41.10", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.41.10", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.41.10", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.41.10", path = "./crates/services/p2p" }
+fuel-core-parallel-executor = { version = "0.41.10", path = "./crates/services/parallel-executor" }
+fuel-core-producer = { version = "0.41.10", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.41.10", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.41.10", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.41.10", path = "./crates/services/txpool_v2" }
+fuel-core-storage = { version = "0.41.10", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.41.10", path = "./crates/trace" }
+fuel-core-types = { version = "0.41.10", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.41.9", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.41.9", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.41.10", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.41.10", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.41.9", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.41.10", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.59.3", package = "fuel-vm", default-features = false }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ git clone https://github.com/FuelLabs/fuel-core.git
 
 Go to the latest release tag for ignition on the `fuel-core` repository :
 ```
-git checkout v0.41.9
+git checkout v0.41.10
 ```
 
 Build your node binary:

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -304,7 +304,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 24,
+  "genesis_state_transition_version": 25,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -308,7 +308,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 24,
+  "genesis_state_transition_version": 25,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -163,7 +163,10 @@ impl<S, R> Executor<S, R> {
         ("0-41-6", 21),
         ("0-41-7", 22),
         ("0-41-8", 23),
-        ("0-41-9", LATEST_STATE_TRANSITION_VERSION),
+        ("0-41-9", 24),
+        // This version of the state transition version shadows the future release,
+        // i.e 0.42.0
+        ("0-41-10", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -784,9 +784,12 @@ mod test {
         services::relayer::Event,
         tai64::Tai64,
     };
-    use std::collections::{
-        BTreeMap,
-        BTreeSet,
+    use std::{
+        cmp::Ordering,
+        collections::{
+            BTreeMap,
+            BTreeSet,
+        },
     };
 
     #[derive(Clone, Debug)]
@@ -848,6 +851,51 @@ mod test {
         }
     }
 
+    /// wrapper type to ensure correct ordering of version strings
+    #[derive(Debug, Eq, PartialEq, Clone)]
+    struct VersionKey(String);
+
+    impl VersionKey {
+        fn new(version: String) -> Self {
+            VersionKey(version)
+        }
+
+        fn as_str(&self) -> &str {
+            &self.0
+        }
+    }
+
+    impl Ord for VersionKey {
+        fn cmp(&self, other: &Self) -> Ordering {
+            let self_parts: Vec<u32> = self
+                .0
+                .split('.')
+                .map(|s| s.parse::<u32>().unwrap_or(0))
+                .collect();
+
+            let other_parts: Vec<u32> = other
+                .0
+                .split('.')
+                .map(|s| s.parse::<u32>().unwrap_or(0))
+                .collect();
+
+            for (a, b) in self_parts.iter().zip(other_parts.iter()) {
+                match a.cmp(b) {
+                    Ordering::Equal => continue,
+                    other => return other,
+                }
+            }
+
+            self_parts.len().cmp(&other_parts.len())
+        }
+    }
+
+    impl PartialOrd for VersionKey {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
     // When this test fails, it is a sign that we need to increase the `Executor::VERSION`.
     #[test]
     fn version_check() {
@@ -860,11 +908,13 @@ mod test {
             .map(|(crate_version, version)| {
                 let executor_crate_version = crate_version.to_string().replace('-', ".");
                 seen_executor_versions.insert(*version);
-                (executor_crate_version, *version)
+                (VersionKey::new(executor_crate_version), *version)
             })
             .collect::<BTreeMap<_, _>>();
 
-        if let Some(expected_version) = seen_crate_versions.get(crate_version) {
+        if let Some(expected_version) =
+            seen_crate_versions.get(&VersionKey::new(crate_version.to_string()))
+        {
             assert_eq!(
                 *expected_version,
                 Executor::<Storage, DisabledRelayer>::VERSION,
@@ -881,7 +931,8 @@ mod test {
 
         let last_crate_version = seen_crate_versions.last_key_value().unwrap().0.clone();
         assert_eq!(
-            crate_version, last_crate_version,
+            crate_version,
+            last_crate_version.as_str(),
             "The last version in the `CRATE_VERSIONS` constant \
                    should be the same as the current crate version."
         );

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -166,7 +166,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 24;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 25;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->
bumps all versions to `0.41.10` also adds a note in the upgradable executor about shadowing of stf version

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
