### PR TITLE
Update to cargo-sort v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
-      - name: setup binstall
-        uses: taiki-e/install-action@cargo-binstall
       - name: Install Cargo.toml linter
-        run: cargo binstall --no-confirm cargo-sort
+        run: cargo install cargo-sort
       - name: Run Cargo.toml sort check
         run: cargo sort -w --check
       - name: Install Prettier and TOML Plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,19 +80,6 @@ jobs:
         run: cargo install cargo-sort
       - name: Run Cargo.toml sort check
         run: cargo sort -w --check
-      - name: Install Prettier and TOML Plugin
-        run: |
-          # prettier has issues with global installation and plugin discovery. The temporary `package.json` created by `npm init -y` is a workaround.
-          npm init -y > /dev/null 2>&1
-          npm install prettier prettier-plugin-toml
-      - name: Check format of Cargo.toml files
-        run: |
-          if ! npx prettier --check "**/Cargo.toml"; then
-            npx prettier --write "**/Cargo.toml" > /dev/null 2>&1
-            echo "Changes required:"
-            git --no-pager diff
-            exit 1
-          fi
       - uses: FuelLabs/.github/.github/actions/slack-notify-template@master
         if: always() && github.ref == 'refs/heads/master'
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,56 +1,46 @@
 [workspace]
 # Use the new resolver to prevent dev-deps and build-deps from enabling debugging or test features in production.
 members = [
-  "benches",
-  "bin/e2e-test-client",
-  "bin/fuel-core",
-  "bin/fuel-core-client",
-  "bin/keygen",
-  "crates/chain-config",
-  "crates/client",
-  "crates/compression",
-  "crates/database",
-  "crates/fuel-core",
-  "crates/fuel-gas-price-algorithm",
-  "crates/keygen",
-  "crates/metrics",
-  "crates/services",
-  "crates/services/compression",
-  "crates/services/consensus_module",
-  "crates/services/consensus_module/bft",
-  "crates/services/consensus_module/poa",
-  "crates/services/executor",
-  "crates/services/gas_price_service",
-  "crates/services/importer",
-  "crates/services/p2p",
-  "crates/services/parallel-executor",
-  "crates/services/producer",
-  "crates/services/relayer",
-  "crates/services/shared-sequencer",
-  "crates/services/sync",
-  "crates/services/tx_status_manager",
-  "crates/services/txpool_v2",
-  "crates/services/upgradable-executor",
-  "crates/services/upgradable-executor/wasm-executor",
-  "crates/storage",
-  "crates/trace",
-  "crates/types",
-  "tests",
-  "xtask",
+    "benches",
+    "bin/e2e-test-client",
+    "bin/fuel-core",
+    "bin/fuel-core-client",
+    "bin/keygen",
+    "crates/chain-config",
+    "crates/client",
+    "crates/compression",
+    "crates/database",
+    "crates/fuel-core",
+    "crates/fuel-gas-price-algorithm",
+    "crates/keygen",
+    "crates/metrics",
+    "crates/services",
+    "crates/services/compression",
+    "crates/services/consensus_module",
+    "crates/services/consensus_module/bft",
+    "crates/services/consensus_module/poa",
+    "crates/services/executor",
+    "crates/services/gas_price_service",
+    "crates/services/importer",
+    "crates/services/p2p",
+    "crates/services/parallel-executor",
+    "crates/services/producer",
+    "crates/services/relayer",
+    "crates/services/shared-sequencer",
+    "crates/services/sync",
+    "crates/services/tx_status_manager",
+    "crates/services/txpool_v2",
+    "crates/services/upgradable-executor",
+    "crates/services/upgradable-executor/wasm-executor",
+    "crates/storage",
+    "crates/trace",
+    "crates/types",
+    "tests",
+    "xtask",
 ]
 resolver = "2"
 
 exclude = ["version-compatibility"]
-
-[profile.release]
-codegen-units = 1
-lto = "fat"
-# The difference in performance for "fat" and "thin" is small,
-# but "thin" LTO is much faster to compile.
-# If you play with benchmarks or flamegraphs, it is better to use "thin"
-# To speedup iterations between compilation.
-#lto = "thin"
-panic = "unwind"
 
 [workspace.package]
 authors = ["Fuel Labs <contact@fuel.sh>"]
@@ -64,44 +54,6 @@ rust-version = "1.85.0"
 version = "0.43.2"
 
 [workspace.dependencies]
