### PR TITLE
Fix client coins endpoint to return all asset types

### DIFF
--- a/.changes/fixed/2984.md
+++ b/.changes/fixed/2984.md
@@ -1,0 +1,1 @@
+Fix client coins endpoint so that passing `None` for `asset_id` no longer defaults to `AssetId::default()` but correctly returns all asset types.

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1486,10 +1486,7 @@ impl FuelClient {
         request: PaginationRequest<String>,
     ) -> io::Result<PaginatedResult<types::Coin, String>> {
         let owner: schema::Address = (*owner).into();
-        let asset_id: schema::AssetId = match asset_id {
-            Some(asset_id) => (*asset_id).into(),
-            None => schema::AssetId::default(),
-        };
+        let asset_id = asset_id.map(|id| (*id).into());
         let args = CoinsConnectionArgs::from((owner, asset_id, request));
         let query = schema::coins::CoinsQuery::build(args);
 

--- a/crates/client/src/client/schema/coins.rs
+++ b/crates/client/src/client/schema/coins.rs
@@ -59,13 +59,13 @@ pub struct CoinsConnectionArgs {
     pub last: Option<i32>,
 }
 
-impl From<(Address, AssetId, PaginationRequest<String>)> for CoinsConnectionArgs {
-    fn from(r: (Address, AssetId, PaginationRequest<String>)) -> Self {
+impl From<(Address, Option<AssetId>, PaginationRequest<String>)> for CoinsConnectionArgs {
+    fn from(r: (Address, Option<AssetId>, PaginationRequest<String>)) -> Self {
         match r.2.direction {
             PageDirection::Forward => CoinsConnectionArgs {
                 filter: CoinFilterInput {
                     owner: r.0,
-                    asset_id: Some(r.1),
+                    asset_id: r.1,
                 },
                 after: r.2.cursor,
                 before: None,
@@ -75,7 +75,7 @@ impl From<(Address, AssetId, PaginationRequest<String>)> for CoinsConnectionArgs
             PageDirection::Backward => CoinsConnectionArgs {
                 filter: CoinFilterInput {
                     owner: r.0,
-                    asset_id: Some(r.1),
+                    asset_id: r.1,
                 },
                 after: None,
                 before: r.2.cursor,


### PR DESCRIPTION
## Linked Issues/PRs
Closes #2960 

<!-- List of related issues/PRs -->
## Description
<!-- List of detailed changes -->
This PR fixes the behavior of the `coins` endpoint on the client side. Previously, if `asset_id` was `None`, it defaulted to `AssetId::default()`, which is incorrect. The expected behavior (and what the query side already supports) is to return all assets when `asset_id` is `None`.
## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [✓] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
