### PR TITLE
feat: Support private keys in coin config and log these if present

### DIFF
--- a/benches/src/bin/tps_bench.rs
+++ b/benches/src/bin/tps_bench.rs
@@ -1,58 +1,25 @@
 // Define arguments
 
 use fuel_core::service::config::Trigger;
-use fuel_core_chain_config::{
-    ChainConfig,
-    CoinConfig,
-    SnapshotMetadata,
-};
+use fuel_core_chain_config::{ChainConfig, CoinConfig, SnapshotMetadata};
 use fuel_core_storage::transactional::AtomicView;
 use fuel_core_types::{
     blockchain::transaction::TransactionExt,
-    fuel_asm::{
-        GMArgs,
-        GTFArgs,
-        RegId,
-        op,
-    },
-    fuel_crypto::{
-        coins_bip32::ecdsa::signature::Signer,
-        *,
-    },
+    fuel_asm::{GMArgs, GTFArgs, RegId, op},
+    fuel_crypto::{coins_bip32::ecdsa::signature::Signer, *},
     fuel_tx::{
-        AssetId,
-        Finalizable,
-        Input,
-        Output,
-        Transaction,
-        TransactionBuilder,
-        input::coin::{
-            CoinPredicate,
-            CoinSigned,
-        },
+        AssetId, Finalizable, Input, Output, Transaction, TransactionBuilder,
+        input::coin::{CoinPredicate, CoinSigned},
     },
-    fuel_types::{
-        Immediate12,
-        Immediate18,
-    },
+    fuel_types::{Immediate12, Immediate18},
     fuel_vm::{
-        checked_transaction::{
-            CheckPredicateParams,
-            EstimatePredicates,
-        },
+        checked_transaction::{CheckPredicateParams, EstimatePredicates},
         interpreter::MemoryInstance,
         predicate::EmptyStorage,
     },
 };
-use rand::{
-    Rng,
-    SeedableRng,
-    rngs::StdRng,
-};
-use test_helpers::builder::{
-    TestContext,
-    TestSetupBuilder,
-};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use test_helpers::builder::{TestContext, TestSetupBuilder};
 fn checked_parameters() -> CheckPredicateParams {
     let metadata = SnapshotMetadata::read("./local-testnet").unwrap();
     let chain_conf = ChainConfig::from_snapshot_metadata(&metadata).unwrap();
@@ -174,7 +141,7 @@ fn main() {
                         output_index: utxo_id.output_index(),
                         tx_pointer_block_height: tx_pointer.block_height(),
                         tx_pointer_tx_idx: tx_pointer.tx_index(),
-                        owner,
+                        owner: owner.into(),
                         amount,
                         asset_id,
                     })

--- a/bin/fuel-core/chainspec/local-testnet/state_config.json
+++ b/bin/fuel-core/chainspec/local-testnet/state_config.json
@@ -5,7 +5,7 @@
       "output_index": 0,
       "tx_pointer_block_height": 0,
       "tx_pointer_tx_idx": 0,
-      "owner": "6b63804cfbf9856e68e5b6e7aef238dc8311ec55bec04df774003a2c96e0418e",
+      "owner_secret": "de97d8624a438121b86a1956544bd72ed68cd69f2c99555b08b1e8c51ffd511c",
       "amount": 1152921504606846976,
       "asset_id": "f8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07"
     },

--- a/bin/fuel-core/src/cli.rs
+++ b/bin/fuel-core/src/cli.rs
@@ -4,10 +4,9 @@ use fuel_core::{
     upgradable_executor,
 };
 use fuel_core_chain_config::{
-    ChainConfig,
-    SnapshotReader,
-    StateConfig,
+    ChainConfig, Owner, SnapshotReader, StateConfig
 };
