### PR TITLE
fix(port|compression_service): prevent syncing from genesis if compression db is empty

### DIFF
--- a/.changes/fixed/2989.md
+++ b/.changes/fixed/2989.md
@@ -1,0 +1,1 @@
+Prevent syncing compression database from genesis if override cli arg `--da-compression-starting-height` is provided.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+## [Version 0.43.2]
+
+### Fixed
+
+- [2978](https://github.com/FuelLabs/fuel-core/pull/2978): Add method to override starting syncing height for compression service if starting from scratch.
+
 ## [Version 0.43.1]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3394,7 +3394,7 @@ dependencies = [
  "fuel-core-trace",
  "fuel-core-tx-status-manager",
  "fuel-core-txpool",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -3449,7 +3449,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-sync",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "hex",
  "itertools 0.12.1",
@@ -3472,11 +3472,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.43.1"
+version = "0.43.2"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3491,7 +3491,7 @@ dependencies = [
  "fuel-core-poa",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "hex",
  "humantime",
  "itertools 0.12.1",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3522,7 +3522,7 @@ dependencies = [
  "educe",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "insta",
  "itertools 0.12.1",
  "parquet",
@@ -3540,14 +3540,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cynic",
  "derive_more 0.99.19",
  "eventsource-client",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -3564,23 +3564,23 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "clap",
  "fuel-core-client",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fuel-core-compression",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "paste",
  "postcard",
  "proptest",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-compression-service"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3604,7 +3604,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "paste",
  "rand 0.8.5",
@@ -3619,30 +3619,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3650,7 +3650,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "hex",
  "humantime-serde",
@@ -3668,12 +3668,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "parking_lot",
  "serde",
  "tracing",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3689,7 +3689,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "fuel-gas-price-algorithm",
  "futures",
  "mockito",
@@ -3709,14 +3709,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "mockall",
  "rayon",
  "test-case",
@@ -3726,18 +3726,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "clap",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3775,7 +3775,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "hex",
  "hickory-resolver",
@@ -3798,17 +3798,17 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-parallel-executor"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "fuel-core-storage",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "fuel-core-upgradable-executor",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3817,7 +3817,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "mockall",
  "rand 0.8.5",
  "serde",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "mockall",
  "proptest",
  "rand 0.8.5",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3864,7 +3864,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "mockall",
  "once_cell",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3908,7 +3908,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -3924,13 +3924,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "fuel-vm 0.60.2",
  "impl-tools",
  "itertools 0.12.1",
@@ -3948,13 +3948,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "mockall",
  "rand 0.8.5",
@@ -3990,7 +3990,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "ctor",
  "tracing",
@@ -4028,14 +4028,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-tx-status-manager"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-tx-status-manager",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "mockall",
  "parking_lot",
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4060,7 +4060,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "lru 0.13.0",
  "mockall",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4101,7 +4101,7 @@ dependencies = [
  "ed25519",
  "ed25519-dalek",
  "educe",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "fuel-vm 0.60.2",
  "k256",
  "postcard",
@@ -4115,13 +4115,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "derive_more 0.99.19",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "fuel-core-wasm-executor",
  "futures",
  "parking_lot",
@@ -4132,13 +4132,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "postcard",
  "proptest",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "proptest",
  "rand 0.8.5",
@@ -9832,7 +9832,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.43.1",
+ "fuel-core-types 0.43.2",
  "futures",
  "itertools 0.12.1",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,44 +61,44 @@ keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
 rust-version = "1.85.0"
-version = "0.43.1"
+version = "0.43.2"
 
 [workspace.dependencies]
 # Workspace members
-fuel-core = { version = "0.43.1", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.43.1", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.43.1", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.43.1", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.43.1", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.43.1", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.43.1", path = "./crates/client" }
-fuel-core-compression = { version = "0.43.1", path = "./crates/compression" }
-fuel-core-compression-service = { version = "0.43.1", path = "./crates/services/compression" }
-fuel-core-database = { version = "0.43.1", path = "./crates/database" }
-fuel-core-metrics = { version = "0.43.1", path = "./crates/metrics" }
-fuel-core-services = { version = "0.43.1", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.43.1", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.43.1", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.43.1", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.43.1", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.43.1", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.43.1", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.43.1", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.43.1", path = "./crates/services/p2p" }
-fuel-core-parallel-executor = { version = "0.43.1", path = "./crates/services/parallel-executor" }
-fuel-core-producer = { version = "0.43.1", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.43.1", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.43.1", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.43.1", path = "./crates/services/txpool_v2" }
-fuel-core-tx-status-manager = { version = "0.43.1", path = "./crates/services/tx_status_manager" }
-fuel-core-storage = { version = "0.43.1", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.43.1", path = "./crates/trace" }
-fuel-core-types = { version = "0.43.1", path = "./crates/types", default-features = false }
+fuel-core = { version = "0.43.2", path = "./crates/fuel-core", default-features = false }
+fuel-core-client-bin = { version = "0.43.2", path = "./bin/fuel-core-client" }
+fuel-core-bin = { version = "0.43.2", path = "./bin/fuel-core" }
+fuel-core-keygen = { version = "0.43.2", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.43.2", path = "./bin/keygen" }
+fuel-core-chain-config = { version = "0.43.2", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.43.2", path = "./crates/client" }
+fuel-core-compression = { version = "0.43.2", path = "./crates/compression" }
+fuel-core-compression-service = { version = "0.43.2", path = "./crates/services/compression" }
+fuel-core-database = { version = "0.43.2", path = "./crates/database" }
+fuel-core-metrics = { version = "0.43.2", path = "./crates/metrics" }
+fuel-core-services = { version = "0.43.2", path = "./crates/services" }
+fuel-core-consensus-module = { version = "0.43.2", path = "./crates/services/consensus_module" }
+fuel-core-bft = { version = "0.43.2", path = "./crates/services/consensus_module/bft" }
+fuel-core-poa = { version = "0.43.2", path = "./crates/services/consensus_module/poa" }
+fuel-core-shared-sequencer = { version = "0.43.2", path = "crates/services/shared-sequencer" }
+fuel-core-executor = { version = "0.43.2", path = "./crates/services/executor", default-features = false }
+fuel-core-importer = { version = "0.43.2", path = "./crates/services/importer" }
+fuel-core-gas-price-service = { version = "0.43.2", path = "crates/services/gas_price_service" }
+fuel-core-p2p = { version = "0.43.2", path = "./crates/services/p2p" }
+fuel-core-parallel-executor = { version = "0.43.2", path = "./crates/services/parallel-executor" }
+fuel-core-producer = { version = "0.43.2", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.43.2", path = "./crates/services/relayer" }
+fuel-core-sync = { version = "0.43.2", path = "./crates/services/sync" }
+fuel-core-txpool = { version = "0.43.2", path = "./crates/services/txpool_v2" }
+fuel-core-tx-status-manager = { version = "0.43.2", path = "./crates/services/tx_status_manager" }
+fuel-core-storage = { version = "0.43.2", path = "./crates/storage", default-features = false }
+fuel-core-trace = { version = "0.43.2", path = "./crates/trace" }
+fuel-core-types = { version = "0.43.2", path = "./crates/types", default-features = false }
 fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.43.1", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.43.1", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-upgradable-executor = { version = "0.43.2", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.43.2", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
 fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.43.1", path = "crates/fuel-gas-price-algorithm" }
+fuel-gas-price-algorithm = { version = "0.43.2", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
 fuel-vm-private = { version = "0.60.2", package = "fuel-vm", default-features = false }

--- a/bin/fuel-core/chainspec/local-testnet/chain_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/chain_config.json
@@ -304,7 +304,7 @@
       "privileged_address": "9f0e19d6c2a6283a3222426ab2630d35516b1799b503f37b02105bebe1b8a3e9"
     }
   },
-  "genesis_state_transition_version": 27,
+  "genesis_state_transition_version": 28,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "e0a9fcde1b73f545252e01b30b50819eb9547d07531fa3df0385c5695736634d",

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -82,7 +82,10 @@ use rlimit::{
 use std::{
     env,
     net,
-    num::NonZeroU64,
+    num::{
+        NonZeroU32,
+        NonZeroU64,
+    },
     path::PathBuf,
     str::FromStr,
     time::Duration,
@@ -238,6 +241,10 @@ pub struct Command {
     #[arg(long = "da-compression", env)]
     pub da_compression: Option<humantime::Duration>,
 
+    /// The starting height of the compression service.
+    #[arg(long = "da-compression-starting-height", env)]
+    pub da_compression_starting_height: Option<NonZeroU32>,
+
     /// A new block is produced instantly when transactions are available.
     #[clap(flatten)]
     pub poa_trigger: PoATriggerArgs,
@@ -341,6 +348,7 @@ impl Command {
             #[cfg(feature = "aws-kms")]
             consensus_aws_kms,
             da_compression,
+            da_compression_starting_height,
             poa_trigger,
             predefined_blocks_path,
             coinbase_recipient,
@@ -556,6 +564,7 @@ impl Command {
             Some(retention_duration) => DaCompressionMode::Enabled(
                 fuel_core::service::config::DaCompressionConfig {
                     retention_duration: retention_duration.into(),
+                    starting_height: da_compression_starting_height,
                     metrics: metrics.is_enabled(Module::Compression),
                 },
             ),

--- a/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
+++ b/crates/chain-config/src/config/snapshots/fuel_core_chain_config__config__chain__tests__snapshot_local_testnet_config.snap
@@ -308,7 +308,7 @@ expression: json
       "privileged_address": "0000000000000000000000000000000000000000000000000000000000000000"
     }
   },
-  "genesis_state_transition_version": 27,
+  "genesis_state_transition_version": 28,
   "consensus": {
     "PoAV2": {
       "genesis_signing_key": "22ec92c3105c942a6640bdc4e4907286ec4728e8cfc0d8ac59aad4d8e1ccaefb",

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -40,7 +40,10 @@ use fuel_core_storage::{
         StorageChanges,
     },
 };
-use fuel_core_types::blockchain::consensus::Consensus;
+use fuel_core_types::{
+    blockchain::consensus::Consensus,
+    fuel_types::BlockHeight,
+};
 
 use crate::{
     combined_database::{
@@ -229,10 +232,14 @@ impl FuelService {
         Ok(())
     }
 
-    /// Wait for the compression service to be in sync with L2 height
-    pub async fn await_compression_synced(&self) -> anyhow::Result<()> {
+    /// Waits until the compression service has synced
+    /// with the given block height
+    pub async fn await_compression_synced_until(
+        &self,
+        block_height: &BlockHeight,
+    ) -> anyhow::Result<()> {
         if let Some(sync_observer) = &self.runner.shared.compression {
-            sync_observer.await_synced().await?;
+            sync_observer.await_synced_until(block_height).await?;
         }
         Ok(())
     }

--- a/crates/fuel-core/src/service/adapters/compression_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/compression_adapters.rs
@@ -60,10 +60,9 @@ impl block_source::BlockSource for CompressionBlockImporterAdapter {
         self.block_importer.events_shared_result()
     }
 
-    fn get_block(&self, height: BlockAt) -> Option<SharedImportResult> {
+    fn get_block(&self, height: BlockAt) -> anyhow::Result<SharedImportResult> {
         self.import_result_provider_adapter
             .result_at_height(height.into())
-            .ok()
     }
 }
 
@@ -71,7 +70,11 @@ impl configuration::CompressionConfigProvider
     for crate::service::config::DaCompressionConfig
 {
     fn config(&self) -> config::CompressionConfig {
-        config::CompressionConfig::new(self.retention_duration, self.metrics)
+        config::CompressionConfig::new(
+            self.retention_duration,
+            self.starting_height,
+            self.metrics,
+        )
     }
 }
 

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -1,6 +1,9 @@
 use clap::ValueEnum;
 use std::{
-    num::NonZeroU64,
+    num::{
+        NonZeroU32,
+        NonZeroU64,
+    },
     path::PathBuf,
     time::Duration,
 };
@@ -360,6 +363,7 @@ impl GasPriceConfig {
 pub struct DaCompressionConfig {
     pub retention_duration: Duration,
     pub metrics: bool,
+    pub starting_height: Option<NonZeroU32>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/services/compression/src/config.rs
+++ b/crates/services/compression/src/config.rs
@@ -1,17 +1,26 @@
-use std::time::Duration;
+use std::{
+    num::NonZeroU32,
+    time::Duration,
+};
 
 /// Compression configuration
 #[derive(Debug, Clone, Copy)]
 pub struct CompressionConfig {
     temporal_registry_retention: Duration,
+    starting_height: Option<NonZeroU32>,
     metrics: bool,
 }
 
 impl CompressionConfig {
     /// Create a new compression configuration
-    pub fn new(temporal_registry_retention: Duration, metrics: bool) -> Self {
+    pub fn new(
+        temporal_registry_retention: Duration,
+        starting_height: Option<NonZeroU32>,
+        metrics: bool,
+    ) -> Self {
         Self {
             temporal_registry_retention,
+            starting_height,
             metrics,
         }
     }
@@ -24,6 +33,11 @@ impl CompressionConfig {
     /// Get the metrics configuration
     pub fn metrics(&self) -> bool {
         self.metrics
+    }
+
+    /// Get the override starting height
+    pub fn starting_height(&self) -> Option<u32> {
+        self.starting_height.map(|height| height.get())
     }
 }
 

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -73,5 +73,5 @@ pub trait BlockSource: Send + Sync {
     /// Should provide a stream of blocks with metadata
     fn subscribe(&self) -> BlockStream;
     /// Should provide the block at a given height
-    fn get_block(&self, height: BlockAt) -> Option<BlockWithMetadata>;
+    fn get_block(&self, height: BlockAt) -> anyhow::Result<BlockWithMetadata>;
 }

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -215,39 +215,88 @@ where
     }
 }
 
+#[derive(Debug)]
+enum SyncHeight {
+    StorageHeight(u32),
+    ConfiguredHeight(u32),
+    Genesis,
+}
+
+impl SyncHeight {
+    #[inline]
+    const fn value(&self) -> u32 {
+        match self {
+            SyncHeight::StorageHeight(height) => *height,
+            SyncHeight::ConfiguredHeight(height) => *height,
+            SyncHeight::Genesis => 0,
+        }
+    }
+
+    #[inline]
+    const fn is_from_storage(&self) -> bool {
+        matches!(self, SyncHeight::StorageHeight(_))
+    }
+}
+
 impl<B, S, CH> UninitializedCompressionService<B, S, CH>
 where
     B: BlockSource,
     S: CompressionStorage + LatestHeight,
     CH: CanonicalHeight,
 {
-    async fn sync_previously_produced_blocks(&mut self) -> crate::Result<()> {
-        let canonical_height = self.canonical_height.get();
+    async fn sync_previously_produced_blocks(
+        &mut self,
+        state_watcher: &StateWatcher,
+    ) -> crate::Result<()> {
         loop {
-            let storage_height = self.storage.latest_height();
-
-            if canonical_height < storage_height {
-                return Err(crate::errors::CompressionError::FailedToGetSyncStatus);
-            }
-
-            if canonical_height == storage_height {
+            // allows early exit if the service is stopping
+            let state = state_watcher.borrow();
+            if !state.starting() {
                 break;
             }
 
-            let next_block_height = storage_height.map(|height| height.saturating_add(1));
-
-            let next_block_height = match next_block_height {
-                Some(block_height) => BlockAt::Specific(block_height),
-                None => BlockAt::Genesis,
+            let canonical_height = match self.canonical_height.get() {
+                Some(height) => height,
+                None => {
+                    // fuel-core started for first time,
+                    // no need to backfill blocks
+                    break;
+                }
             };
 
-            let block_with_metadata = self
-                .block_source
-                .get_block(next_block_height)
-                .ok_or(crate::errors::CompressionError::FailedToGetBlock(format!(
-                    "during synchronization of canonical chain at height: {:?}",
-                    next_block_height
-                )))?;
+            let maybe_height =
+                match (self.storage.latest_height(), self.config.starting_height()) {
+                    (Some(height), _) => SyncHeight::StorageHeight(height),
+                    (None, Some(height)) => SyncHeight::ConfiguredHeight(height),
+                    (None, None) => SyncHeight::Genesis,
+                };
+
+            if canonical_height < maybe_height.value() {
+                tracing::error!("Canonical height is less than fetched height: Canonical height: {:?}, Fetched height: {:?}", &canonical_height, &maybe_height);
+                return Err(crate::errors::CompressionError::FailedToGetSyncStatus);
+            }
+
+            if canonical_height == maybe_height.value() && maybe_height.is_from_storage()
+            {
+                tracing::info!("Compression database is up to date");
+                break;
+            }
+
+            let height_to_sync = match maybe_height {
+                SyncHeight::Genesis => BlockAt::Genesis,
+                SyncHeight::StorageHeight(height) => {
+                    BlockAt::Specific(height.saturating_add(1))
+                }
+                SyncHeight::ConfiguredHeight(height) => BlockAt::Specific(height),
+            };
+
+            let block_with_metadata =
+                self.block_source.get_block(height_to_sync).map_err(|err| {
+                    crate::errors::CompressionError::FailedToGetBlock(format!(
+                        "during synchronization of canonical chain at height: {:?}: {}",
+                        height_to_sync, err
+                    ))
+                })?;
 
             handle_new_block(
                 &mut self.storage,
@@ -271,11 +320,11 @@ pub struct SharedData {
 
 impl SharedData {
     /// Waits until the compression service has synced
-    /// with current l2 block height
-    pub async fn await_synced(&self) -> crate::Result<()> {
+    /// with the given block height
+    pub async fn await_synced_until(&self, block_height: &u32) -> crate::Result<()> {
         let mut observer = self.sync_observer.clone();
         loop {
-            if observer.borrow_and_update().is_synced() {
+            if observer.borrow_and_update().is_synced_until(block_height) {
                 break;
             }
 
@@ -309,10 +358,10 @@ where
 
     async fn into_task(
         mut self,
-        _state_watcher: &StateWatcher,
+        state_watcher: &StateWatcher,
         _params: Self::TaskParams,
     ) -> anyhow::Result<Self::Task> {
-        self.sync_previously_produced_blocks().await?;
+        self.sync_previously_produced_blocks(state_watcher).await?;
 
         let compression_service = CompressionService::new(
             self.block_source.subscribe(),
@@ -362,7 +411,7 @@ where
 
     async fn shutdown(mut self) -> anyhow::Result<()> {
         // gracefully handle all the remaining blocks in the stream and then stop
-        while let Some(block_with_metadata) = self.block_stream.next().await {
+        if let Some(Some(block_with_metadata)) = self.block_stream.next().now_or_never() {
             if let Err(e) = self.handle_new_block(&block_with_metadata) {
                 return Err(anyhow::anyhow!(e).context(format!(
                     "Couldn't compress block: {}. Shutting down. \
@@ -401,6 +450,8 @@ where
 #[allow(non_snake_case)]
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use super::*;
     use crate::{
         ports::block_source::{
@@ -443,8 +494,8 @@ mod tests {
         fn get_block(
             &self,
             _: crate::ports::block_source::BlockAt,
-        ) -> Option<BlockWithMetadata> {
-            None
+        ) -> anyhow::Result<BlockWithMetadata> {
+            anyhow::bail!("Block not found")
         }
     }
 
@@ -475,8 +526,15 @@ mod tests {
         fn default() -> Self {
             Self(crate::config::CompressionConfig::new(
                 std::time::Duration::from_secs(10),
+                None,
                 false,
             ))
+        }
+    }
+
+    impl MockConfigProvider {
+        fn new(config: crate::config::CompressionConfig) -> Self {
+            Self(config)
         }
     }
 
@@ -497,7 +555,10 @@ mod tests {
 
     impl CanonicalHeight for MockCanonicalHeightProvider {
         fn get(&self) -> Option<u32> {
-            Some(self.0)
+            match self.0 {
+                0 => None,
+                _ => Some(self.0),
+            }
         }
     }
 
@@ -541,11 +602,12 @@ mod tests {
         fn get_block(
             &self,
             height: crate::ports::block_source::BlockAt,
-        ) -> Option<BlockWithMetadata> {
+        ) -> anyhow::Result<BlockWithMetadata> {
             self.0
                 .iter()
                 .find(|block| height == *block.height())
                 .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Block not found"))
         }
     }
 
@@ -576,6 +638,7 @@ mod tests {
             .get(&0.into())
             .unwrap();
         assert!(maybe_block.is_none());
+        service.shutdown().await.unwrap();
     }
 
     #[tokio::test]
@@ -604,20 +667,23 @@ mod tests {
         let _ = service.run(&mut StateWatcher::started()).await;
 
         // then
-        sync_observer.await_synced().await.unwrap();
+        let target_block_height = 0;
+        sync_observer
+            .await_synced_until(&target_block_height)
+            .await
+            .unwrap();
         let maybe_block = service
             .storage
             .storage_as_ref::<storage::CompressedBlocks>()
-            .get(&0.into())
+            .get(&target_block_height.into())
             .unwrap();
         assert!(maybe_block.is_some());
+        service.shutdown().await.unwrap();
     }
 
     #[tokio::test]
-    async fn compression_service__can_resync_with_canonical_height() {
-        // given
-        // we provide a block source with some old blocks,
-        // and a canonical height provider with a height of 5
+    async fn compression_service__syncs_from_scratch_when_database_is_empty() {
+        // given: we start the compression service, with a canonical height provider of height 5
         let block_count = 10;
         let mut blocks = Vec::with_capacity(block_count);
         for i in 0..u32::try_from(block_count).unwrap() {
@@ -635,18 +701,62 @@ mod tests {
             canonical_height_provider.clone(),
         );
 
-        // when
+        // when: the syncing with canonical height provider occurs
         let service = uninit_service
-            .into_task(&Default::default(), ())
+            .into_task(&StateWatcher::starting(), ())
             .await
             .unwrap();
 
-        // then
+        // then: it has a compressed block for the canonical height
         let maybe_block = service
             .storage
             .storage_as_ref::<storage::CompressedBlocks>()
             .get(&canonical_height_provider.get().unwrap().into())
             .unwrap();
         assert!(maybe_block.is_some());
+        service.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn compression_service__syncs_from_overridden_starting_height_when_provided() {
+        // given: we start the compression service, with a canonical height provider of height 5,
+        // and a config override of starting height 1
+        let block_count = 10;
+        let override_starting_height = 1;
+        let mut blocks = Vec::with_capacity(block_count);
+        for i in 0..u32::try_from(block_count).unwrap() {
+            blocks.push(BlockWithMetadata::test_block_with_height(i));
+        }
+        let block_source = MockBlockSource::new(blocks);
+        let storage = test_storage();
+        let config_provider =
+            MockConfigProvider::new(crate::config::CompressionConfig::new(
+                std::time::Duration::from_secs(10),
+                Some(NonZeroU32::new(override_starting_height).unwrap()),
+                false,
+            ));
+        let canonical_height_provider = MockCanonicalHeightProvider::new(5);
+
+        let uninit_service = UninitializedCompressionService::new(
+            block_source,
+            storage,
+            config_provider.config(),
+            canonical_height_provider.clone(),
+        );
+
+        // when: the syncing with canonical height provider occurs
+        let service = uninit_service
+            .into_task(&StateWatcher::starting(), ())
+            .await
+            .unwrap();
+
+        // then: it has a block for the overridden starting height
+        let maybe_block = service
+            .storage
+            .storage_as_ref::<storage::CompressedBlocks>()
+            .get(&override_starting_height.into())
+            .unwrap();
+        assert!(maybe_block.is_some());
+        service.shutdown().await.unwrap();
     }
 }

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -272,7 +272,11 @@ where
                 };
 
             if canonical_height < maybe_height.value() {
-                tracing::error!("Canonical height is less than fetched height: Canonical height: {:?}, Fetched height: {:?}", &canonical_height, &maybe_height);
+                tracing::error!(
+                    "Canonical height is less than fetched height: Canonical height: {:?}, Fetched height: {:?}",
+                    &canonical_height,
+                    &maybe_height
+                );
                 return Err(crate::errors::CompressionError::FailedToGetSyncStatus);
             }
 

--- a/crates/services/compression/src/sync_state.rs
+++ b/crates/services/compression/src/sync_state.rs
@@ -12,8 +12,8 @@ pub enum SyncState {
 }
 
 impl SyncState {
-    pub(crate) fn is_synced(&self) -> bool {
-        matches!(self, Self::Synced(_))
+    pub(crate) fn is_synced_until(&self, height: &BlockHeight) -> bool {
+        matches!(self, Self::Synced(h) if h >= height)
     }
 }
 

--- a/crates/services/src/service.rs
+++ b/crates/services/src/service.rs
@@ -403,7 +403,7 @@ async fn run<S>(
     let mut task = service
         .into_task(&state, params)
         .await
-        .unwrap_or_else(|_| panic!("The initialization of {} failed", S::NAME));
+        .unwrap_or_else(|e| panic!("The initialization of {} failed: {}", S::NAME, e));
 
     sender.send_if_modified(|s| {
         if s.starting() {

--- a/crates/services/src/state.rs
+++ b/crates/services/src/state.rs
@@ -68,6 +68,13 @@ impl StateWatcher {
         core::mem::forget(sender);
         Self(receiver)
     }
+
+    /// Create a new `StateWatcher` with the `State::Starting` state.
+    pub fn starting() -> Self {
+        let (sender, receiver) = watch::channel(State::Starting);
+        core::mem::forget(sender);
+        Self(receiver)
+    }
 }
 
 impl StateWatcher {

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -240,7 +240,8 @@ impl<S, R> Executor<S, R> {
         // this is fine because only devnet was upgraded to 0.42.0 before this.
         ("0-41-10", 25),
         ("0-43-0", 26),
-        ("0-43-1", LATEST_STATE_TRANSITION_VERSION),
+        ("0-43-1", 27),
+        ("0-43-2", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/crates/types/src/blockchain/header.rs
+++ b/crates/types/src/blockchain/header.rs
@@ -330,7 +330,7 @@ pub type ConsensusParametersVersion = u32;
 pub type StateTransitionBytecodeVersion = u32;
 
 /// The latest version of the state transition bytecode.
-pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 27;
+pub const LATEST_STATE_TRANSITION_VERSION: StateTransitionBytecodeVersion = 28;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/tests/tests/da_compression.rs
+++ b/tests/tests/da_compression.rs
@@ -38,6 +38,7 @@ use fuel_core_types::{
         Input,
         UniqueIdentifier,
     },
+    fuel_types::BlockHeight,
     secrecy::Secret,
     signer::SignMode,
 };
@@ -52,6 +53,7 @@ use test_helpers::{
         SigningAccount,
     },
     config_with_fee,
+    fuel_core_driver::FuelCoreDriver,
 };
 
 #[tokio::test]
@@ -63,6 +65,7 @@ async fn can_fetch_da_compressed_block_from_graphql() {
     config.consensus_signer = SignMode::Key(Secret::new(poa_secret.into()));
     let compression_config = DaCompressionConfig {
         retention_duration: Duration::from_secs(3600),
+        starting_height: None,
         metrics: false,
     };
     config.da_compression = DaCompressionMode::Enabled(compression_config.clone());
@@ -92,7 +95,9 @@ async fn can_fetch_da_compressed_block_from_graphql() {
             panic!("unexpected result {other:?}")
         }
     };
-    srv.await_compression_synced().await.unwrap();
+    srv.await_compression_synced_until(&block_height)
+        .await
+        .unwrap();
 
     let block = client
         .da_compressed_block(block_height)
@@ -153,6 +158,7 @@ async fn da_compressed_blocks_are_available_from_non_block_producing_nodes() {
     let mut config = Config::local_node();
     config.da_compression = DaCompressionMode::Enabled(DaCompressionConfig {
         retention_duration: Duration::from_secs(3600),
+        starting_height: None,
         metrics: false,
     });
 
@@ -178,7 +184,11 @@ async fn da_compressed_blocks_are_available_from_non_block_producing_nodes() {
     // Insert some txs
     let expected = producer.insert_txs().await;
     validator.consistency_20s(&expected).await;
-    validator.node.await_compression_synced().await.unwrap();
+    validator
+        .node
+        .await_compression_synced_until(&1u32.into())
+        .await
+        .unwrap();
 
     let block_height = 1u32.into();
 
@@ -188,4 +198,130 @@ async fn da_compressed_blocks_are_available_from_non_block_producing_nodes() {
         .unwrap()
         .expect("Compressed block not available from validator");
     let _: VersionedCompressedBlock = postcard::from_bytes(&compressed_block).unwrap();
+}
+
+#[tokio::test]
+async fn da_compression__starts_and_compresses_blocks_correctly_from_empty_database() {
+    // given: the node starts without compression enabled, and produces blocks
+    let args = vec!["--state-rewind-duration", "7d", "--debug"];
+    let driver = FuelCoreDriver::spawn(&args).await.unwrap();
+
+    let blocks_to_produce = 10;
+    let current_height = driver
+        .client
+        .produce_blocks(blocks_to_produce, None)
+        .await
+        .unwrap();
+    assert_eq!(current_height, blocks_to_produce.into());
+
+    let db = driver.kill().await;
+
+    // when: the node is restarted with compression enabled, and blocks are produced
+    let args = vec!["--da-compression", "7d", "--debug"];
+    let driver = FuelCoreDriver::spawn_with_directory(db, &args)
+        .await
+        .unwrap();
+
+    let current_height = driver
+        .client
+        .produce_blocks(blocks_to_produce, None)
+        .await
+        .unwrap();
+    assert_eq!(current_height, BlockHeight::from(blocks_to_produce * 2));
+
+    driver
+        .node
+        .await_compression_synced_until(&current_height)
+        .await
+        .unwrap();
+
+    // then: the da compressed blocks from genesis to height blocks_to_produce exist
+    for height in 0..=blocks_to_produce {
+        let compressed_block = driver
+            .client
+            .da_compressed_block(height.into())
+            .await
+            .unwrap();
+        assert!(
+            compressed_block.is_some(),
+            "DA compressed block at height {} is missing",
+            height
+        );
+    }
+
+    // teardown
+    driver.kill().await;
+}
+
+#[tokio::test]
+async fn da_compression__starts_and_compresses_blocks_correctly_with_overridden_height() {
+    // given: the node starts without compression enabled, and produces blocks
+    let args = vec!["--state-rewind-duration", "7d", "--debug"];
+    let driver = FuelCoreDriver::spawn(&args).await.unwrap();
+
+    let blocks_to_produce = 10;
+
+    let current_height = driver
+        .client
+        .produce_blocks(blocks_to_produce, None)
+        .await
+        .unwrap();
+    assert_eq!(current_height, blocks_to_produce.into());
+
+    let db = driver.kill().await;
+
+    // when: the node is restarted with compression enabled, starting height overridden, blocks are produced
+    let override_starting_height = 10;
+    let override_starting_height_str = format!("{}", override_starting_height);
+    let args = vec![
+        "--da-compression",
+        "7d",
+        "--da-compression-starting-height",
+        &override_starting_height_str,
+        "--debug",
+    ];
+    let driver = FuelCoreDriver::spawn_with_directory(db, &args)
+        .await
+        .unwrap();
+
+    let current_height = driver
+        .client
+        .produce_blocks(blocks_to_produce, None)
+        .await
+        .unwrap();
+    assert_eq!(current_height, BlockHeight::from(blocks_to_produce * 2));
+
+    driver
+        .node
+        .await_compression_synced_until(&current_height)
+        .await
+        .unwrap();
+
+    // then: the da compressed blocks from height 0 to height override_starting_height don't exist
+    // and the da compressed blocks from height override_starting_height to height blocks_to_produce * 2 exist
+    for height in 0..override_starting_height {
+        let compressed_block = driver
+            .client
+            .da_compressed_block(height.into())
+            .await
+            .unwrap();
+        assert!(
+            compressed_block.is_none(),
+            "DA compressed block at height {} is present",
+            height
+        );
+    }
+
+    for height in override_starting_height..=blocks_to_produce * 2 {
+        let compressed_block = driver
+            .client
+            .da_compressed_block(height.into())
+            .await
+            .unwrap();
+        assert!(
+            compressed_block.is_some(),
+            "DA compressed block at height {} is missing",
+            height
+        );
+    }
 }

--- a/tests/tests/da_compression.rs
+++ b/tests/tests/da_compression.rs
@@ -324,4 +324,7 @@ async fn da_compression__starts_and_compresses_blocks_correctly_with_overridden_
             height
         );
     }
+
+    // teardown
+    driver.kill().await;
 }


### PR DESCRIPTION
port of #2978, also bumps versions to 0.43.2