-# Workspace members
-fuel-core = { version = "0.43.2", path = "./crates/fuel-core", default-features = false }
-fuel-core-client-bin = { version = "0.43.2", path = "./bin/fuel-core-client" }
-fuel-core-bin = { version = "0.43.2", path = "./bin/fuel-core" }
-fuel-core-keygen = { version = "0.43.2", path = "./crates/keygen" }
-fuel-core-keygen-bin = { version = "0.43.2", path = "./bin/keygen" }
-fuel-core-chain-config = { version = "0.43.2", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.43.2", path = "./crates/client" }
-fuel-core-compression = { version = "0.43.2", path = "./crates/compression" }
-fuel-core-compression-service = { version = "0.43.2", path = "./crates/services/compression" }
-fuel-core-database = { version = "0.43.2", path = "./crates/database" }
-fuel-core-metrics = { version = "0.43.2", path = "./crates/metrics" }
-fuel-core-services = { version = "0.43.2", path = "./crates/services" }
-fuel-core-consensus-module = { version = "0.43.2", path = "./crates/services/consensus_module" }
-fuel-core-bft = { version = "0.43.2", path = "./crates/services/consensus_module/bft" }
-fuel-core-poa = { version = "0.43.2", path = "./crates/services/consensus_module/poa" }
-fuel-core-shared-sequencer = { version = "0.43.2", path = "crates/services/shared-sequencer" }
-fuel-core-executor = { version = "0.43.2", path = "./crates/services/executor", default-features = false }
-fuel-core-importer = { version = "0.43.2", path = "./crates/services/importer" }
-fuel-core-gas-price-service = { version = "0.43.2", path = "crates/services/gas_price_service" }
-fuel-core-p2p = { version = "0.43.2", path = "./crates/services/p2p" }
-fuel-core-parallel-executor = { version = "0.43.2", path = "./crates/services/parallel-executor" }
-fuel-core-producer = { version = "0.43.2", path = "./crates/services/producer" }
-fuel-core-relayer = { version = "0.43.2", path = "./crates/services/relayer" }
-fuel-core-sync = { version = "0.43.2", path = "./crates/services/sync" }
-fuel-core-txpool = { version = "0.43.2", path = "./crates/services/txpool_v2" }
-fuel-core-tx-status-manager = { version = "0.43.2", path = "./crates/services/tx_status_manager" }
-fuel-core-storage = { version = "0.43.2", path = "./crates/storage", default-features = false }
-fuel-core-trace = { version = "0.43.2", path = "./crates/trace" }
-fuel-core-types = { version = "0.43.2", path = "./crates/types", default-features = false }
-fuel-core-tests = { version = "0.0.0", path = "./tests" }
-fuel-core-upgradable-executor = { version = "0.43.2", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.43.2", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
-fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
-fuel-gas-price-algorithm = { version = "0.43.2", path = "crates/fuel-gas-price-algorithm" }
-
-# Fuel dependencies
-fuel-vm-private = { version = "0.62.0", package = "fuel-vm", default-features = false }
 
 # Common dependencies
 anyhow = "1.0"
@@ -111,64 +63,112 @@ async-graphql = { version = "=7.0.15", features = [
 ], default-features = false }
 async-trait = "0.1"
 aws-sdk-kms = "1.37"
-cynic = { version = "3.1.0", features = ["http-reqwest"] }
+axum = "0.5"
+bytes = "1.5.0"
 clap = "4.4"
+cynic = { version = "3.1.0", features = ["http-reqwest"] }
+derive_more = { version = "0.99" }
+ed25519 = { version = "2.2.3", default-features = false }
+ed25519-dalek = { version = "2.1.1", default-features = false }
 educe = { version = "0.6", default-features = false, features = [
   "Eq",
   "PartialEq",
   "Hash",
   "Debug",
 ] }
-ed25519 = { version = "2.2.3", default-features = false }
-ed25519-dalek = { version = "2.1.1", default-features = false }
-derive_more = { version = "0.99" }
-enum_dispatch = "0.3.13"
 enum-iterator = "1.2"
+enum_dispatch = "0.3.13"
+# Workspace members
+fuel-core = { version = "0.43.2", path = "./crates/fuel-core", default-features = false }
+fuel-core-bft = { version = "0.43.2", path = "./crates/services/consensus_module/bft" }
+fuel-core-bin = { version = "0.43.2", path = "./bin/fuel-core" }
+fuel-core-chain-config = { version = "0.43.2", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.43.2", path = "./crates/client" }
+fuel-core-client-bin = { version = "0.43.2", path = "./bin/fuel-core-client" }
+fuel-core-compression = { version = "0.43.2", path = "./crates/compression" }
+fuel-core-compression-service = { version = "0.43.2", path = "./crates/services/compression" }
+fuel-core-consensus-module = { version = "0.43.2", path = "./crates/services/consensus_module" }
+fuel-core-database = { version = "0.43.2", path = "./crates/database" }
+fuel-core-executor = { version = "0.43.2", path = "./crates/services/executor", default-features = false }
+fuel-core-gas-price-service = { version = "0.43.2", path = "crates/services/gas_price_service" }
+fuel-core-importer = { version = "0.43.2", path = "./crates/services/importer" }
+fuel-core-keygen = { version = "0.43.2", path = "./crates/keygen" }
+fuel-core-keygen-bin = { version = "0.43.2", path = "./bin/keygen" }
+fuel-core-metrics = { version = "0.43.2", path = "./crates/metrics" }
+fuel-core-p2p = { version = "0.43.2", path = "./crates/services/p2p" }
+fuel-core-parallel-executor = { version = "0.43.2", path = "./crates/services/parallel-executor" }
+fuel-core-poa = { version = "0.43.2", path = "./crates/services/consensus_module/poa" }
+fuel-core-producer = { version = "0.43.2", path = "./crates/services/producer" }
+fuel-core-relayer = { version = "0.43.2", path = "./crates/services/relayer" }
+fuel-core-services = { version = "0.43.2", path = "./crates/services" }
+fuel-core-shared-sequencer = { version = "0.43.2", path = "crates/services/shared-sequencer" }
+fuel-core-storage = { version = "0.43.2", path = "./crates/storage", default-features = false }
+fuel-core-sync = { version = "0.43.2", path = "./crates/services/sync" }
+fuel-core-tests = { version = "0.0.0", path = "./tests" }
+fuel-core-trace = { version = "0.43.2", path = "./crates/trace" }
+fuel-core-tx-status-manager = { version = "0.43.2", path = "./crates/services/tx_status_manager" }
+fuel-core-txpool = { version = "0.43.2", path = "./crates/services/txpool_v2" }
+fuel-core-types = { version = "0.43.2", path = "./crates/types", default-features = false }
+fuel-core-upgradable-executor = { version = "0.43.2", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.43.2", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-core-xtask = { version = "0.0.0", path = "./xtask" }
+fuel-gas-price-algorithm = { version = "0.43.2", path = "crates/fuel-gas-price-algorithm" }
+
+# Fuel dependencies
+fuel-vm-private = { version = "0.62.0", package = "fuel-vm", default-features = false }
+futures = "0.3"
 hex = { version = "0.4", features = ["serde"] }
 hyper = { version = "0.14.26" }
+impl-tools = "0.10"
+indicatif = { version = "0.17", default-features = false }
+insta = "1.8"
+itertools = { version = "0.12", default-features = false }
+mockall = "0.11"
 num-rational = "0.4.2"
-primitive-types = { version = "0.12", default-features = false }
-rand = "0.8"
+num_enum = "0.7"
+once_cell = "1.16"
 parking_lot = "0.12"
-tokio = { version = "1.27", default-features = false }
-tokio-rayon = "2.1.0"
-tokio-stream = "0.1"
-tokio-util = { version = "0.7", default-features = false }
-tracing = "0.1"
-thiserror = "1.0"
-futures = "0.3"
+parquet = { version = "49.0", default-features = false }
+paste = "1.0"
+pin-project-lite = "0.2"
 postcard = "1.0"
-tracing-attributes = "0.1"
-tracing-subscriber = "0.3"
+pretty_assertions = "1.4.0"
+primitive-types = { version = "0.12", default-features = false }
+prometheus-client = "0.22.0"
+proptest = "1.1"
+rand = "0.8"
+rayon = "1.10.0"
+# enable cookie store to support L7 sticky sessions
+reqwest = { version = "0.12.0", default-features = false, features = [
+  "rustls-tls",
+  "cookies",
+] }
 serde = "1.0"
 serde-big-array = { version = "0.5", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_with = { version = "3.4", default-features = false }
 strum = { version = "0.25" }
 strum_macros = "0.25"
-# enable cookie store to support L7 sticky sessions
-reqwest = { version = "0.12.0", default-features = false, features = [
-  "rustls-tls",
-  "cookies",
-] }
-mockall = "0.11"
-num_enum = "0.7"
-test-case = "3.3"
-impl-tools = "0.10"
-test-strategy = "0.3"
-parquet = { version = "49.0", default-features = false }
-rayon = "1.10.0"
-bytes = "1.5.0"
-paste = "1.0"
-pretty_assertions = "1.4.0"
-proptest = "1.1"
-pin-project-lite = "0.2"
-axum = "0.5"
-once_cell = "1.16"
-prometheus-client = "0.22.0"
-indicatif = { version = "0.17", default-features = false }
-itertools = { version = "0.12", default-features = false }
-insta = "1.8"
 tempfile = "3.4"
+test-case = "3.3"
+test-strategy = "0.3"
+thiserror = "1.0"
 tikv-jemallocator = "0.5"
+tokio = { version = "1.27", default-features = false }
+tokio-rayon = "2.1.0"
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", default-features = false }
+tracing = "0.1"
+tracing-attributes = "0.1"
+tracing-subscriber = "0.3"
 url = "2.2"
+
+[profile.release]
+codegen-units = 1
+lto = "fat"
+# The difference in performance for "fat" and "thin" is small,
+# but "thin" LTO is much faster to compile.
+# If you play with benchmarks or flamegraphs, it is better to use "thin"
+# To speedup iterations between compilation.
+#lto = "thin"
+panic = "unwind"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,6 +6,17 @@ publish = false
 rust-version = { workspace = true }
 version = "0.0.0"
 
+[features]
+default = ["fuel-core/rocksdb", "fuel-core/rocksdb-production"]
+fault-proving = [
+    "fuel-core-types/fault-proving",
+    "fuel-core-chain-config/fault-proving",
+    "fuel-core/fault-proving",
+    "fuel-core-storage/fault-proving",
+    "fuel-core-database/fault-proving",
+    "fuel-core-sync/fault-proving",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -65,17 +76,6 @@ name = "state"
 [[bench]]
 harness = false
 name = "vm"
-
-[features]
-default = ["fuel-core/rocksdb", "fuel-core/rocksdb-production"]
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-chain-config/fault-proving",
-  "fuel-core/fault-proving",
-  "fuel-core-storage/fault-proving",
-  "fuel-core-database/fault-proving",
-  "fuel-core-sync/fault-proving",
-]
 
 [[bench]]
 harness = false

--- a/bin/e2e-test-client/Cargo.toml
+++ b/bin/e2e-test-client/Cargo.toml
@@ -11,6 +11,9 @@ rust-version = { workspace = true }
 version = { workspace = true }
 name = "fuel-core-e2e-client"
 publish = false
+
+[features]
+default = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -41,6 +44,3 @@ fuel-core = { workspace = true, features = [
 fuel-core-trace = { path = "../../crates/trace" }
 insta = { workspace = true }
 tempfile = { workspace = true }
-
-[features]
-default = []

--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -16,6 +16,34 @@ publish = true
 name = "fuel-core"
 path = "src/main.rs"
 
+[features]
+default = ["env", "relayer", "rocksdb"]
+aws-kms = ["dep:aws-config", "dep:aws-sdk-kms", "fuel-core-types/aws-kms"]
+env = ["dep:dotenvy"]
+p2p = ["fuel-core/p2p", "const_format", "dep:fuel-core-poa"]
+shared-sequencer = ["dep:fuel-core-shared-sequencer", "fuel-core/shared-sequencer"]
+relayer = ["fuel-core/relayer", "dep:url"]
+parquet = ["fuel-core-chain-config/parquet", "fuel-core-types/serde"]
+rocksdb = ["fuel-core/rocksdb"]
+rocksdb-production = ["fuel-core/rocksdb-production", "rocksdb"]
+# features to enable in production, but increase build times
+production = [
+    "env",
+    "relayer",
+    "rocksdb-production",
+    "p2p",
+    "shared-sequencer",
+    "parquet",
+    "aws-kms",
+]
+parallel-executor = ["fuel-core/parallel-executor"]
+fault-proving = [
+    "fuel-core-storage/fault-proving",
+    "fuel-core-types/fault-proving",
+    "fuel-core-chain-config/fault-proving",
+    "fuel-core/fault-proving",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 aws-config = { version = "1.1.7", features = [
@@ -59,34 +87,3 @@ serde = { workspace = true }
 strum = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-default = ["env", "relayer", "rocksdb"]
-aws-kms = ["dep:aws-config", "dep:aws-sdk-kms", "fuel-core-types/aws-kms"]
-env = ["dep:dotenvy"]
-p2p = ["fuel-core/p2p", "const_format", "dep:fuel-core-poa"]
-shared-sequencer = [
-  "dep:fuel-core-shared-sequencer",
-  "fuel-core/shared-sequencer",
-]
-relayer = ["fuel-core/relayer", "dep:url"]
-parquet = ["fuel-core-chain-config/parquet", "fuel-core-types/serde"]
-rocksdb = ["fuel-core/rocksdb"]
-rocksdb-production = ["fuel-core/rocksdb-production", "rocksdb"]
-# features to enable in production, but increase build times
-production = [
-  "env",
-  "relayer",
-  "rocksdb-production",
-  "p2p",
-  "shared-sequencer",
-  "parquet",
-  "aws-kms",
-]
-parallel-executor = ["fuel-core/parallel-executor"]
-fault-proving = [
-  "fuel-core-storage/fault-proving",
-  "fuel-core-types/fault-proving",
-  "fuel-core-chain-config/fault-proving",
-  "fuel-core/fault-proving",
-]

--- a/crates/chain-config/Cargo.toml
+++ b/crates/chain-config/Cargo.toml
@@ -11,6 +11,27 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Fuel Chain config types"
 
+[features]
+std = [
+    "itertools/use_std",
+    "serde_json/std",
+    "fuel-core-types/std",
+    "anyhow/std",
+    "tracing?/std",
+    "bech32?/std",
+]
+default = ["std"]
+parquet = ["std", "dep:parquet", "postcard/use-std"]
+random = ["dep:rand", "fuel-core-types/random"]
+test-helpers = [
+    "dep:bech32",
+    "dep:rand",
+    "dep:tracing",
+    "fuel-core-types/random",
+    "fuel-core-types/test-helpers",
+]
+fault-proving = ["fuel-core-types/fault-proving", "fuel-core-storage/fault-proving"]
+
 [dependencies]
 anyhow = { workspace = true }
 bech32 = { version = "0.9.0", default-features = false, optional = true }
@@ -44,27 +65,3 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 strum = { workspace = true, features = ["derive"] }
 tempfile = { workspace = true }
 test-case = { workspace = true }
-
-[features]
-std = [
-  "itertools/use_std",
-  "serde_json/std",
-  "fuel-core-types/std",
-  "anyhow/std",
-  "tracing?/std",
-  "bech32?/std",
-]
-default = ["std"]
-parquet = ["std", "dep:parquet", "postcard/use-std"]
-random = ["dep:rand", "fuel-core-types/random"]
-test-helpers = [
-  "dep:bech32",
-  "dep:rand",
-  "dep:tracing",
-  "fuel-core-types/random",
-  "fuel-core-types/test-helpers",
-]
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,6 +11,13 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Tx client and schema specification."
 
+[features]
+std = ["fuel-core-types/std"]
+default = ["subscriptions", "std"]
+test-helpers = []
+subscriptions = ["base64", "eventsource-client", "futures", "hyper-rustls"]
+fault-proving = ["fuel-core-types/fault-proving"]
+
 [dependencies]
 anyhow = { workspace = true }
 base64 = { version = "0.22.1", optional = true }
@@ -33,6 +40,10 @@ tai64 = { version = "=4.0.0", features = ["serde"] }
 thiserror = "1.0"
 tracing = "0.1"
 
+[build-dependencies]
+schemafy_lib = { version = "0.5" }
+serde_json = { version = "1.0", features = ["raw_value"] }
+
 [dev-dependencies]
 fuel-core-types = { workspace = true, features = [
   "serde",
@@ -40,14 +51,3 @@ fuel-core-types = { workspace = true, features = [
   "test-helpers",
 ] }
 insta = { workspace = true }
-
-[build-dependencies]
-schemafy_lib = { version = "0.5" }
-serde_json = { version = "1.0", features = ["raw_value"] }
-
-[features]
-std = ["fuel-core-types/std"]
-default = ["subscriptions", "std"]
-test-helpers = []
-subscriptions = ["base64", "eventsource-client", "futures", "hyper-rustls"]
-fault-proving = ["fuel-core-types/fault-proving"]

--- a/crates/compression/Cargo.toml
+++ b/crates/compression/Cargo.toml
@@ -6,16 +6,25 @@ categories = ["cryptography::cryptocurrencies"]
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = [
-  "blockchain",
-  "cryptocurrencies",
-  "fuel-core",
-  "fuel-client",
-  "fuel-compression",
+    "blockchain",
+    "cryptocurrencies",
+    "fuel-core",
+    "fuel-client",
+    "fuel-compression",
 ]
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Compression and decompression of Fuel blocks for DA storage."
+
+[features]
+test-helpers = [
+    "dep:rand",
+    "fuel-core-types/test-helpers",
+    "fuel-core-types/random",
+    "fuel-core-types/std",
+]
+fault-proving = ["fuel-core-types/fault-proving"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -36,12 +45,3 @@ fuel-core-compression = { path = ".", features = ["test-helpers"] }
 postcard = { version = "1.0", features = ["use-std"] }
 proptest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-
-[features]
-test-helpers = [
-  "dep:rand",
-  "fuel-core-types/test-helpers",
-  "fuel-core-types/random",
-  "fuel-core-types/std",
-]
-fault-proving = ["fuel-core-types/fault-proving"]

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -6,16 +6,21 @@ categories = ["cryptography::cryptocurrencies"]
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = [
-  "blockchain",
-  "cryptocurrencies",
-  "fuel-core",
-  "fuel-client",
-  "fuel-database",
+    "blockchain",
+    "cryptocurrencies",
+    "fuel-core",
+    "fuel-client",
+    "fuel-database",
 ]
 license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 description = "The crates contains databases used by Fuel core protocol."
+
+[features]
+test-helpers = []
+backup = []
+fault-proving = ["fuel-core-types/fault-proving", "fuel-core-storage/fault-proving"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -25,11 +30,3 @@ fuel-core-types = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 fuel-core-trace = { path = "../trace" }
-
-[features]
-test-helpers = []
-backup = []
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-]

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -11,6 +11,49 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[features]
+default = ["rocksdb", "serde"]
+serde = ["dep:serde_with"]
+smt = [
+    "fuel-core-storage/smt",
+    "fuel-core-executor/smt",
+    "fuel-core-upgradable-executor/smt",
+]
+p2p = ["dep:fuel-core-p2p", "dep:fuel-core-sync"]
+relayer = ["dep:fuel-core-relayer"]
+shared-sequencer = ["dep:fuel-core-shared-sequencer", "dep:cosmrs"]
+rocksdb = ["dep:rocksdb", "dep:tempfile", "dep:num_cpus"]
+backup = ["rocksdb", "fuel-core-database/backup"]
+test-helpers = [
+    "fuel-core-database/test-helpers",
+    "fuel-core-p2p?/test-helpers",
+    "fuel-core-storage/test-helpers",
+    "fuel-core-chain-config/test-helpers",
+    "fuel-core-txpool/test-helpers",
+    "fuel-core-tx-status-manager/test-helpers",
+    "fuel-core-services/test-helpers",
+    "fuel-core-shared-sequencer?/test-helpers",
+    "fuel-core-importer/test-helpers",
+    "fuel-core-poa/test-helpers",
+    "dep:mockall",
+]
+# features to enable in production, but increase build times
+rocksdb-production = ["rocksdb", "rocksdb/jemalloc"]
+wasm-executor = ["fuel-core-upgradable-executor/wasm-executor"]
+parallel-executor = ["fuel-core-parallel-executor"]
+fault-proving = [
+    "fuel-core-types/fault-proving",
+    "fuel-core-executor/fault-proving",
+    "fuel-core-storage/fault-proving",
+    "fuel-core-chain-config/fault-proving",
+    "fuel-core-database/fault-proving",
+    "fuel-core-sync?/fault-proving",
+    "fuel-core-importer/fault-proving",
+    "fuel-core-poa/fault-proving",
+    "fuel-core-compression-service/fault-proving",
+    "fuel-core-upgradable-executor/fault-proving",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 async-graphql = { workspace = true }
@@ -93,46 +136,3 @@ test-case = { workspace = true }
 test-strategy = { workspace = true }
 tokio-test = "0.4.4"
 tracing-subscriber = { workspace = true }
-
-[features]
-default = ["rocksdb", "serde"]
-serde = ["dep:serde_with"]
-smt = [
-  "fuel-core-storage/smt",
-  "fuel-core-executor/smt",
-  "fuel-core-upgradable-executor/smt",
-]
-p2p = ["dep:fuel-core-p2p", "dep:fuel-core-sync"]
-relayer = ["dep:fuel-core-relayer"]
-shared-sequencer = ["dep:fuel-core-shared-sequencer", "dep:cosmrs"]
-rocksdb = ["dep:rocksdb", "dep:tempfile", "dep:num_cpus"]
-backup = ["rocksdb", "fuel-core-database/backup"]
-test-helpers = [
-  "fuel-core-database/test-helpers",
-  "fuel-core-p2p?/test-helpers",
-  "fuel-core-storage/test-helpers",
-  "fuel-core-chain-config/test-helpers",
-  "fuel-core-txpool/test-helpers",
-  "fuel-core-tx-status-manager/test-helpers",
-  "fuel-core-services/test-helpers",
-  "fuel-core-shared-sequencer?/test-helpers",
-  "fuel-core-importer/test-helpers",
-  "fuel-core-poa/test-helpers",
-  "dep:mockall",
-]
-# features to enable in production, but increase build times
-rocksdb-production = ["rocksdb", "rocksdb/jemalloc"]
-wasm-executor = ["fuel-core-upgradable-executor/wasm-executor"]
-parallel-executor = ["fuel-core-parallel-executor"]
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-executor/fault-proving",
-  "fuel-core-storage/fault-proving",
-  "fuel-core-chain-config/fault-proving",
-  "fuel-core-database/fault-proving",
-  "fuel-core-sync?/fault-proving",
-  "fuel-core-importer/fault-proving",
-  "fuel-core-poa/fault-proving",
-  "fuel-core-compression-service/fault-proving",
-  "fuel-core-upgradable-executor/fault-proving",
-]

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -10,6 +10,10 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[features]
+test-helpers = []
+sync-processor = ["dep:rayon"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -25,7 +29,3 @@ tracing = { workspace = true }
 fuel-core-services = { path = ".", features = ["sync-processor"] }
 futures = { workspace = true }
 mockall = { workspace = true }
-
-[features]
-test-helpers = []
-sync-processor = ["dep:rayon"]

--- a/crates/services/compression/Cargo.toml
+++ b/crates/services/compression/Cargo.toml
@@ -9,6 +9,22 @@ license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+test-helpers = [
+    "fuel-core-services/test-helpers",
+    "fuel-core-types/test-helpers",
+    "fuel-core-storage/test-helpers",
+    "fuel-core-compression/test-helpers",
+    "dep:rand",
+    "dep:fuel-core-chain-config",
+]
+fault-proving = [
+    "fuel-core-compression/fault-proving",
+    "fuel-core-chain-config?/fault-proving",
+    "fuel-core-types/fault-proving",
+    "fuel-core-storage/fault-proving",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -34,19 +50,3 @@ tracing = { workspace = true }
 [dev-dependencies]
 fuel-core-compression-service = { path = ".", features = ["test-helpers"] }
 tokio-stream = { workspace = true }
-
-[features]
-test-helpers = [
-  "fuel-core-services/test-helpers",
-  "fuel-core-types/test-helpers",
-  "fuel-core-storage/test-helpers",
-  "fuel-core-compression/test-helpers",
-  "dep:rand",
-  "dep:fuel-core-chain-config",
-]
-fault-proving = [
-  "fuel-core-compression/fault-proving",
-  "fuel-core-chain-config?/fault-proving",
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-]

--- a/crates/services/consensus_module/Cargo.toml
+++ b/crates/services/consensus_module/Cargo.toml
@@ -10,6 +10,14 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[features]
+fault-proving = [
+    "fuel-core-types/fault-proving",
+    "fuel-core-storage/fault-proving",
+    "fuel-core-poa/fault-proving",
+    "fuel-core-chain-config/fault-proving",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 fuel-core-chain-config = { workspace = true }
@@ -20,11 +28,3 @@ fuel-core-types = { workspace = true, features = ["std"] }
 [dev-dependencies]
 fuel-core-types = { path = "../../types", features = ["test-helpers"] }
 test-case = { workspace = true }
-
-[features]
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-  "fuel-core-poa/fault-proving",
-  "fuel-core-chain-config/fault-proving",
-]

--- a/crates/services/consensus_module/poa/Cargo.toml
+++ b/crates/services/consensus_module/poa/Cargo.toml
@@ -10,6 +10,14 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[features]
+test-helpers = ["fuel-core-storage/test-helpers", "fuel-core-types/test-helpers"]
+fault-proving = [
+    "fuel-core-types/fault-proving",
+    "fuel-core-chain-config/fault-proving",
+    "fuel-core-storage/fault-proving",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -34,14 +42,3 @@ mockall = { workspace = true }
 rand = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
-
-[features]
-test-helpers = [
-  "fuel-core-storage/test-helpers",
-  "fuel-core-types/test-helpers",
-]
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-chain-config/fault-proving",
-  "fuel-core-storage/fault-proving",
-]

--- a/crates/services/executor/Cargo.toml
+++ b/crates/services/executor/Cargo.toml
@@ -10,6 +10,15 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Fuel Block Executor"
 
+[features]
+default = ["std"]
+std = ["fuel-core-types/std", "fuel-core-storage/std"]
+alloc = ["fuel-core-types/alloc", "fuel-core-storage/alloc"]
+smt = ["fuel-core-storage/smt"]
+test-helpers = ["fuel-core-types/test-helpers", "fuel-core-storage/test-helpers"]
+limited-tx-count = []
+fault-proving = ["fuel-core-types/fault-proving", "fuel-core-storage/fault-proving"]
+
 [dependencies]
 anyhow = { workspace = true }
 fuel-core-storage = { workspace = true, default-features = false, features = [
@@ -26,18 +35,3 @@ tracing = { workspace = true }
 fuel-core-storage = { workspace = true, features = ["test-helpers"] }
 fuel-core-trace = { path = "../../trace" }
 fuel-core-types = { workspace = true, features = ["test-helpers"] }
-
-[features]
-default = ["std"]
-std = ["fuel-core-types/std", "fuel-core-storage/std"]
-alloc = ["fuel-core-types/alloc", "fuel-core-storage/alloc"]
-smt = ["fuel-core-storage/smt"]
-test-helpers = [
-  "fuel-core-types/test-helpers",
-  "fuel-core-storage/test-helpers",
-]
-limited-tx-count = []
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-]

--- a/crates/services/gas_price_service/Cargo.toml
+++ b/crates/services/gas_price_service/Cargo.toml
@@ -9,6 +9,9 @@ license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+test-helpers = ["dep:mockito"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -39,6 +42,3 @@ fuel-core-storage = { workspace = true, features = ["test-helpers"] }
 fuel-core-types = { path = "./../../types", features = ["test-helpers"] }
 mockito = { version = "1.6.1" }
 serde_json = { workspace = true }
-
-[features]
-test-helpers = ["dep:mockito"]

--- a/crates/services/importer/Cargo.toml
+++ b/crates/services/importer/Cargo.toml
@@ -10,6 +10,14 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Fuel Block Importer"
 
+[features]
+test-helpers = [
+    "dep:mockall",
+    "fuel-core-types/test-helpers",
+    "fuel-core-storage/test-helpers",
+]
+fault-proving = ["fuel-core-types/fault-proving", "fuel-core-storage/fault-proving"]
+
 [dependencies]
 anyhow = { workspace = true }
 derive_more = { workspace = true }
@@ -25,14 +33,3 @@ tracing = { workspace = true }
 fuel-core-trace = { path = "./../../trace" }
 fuel-core-types = { path = "./../../types", features = ["test-helpers"] }
 test-case = { workspace = true }
-
-[features]
-test-helpers = [
-  "dep:mockall",
-  "fuel-core-types/test-helpers",
-  "fuel-core-storage/test-helpers",
-]
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-]

--- a/crates/services/p2p/Cargo.toml
+++ b/crates/services/p2p/Cargo.toml
@@ -11,6 +11,14 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Fuel client networking"
 
+[features]
+test-helpers = ["fuel-core-types/test-helpers"]
+fault-proving = [
+    "fuel-core-types/fault-proving",
+    "fuel-core-storage/fault-proving",
+    "fuel-core-chain-config/fault-proving",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -62,11 +70,3 @@ tracing-attributes = { workspace = true }
 
 [dev-dependencies.libp2p-swarm-test]
 version = "0.4.0"
-
-[features]
-test-helpers = ["fuel-core-types/test-helpers"]
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-  "fuel-core-chain-config/fault-proving",
-]

--- a/crates/services/parallel-executor/Cargo.toml
+++ b/crates/services/parallel-executor/Cargo.toml
@@ -10,11 +10,11 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Fuel Block Parallel Executor"
 
+[features]
+wasm-executor = ["fuel-core-upgradable-executor/wasm-executor"]
+
 [dependencies]
 fuel-core-storage = { workspace = true, features = ["std"] }
 fuel-core-types = { workspace = true, features = ["std"] }
 fuel-core-upgradable-executor = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-
-[features]
-wasm-executor = ["fuel-core-upgradable-executor/wasm-executor"]

--- a/crates/services/producer/Cargo.toml
+++ b/crates/services/producer/Cargo.toml
@@ -10,6 +10,10 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[features]
+test-helpers = ["dep:mockall", "fuel-core-types/test-helpers"]
+fault-proving = ["fuel-core-types/fault-proving", "fuel-core-storage/fault-proving"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -27,10 +31,3 @@ fuel-core-trace = { path = "../../trace" }
 fuel-core-types = { path = "../../types", features = ["test-helpers"] }
 proptest = { workspace = true }
 rand = { workspace = true }
-
-[features]
-test-helpers = ["dep:mockall", "fuel-core-types/test-helpers"]
-fault-proving = [
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-]

--- a/crates/services/relayer/Cargo.toml
+++ b/crates/services/relayer/Cargo.toml
@@ -10,6 +10,16 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Fuel Relayer"
 
+[features]
+test-helpers = [
+    "bytes",
+    "parking_lot",
+    "serde",
+    "serde_json",
+    "thiserror",
+    "fuel-core-types/test-helpers",
+]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -48,13 +58,3 @@ mockall = { workspace = true }
 rand = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true, features = ["macros", "test-util"] }
-
-[features]
-test-helpers = [
-  "bytes",
-  "parking_lot",
-  "serde",
-  "serde_json",
-  "thiserror",
-  "fuel-core-types/test-helpers",
-]

--- a/crates/services/shared-sequencer/Cargo.toml
+++ b/crates/services/shared-sequencer/Cargo.toml
@@ -11,6 +11,9 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[features]
+test-helpers = []
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -30,6 +33,3 @@ tendermint-rpc = { version = "0.36", features = ["http-client"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-
-[features]
-test-helpers = []

--- a/crates/services/sync/Cargo.toml
+++ b/crates/services/sync/Cargo.toml
@@ -10,6 +10,10 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
+[features]
+benchmarking = ["dep:mockall", "fuel-core-types/test-helpers"]
+fault-proving = ["fuel-core-types/fault-proving"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -28,7 +32,3 @@ fuel-core-types = { path = "../../types", features = ["test-helpers"] }
 mockall = { workspace = true }
 test-case = { workspace = true }
 tracing-subscriber = { workspace = true }
-
-[features]
-benchmarking = ["dep:mockall", "fuel-core-types/test-helpers"]
-fault-proving = ["fuel-core-types/fault-proving"]

--- a/crates/services/tx_status_manager/Cargo.toml
+++ b/crates/services/tx_status_manager/Cargo.toml
@@ -9,6 +9,9 @@ license = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+test-helpers = ["fuel-core-types/test-helpers"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -36,6 +39,3 @@ test-case = { workspace = true }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "macros"] }
 tracing = { workspace = true }
-
-[features]
-test-helpers = ["fuel-core-types/test-helpers"]

--- a/crates/services/txpool_v2/Cargo.toml
+++ b/crates/services/txpool_v2/Cargo.toml
@@ -11,6 +11,9 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Transaction pool that manages transactions and their dependencies."
 
+[features]
+test-helpers = ["fuel-core-types/test-helpers", "fuel-core-storage/test-helpers"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -36,9 +39,3 @@ rand = { workspace = true }
 tokio = { workspace = true, features = ["sync", "test-util"] }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
-
-[features]
-test-helpers = [
-  "fuel-core-types/test-helpers",
-  "fuel-core-storage/test-helpers",
-]

--- a/crates/services/upgradable-executor/Cargo.toml
+++ b/crates/services/upgradable-executor/Cargo.toml
@@ -11,6 +11,31 @@ rust-version = { workspace = true }
 description = "Fuel Block Upgradable Executor"
 build = "build.rs"
 
+[features]
+default = ["std"]
+std = ["fuel-core-executor/std", "fuel-core-storage/std", "fuel-core-types/std"]
+smt = [
+    "fuel-core-storage/smt",
+    "fuel-core-executor/smt",
+    "fuel-core-wasm-executor?/smt",
+]
+wasm-executor = [
+    "dep:anyhow",
+    "dep:derive_more",
+    "dep:postcard",
+    "dep:tracing",
+    "dep:fuel-core-wasm-executor",
+    "dep:wasmtime",
+]
+test-helpers = ["fuel-core-storage/test-helpers", "fuel-core-types/test-helpers"]
+limited-tx-count = ["fuel-core-executor/limited-tx-count"]
+fault-proving = [
+    "fuel-core-executor/fault-proving",
+    "fuel-core-storage/fault-proving",
+    "fuel-core-types/fault-proving",
+    "fuel-core-wasm-executor?/fault-proving",
+]
+
 [dependencies]
 anyhow = { workspace = true, optional = true }
 derive_more = { workspace = true, optional = true }
@@ -32,38 +57,10 @@ wasmtime = { version = "31.0.0", default-features = false, features = [
   "runtime",
 ], optional = true }
 
+[build-dependencies]
+fuel-core-wasm-executor = { workspace = true, optional = true, default-features = false }
+
 [dev-dependencies]
 anyhow = { workspace = true }
 fuel-core-storage = { workspace = true, features = ["test-helpers"] }
 fuel-core-types = { workspace = true, features = ["test-helpers"] }
-
-[build-dependencies]
-fuel-core-wasm-executor = { workspace = true, optional = true, default-features = false }
-
-[features]
-default = ["std"]
-std = ["fuel-core-executor/std", "fuel-core-storage/std", "fuel-core-types/std"]
-smt = [
-  "fuel-core-storage/smt",
-  "fuel-core-executor/smt",
-  "fuel-core-wasm-executor?/smt",
-]
-wasm-executor = [
-  "dep:anyhow",
-  "dep:derive_more",
-  "dep:postcard",
-  "dep:tracing",
-  "dep:fuel-core-wasm-executor",
-  "dep:wasmtime",
-]
-test-helpers = [
-  "fuel-core-storage/test-helpers",
-  "fuel-core-types/test-helpers",
-]
-limited-tx-count = ["fuel-core-executor/limited-tx-count"]
-fault-proving = [
-  "fuel-core-executor/fault-proving",
-  "fuel-core-storage/fault-proving",
-  "fuel-core-types/fault-proving",
-  "fuel-core-wasm-executor?/fault-proving",
-]

--- a/crates/services/upgradable-executor/wasm-executor/Cargo.toml
+++ b/crates/services/upgradable-executor/wasm-executor/Cargo.toml
@@ -10,12 +10,22 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 description = "Fuel Block WASM version of the Executor"
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 name = "fuel-core-wasm-executor"
 path = "src/main.rs"
 
-[lib]
-path = "src/lib.rs"
+[features]
+default = ["std"]
+std = ["fuel-core-types-v0"]
+smt = ["fuel-core-storage/smt", "fuel-core-executor/smt"]
+fault-proving = [
+    "fuel-core-storage/fault-proving",
+    "fuel-core-types/fault-proving",
+    "fuel-core-executor/fault-proving",
+]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -41,13 +51,3 @@ serde_json = { workspace = true, default-features = false, features = [
 
 [dev-dependencies]
 proptest = { workspace = true }
-
-[features]
-default = ["std"]
-std = ["fuel-core-types-v0"]
-smt = ["fuel-core-storage/smt", "fuel-core-executor/smt"]
-fault-proving = [
-  "fuel-core-storage/fault-proving",
-  "fuel-core-types/fault-proving",
-  "fuel-core-executor/fault-proving",
-]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -5,17 +5,25 @@ description = "Storage types and primitives used by Fuel core protocol."
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = [
-  "blockchain",
-  "cryptocurrencies",
-  "fuel-client",
-  "fuel-core",
-  "fuel-storage",
+    "blockchain",
+    "cryptocurrencies",
+    "fuel-client",
+    "fuel-core",
+    "fuel-storage",
 ]
 license = { workspace = true }
 name = "fuel-core-storage"
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
+
+[features]
+default = ["std"]
+alloc = ["fuel-vm-private/alloc", "fuel-core-types/alloc"]
+std = ["alloc", "fuel-vm-private/std", "fuel-core-types/std"]
+smt = []
+test-helpers = ["dep:mockall", "dep:rand"]
+fault-proving = ["fuel-core-types/fault-proving"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -45,11 +53,3 @@ fuel-core-types = { workspace = true, default-features = false, features = [
   "test-helpers",
 ] }
 test-case = { workspace = true }
-
-[features]
-default = ["std"]
-alloc = ["fuel-vm-private/alloc", "fuel-core-types/alloc"]
-std = ["alloc", "fuel-vm-private/std", "fuel-core-types/std"]
-smt = []
-test-helpers = ["dep:mockall", "dep:rand"]
-fault-proving = ["fuel-core-types/fault-proving"]

--- a/crates/trace/Cargo.toml
+++ b/crates/trace/Cargo.toml
@@ -5,12 +5,12 @@ description = "A Tokio tracing initializer for testing"
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = [
-  "blockchain",
-  "cryptocurrencies",
-  "fuel-client",
-  "fuel-core",
-  "fuel-tracing",
-  "tracing",
+    "blockchain",
+    "cryptocurrencies",
+    "fuel-client",
+    "fuel-core",
+    "fuel-tracing",
+    "tracing",
 ]
 license = { workspace = true }
 name = "fuel-core-trace"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -5,17 +5,39 @@ description = "The primitives and types use by Fuel core protocol."
 edition = { workspace = true }
 homepage = { workspace = true }
 keywords = [
-  "blockchain",
-  "cryptocurrencies",
-  "fuel-client",
-  "fuel-core",
-  "fuel-types",
+    "blockchain",
+    "cryptocurrencies",
+    "fuel-client",
+    "fuel-core",
+    "fuel-types",
 ]
 license = { workspace = true }
 name = "fuel-core-types"
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
+
+[features]
+default = ["std"]
+alloc = ["fuel-vm-private/alloc", "educe"]
+serde = [
+    "dep:serde",
+    "fuel-vm-private/serde",
+    "ed25519/serde",
+    "ed25519-dalek/serde",
+]
+da-compression = ["fuel-vm-private/da-compression"]
+std = [
+    "alloc",
+    "fuel-vm-private/std",
+    "bs58",
+    "ed25519/std",
+    "ed25519-dalek/std",
+]
+random = ["dep:rand", "fuel-vm-private/random"]
+test-helpers = ["random", "fuel-vm-private/test-helpers"]
+aws-kms = ["dep:aws-sdk-kms"]
+fault-proving = []
 
 [dependencies]
 anyhow = { workspace = true }
@@ -42,25 +64,3 @@ aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 fuel-core-types = { path = ".", features = ["test-helpers", "serde"] }
 postcard = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-
-[features]
-default = ["std"]
-alloc = ["fuel-vm-private/alloc", "educe"]
-serde = [
-  "dep:serde",
-  "fuel-vm-private/serde",
-  "ed25519/serde",
-  "ed25519-dalek/serde",
-]
-da-compression = ["fuel-vm-private/da-compression"]
-std = [
-  "alloc",
-  "fuel-vm-private/std",
-  "bs58",
-  "ed25519/std",
-  "ed25519-dalek/std",
-]
-random = ["dep:rand", "fuel-vm-private/random"]
-test-helpers = ["random", "fuel-vm-private/test-helpers"]
-aws-kms = ["dep:aws-sdk-kms"]
-fault-proving = []

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,10 +12,20 @@ version = "0.0.0"
 autobenches = false
 autotests = false
 
-[[test]]
-harness = true
-name = "integration_tests"
-path = "tests/lib.rs"
+[features]
+default = ["fuel-core/default"]
+only-p2p = ["fuel-core-p2p"]
+aws-kms = ["dep:aws-config", "dep:aws-sdk-kms", "fuel-core-bin/aws-kms"]
+fault-proving = [
+    "fuel-core/fault-proving",
+    "fuel-core-types/fault-proving",
+    "fuel-core-storage/fault-proving",
+    "fuel-core-upgradable-executor/fault-proving",
+    "fuel-core-poa/fault-proving",
+    "fuel-core-compression/fault-proving",
+    "fuel-core-compression-service/fault-proving",
+    "fuel-core-benches/fault-proving",
+]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -89,17 +99,7 @@ pretty_assertions = "1.4"
 proptest = { workspace = true }
 tracing = { workspace = true }
 
-[features]
-default = ["fuel-core/default"]
-only-p2p = ["fuel-core-p2p"]
-aws-kms = ["dep:aws-config", "dep:aws-sdk-kms", "fuel-core-bin/aws-kms"]
-fault-proving = [
-  "fuel-core/fault-proving",
-  "fuel-core-types/fault-proving",
-  "fuel-core-storage/fault-proving",
-  "fuel-core-upgradable-executor/fault-proving",
-  "fuel-core-poa/fault-proving",
-  "fuel-core-compression/fault-proving",
-  "fuel-core-compression-service/fault-proving",
-  "fuel-core-benches/fault-proving",
-]
+[[test]]
+harness = true
+name = "integration_tests"
+path = "tests/lib.rs"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,6 +5,9 @@ rust-version = { workspace = true }
 version = "0.0.0"
 license = { workspace = true }
 publish = false
+
+[features]
+default = ["fuel-core/default"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -12,6 +15,3 @@ clap = { workspace = true, features = ["env", "derive"] }
 fuel-core = { path = "../crates/fuel-core", default-features = false, features = [
   "test-helpers",
 ] }
-
-[features]
-default = ["fuel-core/default"]


### PR DESCRIPTION
## Description

A new cargo sort version, 2.0, was released yesterday. This PR applies the new formatting to `Cargo.toml` files. Since the new version of `cargo sort` also formats the toml files, `npx prettier` is removed.

Moreover, the `cargo binstall` version in our CI isn't working, and errors out with:
```
/home/runner/.cargo/bin/cargo-sort: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /home/runner/.cargo/bin/cargo-sort)
```

So this PR also changes the CI to use `cargo install` until this issue has been resolved.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

