### PR TITLE
fix(compression_service): prevent syncing from genesis if compression db is empty

### DIFF
--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -82,7 +82,10 @@ use rlimit::{
 use std::{
     env,
     net,
-    num::NonZeroU64,
+    num::{
+        NonZeroU32,
+        NonZeroU64,
+    },
     path::PathBuf,
     str::FromStr,
     time::Duration,
@@ -238,6 +241,10 @@ pub struct Command {
     #[arg(long = "da-compression", env)]
     pub da_compression: Option<humantime::Duration>,
 
+    /// Override and resync the compression service from the given starting height.
+    #[arg(long = "da-compression-override-starting-height", env)]
+    pub da_compression_override_starting_height: Option<NonZeroU32>,
+
     /// A new block is produced instantly when transactions are available.
     #[clap(flatten)]
     pub poa_trigger: PoATriggerArgs,
@@ -341,6 +348,7 @@ impl Command {
             #[cfg(feature = "aws-kms")]
             consensus_aws_kms,
             da_compression,
+            da_compression_override_starting_height,
             poa_trigger,
             predefined_blocks_path,
             coinbase_recipient,
@@ -551,6 +559,7 @@ impl Command {
             Some(retention_duration) => DaCompressionMode::Enabled(
                 fuel_core::service::config::DaCompressionConfig {
                     retention_duration: retention_duration.into(),
+                    override_starting_height: da_compression_override_starting_height,
                     metrics: metrics.is_enabled(Module::Compression),
                 },
             ),

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -241,9 +241,9 @@ pub struct Command {
     #[arg(long = "da-compression", env)]
     pub da_compression: Option<humantime::Duration>,
 
-    /// Override and resync the compression service from the given starting height.
-    #[arg(long = "da-compression-override-starting-height", env)]
-    pub da_compression_override_starting_height: Option<NonZeroU32>,
+    /// The starting height of the compression service.
+    #[arg(long = "da-compression-starting-height", env)]
+    pub da_compression_starting_height: Option<NonZeroU32>,
 
     /// A new block is produced instantly when transactions are available.
     #[clap(flatten)]
@@ -348,7 +348,7 @@ impl Command {
             #[cfg(feature = "aws-kms")]
             consensus_aws_kms,
             da_compression,
-            da_compression_override_starting_height,
+            da_compression_starting_height,
             poa_trigger,
             predefined_blocks_path,
             coinbase_recipient,
@@ -559,7 +559,7 @@ impl Command {
             Some(retention_duration) => DaCompressionMode::Enabled(
                 fuel_core::service::config::DaCompressionConfig {
                     retention_duration: retention_duration.into(),
-                    override_starting_height: da_compression_override_starting_height,
+                    starting_height: da_compression_starting_height,
                     metrics: metrics.is_enabled(Module::Compression),
                 },
             ),

--- a/bin/fuel-core/src/cli/run/p2p.rs
+++ b/bin/fuel-core/src/cli/run/p2p.rs
@@ -237,6 +237,7 @@ impl KeypairArg {
             return Ok(KeypairArg::InlineSecret(secret))
         }
         let path = PathBuf::from_str(s);
+        #[allow(irrefutable_let_patterns)]
         if let Ok(pathbuf) = path {
             if pathbuf.exists() {
                 return Ok(KeypairArg::Path(pathbuf))

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -40,7 +40,10 @@ use fuel_core_storage::{
     IsNotFound,
     StorageAsMut,
 };
-use fuel_core_types::blockchain::consensus::Consensus;
+use fuel_core_types::{
+    blockchain::consensus::Consensus,
+    fuel_types::BlockHeight,
+};
 
 use crate::{
     combined_database::{
@@ -229,10 +232,14 @@ impl FuelService {
         Ok(())
     }
 
-    /// Wait for the compression service to be in sync with L2 height
-    pub async fn await_compression_synced(&self) -> anyhow::Result<()> {
+    /// Waits until the compression service has synced
+    /// with the given block height
+    pub async fn await_compression_synced_until(
+        &self,
+        block_height: &BlockHeight,
+    ) -> anyhow::Result<()> {
         if let Some(sync_observer) = &self.runner.shared.compression {
-            sync_observer.await_synced().await?;
+            sync_observer.await_synced_until(block_height).await?;
         }
         Ok(())
     }

--- a/crates/fuel-core/src/service/adapters/compression_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/compression_adapters.rs
@@ -60,10 +60,9 @@ impl block_source::BlockSource for CompressionBlockImporterAdapter {
         self.block_importer.events_shared_result()
     }
 
-    fn get_block(&self, height: BlockAt) -> Option<SharedImportResult> {
+    fn get_block(&self, height: BlockAt) -> anyhow::Result<SharedImportResult> {
         self.import_result_provider_adapter
             .result_at_height(height.into())
-            .ok()
     }
 }
 
@@ -71,7 +70,11 @@ impl configuration::CompressionConfigProvider
     for crate::service::config::DaCompressionConfig
 {
     fn config(&self) -> config::CompressionConfig {
-        config::CompressionConfig::new(self.retention_duration, self.metrics)
+        config::CompressionConfig::new(
+            self.retention_duration,
+            self.override_starting_height,
+            self.metrics,
+        )
     }
 }
 

--- a/crates/fuel-core/src/service/adapters/compression_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/compression_adapters.rs
@@ -72,7 +72,7 @@ impl configuration::CompressionConfigProvider
     fn config(&self) -> config::CompressionConfig {
         config::CompressionConfig::new(
             self.retention_duration,
-            self.override_starting_height,
+            self.starting_height,
             self.metrics,
         )
     }

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -1,6 +1,9 @@
 use clap::ValueEnum;
 use std::{
-    num::NonZeroU64,
+    num::{
+        NonZeroU32,
+        NonZeroU64,
+    },
     path::PathBuf,
     time::Duration,
 };
@@ -360,6 +363,7 @@ impl GasPriceConfig {
 pub struct DaCompressionConfig {
     pub retention_duration: Duration,
     pub metrics: bool,
+    pub override_starting_height: Option<NonZeroU32>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -363,7 +363,7 @@ impl GasPriceConfig {
 pub struct DaCompressionConfig {
     pub retention_duration: Duration,
     pub metrics: bool,
-    pub override_starting_height: Option<NonZeroU32>,
+    pub starting_height: Option<NonZeroU32>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/services/compression/src/config.rs
+++ b/crates/services/compression/src/config.rs
@@ -1,17 +1,26 @@
-use std::time::Duration;
+use std::{
+    num::NonZeroU32,
+    time::Duration,
+};
 
 /// Compression configuration
 #[derive(Debug, Clone, Copy)]
 pub struct CompressionConfig {
     temporal_registry_retention: Duration,
+    override_starting_height: Option<NonZeroU32>,
     metrics: bool,
 }
 
 impl CompressionConfig {
     /// Create a new compression configuration
-    pub fn new(temporal_registry_retention: Duration, metrics: bool) -> Self {
+    pub fn new(
+        temporal_registry_retention: Duration,
+        override_starting_height: Option<NonZeroU32>,
+        metrics: bool,
+    ) -> Self {
         Self {
             temporal_registry_retention,
+            override_starting_height,
             metrics,
         }
     }
@@ -24,6 +33,11 @@ impl CompressionConfig {
     /// Get the metrics configuration
     pub fn metrics(&self) -> bool {
         self.metrics
+    }
+
+    /// Get the override starting height
+    pub fn override_starting_height(&self) -> Option<u32> {
+        self.override_starting_height.map(|height| height.get())
     }
 }
 

--- a/crates/services/compression/src/config.rs
+++ b/crates/services/compression/src/config.rs
@@ -7,7 +7,7 @@ use std::{
 #[derive(Debug, Clone, Copy)]
 pub struct CompressionConfig {
     temporal_registry_retention: Duration,
-    override_starting_height: Option<NonZeroU32>,
+    starting_height: Option<NonZeroU32>,
     metrics: bool,
 }
 
@@ -15,12 +15,12 @@ impl CompressionConfig {
     /// Create a new compression configuration
     pub fn new(
         temporal_registry_retention: Duration,
-        override_starting_height: Option<NonZeroU32>,
+        starting_height: Option<NonZeroU32>,
         metrics: bool,
     ) -> Self {
         Self {
             temporal_registry_retention,
-            override_starting_height,
+            starting_height,
             metrics,
         }
     }
@@ -36,8 +36,8 @@ impl CompressionConfig {
     }
 
     /// Get the override starting height
-    pub fn override_starting_height(&self) -> Option<u32> {
-        self.override_starting_height.map(|height| height.get())
+    pub fn starting_height(&self) -> Option<u32> {
+        self.starting_height.map(|height| height.get())
     }
 }
 

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -73,5 +73,5 @@ pub trait BlockSource: Send + Sync {
     /// Should provide a stream of blocks with metadata
     fn subscribe(&self) -> BlockStream;
     /// Should provide the block at a given height
-    fn get_block(&self, height: BlockAt) -> Option<BlockWithMetadata>;
+    fn get_block(&self, height: BlockAt) -> anyhow::Result<BlockWithMetadata>;
 }

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -222,9 +222,10 @@ where
     CH: CanonicalHeight,
 {
     async fn sync_previously_produced_blocks(&mut self) -> crate::Result<()> {
-        let canonical_height = self.canonical_height.get();
         let mut overridden = false;
         loop {
+            let canonical_height = self.canonical_height.get();
+
             let storage_height =
                 match (self.config.override_starting_height(), overridden) {
                     (Some(height), false) => {

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -225,14 +225,14 @@ where
         let canonical_height = self.canonical_height.get();
         let mut overridden = false;
         loop {
-            let storage_height = match (self.config.override_starting_height(), overridden)
-            {
-                (Some(height), false) => {
-                    overridden = true;
-                    Some(height.saturating_sub(1))
-                }
-                (_, _) => self.storage.latest_height(),
-            };
+            let storage_height =
+                match (self.config.override_starting_height(), overridden) {
+                    (Some(height), false) => {
+                        overridden = true;
+                        Some(height.saturating_sub(1))
+                    }
+                    (_, _) => self.storage.latest_height(),
+                };
 
             if storage_height.is_none() {
                 // if the storage height is unavailable, don't execute blocks from genesis

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -223,12 +223,12 @@ where
 {
     async fn sync_previously_produced_blocks(&mut self) -> crate::Result<()> {
         let canonical_height = self.canonical_height.get();
-        let mut overriden = false;
+        let mut overridden = false;
         loop {
-            let storage_height = match (self.config.override_starting_height(), overriden)
+            let storage_height = match (self.config.override_starting_height(), overridden)
             {
                 (Some(height), false) => {
-                    overriden = true;
+                    overridden = true;
                     Some(height.saturating_sub(1))
                 }
                 (_, _) => self.storage.latest_height(),
@@ -687,7 +687,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compression_service__syncs_from_overriden_starting_height_when_provided() {
+    async fn compression_service__syncs_from_overridden_starting_height_when_provided() {
         // given: we start the compression service, with a canonical height provider of height 5,
         // and a config override of starting height 1
         let block_count = 10;

--- a/crates/services/compression/src/sync_state.rs
+++ b/crates/services/compression/src/sync_state.rs
@@ -12,8 +12,8 @@ pub enum SyncState {
 }
 
 impl SyncState {
-    pub(crate) fn is_synced(&self) -> bool {
-        matches!(self, Self::Synced(_))
+    pub(crate) fn is_synced_until(&self, height: &BlockHeight) -> bool {
+        matches!(self, Self::Synced(h) if h >= height)
     }
 }
 

--- a/crates/services/src/service.rs
+++ b/crates/services/src/service.rs
@@ -402,7 +402,7 @@ async fn run<S>(
     let mut task = service
         .into_task(&state, params)
         .await
-        .unwrap_or_else(|_| panic!("The initialization of {} failed", S::NAME));
+        .unwrap_or_else(|e| panic!("The initialization of {} failed: {}", S::NAME, e));
 
     sender.send_if_modified(|s| {
         if s.starting() {

--- a/crates/services/src/state.rs
+++ b/crates/services/src/state.rs
@@ -68,6 +68,13 @@ impl StateWatcher {
         core::mem::forget(sender);
         Self(receiver)
     }
+
+    /// Create a new `StateWatcher` with the `State::Starting` state.
+    pub fn starting() -> Self {
+        let (sender, receiver) = watch::channel(State::Starting);
+        core::mem::forget(sender);
+        Self(receiver)
+    }
 }
 
 impl StateWatcher {

--- a/tests/tests/da_compression.rs
+++ b/tests/tests/da_compression.rs
@@ -271,7 +271,7 @@ async fn da_compression__starts_and_compresses_blocks_correctly_from_empty_datab
 }
 
 #[tokio::test]
-async fn da_compression__starts_and_compresses_blocks_correctly_with_overriden_height() {
+async fn da_compression__starts_and_compresses_blocks_correctly_with_overridden_height() {
     // given: the node starts without compression enabled, and produces blocks
     let db = CombinedDatabase::temp_database_with_state_rewind_policy(
         StateRewindPolicy::RewindFullRange,
@@ -299,7 +299,7 @@ async fn da_compression__starts_and_compresses_blocks_correctly_with_overriden_h
 
     let mut config = srv.shared.config.clone();
 
-    // when: the node is restarted with compression enabled, starting height overriden, blocks are produced
+    // when: the node is restarted with compression enabled, starting height overridden, blocks are produced
     let override_starting_height = 10;
     config.da_compression = DaCompressionMode::Enabled(DaCompressionConfig {
         retention_duration: Duration::from_secs(3600),

--- a/tests/tests/da_compression.rs
+++ b/tests/tests/da_compression.rs
@@ -51,7 +51,10 @@ use rand::{
     rngs::StdRng,
     SeedableRng,
 };
-use std::str::FromStr;
+use std::{
+    num::NonZeroU32,
+    str::FromStr,
+};
 use test_helpers::{
     assemble_tx::{
         AssembleAndRunTx,
@@ -69,6 +72,7 @@ async fn can_fetch_da_compressed_block_from_graphql() {
     config.consensus_signer = SignMode::Key(Secret::new(poa_secret.into()));
     let compression_config = DaCompressionConfig {
         retention_duration: Duration::from_secs(3600),
+        override_starting_height: None,
         metrics: false,
     };
     config.da_compression = DaCompressionMode::Enabled(compression_config.clone());
@@ -161,6 +165,7 @@ async fn da_compressed_blocks_are_available_from_non_block_producing_nodes() {
     let mut config = Config::local_node();
     config.da_compression = DaCompressionMode::Enabled(DaCompressionConfig {
         retention_duration: Duration::from_secs(3600),
+        override_starting_height: None,
         metrics: false,
     });
 
@@ -234,6 +239,7 @@ async fn da_compression__starts_and_compresses_blocks_correctly_from_empty_datab
     // when: the node is restarted with compression enabled, and blocks are produced
     config.da_compression = DaCompressionMode::Enabled(DaCompressionConfig {
         retention_duration: Duration::from_secs(3600),
+        override_starting_height: None,
         metrics: false,
     });
     let srv = FuelService::from_combined_database(db, config)
@@ -259,6 +265,72 @@ async fn da_compression__starts_and_compresses_blocks_correctly_from_empty_datab
     }
 
     for height in blocks_to_produce + 1..=blocks_to_produce * 2 {
+        let compressed_block = client.da_compressed_block(height.into()).await.unwrap();
+        assert!(compressed_block.is_some());
+    }
+}
+
+#[tokio::test]
+async fn da_compression__starts_and_compresses_blocks_correctly_with_overriden_height() {
+    // given: the node starts without compression enabled, and produces blocks
+    let db = CombinedDatabase::temp_database_with_state_rewind_policy(
+        StateRewindPolicy::RewindFullRange,
+        DatabaseConfig::config_for_tests(),
+    )
+    .unwrap();
+    let mut rng = StdRng::seed_from_u64(10);
+    let poa_secret = SecretKey::random(&mut rng);
+    let blocks_to_produce = 10;
+
+    let mut config = config_with_fee();
+    config.consensus_signer = SignMode::Key(Secret::new(poa_secret.into()));
+    config.da_compression = DaCompressionMode::Disabled;
+    config.combined_db_config.state_rewind_policy = StateRewindPolicy::NoRewind;
+    let srv = FuelService::from_combined_database(db.clone(), config)
+        .await
+        .unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    let current_height = client
+        .produce_blocks(blocks_to_produce, None)
+        .await
+        .unwrap();
+    assert_eq!(current_height, blocks_to_produce.into());
+
+    let mut config = srv.shared.config.clone();
+
+    // when: the node is restarted with compression enabled, starting height overriden, blocks are produced
+    let override_starting_height = 10;
+    config.da_compression = DaCompressionMode::Enabled(DaCompressionConfig {
+        retention_duration: Duration::from_secs(3600),
+        override_starting_height: Some(
+            NonZeroU32::new(override_starting_height).unwrap(),
+        ),
+        metrics: false,
+    });
+    let srv = FuelService::from_combined_database(db, config)
+        .await
+        .unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    let current_height = client
+        .produce_blocks(blocks_to_produce, None)
+        .await
+        .unwrap();
+    assert_eq!(current_height, BlockHeight::from(blocks_to_produce * 2));
+
+    srv.await_compression_synced_until(&current_height)
+        .await
+        .unwrap();
+
+    // then: the da compressed blocks from height 1 to height override_starting_height
+    // and the da compressed blocks from height override_starting_height to height blocks_to_produce * 2 exist
+    for height in 0..override_starting_height {
+        let compressed_block = client.da_compressed_block(height.into()).await.unwrap();
+        assert!(compressed_block.is_none());
+    }
+
+    for height in override_starting_height..=blocks_to_produce * 2 {
         let compressed_block = client.da_compressed_block(height.into()).await.unwrap();
         assert!(compressed_block.is_some());
     }

--- a/tests/tests/da_compression.rs
+++ b/tests/tests/da_compression.rs
@@ -98,7 +98,9 @@ async fn can_fetch_da_compressed_block_from_graphql() {
             panic!("unexpected result {other:?}")
         }
     };
-    srv.await_compression_synced().await.unwrap();
+    srv.await_compression_synced_until(&block_height)
+        .await
+        .unwrap();
 
     let block = client
         .da_compressed_block(block_height)
@@ -184,7 +186,11 @@ async fn da_compressed_blocks_are_available_from_non_block_producing_nodes() {
     // Insert some txs
     let expected = producer.insert_txs().await;
     validator.consistency_20s(&expected).await;
-    validator.node.await_compression_synced().await.unwrap();
+    validator
+        .node
+        .await_compression_synced_until(&1u32.into())
+        .await
+        .unwrap();
 
     let block_height = 1u32.into();
 
@@ -241,7 +247,9 @@ async fn da_compression__starts_and_compresses_blocks_correctly_from_empty_datab
         .unwrap();
     assert_eq!(current_height, BlockHeight::from(blocks_to_produce * 2));
 
-    srv.await_compression_synced().await.unwrap();
+    srv.await_compression_synced_until(&current_height)
+        .await
+        .unwrap();
 
     // then: the da compressed blocks from height 1 to height blocks_to_produce don't exist
     // and the da compressed blocks from height blocks_to_produce + 1 to height blocks_to_produce * 2 exist


### PR DESCRIPTION
improving error handling, and refining synchronization logic. Key changes include adding an override for the starting block height, improving synchronization methods, and updating error reporting.

### Enhancements to Configurability:
* Added an `override_starting_height` field to `DaCompressionConfig` and `CompressionConfig`, allowing the service to start syncing from a specific block height. (`crates/fuel-core/src/service/config.rs` [[1]](diffhunk://#diff-184f5e785485e92ad26d50d0bbca115a93cd4e76d7d0bafb7052225eb31f0245R366) `crates/services/compression/src/config.rs` [[2]](diffhunk://#diff-5d0b8937548df3be41160e9752c4d383b66f498014e123054aa2ec486b93967aL1-R23) [[3]](diffhunk://#diff-5d0b8937548df3be41160e9752c4d383b66f498014e123054aa2ec486b93967aR37-R41)

### Improvements to Synchronization Logic:
* Updated the `sync_previously_produced_blocks` method to support early exit and handle the `override_starting_height` configuration. (`crates/services/compression/src/service.rs` [crates/services/compression/src/service.rsL224-R259](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L224-R259))
* Modified the `await_synced` method to `await_synced_until`, enabling synchronization up to a specified block height. (`crates/fuel-core/src/service.rs` [[1]](diffhunk://#diff-57d6c5d4dadbd1198f75f2070852e4c27a251e756ed40fb6c214b4d78e4a1ecbL232-R242) `crates/services/compression/src/service.rs` [[2]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L274-R306)

### Error Handling Enhancements:
* Updated `get_block` methods in various components to return `anyhow::Result` instead of `Option`, providing more detailed error information. (`crates/fuel-core/src/service/adapters/compression_adapters.rs` [[1]](diffhunk://#diff-9e66cb09255fa99a40c07b24f3002b040d023c09b9469521b2c8ad8736bf33bfL63-R77) `crates/services/compression/src/ports/block_source.rs` [[2]](diffhunk://#diff-b35ece6e136e2fe3793da56f4456d50692646e9d371946e26024ada643151182L76-R76) `crates/services/compression/src/service.rs` [[3]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L247-R278)

### Test Suite Updates:
* Added new test cases to validate the behavior of the `override_starting_height` configuration and ensure proper synchronization logic. (`crates/services/compression/src/service.rs` [[1]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L607-R665) [[2]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L638-R739)

### Miscellaneous Changes:
* Improved error messages across the codebase to include more context, such as the specific block height or initialization errors. (`crates/services/src/service.rs` [[1]](diffhunk://#diff-daa67623825920672e831440a58a430d60cd713481c0e3b956292030162f569cL405-R405) `crates/services/compression/src/service.rs` [[2]](diffhunk://#diff-9fc61045febb6284fa8e01c5c33172787228fe21b8b813c62c8f03d2fec55fe8L247-R278)