### PR TITLE
chore(backup): allow backups on a live database

### DIFF
--- a/crates/fuel-core/src/combined_database.rs
+++ b/crates/fuel-core/src/combined_database.rs
@@ -711,7 +711,7 @@ mod tests {
     }
 
     #[test]
-    fn backup__cannot_backup_while_db_is_opened() {
+    fn backup__should_be_successful_if_db_is_already_opened() {
         // given
         let db_dir = TempDir::new().unwrap();
         let mut combined_db = CombinedDatabase::open(
@@ -734,8 +734,8 @@ mod tests {
         // no drop for combined_db
 
         // then
-        CombinedDatabase::backup(db_dir.path(), backup_dir.path())
-            .expect_err("Backup should fail");
+        let res = CombinedDatabase::backup(db_dir.path(), backup_dir.path());
+        assert!(res.is_ok());
 
         // cleanup
         std::fs::remove_dir_all(db_dir.path()).unwrap();


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- needed for some infra work with @tirkesi

## Description
<!-- List of detailed changes -->
Small changes
- when we open a database for backup, we now open in read-only mode, allowing database writes to occur while the backup is in progress
- increase parallelism for the backup process, improving performance

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
