### PR TITLE
docs: update node operator documentation link

### DIFF
--- a/docs/developers/debugging.md
+++ b/docs/developers/debugging.md
@@ -60,7 +60,7 @@ The resulting key pair printed to the console contains an address and secret. Th
 
 The `--network` argument identifies the name of the network to join. The network name is used during peer discovery. For example, users can specify `--network beta-4` to join the Beta 4 network. Similarly, setting the environment variable `NETWORK="beta-4"` will produce the same result.
 
-For more information about client networking, see the Fuel guide on [running a node](https://docs-hub.vercel.app/guides/running-a-node/).
+For more information about client networking, see the Fuel guide on [running a node](https://docs-hub.vercel.app/docs/node-operator/#running-a-node/).
 
 ## Common Issues
 


### PR DESCRIPTION
Update the external documentation link to reflect the new URL structure for the node operator guide.

Changes:
- Update link from @https://docs-hub.vercel.app/guides/running-a-node/ to @https://docs-hub.vercel.app/docs/node-operator/#running-a-node

This change ensures the documentation link points to the correct location of the node operator guide in the new documentation structure.