### PR TITLE
fix(graphql): pin the version of assets in the graphql playground

### DIFF
--- a/.changes/fixed/2993.md
+++ b/.changes/fixed/2993.md
@@ -1,0 +1,1 @@
+Pin the graphiql playground to v3, and cache the result to be reused across multiple calls to render the playground.


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
playground broken across various networks due to https://github.com/async-graphql/async-graphql/issues/1703

## Description
<!-- List of detailed changes -->
2 main things - 
- [x] we generate the html body once, and reuse it across calls to `/v1/playground`. previously we were re-rendering the template every time, which might not be a good solution
- [x] in the raw html generated, we pin the versions of the js and css assets distributed by unpkg 

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
