### PR TITLE
chore: use Cow in scalars/HexString

### DIFF
--- a/crates/fuel-core/src/schema/blob.rs
+++ b/crates/fuel-core/src/schema/blob.rs
@@ -28,11 +28,11 @@ impl Blob {
     }
 
     #[graphql(complexity = "query_costs().bytecode_read")]
-    async fn bytecode(&self, ctx: &Context<'_>) -> async_graphql::Result<HexString> {
+    async fn bytecode(&self, ctx: &Context<'_>) -> async_graphql::Result<HexString<'_>> {
         let query = ctx.read_view()?;
         query
             .blob_bytecode(self.0)
-            .map(HexString)
+            .map(|bytes| HexString(bytes.into()))
             .map_err(async_graphql::Error::from)
     }
 }

--- a/crates/fuel-core/src/schema/contract.rs
+++ b/crates/fuel-core/src/schema/contract.rs
@@ -48,11 +48,11 @@ impl Contract {
     }
 
     #[graphql(complexity = "query_costs().bytecode_read")]
-    async fn bytecode(&self, ctx: &Context<'_>) -> async_graphql::Result<HexString> {
+    async fn bytecode(&self, ctx: &Context<'_>) -> async_graphql::Result<HexString<'_>> {
         let query = ctx.read_view()?;
         query
             .contract_bytecode(self.0)
-            .map(HexString)
+            .map(|bytes|HexString(bytes.into()))
             .map_err(Into::into)
     }
 

--- a/crates/fuel-core/src/schema/da_compressed.rs
+++ b/crates/fuel-core/src/schema/da_compressed.rs
@@ -24,8 +24,8 @@ impl From<Vec<u8>> for DaCompressedBlock {
 
 #[Object]
 impl DaCompressedBlock {
-    async fn bytes(&self) -> HexString {
-        HexString(self.bytes.clone())
+    async fn bytes(&self) -> HexString<'_> {
+        HexString(self.bytes.as_slice().into())
     }
 }
 

--- a/crates/fuel-core/src/schema/message.rs
+++ b/crates/fuel-core/src/schema/message.rs
@@ -52,7 +52,7 @@ impl Message {
         (*self.0.nonce()).into()
     }
 
-    async fn data(&self) -> HexString {
+    async fn data(&self) -> HexString<'_> {
         self.0.data().clone().into()
     }
 
@@ -90,7 +90,7 @@ impl MessageQuery {
         after: Option<String>,
         last: Option<i32>,
         before: Option<String>,
-    ) -> async_graphql::Result<Connection<HexString, Message, EmptyFields, EmptyFields>>
+    ) -> async_graphql::Result<Connection<HexString<'_>, Message, EmptyFields, EmptyFields>>
     {
         let query = ctx.read_view()?;
         let owner = owner.map(|owner| owner.0);
@@ -221,7 +221,7 @@ impl MessageProof {
         self.0.amount.into()
     }
 
-    async fn data(&self) -> HexString {
+    async fn data(&self) -> HexString<'_> {
         self.0.data.clone().into()
     }
 }

--- a/crates/fuel-core/src/schema/storage.rs
+++ b/crates/fuel-core/src/schema/storage.rs
@@ -160,7 +160,7 @@ impl StorageSlot {
         self.key.into()
     }
 
-    async fn value(&self) -> HexString {
-        HexString(self.value.clone())
+    async fn value(&self) -> HexString<'_> {
+        HexString::from(self.value.as_ref())
     }
 }

--- a/crates/fuel-core/src/schema/tx.rs
+++ b/crates/fuel-core/src/schema/tx.rs
@@ -124,7 +124,7 @@ impl TxQuery {
     async fn dry_run_inner(
         &self,
         ctx: &Context<'_>,
-        txs: Vec<HexString>,
+        txs: Vec<HexString<'_>>,
         // If set to false, disable input utxo validation, overriding the configuration of the node.
         // This allows for non-existent inputs to be used without signature validation
         // for read-only calls.
@@ -375,7 +375,7 @@ impl TxQuery {
         #[graphql(
             desc = "The original transaction that contains application level logic only"
         )]
-        tx: HexString,
+        tx: HexString<'_>,
         #[graphql(
             desc = "Number of blocks into the future to estimate the gas price for"
         )]
@@ -519,7 +519,7 @@ impl TxQuery {
     async fn estimate_predicates(
         &self,
         ctx: &Context<'_>,
-        tx: HexString,
+        tx: HexString<'_>,
     ) -> async_graphql::Result<Transaction> {
         let query = ctx.read_view()?.into_owned();
 
@@ -550,7 +550,7 @@ impl TxQuery {
     async fn dry_run(
         &self,
         ctx: &Context<'_>,
-        txs: Vec<HexString>,
+        txs: Vec<HexString<'_>>,
         // If set to false, disable input utxo validation, overriding the configuration of the node.
         // This allows for non-existent inputs to be used without signature validation
         // for read-only calls.
@@ -574,7 +574,7 @@ impl TxQuery {
     async fn dry_run_record_storage_reads(
         &self,
         ctx: &Context<'_>,
-        txs: Vec<HexString>,
+        txs: Vec<HexString<'_>>,
         // If set to false, disable input utxo validation, overriding the configuration of the node.
         // This allows for non-existent inputs to be used without signature validation
         // for read-only calls.
@@ -627,7 +627,7 @@ impl TxMutation {
     async fn dry_run(
         &self,
         ctx: &Context<'_>,
-        txs: Vec<HexString>,
+        txs: Vec<HexString<'_>>,
         // If set to false, disable input utxo validation, overriding the configuration of the node.
         // This allows for non-existent inputs to be used without signature validation
         // for read-only calls.
@@ -648,7 +648,7 @@ impl TxMutation {
     async fn submit(
         &self,
         ctx: &Context<'_>,
-        tx: HexString,
+        tx: HexString<'_>,
         estimate_predicates: Option<bool>,
     ) -> async_graphql::Result<Transaction> {
         let txpool = ctx.data_unchecked::<TxPool>();
@@ -679,7 +679,7 @@ impl TxMutation {
 pub struct TxStatusSubscription;
 
 #[Subscription]
-impl TxStatusSubscription {
+impl<'a> TxStatusSubscription {
     /// Returns a stream of status updates for the given transaction id.
     /// If the current status is [`TransactionStatus::Success`], [`TransactionStatus::Failed`],
     /// or [`TransactionStatus::SqueezedOut`] the stream will return that and end immediately.
@@ -693,7 +693,7 @@ impl TxStatusSubscription {
     /// a status. If this occurs the stream can simply be restarted to return
     /// the latest status.
     #[graphql(complexity = "query_costs().status_change + child_complexity")]
-    async fn status_change<'a>(
+    async fn status_change(
         &self,
         ctx: &'a Context<'a>,
         #[graphql(desc = "The ID of the transaction")] id: TransactionId,
@@ -721,7 +721,7 @@ impl TxStatusSubscription {
     }
 
     #[graphql(name = "alpha__preconfirmations")]
-    async fn preconfirmations<'a>(
+    async fn preconfirmations(
         &self,
         ctx: &'a Context<'a>,
     ) -> async_graphql::Result<
@@ -745,10 +745,10 @@ impl TxStatusSubscription {
 
     /// Submits transaction to the `TxPool` and await either success or failure.
     #[graphql(complexity = "query_costs().submit_and_await + child_complexity")]
-    async fn submit_and_await<'a>(
+    async fn submit_and_await(
         &self,
         ctx: &'a Context<'a>,
-        tx: HexString,
+        tx: HexString<'a>,
         estimate_predicates: Option<bool>,
     ) -> async_graphql::Result<
         impl Stream<Item = async_graphql::Result<TransactionStatus>> + 'a + use<'a>,
@@ -767,10 +767,10 @@ impl TxStatusSubscription {
     /// Compared to the `submitAndAwait`, the stream also contains
     /// `SubmittedStatus` and potentially preconfirmation as an intermediate state.
     #[graphql(complexity = "query_costs().submit_and_await + child_complexity")]
-    async fn submit_and_await_status<'a>(
+    async fn submit_and_await_status(
         &self,
         ctx: &'a Context<'a>,
-        tx: HexString,
+        tx: HexString<'a>,
         estimate_predicates: Option<bool>,
         include_preconfirmation: Option<bool>,
     ) -> async_graphql::Result<
@@ -788,7 +788,7 @@ impl TxStatusSubscription {
 
 async fn submit_and_await_status<'a>(
     ctx: &'a Context<'a>,
-    tx: HexString,
+    tx: HexString<'a>,
     estimate_predicates: bool,
     include_preconfirmation: bool,
 ) -> async_graphql::Result<
@@ -884,8 +884,8 @@ pub mod schema_types {
         // signature verification. They provide a mocked version of the predicate that
         // returns `true` even if the signature doesn't match.
         pub predicate_address: Address,
-        pub predicate: HexString,
-        pub predicate_data: HexString,
+        pub predicate: HexString<'static>,
+        pub predicate_data: HexString<'static>,
     }
 
     #[derive(async_graphql::InputObject)]

--- a/crates/fuel-core/src/schema/tx/input.rs
+++ b/crates/fuel-core/src/schema/tx/input.rs
@@ -17,13 +17,13 @@ use async_graphql::{
 use fuel_core_types::fuel_tx;
 
 #[derive(Union)]
-pub enum Input {
-    Coin(InputCoin),
+pub enum Input<'a> {
+    Coin(InputCoin<'a>),
     Contract(InputContract),
-    Message(InputMessage),
+    Message(InputMessage<'a>),
 }
 
-pub struct InputCoin {
+pub struct InputCoin<'a> {
     utxo_id: UtxoId,
     owner: Address,
     amount: U64,
@@ -31,12 +31,12 @@ pub struct InputCoin {
     tx_pointer: TxPointer,
     witness_index: u16,
     predicate_gas_used: U64,
-    predicate: HexString,
-    predicate_data: HexString,
+    predicate: HexString<'a>,
+    predicate_data: HexString<'a>,
 }
 
 #[Object]
-impl InputCoin {
+impl InputCoin<'_> {
     async fn utxo_id(&self) -> UtxoId {
         self.utxo_id
     }
@@ -65,11 +65,11 @@ impl InputCoin {
         self.predicate_gas_used
     }
 
-    async fn predicate(&self) -> HexString {
+    async fn predicate(&self) -> HexString<'_> {
         self.predicate.clone()
     }
 
-    async fn predicate_data(&self) -> HexString {
+    async fn predicate_data(&self) -> HexString<'_> {
         self.predicate_data.clone()
     }
 }
@@ -105,20 +105,20 @@ impl InputContract {
     }
 }
 
-pub struct InputMessage {
+pub struct InputMessage<'a> {
     sender: Address,
     recipient: Address,
     amount: U64,
     nonce: Nonce,
     witness_index: u16,
     predicate_gas_used: U64,
-    data: HexString,
-    predicate: HexString,
-    predicate_data: HexString,
+    data: HexString<'a>,
+    predicate: HexString<'a>,
+    predicate_data: HexString<'a>,
 }
 
 #[Object]
-impl InputMessage {
+impl InputMessage<'_> {
     async fn sender(&self) -> Address {
         self.sender
     }
@@ -143,21 +143,21 @@ impl InputMessage {
         self.predicate_gas_used
     }
 
-    async fn data(&self) -> &HexString {
+    async fn data(&self) -> &HexString<'_> {
         &self.data
     }
 
-    async fn predicate(&self) -> &HexString {
+    async fn predicate(&self) -> &HexString<'_> {
         &self.predicate
     }
 
-    async fn predicate_data(&self) -> &HexString {
+    async fn predicate_data(&self) -> &HexString<'_> {
         &self.predicate_data
     }
 }
 
-impl From<&fuel_tx::Input> for Input {
-    fn from(input: &fuel_tx::Input) -> Self {
+impl <'a> From<&'a fuel_tx::Input> for Input<'a> {
+    fn from(input: &'a fuel_tx::Input) -> Self {
         match input {
             fuel_tx::Input::CoinSigned(fuel_tx::input::coin::CoinSigned {
                 utxo_id,
@@ -175,7 +175,7 @@ impl From<&fuel_tx::Input> for Input {
                 tx_pointer: TxPointer(*tx_pointer),
                 witness_index: *witness_index,
                 predicate_gas_used: 0.into(),
-                predicate: HexString(Default::default()),
+                predicate: HexString(vec![].into()),
                 predicate_data: HexString(Default::default()),
             }),
             fuel_tx::Input::CoinPredicate(fuel_tx::input::coin::CoinPredicate {
@@ -196,8 +196,8 @@ impl From<&fuel_tx::Input> for Input {
                 tx_pointer: TxPointer(*tx_pointer),
                 witness_index: Default::default(),
                 predicate_gas_used: (*predicate_gas_used).into(),
-                predicate: HexString(predicate.to_vec()),
-                predicate_data: HexString(predicate_data.clone().into_inner()),
+                predicate: HexString::from(predicate.as_ref()),
+                predicate_data: HexString::from(predicate_data.as_ref()),
             }),
             fuel_tx::Input::Contract(contract) => Input::Contract(contract.into()),
             fuel_tx::Input::MessageCoinSigned(
@@ -239,8 +239,8 @@ impl From<&fuel_tx::Input> for Input {
                 witness_index: Default::default(),
                 predicate_gas_used: (*predicate_gas_used).into(),
                 data: HexString(Default::default()),
-                predicate: HexString(predicate.to_vec()),
-                predicate_data: HexString(predicate_data.clone().into_inner()),
+                predicate: HexString::from(predicate.as_ref()),
+                predicate_data: HexString::from(predicate_data.as_ref()),
             }),
             fuel_tx::Input::MessageDataSigned(
                 fuel_tx::input::message::MessageDataSigned {
@@ -259,9 +259,9 @@ impl From<&fuel_tx::Input> for Input {
                 nonce: Nonce(*nonce),
                 witness_index: *witness_index,
                 predicate_gas_used: 0.into(),
-                data: HexString(data.clone().into_inner()),
-                predicate: HexString(Default::default()),
-                predicate_data: HexString(Default::default()),
+                data: HexString::from(data.as_ref()),
+                predicate: HexString(vec![].into()),
+                predicate_data: HexString(vec![].into()),
             }),
             fuel_tx::Input::MessageDataPredicate(
                 fuel_tx::input::message::MessageDataPredicate {
@@ -282,9 +282,9 @@ impl From<&fuel_tx::Input> for Input {
                 nonce: Nonce(*nonce),
                 witness_index: Default::default(),
                 predicate_gas_used: (*predicate_gas_used).into(),
-                data: HexString(data.clone().into_inner()),
-                predicate: HexString(predicate.to_vec()),
-                predicate_data: HexString(predicate_data.clone().into_inner()),
+                data: HexString::from(data.as_ref()),
+                predicate: HexString::from(predicate.as_ref()),
+                predicate_data: HexString::from(predicate_data.as_ref()),
             }),
         }
     }

--- a/crates/fuel-core/src/schema/tx/receipt.rs
+++ b/crates/fuel-core/src/schema/tx/receipt.rs
@@ -126,7 +126,7 @@ impl Receipt {
     async fn gas_used(&self) -> Option<U64> {
         self.0.gas_used().map(Into::into)
     }
-    async fn data(&self) -> Option<HexString> {
+    async fn data(&self) -> Option<HexString<'_>> {
         self.0.data().map(|d| d.to_vec().into())
     }
     async fn sender(&self) -> Option<Address> {

--- a/crates/fuel-core/src/schema/tx/types.rs
+++ b/crates/fuel-core/src/schema/tx/types.rs
@@ -107,7 +107,7 @@ impl ProgramState {
         self.return_type
     }
 
-    async fn data(&self) -> HexString {
+    async fn data(&self) -> HexString<'_> {
         self.data.clone().into()
     }
 }
@@ -671,7 +671,7 @@ impl Transaction {
         self.0.is_blob()
     }
 
-    async fn inputs(&self) -> Option<Vec<Input>> {
+    async fn inputs(&self) -> Option<Vec<Input<'_>>> {
         match &self.0 {
             fuel_tx::Transaction::Script(tx) => {
                 Some(tx.inputs().iter().map(Into::into).collect())
@@ -724,37 +724,37 @@ impl Transaction {
         }
     }
 
-    async fn witnesses(&self) -> Option<Vec<HexString>> {
+    async fn witnesses<'a>(&'a self) -> Option<Vec<HexString<'a>>> {
         match &self.0 {
             fuel_tx::Transaction::Script(tx) => Some(
                 tx.witnesses()
                     .iter()
-                    .map(|w| HexString(w.clone().into_inner()))
+                    .map(|w| HexString::from(w.as_vec().as_ref()))
                     .collect(),
             ),
             fuel_tx::Transaction::Create(tx) => Some(
                 tx.witnesses()
                     .iter()
-                    .map(|w| HexString(w.clone().into_inner()))
+                    .map(|w| HexString::from(w.as_vec().as_ref()))
                     .collect(),
             ),
             fuel_tx::Transaction::Mint(_) => None,
             fuel_tx::Transaction::Upgrade(tx) => Some(
                 tx.witnesses()
                     .iter()
-                    .map(|w| HexString(w.clone().into_inner()))
+                    .map(|w| HexString::from(w.as_vec().as_ref()))
                     .collect(),
             ),
             fuel_tx::Transaction::Upload(tx) => Some(
                 tx.witnesses()
                     .iter()
-                    .map(|w| HexString(w.clone().into_inner()))
+                    .map(|w| HexString::from(w.as_vec().as_ref()))
                     .collect(),
             ),
             fuel_tx::Transaction::Blob(tx) => Some(
                 tx.witnesses()
                     .iter()
-                    .map(|w| HexString(w.clone().into_inner()))
+                    .map(|w| HexString::from(w.as_vec().as_ref()))
                     .collect(),
             ),
         }
@@ -795,10 +795,10 @@ impl Transaction {
         .map_err(Into::into)
     }
 
-    async fn script(&self) -> Option<HexString> {
+    async fn script(&self) -> Option<HexString<'_>> {
         match &self.0 {
             fuel_tx::Transaction::Script(script) => {
-                Some(HexString(script.script().clone()))
+                Some(HexString::from(script.script().as_ref()))
             }
             fuel_tx::Transaction::Create(_)
             | fuel_tx::Transaction::Mint(_)
@@ -808,10 +808,10 @@ impl Transaction {
         }
     }
 
-    async fn script_data(&self) -> Option<HexString> {
+    async fn script_data(&self) -> Option<HexString<'_>> {
         match &self.0 {
             fuel_tx::Transaction::Script(script) => {
-                Some(HexString(script.script_data().clone()))
+                Some(HexString::from(script.script_data().as_ref()))
             }
             fuel_tx::Transaction::Create(_)
             | fuel_tx::Transaction::Mint(_)
@@ -854,7 +854,7 @@ impl Transaction {
         }
     }
 
-    async fn storage_slots(&self) -> Option<Vec<HexString>> {
+    async fn storage_slots(&self) -> Option<Vec<HexString<'_>>> {
         match &self.0 {
             fuel_tx::Transaction::Script(_) => None,
             fuel_tx::Transaction::Create(create) => Some(
@@ -939,8 +939,8 @@ impl Transaction {
 
     #[graphql(complexity = "query_costs().tx_raw_payload")]
     /// Return the transaction bytes using canonical encoding
-    async fn raw_payload(&self) -> HexString {
-        HexString(self.0.clone().to_bytes())
+    async fn raw_payload(&self) -> HexString<'_> {
+        HexString::from(self.0.to_bytes())
     }
 }
 
@@ -1094,8 +1094,8 @@ impl DryRunStorageReads {
 #[derive(Clone)]
 pub struct StorageReadReplayEvent {
     column: U32,
-    key: HexString,
-    value: Option<HexString>,
+    key: HexString<'static>,
+    value: Option<HexString<'static>>,
 }
 
 impl From<fuel_core_types::services::executor::StorageReadReplayEvent>
@@ -1104,8 +1104,8 @@ impl From<fuel_core_types::services::executor::StorageReadReplayEvent>
     fn from(event: fuel_core_types::services::executor::StorageReadReplayEvent) -> Self {
         Self {
             column: event.column.into(),
-            key: HexString(event.key),
-            value: event.value.map(HexString),
+            key: HexString(event.key.into()),
+            value: event.value.map(|bytes|HexString(bytes.into())),
         }
     }
 }
@@ -1116,11 +1116,11 @@ impl StorageReadReplayEvent {
         self.column
     }
 
-    async fn key(&self) -> HexString {
+    async fn key(&self) -> HexString<'_> {
         self.key.clone()
     }
 
-    async fn value(&self) -> Option<HexString> {
+    async fn value(&self) -> Option<HexString<'_>> {
         self.value.clone()
     }
 }

--- a/crates/fuel-core/src/schema/upgrades.rs
+++ b/crates/fuel-core/src/schema/upgrades.rs
@@ -63,7 +63,7 @@ impl UpgradeQuery {
     #[graphql(complexity = "query_costs().storage_read + child_complexity")]
     async fn state_transition_bytecode_by_root(
         &self,
-        root: HexString,
+        root: HexString<'_>,
     ) -> async_graphql::Result<StateTransitionBytecode> {
         StateTransitionBytecode::try_from(root)
     }
@@ -75,15 +75,15 @@ pub struct StateTransitionBytecode {
 
 #[Object]
 impl StateTransitionBytecode {
-    async fn root(&self) -> HexString {
-        HexString(self.root.to_vec())
+    async fn root(&self) -> HexString<'_> {
+        HexString::from(self.root.as_ref())
     }
 
     #[graphql(complexity = "query_costs().state_transition_bytecode_read")]
     async fn bytecode(
         &self,
         ctx: &Context<'_>,
-    ) -> async_graphql::Result<UploadedBytecode> {
+    ) -> async_graphql::Result<UploadedBytecode<'_>> {
         let query = ctx.read_view()?;
         query
             .state_transition_bytecode(self.root)
@@ -98,38 +98,38 @@ impl From<fuel_types::Bytes32> for StateTransitionBytecode {
     }
 }
 
-impl TryFrom<HexString> for StateTransitionBytecode {
+impl TryFrom<HexString<'_>> for StateTransitionBytecode {
     type Error = async_graphql::Error;
 
     fn try_from(root: HexString) -> Result<Self, Self::Error> {
-        let root = root.0.as_slice().try_into()?;
+        let root = (*root.0).try_into()?;
         Ok(Self { root })
     }
 }
 
 #[derive(SimpleObject)]
-pub struct UploadedBytecode {
+pub struct UploadedBytecode<'a> {
     /// Combined bytecode of all uploaded subsections.
-    bytecode: HexString,
+    bytecode: HexString<'a>,
     /// Number of uploaded subsections (if incomplete).
     uploaded_subsections_number: Option<u16>,
     /// Indicates if the bytecode upload is complete.
     completed: bool,
 }
 
-impl From<StorageUploadedBytecode> for UploadedBytecode {
+impl From<StorageUploadedBytecode> for UploadedBytecode<'_> {
     fn from(value: fuel_core_types::fuel_vm::UploadedBytecode) -> Self {
         match value {
             StorageUploadedBytecode::Uncompleted {
                 bytecode,
                 uploaded_subsections_number,
             } => Self {
-                bytecode: HexString(bytecode),
+                bytecode: HexString(bytecode.into()),
                 uploaded_subsections_number: Some(uploaded_subsections_number),
                 completed: false,
             },
             StorageUploadedBytecode::Completed(bytecode) => Self {
-                bytecode: HexString(bytecode),
+                bytecode: HexString(bytecode.into()),
                 uploaded_subsections_number: None,
                 completed: true,
             },


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
close https://github.com/FuelLabs/fuel-core/issues/2657
## Description
<!-- List of detailed changes -->

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces owned HexString with Cow-backed HexString<'_> and updates GraphQL types/methods to borrow bytes where possible, reducing clones and adding required lifetimes.
> 
> - **Scalars**
>   - Replace `HexString` with `HexString<'a>` backed by `Cow<[u8]>`.
>   - Add conversions: `From<Vec<u8>>`, `From<&[u8]>`, `From<HexString> for Vec<u8>`; update `Display`, `ScalarType`, `CursorType`, `FromStr`, and `Nonce` conversions to support borrowing.
> - **GraphQL Schema Updates**
>   - Change return/input types from `HexString` to `HexString<'_>` across schema: `blob`, `contract`, `da_compressed`, `message`, `storage`, `tx` (queries, mutations, subscriptions, types, receipts), and `upgrades`.
>   - Introduce lifetimes in types and unions where needed (e.g., `Input<'a>`, `InputCoin<'a>`, `InputMessage<'a>`, `UploadedBytecode<'a>`, subscriptions).
>   - Construct `HexString` via borrowing (`HexString::from(&[..])` / `.into()`) and remove unnecessary clones in mappers (e.g., witnesses, scripts, predicate/data, storage slots, block/tx streams).
>   - Adjust pagination and connection cursors to use `HexString<'_>` where relevant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae7848d887620ce4be7ddc21a087ae86ccff2b12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->