### PR TITLE
chore: Add simple makefile to help people use the right build command

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,7 @@
 [alias]
 xtask = "run --package xtask --"
+build-fuel-core-bin-release = "build --release -p fuel-core-bin --no-default-features --features production"
+build-fuel-core-bin-debug = "build -p fuel-core-bin --no-default-features --features production"
 
 [registries.crates-io]
 protocol = "sparse"

--- a/.changes/added/2994.md
+++ b/.changes/added/2994.md
@@ -1,0 +1,1 @@
+Simple makefile with basic commands.

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ help:
 
 .PHONY: build
 build:
-	cargo build --release -p fuel-core-bin --no-default-features --features production
+	cargo build-fuel-core-bin-release
 
 .PHONY: debug
 debug:
-	cargo build -p fuel-core-bin --no-default-features --features production
+	cargo build-fuel-core-bin
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.PHONY: help
+help:
+	@echo "Supported make targets:"
+	@echo "  make build        - Build release binary with production features"
+	@echo "  make debug        - Build debug binary with production features"
+	@echo "  make fmt          - Format all code"
+	@echo "  make test         - Run all tests"
+	@echo "  make ci-checks    - Run all CI checks"
+	@echo "  make bench        - Run benchmarks"
+	@echo "  make clean        - Clean build artifacts"
+
+.PHONY: build
+build:
+	cargo build --release -p fuel-core-bin --no-default-features --features production
+
+.PHONY: debug
+debug:
+	cargo build -p fuel-core-bin --no-default-features --features production
+
+.PHONY: fmt
+fmt:
+	cargo +nightly fmt
+
+.PHONY: test
+test:
+	cargo nextest run --all-targets --all-features
+
+.PHONY: ci-checks
+ci-checks:
+	./ci_checks.sh
+
+.PHONY: bench
+bench:
+	cargo bench -p fuel-core-benches
+
+.PHONY: clean
+clean:
+	cargo clean 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ git checkout v0.42.0
 
 Build your node binary:
 ```bash
-cargo build --release --bin fuel-core --no-default-features --features production
+make build
 ```
 
 To run the node follow : https://docs.fuel.network/docs/node-operator/fuel-ignition/mainnet-node/
@@ -94,7 +94,7 @@ git clone https://github.com/FuelLabs/fuel-core.git
 
 Build your node binary:
 ```bash
-cargo build --release --bin fuel-core --no-default-features --features production
+make build
 ```
 
 To run the node follow : https://docs.fuel.network/docs/node-operator/fuel-ignition/local-node/
@@ -103,7 +103,7 @@ To run the node follow : https://docs.fuel.network/docs/node-operator/fuel-ignit
 
 ### Compiling
 
-We recommend using `xtask` to build fuel-core:
+We recommend using `xtask` to build fuel-core for development:
 
 ```sh
 cargo xtask build


### PR DESCRIPTION
This PR adds a simple makefile serving as a quick and easy entry point for new developers wanting to build the latest fuel-core with the appropriate arguments.
