### PR TITLE
chore(compression): disable merkleized compression for now

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,6 @@ default = ["fuel-core/rocksdb", "fuel-core/rocksdb-production"]
 fault-proving = [
     "fuel-core-types/fault-proving",
     "fuel-core-chain-config/fault-proving",
-    "fuel-core/fault-proving",
     "fuel-core-storage/fault-proving",
     "fuel-core-database/fault-proving",
     "fuel-core-sync/fault-proving",

--- a/bin/fuel-core/Cargo.toml
+++ b/bin/fuel-core/Cargo.toml
@@ -41,7 +41,6 @@ fault-proving = [
     "fuel-core-storage/fault-proving",
     "fuel-core-types/fault-proving",
     "fuel-core-chain-config/fault-proving",
-    "fuel-core/fault-proving",
 ]
 
 [dependencies]

--- a/crates/compression/Cargo.toml
+++ b/crates/compression/Cargo.toml
@@ -24,7 +24,7 @@ test-helpers = [
     "fuel-core-types/random",
     "fuel-core-types/std",
 ]
-fault-proving = ["fuel-core-types/fault-proving"]
+# fault-proving = ["fuel-core-types/fault-proving"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/compression/src/lib.rs
+++ b/crates/compression/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::cast_possible_truncation)]
 #![deny(unused_crate_dependencies)]
 #![deny(warnings)]
+#![allow(unexpected_cfgs)]
 
 pub mod compress;
 mod compressed_block_payload;

--- a/crates/fuel-core/Cargo.toml
+++ b/crates/fuel-core/Cargo.toml
@@ -50,7 +50,6 @@ fault-proving = [
     "fuel-core-sync?/fault-proving",
     "fuel-core-importer/fault-proving",
     "fuel-core-poa/fault-proving",
-    "fuel-core-compression-service/fault-proving",
     "fuel-core-upgradable-executor/fault-proving",
 ]
 

--- a/crates/fuel-core/src/database/database_description/compression.rs
+++ b/crates/fuel-core/src/database/database_description/compression.rs
@@ -1,13 +1,12 @@
 use crate::database::database_description::DatabaseDescription;
 use fuel_core_compression_service::storage::column::CompressionColumn;
-use fuel_core_storage::merkle::column::MerkleizedColumn;
 use fuel_core_types::fuel_types::BlockHeight;
 
 #[derive(Clone, Copy, Debug)]
 pub struct CompressionDatabase;
 
 impl DatabaseDescription for CompressionDatabase {
-    type Column = MerkleizedColumn<CompressionColumn>;
+    type Column = CompressionColumn;
     type Height = BlockHeight;
 
     fn version() -> u32 {

--- a/crates/services/compression/Cargo.toml
+++ b/crates/services/compression/Cargo.toml
@@ -18,12 +18,12 @@ test-helpers = [
     "dep:rand",
     "dep:fuel-core-chain-config",
 ]
-fault-proving = [
-    "fuel-core-compression/fault-proving",
-    "fuel-core-chain-config?/fault-proving",
-    "fuel-core-types/fault-proving",
-    "fuel-core-storage/fault-proving",
-]
+# fault-proving = [
+#     "fuel-core-compression/fault-proving",
+#     "fuel-core-chain-config?/fault-proving",
+#     "fuel-core-types/fault-proving",
+#     "fuel-core-storage/fault-proving",
+# ]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/services/compression/src/lib.rs
+++ b/crates/services/compression/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(unused_crate_dependencies)]
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(unexpected_cfgs)]
 
 /// Configuration for the compression service
 pub mod config;

