### PR TITLE
fix(parallel-executor): clean up for longer lived vecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3804,6 +3804,7 @@ dependencies = [
  "fuel-core-types 0.43.1",
  "fuel-core-upgradable-executor",
  "futures",
+ "fxhash",
  "rand 0.8.5",
  "tokio",
  "tracing",

--- a/crates/services/parallel-executor/Cargo.toml
+++ b/crates/services/parallel-executor/Cargo.toml
@@ -15,9 +15,14 @@ fuel-core-storage = { workspace = true, features = ["std"] }
 fuel-core-types = { workspace = true, features = ["std"] }
 fuel-core-upgradable-executor = { workspace = true, features = ["std"] }
 futures = { workspace = true, features = ["std"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
-tracing = { workspace = true }
 fxhash = { version = "0.2.1", default-features = false }
+tokio = { workspace = true, features = [
+  "rt-multi-thread",
+  "macros",
+  "sync",
+  "time",
+] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 fuel-core-storage = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/parallel-executor/Cargo.toml
+++ b/crates/services/parallel-executor/Cargo.toml
@@ -15,7 +15,7 @@ fuel-core-storage = { workspace = true, features = ["std"] }
 fuel-core-types = { workspace = true, features = ["std"] }
 fuel-core-upgradable-executor = { workspace = true, features = ["std"] }
 futures = { workspace = true, features = ["std"] }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/services/parallel-executor/Cargo.toml
+++ b/crates/services/parallel-executor/Cargo.toml
@@ -17,6 +17,7 @@ fuel-core-upgradable-executor = { workspace = true, features = ["std"] }
 futures = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing = { workspace = true }
+fxhash = { version = "0.2.1", default-features = false }
 
 [dev-dependencies]
 fuel-core-storage = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/parallel-executor/src/column_adapter.rs
+++ b/crates/services/parallel-executor/src/column_adapter.rs
@@ -1,0 +1,41 @@
+use fuel_core_storage::column::Column;
+
+pub(crate) struct ContractColumnsIterator {
+    index: usize,
+}
+
+impl ContractColumnsIterator {
+    pub fn new() -> Self {
+        Self { index: 0 }
+    }
+
+    fn columns() -> &'static [Column] {
+        static COLUMNS: [Column; 8] = [
+            Column::ContractsRawCode,
+            Column::ContractsState,
+            Column::ContractsLatestUtxo,
+            Column::ContractsAssets,
+            Column::ContractsAssetsMerkleData,
+            Column::ContractsAssetsMerkleMetadata,
+            Column::ContractsStateMerkleData,
+            Column::ContractsStateMerkleMetadata,
+        ];
+        &COLUMNS
+    }
+}
+
+impl Iterator for ContractColumnsIterator {
+    type Item = Column;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let columns = Self::columns();
+
+        if self.index < columns.len() {
+            let column = columns[self.index];
+            self.index += 1;
+            Some(column)
+        } else {
+            None
+        }
+    }
+}

--- a/crates/services/parallel-executor/src/lib.rs
+++ b/crates/services/parallel-executor/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod column_adapter;
 pub mod config;
 pub mod executor;
 pub mod ports;

--- a/crates/services/parallel-executor/src/scheduler.rs
+++ b/crates/services/parallel-executor/src/scheduler.rs
@@ -35,7 +35,6 @@ use ::futures::{
 };
 use fuel_core_storage::{
     Error as StorageError,
-    column::Column,
     transactional::{
         Changes,
         StorageChanges,
@@ -52,11 +51,14 @@ use fuel_core_types::{
 };
 use tokio::runtime::Runtime;
 
-use crate::ports::{
-    Filter,
-    Storage,
-    TransactionFiltered,
-    TransactionsSource,
+use crate::{
+    column_adapter::ContractColumnsIterator,
+    ports::{
+        Filter,
+        Storage,
+        TransactionFiltered,
+        TransactionsSource,
+    },
 };
 
 /// Config for the scheduler
@@ -415,16 +417,7 @@ where
         // Did I listed all column ?
         // Need future proof
         let mut tmp_contracts_changes = HashMap::new();
-        for column in [
-            Column::ContractsRawCode,
-            Column::ContractsState,
-            Column::ContractsLatestUtxo,
-            Column::ContractsAssets,
-            Column::ContractsAssetsMerkleData,
-            Column::ContractsAssetsMerkleMetadata,
-            Column::ContractsStateMerkleData,
-            Column::ContractsStateMerkleMetadata,
-        ] {
+        for column in ContractColumnsIterator::new() {
             let column = column.as_u32();
             if let Some(changes) = res.changes.remove(&column) {
                 tmp_contracts_changes.insert(column, changes);

--- a/crates/services/parallel-executor/src/scheduler.rs
+++ b/crates/services/parallel-executor/src/scheduler.rs
@@ -635,6 +635,7 @@ impl CoinDependencyChainVerifier {
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn get_contracts_and_coins_used(
     batch: &[CheckedTransaction],
 ) -> (Arc<[ContractId]>, Arc<[(UtxoId, usize)]>) {


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->

The function `get_contracts_and_coins_used` returns a vec of elements which isn't really mutated or resized later, so it is more optimal to wrap the data within an `Arc<[T]>`. Cleaned up some of the functions which accepted a whole vec in the input to instead accept an iterator (`verify_coins_used` and `add_changes`)

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
