### PR TITLE
chore(parallel-executor): compressed coin validation

### DIFF
--- a/crates/services/parallel-executor/src/coin.rs
+++ b/crates/services/parallel-executor/src/coin.rs
@@ -1,0 +1,138 @@
+use fuel_core_types::{
+    entities::coins::coin::{
+        CompressedCoin,
+        CompressedCoinV1,
+    },
+    fuel_tx::{
+        Address,
+        AssetId,
+        Input,
+        UtxoId,
+        Word,
+        input::coin::{
+            CoinPredicate,
+            CoinSigned,
+        },
+    },
+};
+
+/// can either be a predicate coin or a signed coin
+#[derive(Debug)]
+enum Variant {
+    Predicate,
+    Signed,
+}
+
+#[derive(Debug)]
+pub(crate) struct CoinInBatch {
+    /// The utxo id
+    utxo_id: UtxoId,
+    /// The index of the transaction using this coin in the batch
+    idx: usize,
+    /// the owner of the coin
+    owner: Address,
+    /// the amount stored in the coin
+    amount: Word,
+    /// the asset the coin stores
+    asset_id: AssetId,
+    /// variant
+    variant: Variant,
+}
+
+impl CoinInBatch {
+    pub(crate) fn utxo(&self) -> &UtxoId {
+        &self.utxo_id
+    }
+
+    pub(crate) fn idx(&self) -> usize {
+        self.idx
+    }
+
+    pub(crate) fn from_signed_coin(signed_coin: &CoinSigned, idx: usize) -> Self {
+        let CoinSigned {
+            utxo_id,
+            owner,
+            amount,
+            asset_id,
+            ..
+        } = signed_coin;
+
+        CoinInBatch {
+            utxo_id: *utxo_id,
+            idx,
+            owner: *owner,
+            amount: *amount,
+            asset_id: *asset_id,
+            variant: Variant::Signed,
+        }
+    }
+
+    pub(crate) fn from_predicate_coin(
+        predicate_coin: &CoinPredicate,
+        idx: usize,
+    ) -> Self {
+        let CoinPredicate {
+            utxo_id,
+            owner,
+            amount,
+            asset_id,
+            ..
+        } = predicate_coin;
+
+        CoinInBatch {
+            utxo_id: *utxo_id,
+            idx,
+            owner: *owner,
+            amount: *amount,
+            asset_id: *asset_id,
+            variant: Variant::Predicate,
+        }
+    }
+}
+
+impl From<CoinInBatch> for CompressedCoin {
+    fn from(value: CoinInBatch) -> Self {
+        let CoinInBatch {
+            owner,
+            amount,
+            asset_id,
+            ..
+        } = value;
+
+        CompressedCoin::V1(CompressedCoinV1 {
+            owner,
+            amount,
+            asset_id,
+            tx_pointer: Default::default(), // purposely left blank
+        })
+    }
+}
+
+impl From<&CoinInBatch> for Input {
+    fn from(value: &CoinInBatch) -> Self {
+        let CoinInBatch {
+            utxo_id,
+            owner,
+            amount,
+            asset_id,
+            ..
+        } = value;
+
+        match value.variant {
+            Variant::Signed => Input::CoinSigned(CoinSigned {
+                utxo_id: *utxo_id,
+                owner: *owner,
+                amount: *amount,
+                asset_id: *asset_id,
+                ..Default::default()
+            }),
+            Variant::Predicate => Input::CoinPredicate(CoinPredicate {
+                utxo_id: *utxo_id,
+                owner: *owner,
+                amount: *amount,
+                asset_id: *asset_id,
+                ..Default::default()
+            }),
+        }
+    }
+}

--- a/crates/services/parallel-executor/src/coin.rs
+++ b/crates/services/parallel-executor/src/coin.rs
@@ -17,13 +17,13 @@ use fuel_core_types::{
 };
 
 /// can either be a predicate coin or a signed coin
