### PR TITLE
chore: Enable fault-proving feature on upgradable executor

### DIFF
--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -134,4 +134,5 @@ fault-proving = [
   "fuel-core-importer/fault-proving",
   "fuel-core-poa/fault-proving",
   "fuel-core-compression-service/fault-proving",
+  "fuel-core-upgradable-executor/fault-proving",
 ]


### PR DESCRIPTION
Previously we didn't enable the `fault-proving` feature on the upgradable executor when `fuel-core` is compiled with this feature. This caused compilation failures in the network watchtower, while working on https://github.com/FuelLabs/network-watchtower/pull/53

This PR fixes that.

