### PR TITLE
Make txpool pre-conf broadcast conditional on there being some txs in the list

### DIFF
--- a/.changes/fixed/2987.md
+++ b/.changes/fixed/2987.md
@@ -1,0 +1,1 @@
+Make txpool pre-conf broadcast conditional on there being some txs in the list

--- a/crates/services/executor/src/executor.rs
+++ b/crates/services/executor/src/executor.rs
@@ -777,7 +777,7 @@ where
             .into_iter()
             .take(remaining_tx_count as usize)
             .peekable();
-        let mut status = vec![];
+        let mut statuses = vec![];
         while regular_tx_iter.peek().is_some() {
             for transaction in regular_tx_iter {
                 let tx_id = transaction.id(&self.consensus_params.chain_id());
@@ -818,10 +818,10 @@ where
                                 *block.header.height(),
                                 data.tx_count,
                             );
-                        status.push(preconfirmation_status);
+                        statuses.push(preconfirmation_status);
                     }
                     Err(err) => {
-                        status.push(Preconfirmation {
+                        statuses.push(Preconfirmation {
                             tx_id,
                             status: PreconfirmationStatus::SqueezedOut {
                                 reason: err.to_string(),
@@ -830,7 +830,7 @@ where
                         data.skipped_transactions.push((tx_id, err));
                     }
                 }
-                status = self.preconfirmation_sender.try_send(status);
+                statuses = self.preconfirmation_sender.try_send(statuses);
                 remaining_gas_limit = block_gas_limit.saturating_sub(data.used_gas);
                 remaining_block_transaction_size_limit =
                     block_transaction_size_limit.saturating_sub(data.used_size);
@@ -847,8 +847,8 @@ where
                 .take(remaining_tx_count as usize)
                 .peekable();
         }
-        if !status.is_empty() {
-            self.preconfirmation_sender.send(status).await;
+        if !statuses.is_empty() {
+            self.preconfirmation_sender.send(statuses).await;
         }
 
         Ok(())

--- a/crates/services/executor/src/ports.rs
+++ b/crates/services/executor/src/ports.rs
@@ -41,6 +41,7 @@ use core::future::Future;
 
 /// The wrapper around either `Transaction` or `CheckedTransaction`.
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
 pub enum MaybeCheckedTransaction {
     CheckedTransaction(CheckedTransaction, ConsensusParametersVersion),
     Transaction(fuel_tx::Transaction),

--- a/crates/services/p2p/src/service.rs
+++ b/crates/services/p2p/src/service.rs
@@ -960,9 +960,9 @@ where
                     }
                     Some(TaskRequest::BroadcastPreConfirmations(pre_confirmation_message)) => {
                         let broadcast = GossipsubBroadcastRequest::TxPreConfirmations(pre_confirmation_message);
-                        let result = self.p2p_service.publish_message(broadcast);
+                        let result = self.p2p_service.publish_message(broadcast.clone());
                         if let Err(e) = result {
-                            tracing::error!("Got an error during pre-confirmation message broadcasting {}", e);
+                            tracing::error!("Got an error during pre-confirmation message broadcasting {:?}: {}", broadcast, e);
                         }
                     }
                     Some(TaskRequest::GetSealedHeaders { block_height_range, channel}) => {

--- a/crates/services/txpool_v2/src/pool.rs
+++ b/crates/services/txpool_v2/src/pool.rs
@@ -253,8 +253,10 @@ where
                 (removed_tx_id, status.clone())
             })
             .collect::<Vec<_>>();
-        self.tx_status_manager
-            .squeezed_out_txs(removed_transactions);
+        if !removed_transactions.is_empty() {
+            self.tx_status_manager
+                .squeezed_out_txs(removed_transactions);
+        }
 
         self.update_stats();
         Ok(())
@@ -637,9 +639,10 @@ where
                 }));
             }
         }
-
-        self.tx_status_manager
-            .squeezed_out_txs(removed_transactions);
+        if !removed_transactions.is_empty() {
+            self.tx_status_manager
+                .squeezed_out_txs(removed_transactions);
+        }
         self.update_stats();
     }
 
@@ -677,15 +680,16 @@ where
                 // It's not needed to inform the status manager about the skipped transaction herself
                 // because he give the information but we need to inform him about the dependents
                 // that will be deleted
-                let iter = removed
+                let removed_txs: Vec<_> = removed
                     .into_iter()
                     .map(|data| {
                         let tx_id = data.transaction.id();
-
                         (tx_id, tx_status.clone())
                     })
                     .collect();
-                self.tx_status_manager.squeezed_out_txs(iter);
+                if !removed_txs.is_empty() {
+                    self.tx_status_manager.squeezed_out_txs(removed_txs);
+                }
             }
         }
 

--- a/tests/tests/preconfirmations_gossip.rs
+++ b/tests/tests/preconfirmations_gossip.rs
@@ -95,7 +95,6 @@ async fn preconfirmation__propagate_p2p_after_successful_execution() {
         .flat_map(|op| u32::from(*op).to_be_bytes())
         .collect();
 
-    // Given
     let tx = TransactionBuilder::script(script, vec![])
         .script_gas_limit(gas_limit)
         .add_unsigned_coin_input(


### PR DESCRIPTION
## Related Issues
closes https://github.com/FuelLabs/fuel-core/issues/2988

## Description
<!-- List of detailed changes -->
We noticed many messages while running in production that said:
```
│ stamp":"2025-05-01T20:41:55.374539Z","level":"ERROR","fields":{"message":"Got an error during pre-confirmation message broadcasting Duplicate"},"target":"fu │
```
After some finagling I was able to reproduce this in the integ tests and I added additional tracing to find that those duplicate messages were empty (no pre-confirmations were included).

I found that the txpool was sending these pre-confirmation batches because it would just send on every iteration regardless if any were squeezed out or not.

After preventing this from happening, by checking that the batch wasn't empty first, the error log disappeared. 

### Does this solve the problem in production?

In prod, we would see the log message every time a new tx was submitted. This probably was happening due to the `insert_inner` method that would always call:
```rs
            self.tx_status_manager
                .squeezed_out_txs(removed_transactions);
```
and generate another  empty pre-confirmation which would be considered a duplicate.

Just in case, I have left the extra log information in that tracing log which will give us details on the actual duplicate message:
```rs
                        let result = self.p2p_service.publish_message(broadcast.clone());
                        if let Err(e) = result {
                            tracing::error!("Got an error during pre-confirmation message broadcasting {:?}: {}", broadcast, e);
                        }
``` 
