### PR TITLE
Fix Typo in KeyConverter Documentation Comments

### DIFF
--- a/crates/storage/src/structured_storage/balances.rs
+++ b/crates/storage/src/structured_storage/balances.rs
@@ -24,7 +24,7 @@ mod smt {
     };
     use alloc::borrow::Cow;
 
-    /// The key convertor used to convert the key from the `ContractsAssets` table
+    /// The key converter used to convert the key from the `ContractsAssets` table
     /// to the key of the `ContractsAssetsMerkleMetadata` table.
     pub struct KeyConverter;
 

--- a/crates/storage/src/structured_storage/state.rs
+++ b/crates/storage/src/structured_storage/state.rs
@@ -21,7 +21,7 @@ mod smt {
     };
     use alloc::borrow::Cow;
 
-    /// The key convertor used to convert the key from the `ContractsState` table
+    /// The key converter used to convert the key from the `ContractsState` table
     /// to the key of the `ContractsStateMerkleMetadata` table.
     pub struct KeyConverter;
 


### PR DESCRIPTION


---



## Description
This pull request corrects a minor typo in the documentation comments for the `KeyConverter` struct in both `balances.rs` and `state.rs`. The word "convertor" has been updated to the correct spelling "converter" for improved clarity and consistency.

---