+use fuel_core_types::fuel_tx::Address;
 use std::{
     env,
     path::PathBuf,
@@ -166,6 +165,16 @@ pub fn local_testnet_reader() -> SnapshotReader {
         include_bytes!("../chainspec/local-testnet/state_config.json");
 
     let state_config: StateConfig = serde_json::from_slice(TESTNET_STATE_CONFIG).unwrap();
+
+    for coin in &state_config.coins {
+        let amount = coin.amount;
+        let (address, secret) = match coin.owner {
+            Owner::Address(address) => (address.to_string(), "not provided".to_string()),
+            Owner::SecretKey(secret) => (Address::from(coin.owner.clone()).to_string(), secret.to_string()),
+        };
+
+        tracing::info!(amount, address, secret, "Reading genesis coin");
+    }
 
     SnapshotReader::new_in_memory(local_testnet_chain_config(), state_config)
 }

--- a/crates/chain-config/src/config/coin.rs
+++ b/crates/chain-config/src/config/coin.rs
@@ -1,30 +1,13 @@
 use crate::GenesisCommitment;
-use fuel_core_storage::{
-    MerkleRoot,
-    tables::Coins,
-};
+use fuel_core_storage::{MerkleRoot, tables::Coins};
 use fuel_core_types::{
-    entities::coins::coin::{
-        Coin,
-        CompressedCoin,
-        CompressedCoinV1,
-    },
+    entities::coins::coin::{Coin, CompressedCoin, CompressedCoinV1},
     fuel_crypto::Hasher,
-    fuel_tx::{
-        TxPointer,
-        UtxoId,
-    },
-    fuel_types::{
-        Address,
-        AssetId,
-        BlockHeight,
-        Bytes32,
-    },
+    fuel_tx::{TxPointer, UtxoId},
+    fuel_types::{Address, AssetId, BlockHeight, Bytes32},
+    fuel_vm::SecretKey,
 };
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use serde::{Deserialize, Serialize};
 
 use super::table_entry::TableEntry;
 
@@ -38,7 +21,8 @@ pub struct CoinConfig {
     /// used if coin is forked from another chain to preserve id & tx_pointer
     /// The index of the originating tx within `tx_pointer_block_height`
     pub tx_pointer_tx_idx: u16,
-    pub owner: Address,
+    #[serde(flatten)]
+    pub owner: Owner,
     pub amount: u64,
     pub asset_id: AssetId,
 }
@@ -50,7 +34,7 @@ impl From<TableEntry<Coins>> for CoinConfig {
             output_index: value.key.output_index(),
             tx_pointer_block_height: value.value.tx_pointer().block_height(),
             tx_pointer_tx_idx: value.value.tx_pointer().tx_index(),
-            owner: *value.value.owner(),
+            owner: (*value.value.owner()).into(),
             amount: *value.value.amount(),
             asset_id: *value.value.asset_id(),
         }
@@ -62,7 +46,7 @@ impl From<CoinConfig> for TableEntry<Coins> {
         Self {
             key: UtxoId::new(config.tx_id, config.output_index),
             value: CompressedCoin::V1(CompressedCoinV1 {
-                owner: config.owner,
+                owner: config.owner.into(),
                 amount: config.amount,
                 asset_id: config.asset_id,
                 tx_pointer: TxPointer::new(
@@ -121,16 +105,54 @@ impl GenesisCommitment for Coin {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub enum Owner {
+    #[serde(rename = "owner")]
+    Address(Address),
+    #[serde(rename = "owner_secret")]
+    SecretKey(SecretKey),
+}
+
+impl Default for Owner {
+    fn default() -> Self {
+        Self::Address(Address::default())
+    }
+}
+
+impl From<Owner> for Address {
+    fn from(owner: Owner) -> Self {
+        match owner {
+            Owner::Address(address) => address,
+            Owner::SecretKey(secret_key) => {
+                Address::from(<[u8; Address::LEN]>::from(secret_key.public_key().hash()))
+            }
+        }
+    }
+}
+
+impl From<Address> for Owner {
+    fn from(address: Address) -> Self {
+        Self::Address(address)
+    }
+}
+
+impl From<SecretKey> for Owner {
+    fn from(secret: SecretKey) -> Self {
+        Self::SecretKey(secret)
+    }
+}
+
+#[cfg(feature = "test-helpers")]
+impl crate::Randomize for Owner {
+    fn randomize(rng: impl rand::Rng) -> Self {
+        Self::Address(Address::randomize(rng))
+    }
+}
+
 #[cfg(feature = "test-helpers")]
 pub mod coin_config_helpers {
     use crate::CoinConfig;
-    use fuel_core_types::{
-        fuel_types::{
-            Address,
-            Bytes32,
-        },
-        fuel_vm::SecretKey,
-    };
+    use fuel_core_types::{fuel_types::Bytes32, fuel_vm::SecretKey};
 
     type CoinCount = u16;
 
@@ -166,11 +188,9 @@ pub mod coin_config_helpers {
         }
 
         pub fn generate_with(&mut self, secret: SecretKey, amount: u64) -> CoinConfig {
-            let owner = Address::from(*secret.public_key().hash());
-
             CoinConfig {
                 amount,
-                owner,
+                owner: secret.into(),
                 ..self.generate()
             }
         }
@@ -180,10 +200,7 @@ pub mod coin_config_helpers {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fuel_core_types::{
-        fuel_types::Address,
-        fuel_vm::SecretKey,
-    };
+    use fuel_core_types::fuel_vm::SecretKey;
 
     #[test]
     fn test_generate_unique_utxo_id() {
@@ -203,7 +220,7 @@ mod tests {
         let mut generator = coin_config_helpers::CoinConfigGenerator::new();
         let config = generator.generate_with(secret, amount);
 
-        assert_eq!(config.owner, Address::from(*secret.public_key().hash()));
+        assert_eq!(config.owner, secret.into());
         assert_eq!(config.amount, amount);
     }
 }

--- a/crates/fuel-core/src/service/genesis.rs
+++ b/crates/fuel-core/src/service/genesis.rs
@@ -469,12 +469,12 @@ mod tests {
                     output_index: alice_output_index,
                     tx_pointer_block_height: alice_block_created,
                     tx_pointer_tx_idx: alice_block_created_tx_idx,
-                    owner: alice,
+                    owner: alice.into(),
                     amount: alice_value,
                     asset_id: asset_id_alice,
                 },
                 CoinConfig {
-                    owner: bob,
+                    owner: bob.into(),
                     amount: bob_value,
                     asset_id: asset_id_bob,
                     ..Default::default()

--- a/tests/test-helpers/src/builder.rs
+++ b/tests/test-helpers/src/builder.rs
@@ -188,7 +188,7 @@ impl TestSetupBuilder {
                             output_index: utxo_id.output_index(),
                             tx_pointer_block_height: tx_pointer.block_height(),
                             tx_pointer_tx_idx: tx_pointer.tx_index(),
-                            owner: *owner,
+                            owner: (*owner).into(),
                             amount: *amount,
                             asset_id: *asset_id,
                         })

--- a/tests/tests/assemble_tx.rs
+++ b/tests/tests/assemble_tx.rs
@@ -330,9 +330,9 @@ async fn assemble_transaction__transfer_non_based_asset() {
     assert_ne!(base_asset_id, non_base_asset_id);
 
     // Given
-    state_config.coins[0].owner = owner;
+    state_config.coins[0].owner = owner.into();
     state_config.coins[0].asset_id = base_asset_id;
-    state_config.coins[1].owner = owner;
+    state_config.coins[1].owner = owner.into();
     state_config.coins[1].asset_id = non_base_asset_id;
 
     let mut config = Config::local_node_with_configs(chain_config, state_config);
@@ -390,9 +390,9 @@ async fn assemble_transaction__adds_change_output_for_non_required_non_base_bala
     assert_ne!(base_asset_id, non_base_asset_id);
 
     // Given
-    state_config.coins[0].owner = owner;
+    state_config.coins[0].owner = owner.into();
     state_config.coins[0].asset_id = base_asset_id;
-    state_config.coins[1].owner = owner;
+    state_config.coins[1].owner = owner.into();
     state_config.coins[1].asset_id = non_base_asset_id;
 
     let mut config = Config::local_node_with_configs(chain_config, state_config);

--- a/tests/tests/balances.rs
+++ b/tests/tests/balances.rs
@@ -57,7 +57,7 @@ async fn balance() {
         ]
         .into_iter()
         .map(|(owner, amount, asset_id)| CoinConfig {
-            owner,
+            owner: owner.into(),
             amount,
             asset_id,
             ..coin_generator.generate()
@@ -221,7 +221,7 @@ async fn first_5_balances() {
                         ]
                     })
                     .map(|(owner, amount, asset_id)| CoinConfig {
-                        owner: *owner,
+                        owner: (*owner).into(),
                         amount,
                         asset_id,
                         ..coin_generator.generate()
@@ -337,7 +337,7 @@ mod pagination {
                 coin.iter()
                     .flat_map(|(asset_id, amount)| vec![(owner, amount, asset_id)])
                     .map(|(owner, amount, asset_id)| CoinConfig {
-                        owner: *owner,
+                        owner: (*owner).into(),
                         amount: *amount as u64,
                         asset_id: *asset_id,
                         ..coin_generator.generate()

--- a/tests/tests/blob.rs
+++ b/tests/tests/blob.rs
@@ -289,8 +289,8 @@ async fn predicate_can_load_blob() {
 
     let mut state = StateConfig::local_testnet();
 
-    state.coins[0].owner = blob_owner;
-    state.coins[1].owner = predicate_with_blob_owner;
+    state.coins[0].owner = blob_owner.into();
+    state.coins[1].owner = predicate_with_blob_owner.into();
 
     let blob_predicate_account = SigningAccount::Predicate {
         predicate: blob_predicate,

--- a/tests/tests/chain.rs
+++ b/tests/tests/chain.rs
@@ -65,7 +65,7 @@ async fn network_operates_with_non_zero_chain_id() {
         coins: vec![CoinConfig {
             tx_id: *utxo_id.tx_id(),
             output_index: utxo_id.output_index(),
-            owner,
+            owner: owner.into(),
             amount,
             asset_id: AssetId::BASE,
             ..Default::default()
@@ -113,7 +113,7 @@ async fn network_operates_with_non_zero_base_asset_id() {
         coins: vec![CoinConfig {
             tx_id: *utxo_id.tx_id(),
             output_index: utxo_id.output_index(),
-            owner,
+            owner: owner.into(),
             amount,
             asset_id: new_base_asset_id,
             ..Default::default()

--- a/tests/tests/coin.rs
+++ b/tests/tests/coin.rs
@@ -73,7 +73,7 @@ async fn first_5_coins(
     let mut coin_generator = CoinConfigGenerator::new();
     let coins: Vec<_> = (1..10usize)
         .map(|i| CoinConfig {
-            owner,
+            owner: owner.into(),
             amount: i as Word,
             ..coin_generator.generate()
         })
@@ -109,7 +109,7 @@ async fn only_asset_id_filtered_coins() {
     let mut coin_generator = CoinConfigGenerator::new();
     let coins: Vec<_> = (1..10usize)
         .map(|i| CoinConfig {
-            owner,
+            owner: owner.into(),
             amount: i as Word,
             asset_id: if i <= 5 { asset_id } else { Default::default() },
             ..coin_generator.generate()
@@ -147,7 +147,7 @@ async fn get_coins_forwards_backwards(
     // setup test data in the node
     let coins: Vec<_> = (1..11usize)
         .map(|i| CoinConfig {
-            owner,
+            owner: owner.into(),
             amount: i as Word,
             asset_id,
             output_index: i as u16,

--- a/tests/tests/coins.rs
+++ b/tests/tests/coins.rs
@@ -58,7 +58,7 @@ mod coin {
             ]
             .into_iter()
             .map(|(owner, amount, asset_id)| CoinConfig {
-                owner,
+                owner: owner.into(),
                 amount,
                 asset_id,
                 ..coin_generator.generate()
@@ -530,7 +530,7 @@ mod all_coins {
             ]
             .into_iter()
             .map(|(owner, amount, asset_id)| CoinConfig {
-                owner,
+                owner: owner.into(),
                 amount,
                 asset_id,
                 ..coin_generator.generate()

--- a/tests/tests/contract.rs
+++ b/tests/tests/contract.rs
@@ -55,7 +55,7 @@ async fn calling_the_contract_with_enabled_utxo_validation_is_successful() {
             CoinConfig {
                 tx_id: *utxo_id_1.tx_id(),
                 output_index: utxo_id_1.output_index(),
-                owner,
+                owner: owner.into(),
                 amount,
                 asset_id: AssetId::BASE,
                 ..Default::default()
@@ -63,7 +63,7 @@ async fn calling_the_contract_with_enabled_utxo_validation_is_successful() {
             CoinConfig {
                 tx_id: *utxo_id_2.tx_id(),
                 output_index: utxo_id_2.output_index(),
-                owner,
+                owner: owner.into(),
                 amount,
                 asset_id: AssetId::BASE,
                 ..Default::default()

--- a/tests/tests/tx/tx_pointer.rs
+++ b/tests/tests/tx/tx_pointer.rs
@@ -57,7 +57,7 @@ async fn tx_pointer_set_from_genesis_for_coin_and_contract_inputs() {
         output_index: coin_utxo_id.output_index(),
         tx_pointer_block_height: coin_tx_pointer.block_height(),
         tx_pointer_tx_idx: coin_tx_pointer.tx_index(),
-        owner,
+        owner: owner.into(),
         amount,
         asset_id: Default::default(),
     });


### PR DESCRIPTION
This PR extends the `CoinConfig` in the state configuration to hold either an owner address or a private key. Additionally, I've added info logs when the node is started from a local testnet reader to print these.

The purpose is to make it easier to find and keep track of secret keys with funds when running a local node.