### PR TITLE
chore(codeowners): update with new policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Default code owners for fuel-core
-* @xgreenx @Dentosal @MitchTurner
+* @xgreenx @Dentosal @MitchTurner @AurelienFT @rymnc
 
 # Code owners for the gas price algorithm
-crates/fuel-gas-price-algorithm @xgreenx @Dentosal @MitchTurner @rafal-ch
+crates/fuel-gas-price-algorithm @xgreenx @Dentosal @MitchTurner
 
 # Code owners for the transaction pool
 crates/services/txpool_v2 @xgreenx @Dentosal @MitchTurner @AurelienFT
@@ -13,30 +13,17 @@ crates/services/gas_price_service @xgreenx @Dentosal @MitchTurner @rymnc
 # Code owners for the compression service
 crates/services/compression @xgreenx @Dentosal @rymnc
 
-# Code owners for the GraphQL API
-crates/fuel-core/src/graphql_api @xgreenx @Dentosal @MitchTurner @netrome @acerone85
-crates/fuel-core/src/graphql_api.rs @xgreenx @Dentosal @MitchTurner @netrome @acerone85
-crates/fuel-core/src/schema.rs @xgreenx @Dentosal @MitchTurner @netrome @acerone85
-crates/fuel-core/src/schema.sdl @xgreenx @Dentosal @MitchTurner @netrome @acerone85
-crates/fuel-core/src/query @xgreenx @Dentosal @MitchTurner @netrome @acerone85
-
-# Code owners for the indexation
-crates/fuel-core/src/graphql_api/indexation @xgreenx @Dentosal @MitchTurner @rafal-ch
-
 # Code owners for the client
-crates/client @xgreenx @Dentosal @MitchTurner @netrome
+crates/client @xgreenx @Dentosal @MitchTurner
 
 # Code owners for the integration tests
-tests/ @xgreenx @Dentosal @MitchTurner @netrome
+tests/ @xgreenx @Dentosal @MitchTurner
 
 # Code owners for benches
-benches/ @xgreenx @Dentosal @MitchTurner @netrome
+benches/ @xgreenx @Dentosal @MitchTurner
 
 # Code owners for docs
-docs/ @xgreenx @Dentosal @MitchTurner @netrome
-
-# Code owners for the fraud proofs
-crates/fraud_proofs @xgreenx @netrome @acerone85 @rymnc
+docs/ @xgreenx @Dentosal @MitchTurner
 
 # Code owners for common files
 CHANGELOG.md @FuelLabs/client


### PR DESCRIPTION

## Linked Issues/PRs
<!-- List of related issues/PRs -->
- none

## Description
<!-- List of detailed changes -->
adds @AurelienFT and @rymnc to default codeowners

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
