### PR TITLE
chore: avoid usage of the BoxedStream

### DIFF
--- a/crates/services/tx_status_manager/src/subscriptions.rs
+++ b/crates/services/tx_status_manager/src/subscriptions.rs
@@ -1,7 +1,20 @@
+use async_trait::async_trait;
+use tokio_stream::StreamExt;
 use fuel_core_services::stream::BoxStream;
 
 use crate::ports::P2PPreConfirmationGossipData;
 
-pub(super) struct Subscriptions {
+#[async_trait]
+pub trait TxStatusSubscription: Send {
+    async fn next_tx_status(&mut self) -> Option<P2PPreConfirmationGossipData>;
+}
+pub struct Subscriptions {
     pub new_tx_status: BoxStream<P2PPreConfirmationGossipData>,
+}
+
+#[async_trait]
+impl TxStatusSubscription for Subscriptions {
+    async fn next_tx_status(&mut self) -> Option<P2PPreConfirmationGossipData> {
+        self.new_tx_status.next().await
+    }
 }


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->
Close #2836
Introduce `AsyncIterTrait` that just returns next element.
Refactor returns of `BoxStream` with the trait above.
Note: in stable rust it's not possible to create type alias like 
`type AsyncIterAlias<T> = impl AsyncIterTrait<Item=T> + Send + Sync + Unpin + 'static;`, so expect to see in code a lot of long returns like `-> impl AsyncIterTrait<Item = Self::GossipedStatuses> + Send + Unpin + 'static`.

<img width="524" height="338" alt="Screenshot 2025-07-13 at 16 22 15" src="https://github.com/user-attachments/assets/f0e5d011-e197-4c37-a567-4c440ca5a91f" />


## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
