### PR TITLE
chore: Update fuel-vm to 0.61.1

### DIFF
--- a/.changes/breaking/3002.md
+++ b/.changes/breaking/3002.md
@@ -1,0 +1,1 @@
+Update `fuel-vm` to `0.61.1`. In doing this, we've changed Receipts to use the `SubId` scalar type for sub asset IDs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,24 +3338,24 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da0b560abd7105b17c363d4c7eb7113c5d012c80ee37548b27909acd1b18d1c"
+checksum = "0a0cf2db7794fe5171442d9cd926dc3c8e3e96021187a49415109d37a2e8f5c0"
 dependencies = [
  "bitflags 2.9.0",
- "fuel-types 0.60.2",
+ "fuel-types 0.61.1",
  "serde",
  "strum 0.24.1",
 ]
 
 [[package]]
 name = "fuel-compression"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b56ceef5e2ea5f63e61fb890c732c80676ae53878019145b49344f31c38d950"
+checksum = "04a9de6507ced02b055afee1980028efb1b1967e39a1614cdb95f912d47f9927"
 dependencies = [
- "fuel-derive 0.60.2",
- "fuel-types 0.60.2",
+ "fuel-derive 0.61.1",
+ "fuel-types 0.61.1",
  "serde",
 ]
 
@@ -3931,7 +3931,7 @@ dependencies = [
  "enum-iterator",
  "fuel-core-storage",
  "fuel-core-types 0.43.1",
- "fuel-vm 0.60.2",
+ "fuel-vm 0.61.1",
  "impl-tools",
  "itertools 0.12.1",
  "mockall",
@@ -4102,7 +4102,7 @@ dependencies = [
  "ed25519-dalek",
  "educe",
  "fuel-core-types 0.43.1",
- "fuel-vm 0.60.2",
+ "fuel-vm 0.61.1",
  "k256",
  "postcard",
  "rand 0.8.5",
@@ -4164,16 +4164,16 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bbb6ef7a5451f4e73b6a4811ed176e902af141d1b7006f5132ffee5fde86883"
+checksum = "18dc617d0a28aa64ef36c9c9957411fdc5cb20ac25bf939372710fef187026ad"
 dependencies = [
  "base64ct",
  "coins-bip32",
  "coins-bip39",
  "ecdsa",
  "ed25519-dalek",
- "fuel-types 0.60.2",
+ "fuel-types 0.61.1",
  "k256",
  "p256",
  "rand 0.8.5",
@@ -4197,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982cdb2e97a5831621b47562a4ed88fecb9797605b2077c7f30d1ffbb63d4958"
+checksum = "b3c492975e6e0d7921c737bc228a15956ea651987ee07b213c58f45a66e10edb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4235,13 +4235,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3848d4c7d0485554eb8280b3b3da67e56dc01fb6f31af1a994f9e453989117cf"
+checksum = "8b5e20f8b92a95f2926675285ca368dd03ed4898f09c78273cfddbc35d92a1d2"
 dependencies = [
  "derive_more 0.99.19",
  "digest 0.10.7",
- "fuel-storage 0.60.2",
+ "fuel-storage 0.61.1",
  "hashbrown 0.13.2",
  "hex",
  "serde",
@@ -4268,9 +4268,9 @@ checksum = "4c1b711f28553ddc5f3546711bd220e144ce4c1af7d9e9a1f70b2f20d9f5b791"
 
 [[package]]
 name = "fuel-storage"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d874d57e5ccaa1ad80f39304a9e50dcc0ced5aad3710730fcb629a55ab478f5"
+checksum = "1d7acf0ee9bac45dcd0c03412170c1e8fd3d922770b7c4adba866844d8969cfb"
 
 [[package]]
 name = "fuel-tx"
@@ -4296,18 +4296,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-tx"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50239ffd36450fe7a520a13ed23e26cc9caedb7ac24fa65f5b02e1af8074da09"
+checksum = "c01fc4c2d864dc86c395b18b7a6c1316d7a5b4cb505710e80409a1a05f9e5f81"
 dependencies = [
  "bitflags 2.9.0",
  "derive_more 1.0.0",
  "educe",
- "fuel-asm 0.60.2",
+ "fuel-asm 0.61.1",
  "fuel-compression",
- "fuel-crypto 0.60.2",
- "fuel-merkle 0.60.2",
- "fuel-types 0.60.2",
+ "fuel-crypto 0.61.1",
+ "fuel-merkle 0.61.1",
+ "fuel-types 0.61.1",
  "hashbrown 0.14.5",
  "itertools 0.10.5",
  "postcard",
@@ -4330,11 +4330,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2d9bc4981b2ecf6896577dd569ce1d9a86bf88352f8c3f7618fe5c910c5176"
+checksum = "c6f64373530c9254e3a5e91c70009c7440692b7daebfdfa2532891c997236c23"
 dependencies = [
- "fuel-derive 0.60.2",
+ "fuel-derive 0.61.1",
  "hex",
  "rand 0.8.5",
  "serde",
@@ -4373,9 +4373,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.60.2"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676037dcbf91d010288c6c75eca649cb0064673aa81341a3d3c6f8198e45776b"
+checksum = "b55bef3d760f262c72c1e110d6a752752d2c4bf3a04a67e11e729e4a2538e42d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4384,13 +4384,13 @@ dependencies = [
  "derive_more 0.99.19",
  "educe",
  "ethnum",
- "fuel-asm 0.60.2",
+ "fuel-asm 0.61.1",
  "fuel-compression",
- "fuel-crypto 0.60.2",
- "fuel-merkle 0.60.2",
- "fuel-storage 0.60.2",
- "fuel-tx 0.60.2",
- "fuel-types 0.60.2",
+ "fuel-crypto 0.61.1",
+ "fuel-merkle 0.61.1",
+ "fuel-storage 0.61.1",
+ "fuel-tx 0.61.1",
+ "fuel-types 0.61.1",
  "hashbrown 0.14.5",
  "itertools 0.10.5",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
 fuel-gas-price-algorithm = { version = "0.43.1", path = "crates/fuel-gas-price-algorithm" }
 
 # Fuel dependencies
-fuel-vm-private = { version = "0.60.2", package = "fuel-vm", default-features = false }
+fuel-vm-private = { version = "0.61.1", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"

--- a/benches/benches/block_target_gas.rs
+++ b/benches/benches/block_target_gas.rs
@@ -94,6 +94,7 @@ use fuel_core_types::{
     },
     services::executor::TransactionExecutionResult,
 };
+use fuel_types::SubAssetId;
 use rand::SeedableRng;
 use utils::{
     make_u128,
@@ -332,7 +333,7 @@ fn service_with_many_contracts(
             .unwrap();
 
         let mut storage_key = primitive_types::U256::zero();
-        let mut sub_id = Bytes32::zeroed();
+        let mut sub_id = SubAssetId::zeroed();
         database
             .init_contract_balances(
                 contract_id,

--- a/benches/benches/vm_set/blockchain.rs
+++ b/benches/benches/vm_set/blockchain.rs
@@ -108,7 +108,7 @@ impl BenchDb {
         )?;
 
         let mut storage_key = primitive_types::U256::zero();
-        let mut sub_id = Bytes32::zeroed();
+        let mut sub_id = SubAssetId::zeroed();
         database.init_contract_balances(
             contract_id,
             (0..state_size).map(|k| {

--- a/crates/client/assets/schema.sdl
+++ b/crates/client/assets/schema.sdl
@@ -1201,7 +1201,7 @@ type Receipt {
 	Set in the case of a Panic receipt to indicate a missing contract input id
 	"""
 	contractId: ContractId
-	subId: Bytes32
+	subId: SubId
 }
 
 enum ReceiptType {

--- a/crates/client/src/client/schema/primitives.rs
+++ b/crates/client/src/client/schema/primitives.rs
@@ -111,7 +111,7 @@ fuel_type_scalar!(BlockId, Bytes32);
 fuel_type_scalar!(AssetId, AssetId);
 fuel_type_scalar!(BlobId, BlobId);
 fuel_type_scalar!(ContractId, ContractId);
-fuel_type_scalar!(SubId, Bytes32);
+fuel_type_scalar!(SubId, SubAssetId);
 fuel_type_scalar!(Salt, Salt);
 fuel_type_scalar!(TransactionId, Bytes32);
 fuel_type_scalar!(RelayedTransactionId, Bytes32);

--- a/crates/client/src/client/schema/tx/transparent_receipt.rs
+++ b/crates/client/src/client/schema/tx/transparent_receipt.rs
@@ -3,10 +3,13 @@ use crate::client::schema::{
     AssetId,
     Bytes32,
     ContractId,
-    ConversionError,
-    ConversionError::MissingField,
+    ConversionError::{
+        self,
+        MissingField,
+    },
     HexString,
     Nonce,
+    SubId,
     U64,
     schema,
 };
@@ -45,7 +48,7 @@ pub struct Receipt {
     pub recipient: Option<Address>,
     pub nonce: Option<Nonce>,
     pub contract_id: Option<ContractId>,
-    pub sub_id: Option<Bytes32>,
+    pub sub_id: Option<SubId>,
 }
 
 #[derive(cynic::Enum, Clone, Copy, Debug)]

--- a/crates/client/src/client/types/asset.rs
+++ b/crates/client/src/client/types/asset.rs
@@ -1,13 +1,13 @@
 use crate::client::schema;
 use fuel_core_types::{
-    fuel_tx::Bytes32,
+    fuel_tx::SubAssetId,
     fuel_types::ContractId,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct AssetDetail {
     pub contract_id: ContractId,
-    pub sub_id: Bytes32,
+    pub sub_id: SubAssetId,
     pub total_supply: u128,
 }
 

--- a/crates/fuel-core/src/graphql_api/indexation/asset_metadata.rs
+++ b/crates/fuel-core/src/graphql_api/indexation/asset_metadata.rs
@@ -97,7 +97,7 @@ where
         receipt => {
             return Err(IndexationError::UnexpectedReceipt {
                 receipt: receipt.to_string(),
-            })
+            });
         }
     };
     Ok(new_supply)
@@ -110,10 +110,10 @@ mod tests {
         transactional::WriteTransaction,
     };
     use fuel_core_types::fuel_tx::{
-        Bytes32,
         ContractId,
         ContractIdExt,
         Receipt,
+        SubAssetId,
     };
 
     use crate::{
@@ -145,7 +145,7 @@ mod tests {
 
         const ASSET_METADATA_IS_ENABLED: bool = true;
 
-        let sub_id: Bytes32 = Bytes32::from([1u8; 32]);
+        let sub_id = SubAssetId::from([1u8; 32]);
         let contract_id: ContractId = ContractId::from([2u8; 32]);
         let contract_asset_id = contract_id.asset_id(&sub_id);
         const MINT_AMOUNT: u64 = 3;
@@ -189,7 +189,7 @@ mod tests {
 
         const ASSET_METADATA_IS_DISABLED: bool = false;
 
-        let sub_id: Bytes32 = Bytes32::from([1u8; 32]);
+        let sub_id = SubAssetId::from([1u8; 32]);
         let contract_id: ContractId = ContractId::from([2u8; 32]);
         let contract_asset_id = contract_id.asset_id(&sub_id);
         const MINT_AMOUNT: u64 = 3;

--- a/crates/fuel-core/src/graphql_api/storage/assets.rs
+++ b/crates/fuel-core/src/graphql_api/storage/assets.rs
@@ -7,10 +7,12 @@ use fuel_core_storage::{
     },
     structured_storage::TableWithBlueprint,
 };
-use fuel_core_types::fuel_tx::{
-    AssetId,
-    Bytes32,
-    ContractId,
+use fuel_core_types::{
+    fuel_tx::{
+        AssetId,
+        ContractId,
+    },
+    fuel_types::SubAssetId,
 };
 
 /// Asset info table to store information about the asset like total minted amounts,
@@ -20,7 +22,7 @@ pub struct AssetsInfo;
 #[derive(Default, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AssetDetails {
     pub contract_id: ContractId,
-    pub sub_id: Bytes32,
+    pub sub_id: SubAssetId,
     pub total_supply: u128,
 }
 

--- a/crates/fuel-core/src/schema/scalars.rs
+++ b/crates/fuel-core/src/schema/scalars.rs
@@ -7,8 +7,10 @@ use async_graphql::{
     connection::CursorType,
 };
 use fuel_core_types::{
-    fuel_types,
-    fuel_types::BlockHeight,
+    fuel_types::{
+        self,
+        BlockHeight,
+    },
     tai64::Tai64,
 };
 use std::{
@@ -300,7 +302,7 @@ fuel_type_scalar!("BlockId", BlockId, Bytes32, 32);
 fuel_type_scalar!("AssetId", AssetId, AssetId, 32);
 fuel_type_scalar!("BlobId", BlobId, BlobId, 32);
 fuel_type_scalar!("ContractId", ContractId, ContractId, 32);
-fuel_type_scalar!("SubId", SubId, Bytes32, 32);
+fuel_type_scalar!("SubId", SubId, SubAssetId, 32);
 fuel_type_scalar!("Salt", Salt, Salt, 32);
 fuel_type_scalar!("TransactionId", TransactionId, Bytes32, 32);
 fuel_type_scalar!("RelayedTransactionId", RelayedTransactionId, Bytes32, 32);

--- a/crates/fuel-core/src/schema/tx/receipt.rs
+++ b/crates/fuel-core/src/schema/tx/receipt.rs
@@ -5,6 +5,7 @@ use crate::schema::scalars::{
     ContractId,
     HexString,
     Nonce,
+    SubId,
     U64,
 };
 use async_graphql::{
@@ -142,7 +143,7 @@ impl Receipt {
     async fn contract_id(&self) -> Option<ContractId> {
         self.0.contract_id().map(|id| ContractId(*id))
     }
-    async fn sub_id(&self) -> Option<Bytes32> {
+    async fn sub_id(&self) -> Option<SubId> {
         self.0.sub_id().copied().map(Into::into)
     }
 }
@@ -246,14 +247,14 @@ pub fn all_receipts() -> Vec<fuel_tx::Receipt> {
                 vec![5; 30],
             ),
             ReceiptType::Mint => fuel_tx::Receipt::mint(
-                fuel_tx::Bytes32::from([1u8; 32]),
+                fuel_tx::SubAssetId::from([1u8; 32]),
                 fuel_tx::ContractId::from([2u8; 32]),
                 3,
                 4,
                 5,
             ),
             ReceiptType::Burn => fuel_tx::Receipt::burn(
-                fuel_tx::Bytes32::from([1u8; 32]),
+                fuel_tx::SubAssetId::from([1u8; 32]),
                 fuel_tx::ContractId::from([2u8; 32]),
                 3,
                 4,

--- a/crates/services/txpool_v2/src/tests/tests_pool.rs
+++ b/crates/services/txpool_v2/src/tests/tests_pool.rs
@@ -1119,7 +1119,7 @@ fn insert__tx_with_predicate_without_enough_gas() {
     assert!(matches!(
         err,
         Error::ConsensusValidity(CheckError::PredicateVerificationFailed(
-            PredicateVerificationFailed::OutOfGas
+            PredicateVerificationFailed::OutOfGas { index: 0 }
         ))
     ));
     universe.assert_pool_integrity(&[]);
@@ -1153,7 +1153,10 @@ fn insert__tx_with_predicate_that_returns_false() {
     assert!(matches!(
         err,
         Error::ConsensusValidity(CheckError::PredicateVerificationFailed(
-            PredicateVerificationFailed::Panic(PanicReason::PredicateReturnedNonOne)
+            PredicateVerificationFailed::Panic {
+                index: 0,
+                reason: PanicReason::PredicateReturnedNonOne
+            }
         ))
     ));
     universe.assert_pool_integrity(&[]);

--- a/crates/storage/src/blueprint/sparse.rs
+++ b/crates/storage/src/blueprint/sparse.rs
@@ -110,7 +110,7 @@ where
         let mut tree: MerkleTree<Nodes, _> = MerkleTree::load(storage, &root)
             .map_err(|err| StorageError::Other(anyhow::anyhow!("{err:?}")))?;
 
-        tree.update(MerkleTreeKey::new(key_bytes), value_bytes)
+        tree.insert(MerkleTreeKey::new(key_bytes), value_bytes)
             .map_err(|err| StorageError::Other(anyhow::anyhow!("{err:?}")))?;
 
         // Generate new metadata for the updated tree
@@ -322,7 +322,7 @@ where
                 "The {} is already initialized",
                 M::column().name()
             )
-            .into())
+            .into());
         }
 
         let encoded_set = set
@@ -398,7 +398,7 @@ where
             .collect_vec();
 
         for (key_bytes, value_bytes) in encoded_set.iter() {
-            tree.update(MerkleTreeKey::new(key_bytes), value_bytes)
+            tree.insert(MerkleTreeKey::new(key_bytes), value_bytes)
                 .map_err(|err| StorageError::Other(anyhow::anyhow!("{err:?}")))?;
         }
         let root = tree.root();

--- a/tests/test-helpers/src/mint_contract.rs
+++ b/tests/test-helpers/src/mint_contract.rs
@@ -18,6 +18,7 @@ use fuel_core_types::{
         Output,
         Receipt,
         StorageSlot,
+        SubAssetId,
         Transaction,
         TransactionBuilder,
         field::Outputs,
@@ -81,7 +82,7 @@ pub async fn deploy(
 pub fn mint_tx(
     rng: &mut rand::rngs::StdRng,
     contract_id: ContractId,
-    sub_asset_id: Bytes32,
+    sub_asset_id: SubAssetId,
     amount: u64,
 ) -> Transaction {
     let script = [
@@ -128,7 +129,7 @@ pub async fn mint(
     client: &FuelClient,
     rng: &mut rand::rngs::StdRng,
     contract_id: ContractId,
-    sub_asset_id: Bytes32,
+    sub_asset_id: SubAssetId,
     amount: u64,
 ) -> BlockHeight {
     let tx = mint_tx(rng, contract_id, sub_asset_id, amount);

--- a/tests/tests/assets.rs
+++ b/tests/tests/assets.rs
@@ -15,6 +15,7 @@ use fuel_core_types::{
         ContractIdExt,
         Input,
         Output,
+        SubAssetId,
         TransactionBuilder,
         TxPointer,
         UtxoId,
@@ -126,7 +127,7 @@ async fn asset_info_mint_burn() {
     // When
     // Query asset info before burn
     let initial_supply = client
-        .asset_info(&contract_id.asset_id(&Bytes32::zeroed()))
+        .asset_info(&contract_id.asset_id(&SubAssetId::zeroed()))
         .await
         .unwrap()
         .total_supply;
@@ -173,7 +174,7 @@ async fn asset_info_mint_burn() {
     // When
     // Query asset info after burn
     let final_supply = client
-        .asset_info(&contract_id.asset_id(&Bytes32::zeroed()))
+        .asset_info(&contract_id.asset_id(&SubAssetId::zeroed()))
         .await
         .unwrap()
         .total_supply;

--- a/tests/tests/balances.rs
+++ b/tests/tests/balances.rs
@@ -26,8 +26,8 @@ use fuel_core_poa::Trigger;
 use fuel_core_types::{
     blockchain::primitives::DaBlockHeight,
     fuel_tx::{
-        Bytes32,
         ContractIdExt,
+        SubAssetId,
     },
 };
 use rand::SeedableRng;
@@ -562,7 +562,7 @@ async fn contract_balances_in_the_past() {
     let client = FuelClient::from(srv.bound_address);
 
     // Given
-    let sub_asset_id = Bytes32::new([1u8; 32]);
+    let sub_asset_id = SubAssetId::new([1u8; 32]);
     let amount = 1234;
 
     let (deployed_height, contract_id) = mint_contract::deploy(&client, &mut rng).await;

--- a/tests/tests/tx/predicates.rs
+++ b/tests/tests/tx/predicates.rs
@@ -175,7 +175,7 @@ async fn transaction_with_predicates_that_exhaust_gas_limit_are_rejected() {
 
     assert!(
         err.to_string()
-            .contains("PredicateVerificationFailed(OutOfGas)"),
+            .contains("PredicateVerificationFailed(OutOfGas { index: 0 })"),
         "got unexpected error {err}"
     )
 }


### PR DESCRIPTION
Updates the `fuel-vm` version to `0.61.1` and applies all required breaking changes.