--- a/crates/services/compression/src/ports/compression_storage.rs
+++ b/crates/services/compression/src/ports/compression_storage.rs
@@ -10,7 +10,6 @@ use fuel_core_storage::{
     StorageAsMut,
     StorageSize,
     kv_store::KeyValueInspect,
-    merkle::column::MerkleizedColumn,
     not_found,
     transactional::{
         Modifiable,
@@ -29,15 +28,12 @@ pub trait LatestHeight {
 
 /// Trait for interacting with storage that supports compression
 pub trait CompressionStorage:
-    KeyValueInspect<Column = MerkleizedColumn<storage::column::CompressionColumn>>
-    + Modifiable
-    + Send
-    + Sync
+    KeyValueInspect<Column = storage::column::CompressionColumn> + Modifiable + Send + Sync
 {
 }
 
 impl<T> CompressionStorage for T where
-    T: KeyValueInspect<Column = MerkleizedColumn<storage::column::CompressionColumn>>
+    T: KeyValueInspect<Column = storage::column::CompressionColumn>
         + Modifiable
         + Send
         + Sync
@@ -54,8 +50,7 @@ pub(crate) trait WriteCompressedBlock {
 
 impl<Storage> WriteCompressedBlock for StorageTransaction<Storage>
 where
-    Storage:
-        KeyValueInspect<Column = MerkleizedColumn<storage::column::CompressionColumn>>,
+    Storage: KeyValueInspect<Column = storage::column::CompressionColumn>,
 {
     fn write_compressed_block(
         &mut self,

--- a/crates/services/compression/src/storage.rs
+++ b/crates/services/compression/src/storage.rs
@@ -1,5 +1,3 @@
-use fuel_core_storage::merkle::sparse::Merkleized;
-
 /// Generates a random RegistryKey
 #[cfg(feature = "test-helpers")]
 #[allow(clippy::arithmetic_side_effects)]
@@ -25,32 +23,32 @@ pub mod registrations;
 pub mod timestamps;
 
 /// Merkleized Address table type alias
-pub type Address = Merkleized<address::Address>;
+pub type Address = address::Address;
 
 /// Merkleized AssetId table type alias
-pub type AssetId = Merkleized<asset_id::AssetId>;
+pub type AssetId = asset_id::AssetId;
 
 /// Merkleized ContractId table type alias
-pub type ContractId = Merkleized<contract_id::ContractId>;
+pub type ContractId = contract_id::ContractId;
 
 /// Merkleized EvictorCache table type alias
-pub type EvictorCache = Merkleized<evictor_cache::EvictorCache>;
+pub type EvictorCache = evictor_cache::EvictorCache;
 
 /// Merkleized PredicateCode table type alias
-pub type PredicateCode = Merkleized<predicate_code::PredicateCode>;
+pub type PredicateCode = predicate_code::PredicateCode;
 
 /// Merkleized ScriptCode table type alias
-pub type ScriptCode = Merkleized<script_code::ScriptCode>;
+pub type ScriptCode = script_code::ScriptCode;
 
 /// Merkleized RegistryIndex table type alias
-pub type RegistryIndex = Merkleized<registry_index::RegistryIndex>;
+pub type RegistryIndex = registry_index::RegistryIndex;
 
 /// Merkleized Timestamps table type alias
-pub type Timestamps = Merkleized<timestamps::Timestamps>;
+pub type Timestamps = timestamps::Timestamps;
 
 /// Re-export to match api
 pub use compressed_blocks::CompressedBlocks;
 
 /// Merkleized Registrations table type alias
 #[cfg(feature = "fault-proving")]
-pub type Registrations = Merkleized<registrations::Registrations>;
+pub type Registrations = registrations::Registrations;

--- a/crates/services/compression/src/storage/address.rs
+++ b/crates/services/compression/src/storage/address.rs
@@ -7,26 +7,14 @@ use fuel_core_storage::{
         postcard::Postcard,
         raw::Raw,
     },
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 use fuel_core_types::fuel_compression::RegistryKey;
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 
 /// Table that indexes the addresses.
 pub struct Address;
-
-impl MerkleizedTableColumn for Address {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::Address
-    }
-}
 
 impl Mappable for Address {
     type Key = Self::OwnedKey;
@@ -37,10 +25,10 @@ impl Mappable for Address {
 
 impl TableWithBlueprint for Address {
     type Blueprint = Plain<Postcard, Raw>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::Address
     }
 }
 

--- a/crates/services/compression/src/storage/asset_id.rs
+++ b/crates/services/compression/src/storage/asset_id.rs
@@ -7,26 +7,14 @@ use fuel_core_storage::{
         postcard::Postcard,
         raw::Raw,
     },
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 use fuel_core_types::fuel_compression::RegistryKey;
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 
 /// Table that indexes the asset ids.
 pub struct AssetId;
-
-impl MerkleizedTableColumn for AssetId {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::AssetId
-    }
-}
 
 impl Mappable for AssetId {
     type Key = Self::OwnedKey;
@@ -37,10 +25,10 @@ impl Mappable for AssetId {
 
 impl TableWithBlueprint for AssetId {
     type Blueprint = Plain<Postcard, Raw>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::AssetId
     }
 }
 

--- a/crates/services/compression/src/storage/column.rs
+++ b/crates/services/compression/src/storage/column.rs
@@ -1,11 +1,8 @@
 //! Column enum for the database.
 
-use fuel_core_storage::merkle::{
-    column::{
-        AsU32,
-        MerkleizedColumn,
-    },
-    sparse::MerkleizedTableColumn,
+use fuel_core_storage::{
+    kv_store::StorageColumn,
+    merkle::column::AsU32,
 };
 
 /// Enum representing the columns in the storage.
@@ -43,6 +40,8 @@ pub enum CompressionColumn {
     #[cfg(feature = "fault-proving")]
     /// Keeps track of registrations per table associated with a compressed block, see [`Registrations`](crate::storage::registrations::Registrations)
     Registrations = 9,
+    /// Metadata table
+    Metadata = 10,
 }
 
 impl AsU32 for CompressionColumn {
@@ -51,6 +50,13 @@ impl AsU32 for CompressionColumn {
     }
 }
 
-/// Type alias to get the `MerkleizedColumn` for some type that implements `MerkleizedTableColumn`.
-pub type MerkleizedColumnOf<TC> =
-    MerkleizedColumn<<TC as MerkleizedTableColumn>::TableColumn>;
+impl StorageColumn for CompressionColumn {
+    fn name(&self) -> String {
+        let str: &str = self.into();
+        str.to_string()
+    }
+
+    fn id(&self) -> u32 {
+        *self as u32
+    }
+}

--- a/crates/services/compression/src/storage/compressed_blocks.rs
+++ b/crates/services/compression/src/storage/compressed_blocks.rs
@@ -1,9 +1,6 @@
 //! The table for the compressed blocks sent to DA.
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 use fuel_core_compression::VersionedCompressedBlock;
 use fuel_core_storage::{
     Mappable,
@@ -12,7 +9,6 @@ use fuel_core_storage::{
         postcard::Postcard,
         primitive::Primitive,
     },
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 
@@ -28,21 +24,13 @@ impl Mappable for CompressedBlocks {
     type OwnedValue = VersionedCompressedBlock;
 }
 
-impl MerkleizedTableColumn for CompressedBlocks {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::CompressedBlocks
-    }
-}
-
 impl TableWithBlueprint for CompressedBlocks {
     // we don't use the Merkleized blueprint because we don't need it for this table
     type Blueprint = Plain<Primitive<4>, Postcard>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::CompressedBlocks
     }
 }
 

--- a/crates/services/compression/src/storage/contract_id.rs
+++ b/crates/services/compression/src/storage/contract_id.rs
@@ -7,26 +7,14 @@ use fuel_core_storage::{
         postcard::Postcard,
         raw::Raw,
     },
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 use fuel_core_types::fuel_compression::RegistryKey;
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 
 /// Table that indexes the addresses.
 pub struct ContractId;
-
-impl MerkleizedTableColumn for ContractId {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::ContractId
-    }
-}
 
 impl Mappable for ContractId {
     type Key = Self::OwnedKey;
@@ -37,10 +25,10 @@ impl Mappable for ContractId {
 
 impl TableWithBlueprint for ContractId {
     type Blueprint = Plain<Postcard, Raw>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::ContractId
     }
 }
 

--- a/crates/services/compression/src/storage/evictor_cache.rs
+++ b/crates/services/compression/src/storage/evictor_cache.rs
@@ -4,15 +4,11 @@ use fuel_core_storage::{
     Mappable,
     blueprint::plain::Plain,
     codec::postcard::Postcard,
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 use fuel_core_types::fuel_compression::RegistryKey;
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 
 /// The metadata key used by `EvictorCache` table to
 /// store progress of the evictor.
@@ -57,14 +53,6 @@ impl rand::distributions::Distribution<MetadataKey> for rand::distributions::Sta
 /// Table that indexes the addresses.
 pub struct EvictorCache;
 
-impl MerkleizedTableColumn for EvictorCache {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::EvictorCache
-    }
-}
-
 impl Mappable for EvictorCache {
     type Key = Self::OwnedKey;
     type OwnedKey = MetadataKey;
@@ -74,10 +62,10 @@ impl Mappable for EvictorCache {
 
 impl TableWithBlueprint for EvictorCache {
     type Blueprint = Plain<Postcard, Postcard>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::EvictorCache
     }
 }
 

--- a/crates/services/compression/src/storage/predicate_code.rs
+++ b/crates/services/compression/src/storage/predicate_code.rs
@@ -7,26 +7,14 @@ use fuel_core_storage::{
         postcard::Postcard,
         raw::Raw,
     },
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 use fuel_core_types::fuel_compression::RegistryKey;
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 
 /// Table that indexes the predicate codes
 pub struct PredicateCode;
-
-impl MerkleizedTableColumn for PredicateCode {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::PredicateCode
-    }
-}
 
 impl Mappable for PredicateCode {
     type Key = Self::OwnedKey;
@@ -37,10 +25,10 @@ impl Mappable for PredicateCode {
 
 impl TableWithBlueprint for PredicateCode {
     type Blueprint = Plain<Postcard, Raw>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::PredicateCode
     }
 }
 

--- a/crates/services/compression/src/storage/registrations.rs
+++ b/crates/services/compression/src/storage/registrations.rs
@@ -5,7 +5,6 @@ use fuel_core_storage::{
     Mappable,
     blueprint::plain::Plain,
     codec::postcard::Postcard,
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 
@@ -17,14 +16,6 @@ use super::column::{
 /// Table that indexes the registrations.
 pub struct Registrations;
 
-impl MerkleizedTableColumn for Registrations {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::Registrations
-    }
-}
-
 impl Mappable for Registrations {
     type Key = Self::OwnedKey;
     type OwnedKey = fuel_core_types::fuel_types::BlockHeight;
@@ -34,10 +25,10 @@ impl Mappable for Registrations {
 
 impl TableWithBlueprint for Registrations {
     type Blueprint = Plain<Postcard, Postcard>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::Registrations
     }
 }
 

--- a/crates/services/compression/src/storage/registry_index.rs
+++ b/crates/services/compression/src/storage/registry_index.rs
@@ -4,7 +4,6 @@ use fuel_core_storage::{
     Mappable,
     blueprint::plain::Plain,
     codec::postcard::Postcard,
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 use fuel_core_types::{
@@ -20,10 +19,7 @@ use fuel_core_types::{
 };
 use std::ops::Deref;
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 
 #[derive(
     Debug,
@@ -100,14 +96,6 @@ impl rand::distributions::Distribution<ReverseKey> for rand::distributions::Stan
 /// Table that indexes the script codes
 pub struct RegistryIndex;
 
-impl MerkleizedTableColumn for RegistryIndex {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::RegistryIndex
-    }
-}
-
 impl Mappable for RegistryIndex {
     type Key = Self::OwnedKey;
     type OwnedKey = ReverseKey;
@@ -117,10 +105,10 @@ impl Mappable for RegistryIndex {
 
 impl TableWithBlueprint for RegistryIndex {
     type Blueprint = Plain<Postcard, Postcard>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::RegistryIndex
     }
 }
 

--- a/crates/services/compression/src/storage/script_code.rs
+++ b/crates/services/compression/src/storage/script_code.rs
@@ -7,26 +7,14 @@ use fuel_core_storage::{
         postcard::Postcard,
         raw::Raw,
     },
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 use fuel_core_types::fuel_compression::RegistryKey;
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 
 /// Table that indexes the script codes
 pub struct ScriptCode;
-
-impl MerkleizedTableColumn for ScriptCode {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::ScriptCode
-    }
-}
 
 impl Mappable for ScriptCode {
     type Key = Self::OwnedKey;
@@ -37,10 +25,10 @@ impl Mappable for ScriptCode {
 
 impl TableWithBlueprint for ScriptCode {
     type Blueprint = Plain<Postcard, Raw>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::ScriptCode
     }
 }
 

--- a/crates/services/compression/src/storage/timestamps.rs
+++ b/crates/services/compression/src/storage/timestamps.rs
@@ -9,14 +9,10 @@ use fuel_core_storage::{
     Mappable,
     blueprint::plain::Plain,
     codec::postcard::Postcard,
-    merkle::sparse::MerkleizedTableColumn,
     structured_storage::TableWithBlueprint,
 };
 
-use super::column::{
-    CompressionColumn,
-    MerkleizedColumnOf,
-};
+use super::column::CompressionColumn;
 
 /// The metadata key used by `DaCompressionTemporalRegistryTimsetamps` table to
 /// keep track of when each key was last updated.
@@ -83,14 +79,6 @@ impl rand::distributions::Distribution<TimestampKeyspace>
 /// Table that indexes the timestamps.
 pub struct Timestamps;
 
-impl MerkleizedTableColumn for Timestamps {
-    type TableColumn = CompressionColumn;
-
-    fn table_column() -> Self::TableColumn {
-        Self::TableColumn::Timestamps
-    }
-}
-
 impl Mappable for Timestamps {
     type Key = Self::OwnedKey;
     type OwnedKey = TimestampKey;
@@ -100,10 +88,10 @@ impl Mappable for Timestamps {
 
 impl TableWithBlueprint for Timestamps {
     type Blueprint = Plain<Postcard, Postcard>;
-    type Column = MerkleizedColumnOf<Self>;
+    type Column = CompressionColumn;
 
     fn column() -> Self::Column {
-        Self::Column::TableColumn(Self::table_column())
+        Self::Column::Timestamps
     }
 }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -17,13 +17,10 @@ default = ["fuel-core/default"]
 only-p2p = ["fuel-core-p2p"]
 aws-kms = ["dep:aws-config", "dep:aws-sdk-kms", "fuel-core-bin/aws-kms"]
 fault-proving = [
-    "fuel-core/fault-proving",
     "fuel-core-types/fault-proving",
     "fuel-core-storage/fault-proving",
     "fuel-core-upgradable-executor/fault-proving",
     "fuel-core-poa/fault-proving",
-    "fuel-core-compression/fault-proving",
-    "fuel-core-compression-service/fault-proving",
     "fuel-core-benches/fault-proving",
 ]
 


### PR DESCRIPTION
> [!WARNING]
> this introduces some tech debt on the fault proving feature flag
> 1. introduced `#[allow(unexpected_cfgs)]` in compression and compression service crate
> 2. disabled instances of usage of fault proving feature for the above 2 crates

This PR is meant to be reverted later when we continue work on FP.

## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
