### PR TITLE
chore(port): bump version to 0.43.1, bump stf, etc

### DIFF
--- a/.changes/fixed/2969.md
+++ b/.changes/fixed/2969.md
@@ -1,0 +1,1 @@
+Ensure that vm heap memory is zeroed out on rellocation after `reset`. Adds support for `GM::GetGasPrice` Bumps `fuel-vm` to `0.60.2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+## [Version 0.43.1]
+
+### Fixed
+
+- [2964](https://github.com/FuelLabs/fuel-core/pull/2964): Ensure that vm heap memory is zeroed out on rellocation after `reset`. Adds support for `GM::GetGasPrice` Bumps `fuel-vm` to `0.60.2`.
+
 ## [Version 0.43.0]
 
 ### Breaking
@@ -166,6 +172,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 - [2863](https://github.com/FuelLabs/fuel-core/pull/2863): Removed everything related to the state root service, as it has been moved to another repo.
+
+## [Version 0.41.10]
+
+### Fixed 
+
+- [2963](https://github.com/FuelLabs/fuel-core/pull/2963): Ensure that vm heap memory is zeroed out on rellocation after `reset`. Bumps `fuel-vm` to `0.59.3`.
 
 ## [Version 0.41.9]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,30 +3338,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4702e63db53a308a4bb57ba21e8f7dcb08f1146a9b34fce06d964306ed3e1497"
+checksum = "3da0b560abd7105b17c363d4c7eb7113c5d012c80ee37548b27909acd1b18d1c"
 dependencies = [
  "bitflags 2.9.0",
- "fuel-types 0.60.0",
+ "fuel-types 0.60.2",
  "serde",
  "strum 0.24.1",
 ]
 
 [[package]]
 name = "fuel-compression"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad1694f1c4f53309056d5343aae7f1944408b5c426d52d34027f4005778e54c"
+checksum = "6b56ceef5e2ea5f63e61fb890c732c80676ae53878019145b49344f31c38d950"
 dependencies = [
- "fuel-derive 0.60.0",
- "fuel-types 0.60.0",
+ "fuel-derive 0.60.2",
+ "fuel-types 0.60.2",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3394,7 +3394,7 @@ dependencies = [
  "fuel-core-trace",
  "fuel-core-tx-status-manager",
  "fuel-core-txpool",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3449,7 +3449,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-sync",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "hex",
  "itertools 0.12.1",
@@ -3472,11 +3472,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.43.0"
+version = "0.43.1"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3491,7 +3491,7 @@ dependencies = [
  "fuel-core-poa",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3522,7 +3522,7 @@ dependencies = [
  "educe",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3540,14 +3540,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more 0.99.19",
  "eventsource-client",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -3564,23 +3564,23 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "clap",
  "fuel-core-client",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fuel-core-compression",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "paste",
  "postcard",
  "proptest",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-compression-service"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3604,7 +3604,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "paste",
  "rand 0.8.5",
@@ -3619,30 +3619,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3650,7 +3650,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "hex",
  "humantime-serde",
@@ -3668,12 +3668,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "parking_lot",
  "serde",
  "tracing",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3689,7 +3689,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "fuel-gas-price-algorithm",
  "futures",
  "mockito",
@@ -3709,14 +3709,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "mockall",
  "rayon",
  "test-case",
@@ -3726,18 +3726,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "clap",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3775,7 +3775,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3798,17 +3798,17 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-parallel-executor"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "fuel-core-storage",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "fuel-core-upgradable-executor",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3817,7 +3817,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "mockall",
  "rand 0.8.5",
  "serde",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "mockall",
  "proptest",
  "rand 0.8.5",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3864,7 +3864,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "mockall",
  "once_cell",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3908,7 +3908,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -3924,14 +3924,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.43.0",
- "fuel-vm 0.60.0",
+ "fuel-core-types 0.43.1",
+ "fuel-vm 0.60.2",
  "impl-tools",
  "itertools 0.12.1",
  "mockall",
@@ -3948,13 +3948,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "mockall",
  "rand 0.8.5",
@@ -3990,7 +3990,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "ctor",
  "tracing",
@@ -4028,14 +4028,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-tx-status-manager"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-tx-status-manager",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "mockall",
  "parking_lot",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4060,7 +4060,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "lru 0.13.0",
  "mockall",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4101,8 +4101,8 @@ dependencies = [
  "ed25519",
  "ed25519-dalek",
  "educe",
- "fuel-core-types 0.43.0",
- "fuel-vm 0.60.0",
+ "fuel-core-types 0.43.1",
+ "fuel-vm 0.60.2",
  "k256",
  "postcard",
  "rand 0.8.5",
@@ -4115,13 +4115,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "fuel-core-wasm-executor",
  "futures",
  "parking_lot",
@@ -4132,13 +4132,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "postcard",
  "proptest",
@@ -4164,16 +4164,16 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b478d21160fa528667ca477b82e2426efa5ac226a7b6fce67987d62f1b041cac"
+checksum = "0bbb6ef7a5451f4e73b6a4811ed176e902af141d1b7006f5132ffee5fde86883"
 dependencies = [
  "base64ct",
  "coins-bip32",
  "coins-bip39",
  "ecdsa",
  "ed25519-dalek",
- "fuel-types 0.60.0",
+ "fuel-types 0.60.2",
  "k256",
  "p256",
  "rand 0.8.5",
@@ -4197,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0b24c724f47a73f021dae315e5d2b5aec03ba6b9ef9d66377106a20a5fdcde"
+checksum = "982cdb2e97a5831621b47562a4ed88fecb9797605b2077c7f30d1ffbb63d4958"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "proptest",
  "rand 0.8.5",
@@ -4235,13 +4235,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3a023169ea7231b6bd107c513b8b9a7ff849df5ca023c120b348da234ec20a"
+checksum = "3848d4c7d0485554eb8280b3b3da67e56dc01fb6f31af1a994f9e453989117cf"
 dependencies = [
  "derive_more 0.99.19",
  "digest 0.10.7",
- "fuel-storage 0.60.0",
+ "fuel-storage 0.60.2",
  "hashbrown 0.13.2",
  "hex",
  "serde",
@@ -4268,9 +4268,9 @@ checksum = "4c1b711f28553ddc5f3546711bd220e144ce4c1af7d9e9a1f70b2f20d9f5b791"
 
 [[package]]
 name = "fuel-storage"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8425dc32f86e2d6082126ee34998a9556306c6a79d95b85a62a05b439ff9bb19"
+checksum = "0d874d57e5ccaa1ad80f39304a9e50dcc0ced5aad3710730fcb629a55ab478f5"
 
 [[package]]
 name = "fuel-tx"
@@ -4296,18 +4296,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db32cb7845a7462b02a8406303bfc5387589387418b5f4817a01bd5d3d16b287"
+checksum = "50239ffd36450fe7a520a13ed23e26cc9caedb7ac24fa65f5b02e1af8074da09"
 dependencies = [
  "bitflags 2.9.0",
  "derive_more 1.0.0",
  "educe",
- "fuel-asm 0.60.0",
+ "fuel-asm 0.60.2",
  "fuel-compression",
- "fuel-crypto 0.60.0",
- "fuel-merkle 0.60.0",
- "fuel-types 0.60.0",
+ "fuel-crypto 0.60.2",
+ "fuel-merkle 0.60.2",
+ "fuel-types 0.60.2",
  "hashbrown 0.14.5",
  "itertools 0.10.5",
  "postcard",
@@ -4330,11 +4330,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f4e00bb184c4d24e7fe12f5a698612c384f2b9354eba4478bb022b4fb0a33"
+checksum = "da2d9bc4981b2ecf6896577dd569ce1d9a86bf88352f8c3f7618fe5c910c5176"
 dependencies = [
- "fuel-derive 0.60.0",
+ "fuel-derive 0.60.2",
  "hex",
  "rand 0.8.5",
  "serde",
@@ -4373,9 +4373,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07bfdb498244dc1e82de4e396a6c1f4183fd05355454e4847a727c9b5fb3331"
+checksum = "676037dcbf91d010288c6c75eca649cb0064673aa81341a3d3c6f8198e45776b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4384,13 +4384,13 @@ dependencies = [
  "derive_more 0.99.19",
  "educe",
  "ethnum",
- "fuel-asm 0.60.0",
+ "fuel-asm 0.60.2",
  "fuel-compression",
- "fuel-crypto 0.60.0",
- "fuel-merkle 0.60.0",
- "fuel-storage 0.60.0",
- "fuel-tx 0.60.0",
- "fuel-types 0.60.0",
+ "fuel-crypto 0.60.2",
+ "fuel-merkle 0.60.2",
+ "fuel-storage 0.60.2",
+ "fuel-tx 0.60.2",
+ "fuel-types 0.60.2",
  "hashbrown 0.14.5",
  "itertools 0.10.5",
  "libm",
@@ -9832,7 +9832,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.43.0",
+ "fuel-core-types 0.43.1",
  "futures",
  "itertools 0.12.1",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,47 +61,47 @@ keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
 rust-version = "1.85.0"
-version = "0.43.0"
+version = "0.43.1"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.43.0", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.43.0", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.43.0", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.43.0", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.43.0", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.43.0", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.43.0", path = "./crates/client" }
-fuel-core-compression = { version = "0.43.0", path = "./crates/compression" }
-fuel-core-compression-service = { version = "0.43.0", path = "./crates/services/compression" }
-fuel-core-database = { version = "0.43.0", path = "./crates/database" }
-fuel-core-metrics = { version = "0.43.0", path = "./crates/metrics" }
-fuel-core-services = { version = "0.43.0", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.43.0", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.43.0", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.43.0", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.43.0", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.43.0", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.43.0", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.43.0", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.43.0", path = "./crates/services/p2p" }
-fuel-core-parallel-executor = { version = "0.43.0", path = "./crates/services/parallel-executor" }
-fuel-core-producer = { version = "0.43.0", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.43.0", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.43.0", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.43.0", path = "./crates/services/txpool_v2" }
-fuel-core-tx-status-manager = { version = "0.43.0", path = "./crates/services/tx_status_manager" }
-fuel-core-storage = { version = "0.43.0", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.43.0", path = "./crates/trace" }
-fuel-core-types = { version = "0.43.0", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.43.1", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.43.1", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.43.1", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.43.1", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.43.1", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.43.1", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.43.1", path = "./crates/client" }
+fuel-core-compression = { version = "0.43.1", path = "./crates/compression" }
+fuel-core-compression-service = { version = "0.43.1", path = "./crates/services/compression" }
+fuel-core-database = { version = "0.43.1", path = "./crates/database" }
+fuel-core-metrics = { version = "0.43.1", path = "./crates/metrics" }
+fuel-core-services = { version = "0.43.1", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.43.1", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.43.1", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.43.1", path = "./crates/services/consensus_module/poa" }
+fuel-core-shared-sequencer = { version = "0.43.1", path = "crates/services/shared-sequencer" }
+fuel-core-executor = { version = "0.43.1", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.43.1", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.43.1", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.43.1", path = "./crates/services/p2p" }
+fuel-core-parallel-executor = { version = "0.43.1", path = "./crates/services/parallel-executor" }
+fuel-core-producer = { version = "0.43.1", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.43.1", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.43.1", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.43.1", path = "./crates/services/txpool_v2" }
+fuel-core-tx-status-manager = { version = "0.43.1", path = "./crates/services/tx_status_manager" }
+fuel-core-storage = { version = "0.43.1", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.43.1", path = "./crates/trace" }
+fuel-core-types = { version = "0.43.1", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.43.0", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.43.0", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.43.1", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.43.1", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.43.0", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.43.1", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.60.0", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.60.2", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -304,7 +304,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 26,
+  "genesis_state_transition_version": 27,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -308,7 +308,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 26,
+  "genesis_state_transition_version": 27,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -330,7 +330,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 26;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 27;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/tests/tests/tx/vm_memory.rs
+++ b/tests/tests/tx/vm_memory.rs
@@ -1,0 +1,124 @@
+//! Tests related to vm memory usage
+
+use fuel_core_types::{
+    fuel_asm::{
+        op,
+        GTFArgs,
+        RegId,
+    },
+    fuel_tx::{
+        Finalizable,
+        Input,
+        TransactionBuilder,
+    },
+    fuel_types::AssetId,
+};
+use rand::{
+    rngs::StdRng,
+    Rng,
+    SeedableRng,
+};
+use test_helpers::builder::TestSetupBuilder;
+
+#[tokio::test]
+async fn predicate_that_uses_heap_does_not_leave_dirty_memory_for_next_predicate() {
+    // This test checks that a first predicate that uses the heap does not leave
+    // dirty memory for the next predicate.
+    // First predicate:
+    // 1. Allocates memory on the heap 10_000.
+    // 2. Copies data from predicate input where it is [1; 10_000]
+    // 3. Compares data from the predicate input with copied data on the heap.
+    //
+    // Second predicate:
+    // 1. Allocates memory on the heap 100_000.
+    // 2. Compares data from the predicate input(it is [0; 100_000]) with the heap.
+    let mut rng = StdRng::seed_from_u64(121210);
+
+    const AMOUNT: u64 = 1_000;
+
+    let size_reg = 0x10;
+    let data_start_reg = 0x11;
+    let result_reg = 0x12;
+    let first_data_size = 10_000;
+    let first_predicate_index = 0;
+
+    let first_predicate = vec![
+        op::movi(size_reg, first_data_size),
+        op::aloc(size_reg),
+        op::gtf_args(
+            data_start_reg,
+            first_predicate_index,
+            GTFArgs::InputCoinPredicateData,
+        ),
+        op::mcp(RegId::HP, data_start_reg, size_reg),
+        op::meq(result_reg, RegId::HP, data_start_reg, size_reg),
+        op::ret(result_reg),
+    ];
+    let first_predicate_data = vec![1u8; first_data_size as usize];
+    let first_predicate: Vec<u8> = first_predicate.into_iter().collect();
+    let first_predicate_owner = Input::predicate_owner(&first_predicate);
+
+    let second_data_size = 100_000;
+    let second_predicate_index = 1;
+
+    let second_predicate = vec![
+        op::movi(size_reg, second_data_size),
+        op::aloc(size_reg),
+        op::gtf_args(
+            data_start_reg,
+            second_predicate_index,
+            GTFArgs::InputCoinPredicateData,
+        ),
+        op::meq(result_reg, RegId::HP, data_start_reg, size_reg),
+        op::ret(result_reg),
+    ];
+    let second_predicate_data = vec![0u8; second_data_size as usize];
+    let second_predicate: Vec<u8> = second_predicate.into_iter().collect();
+    let second_predicate_owner = Input::predicate_owner(&second_predicate);
+
+    // Given
+    let transaction_with_predicates =
+        TransactionBuilder::script(Default::default(), Default::default())
+            .add_input(Input::coin_predicate(
+                rng.gen(),
+                first_predicate_owner,
+                AMOUNT,
+                AssetId::BASE,
+                Default::default(),
+                Default::default(),
+                first_predicate,
+                first_predicate_data,
+            ))
+            .add_input(Input::coin_predicate(
+                rng.gen(),
+                second_predicate_owner,
+                AMOUNT,
+                AssetId::BASE,
+                Default::default(),
+                Default::default(),
+                second_predicate,
+                second_predicate_data,
+            ))
+            .finalize();
+
+    let mut context = TestSetupBuilder::default();
+    context.utxo_validation = true;
+    context.config_coin_inputs_from_transactions(&[&transaction_with_predicates]);
+    let context = context.finalize().await;
+
+    let mut transaction_with_predicates = transaction_with_predicates.into();
+    context
+        .client
+        .estimate_predicates(&mut transaction_with_predicates)
+        .await
+        .unwrap();
+
+    // When
+    let result = context
+        .client
+        .submit_and_await_commit(&transaction_with_predicates)
+        .await;
+
+    // Then
+    result.expect("Transaction should be executed successfully");
+}


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- fuel-vm pr: https://github.com/fuellabs/fuel-vm/pull/942

## Description
<!-- List of detailed changes -->
- bumps `fuel-vm` to 0.60.2
- adds integ test for vm heap memory reallocation
- adds integ test for `GM::GetGasPrice`


## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