-#[derive(Debug)]
-enum Variant {
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum Variant {
     Predicate,
     Signed,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq)]
 pub(crate) struct CoinInBatch {
     /// The utxo id
     utxo_id: UtxoId,
@@ -39,6 +39,17 @@ pub(crate) struct CoinInBatch {
     variant: Variant,
 }
 
+impl PartialEq for CoinInBatch {
+    fn eq(&self, other: &Self) -> bool {
+        self.utxo() == other.utxo()
+            && self.owner() == other.owner()
+            && self.amount() == other.amount()
+            && self.asset_id() == other.asset_id()
+            && self.variant() == other.variant()
+        // we don't include the idx here
+    }
+}
+
 impl CoinInBatch {
     pub(crate) fn utxo(&self) -> &UtxoId {
         &self.utxo_id
@@ -46,6 +57,22 @@ impl CoinInBatch {
 
     pub(crate) fn idx(&self) -> usize {
         self.idx
+    }
+
+    pub(crate) fn owner(&self) -> &Address {
+        &self.owner
+    }
+
+    pub(crate) fn amount(&self) -> &Word {
+        &self.amount
+    }
+
+    pub(crate) fn asset_id(&self) -> &AssetId {
+        &self.asset_id
+    }
+
+    pub(crate) fn variant(&self) -> Variant {
+        self.variant
     }
 
     pub(crate) fn from_signed_coin(signed_coin: &CoinSigned, idx: usize) -> Self {

--- a/crates/services/parallel-executor/src/lib.rs
+++ b/crates/services/parallel-executor/src/lib.rs
@@ -1,4 +1,5 @@
-pub mod column_adapter;
+pub(crate) mod coin;
+pub(crate) mod column_adapter;
 pub mod config;
 pub mod executor;
 pub mod ports;

--- a/crates/services/parallel-executor/src/scheduler.rs
+++ b/crates/services/parallel-executor/src/scheduler.rs
@@ -567,7 +567,7 @@ where
 }
 
 struct CoinDependencyChainVerifier {
-    coins_registered: FxHashMap<UtxoId, (usize, usize)>,
+    coins_registered: FxHashMap<UtxoId, (usize, CoinInBatch)>,
 }
 
 impl CoinDependencyChainVerifier {
@@ -583,8 +583,7 @@ impl CoinDependencyChainVerifier {
         coins_created: Vec<CoinInBatch>,
     ) {
         for coin in coins_created {
-            self.coins_registered
-                .insert(*coin.utxo(), (batch_id, coin.idx()));
+            self.coins_registered.insert(*coin.utxo(), (batch_id, coin));
         }
     }
 
@@ -624,7 +623,7 @@ impl CoinDependencyChainVerifier {
                         Some((coin_creation_batch_id, coin_creation_tx_idx)) => {
                             // Coin is in the block
                             if coin_creation_batch_id <= &batch_id
-                                && coin_creation_tx_idx <= &coin.idx()
+                                && coin_creation_tx_idx.idx() <= coin.idx()
                             {
                                 // Coin is created in a batch that is before the current one
                             } else {


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
closes https://github.com/FuelLabs/fuel-core/issues/2996

## Description
<!-- List of detailed changes -->
This pull request introduces a new `CoinInBatch` struct to encapsulate coin-related data and replaces the previous tuple-based representation of coins in the `parallel-executor` module. 

### Introduction of `CoinInBatch` struct:
* [`crates/services/parallel-executor/src/coin.rs`](diffhunk://#diff-d9a514e87bb0920ce48dc225aa9e274b40f77a516334df0edfbfcd4ce0b8c856R1-R138): Added the `CoinInBatch` struct, which encapsulates coin data such as `utxo_id`, `owner`, `amount`, `asset_id`, and its variant (`Signed` or `Predicate`). Implemented methods for constructing `CoinInBatch` from `CoinSigned` and `CoinPredicate`, as well as conversions to `CompressedCoin` and `Input`.

### Refactoring to use `CoinInBatch`:
* [`crates/services/parallel-executor/src/scheduler.rs`](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L159-R163): Replaced all instances of `(UtxoId, usize)` with `CoinInBatch` in the `WorkSessionExecutionResult` and `WorkSessionSavedData` structs, as well as in the `CoinDependencyChainVerifier`. Updated methods like `register_coins_created` and `verify_coins_used` to work with the new struct. [[1]](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L159-R163) [[2]](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L178-R182) [[3]](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L569-R570) [[4]](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L582-R648)

### Updates to coin dependency verification:
* [`crates/services/parallel-executor/src/scheduler.rs`](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L582-R648): Enhanced the `verify_coins_used` method to validate coins using the `CoinInBatch` struct. Added logic to compare `CoinInBatch` instances with database coins and verify their validity.

### Integration of `CoinInBatch` in batch processing:
* [`crates/services/parallel-executor/src/scheduler.rs`](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L641-R660): Updated the `get_contracts_and_coins_used` function to construct `CoinInBatch` instances from `CoinSigned` and `CoinPredicate` inputs during batch processing. [[1]](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L641-R660) [[2]](diffhunk://#diff-bda48bcdc8ef69f69b955b2d196981ee95ef75d85c7d7438438d22ad4110ba42L653-R675)

### Module organization:
* [`crates/services/parallel-executor/src/lib.rs`](diffhunk://#diff-ae71c4af5cfc6793160ece59523c9f21c5097593c6667898583b09b3443c8c80L1-R2): Added the new `coin` module to the project and made it accessible within the crate.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
