### PR TITLE
Use inputs/outputs instead of events to compress blocks

### DIFF
--- a/.changes/fixed/3071.md
+++ b/.changes/fixed/3071.md
@@ -1,0 +1,1 @@
+Use outputs instead of events to compress blocks

--- a/crates/fuel-core/src/service/adapters/compression_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/compression_adapters.rs
@@ -21,7 +21,10 @@ use fuel_core_compression_service::{
     },
 };
 use fuel_core_storage::transactional::HistoricalView;
-use fuel_core_types::services::block_importer::SharedImportResult;
+use fuel_core_types::{
+    fuel_types::ChainId,
+    services::block_importer::SharedImportResult,
+};
 
 use super::import_result_provider::{
     self,
@@ -69,11 +72,12 @@ impl block_source::BlockSource for CompressionBlockImporterAdapter {
 impl configuration::CompressionConfigProvider
     for crate::service::config::DaCompressionConfig
 {
-    fn config(&self) -> config::CompressionConfig {
+    fn config(&self, chain_id: ChainId) -> config::CompressionConfig {
         config::CompressionConfig::new(
             self.retention_duration,
             self.starting_height,
             self.metrics,
+            chain_id,
         )
     }
 }

--- a/crates/fuel-core/src/service/adapters/compression_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/compression_adapters.rs
@@ -1,3 +1,7 @@
+use super::import_result_provider::{
+    self,
+    ImportResultProvider,
+};
 use crate::{
     database::{
         Database,
@@ -22,13 +26,9 @@ use fuel_core_compression_service::{
 };
 use fuel_core_storage::transactional::HistoricalView;
 use fuel_core_types::{
+    blockchain::block::Block,
     fuel_types::ChainId,
     services::block_importer::SharedImportResult,
-};
-
-use super::import_result_provider::{
-    self,
-    ImportResultProvider,
 };
 
 /// Provides the necessary functionality for accessing latest and historical block data.
@@ -63,9 +63,13 @@ impl block_source::BlockSource for CompressionBlockImporterAdapter {
         self.block_importer.events_shared_result()
     }
 
-    fn get_block(&self, height: BlockAt) -> anyhow::Result<SharedImportResult> {
-        self.import_result_provider_adapter
-            .result_at_height(height.into())
+    fn get_block(&self, height: BlockAt) -> anyhow::Result<Block> {
+        let block = &self
+            .import_result_provider_adapter
+            .result_at_height(height.into())?
+            .sealed_block
+            .entity;
+        Ok(block.clone())
     }
 }
 

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -42,7 +42,7 @@ use super::{
         P2PAdapter,
         TxStatusManagerAdapter,
         compression_adapters::{
-            CompressionBlockImporterAdapter,
+            CompressionBlockDBAdapter,
             CompressionServiceAdapter,
         },
     },
@@ -401,9 +401,9 @@ pub fn init_sub_services(
     let compression_service_adapter =
         CompressionServiceAdapter::new(database.compression().clone());
 
-    let compression_importer_adapter = CompressionBlockImporterAdapter::new(
+    let compression_importer_adapter = CompressionBlockDBAdapter::new(
         importer_adapter.clone(),
-        import_result_provider.clone(),
+        database.on_chain().clone(),
     );
 
     let compression_service = match &config.da_compression {

--- a/crates/fuel-core/src/service/sub_services.rs
+++ b/crates/fuel-core/src/service/sub_services.rs
@@ -414,6 +414,7 @@ pub fn init_sub_services(
                 database.compression().clone(),
                 cfg.clone(),
                 database.on_chain().clone(),
+                chain_id,
             )
             .map_err(|e| anyhow::anyhow!(e))?,
         ),

--- a/crates/services/compression/src/config.rs
+++ b/crates/services/compression/src/config.rs
@@ -1,3 +1,4 @@
+use fuel_core_types::fuel_types::ChainId;
 use std::{
     num::NonZeroU32,
     time::Duration,
@@ -9,6 +10,7 @@ pub struct CompressionConfig {
     temporal_registry_retention: Duration,
     starting_height: Option<NonZeroU32>,
     metrics: bool,
+    chain_id: ChainId,
 }
 
 impl CompressionConfig {
@@ -17,11 +19,13 @@ impl CompressionConfig {
         temporal_registry_retention: Duration,
         starting_height: Option<NonZeroU32>,
         metrics: bool,
+        chain_id: ChainId,
     ) -> Self {
         Self {
             temporal_registry_retention,
             starting_height,
             metrics,
+            chain_id,
         }
     }
 
@@ -38,6 +42,11 @@ impl CompressionConfig {
     /// Get the override starting height
     pub fn starting_height(&self) -> Option<u32> {
         self.starting_height.map(|height| height.get())
+    }
+
+    /// Get the chain ID
+    pub fn chain_id(&self) -> ChainId {
+        self.chain_id
     }
 }
 

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -1,4 +1,5 @@
 use fuel_core_services::stream::BoxStream;
+use fuel_core_types::blockchain::block::Block;
 pub(crate) use fuel_core_types::services::block_importer::SharedImportResult as BlockWithMetadata;
 
 pub(crate) type BlockHeight = u32;
@@ -68,5 +69,5 @@ pub trait BlockSource: Send + Sync {
     /// Should provide a stream of blocks with metadata
     fn subscribe(&self) -> BlockStream;
     /// Should provide the block at a given height
-    fn get_block(&self, height: BlockAt) -> anyhow::Result<BlockWithMetadata>;
+    fn get_block(&self, height: BlockAt) -> anyhow::Result<Block>;
 }

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -5,7 +5,6 @@ pub(crate) type BlockHeight = u32;
 
 pub(crate) trait BlockWithMetadataExt {
     fn height(&self) -> &BlockHeight;
-    fn events(&self) -> &[fuel_core_types::services::executor::Event];
     fn block(&self) -> &fuel_core_types::blockchain::block::Block;
     #[cfg(test)]
     fn default() -> Self;
@@ -14,10 +13,6 @@ pub(crate) trait BlockWithMetadataExt {
 }
 
 impl BlockWithMetadataExt for BlockWithMetadata {
-    fn events(&self) -> &[fuel_core_types::services::executor::Event] {
-        self.events.as_ref()
-    }
-
     fn height(&self) -> &BlockHeight {
         self.block().header().height()
     }

--- a/crates/services/compression/src/ports/block_source.rs
+++ b/crates/services/compression/src/ports/block_source.rs
@@ -55,15 +55,6 @@ pub enum BlockAt {
     Genesis,
 }
 
-impl PartialEq<BlockHeight> for BlockAt {
-    fn eq(&self, other: &BlockHeight) -> bool {
-        match self {
-            Self::Genesis => 0 == *other,
-            Self::Specific(h) => h == other,
-        }
-    }
-}
-
 /// Port for L2 blocks source
 pub trait BlockSource: Send + Sync {
     /// Should provide a stream of blocks with metadata

--- a/crates/services/compression/src/ports/configuration.rs
+++ b/crates/services/compression/src/ports/configuration.rs
@@ -1,7 +1,8 @@
 use crate::config::CompressionConfig;
+use fuel_core_types::fuel_types::ChainId;
 
 /// Configuration for the compression service
 pub trait CompressionConfigProvider: Send + Sync {
     /// getter for the compression config
-    fn config(&self) -> CompressionConfig;
+    fn config(&self, chain_id: ChainId) -> CompressionConfig;
 }

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -134,8 +134,7 @@ where
     let mut storage_tx = storage.write_transaction();
 
     // compress the block
-    // TODO: pass correct ChainId
-    let chain_id = ChainId::new(999);
+    let chain_id = config.chain_id();
     let compression_context = CompressionContext::create_from_block(
         &mut storage_tx,
         block_with_metadata.block(),
@@ -435,6 +434,7 @@ pub fn new_service<B, S, C, CH>(
     storage: S,
     config_provider: C,
     canonical_height: CH,
+    chain_id: ChainId,
 ) -> crate::Result<ServiceRunner<UninitializedCompressionService<B, S, CH>>>
 where
     B: BlockSource,
@@ -442,7 +442,7 @@ where
     C: CompressionConfigProvider,
     CH: CanonicalHeight,
 {
-    let config = config_provider.config();
+    let config = config_provider.config(chain_id);
     Ok(ServiceRunner::new(UninitializedCompressionService::new(
         block_source,
         storage,

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -596,13 +596,15 @@ mod tests {
             tokio_stream::iter(self.0.clone()).into_boxed()
         }
 
-        fn get_block(
-            &self,
-            height: crate::ports::block_source::BlockAt,
-        ) -> anyhow::Result<Block> {
+        fn get_block(&self, height: BlockAt) -> anyhow::Result<Block> {
+            let block_height = match height {
+                BlockAt::Specific(h) => h,
+                // this is not always true, but for our tests we assume genesis is at height 0
+                BlockAt::Genesis => 0,
+            };
             self.0
                 .iter()
-                .find(|block| height == *block.height())
+                .find(|block| block.height() == &block_height)
                 .map(|block| block.block().clone())
                 .ok_or_else(|| anyhow::anyhow!("Block not found"))
         }

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::CompressionConfig,
+    errors::CompressionError,
     metrics::CompressionMetricsManager,
     ports::{
         block_source::{
@@ -133,20 +134,14 @@ where
     let mut storage_tx = storage.write_transaction();
 
     // compress the block
-    // TODO: This creation should iterate over all the txs in the block and create a hashmap of UTxO ID -> Tx Pointer
-    // let compression_context = CompressionContext {
-    //     compression_storage: CompressionStorageWrapper {
-    //         storage_tx: &mut storage_tx,
-    //     },
-    //     block_events: block_with_metadata.events(),
-    // };
+    // TODO: pass correct ChainId
     let chain_id = ChainId::new(999);
     let compression_context = CompressionContext::create_from_block(
         &mut storage_tx,
-        &block_with_metadata.block(),
+        block_with_metadata.block(),
         chain_id,
     )
-    .map_err(|e| crate::errors::CompressionError::FailedToCompressBlock(e))?;
+    .map_err(CompressionError::FailedToCompressBlock)?;
     let compressed_block = compress(
         &config.into(),
         compression_context,

--- a/crates/services/compression/src/service.rs
+++ b/crates/services/compression/src/service.rs
@@ -517,7 +517,7 @@ mod tests {
 
     impl Default for MockConfigProvider {
         fn default() -> Self {
-            let chain_id = ChainId::new(123);
+            let chain_id = ChainId::default();
             Self(CompressionConfig::new(
                 std::time::Duration::from_secs(10),
                 None,
@@ -560,7 +560,7 @@ mod tests {
     #[tokio::test]
     async fn compression_service__can_be_started_and_stopped() {
         // given
-        let chain_id = ChainId::new(123);
+        let chain_id = ChainId::default();
         let block_source = EmptyBlockSource;
         let storage = test_storage();
         let config_provider = MockConfigProvider::default();
@@ -612,7 +612,7 @@ mod tests {
     async fn compression_service__run__does_not_compress_blocks_if_no_blocks_provided() {
         // given
         // we provide a block source that will return None upon calling .next()
-        let chain_id = ChainId::new(123);
+        let chain_id = ChainId::default();
         let block_source = MockBlockSource::new(vec![]);
         let storage = test_storage();
         let config_provider = MockConfigProvider::default();
@@ -643,7 +643,7 @@ mod tests {
     async fn compression_service__run__compresses_blocks() {
         // given
         // we provide a block source that will return a block upon calling .next()
-        let chain_id = ChainId::new(123);
+        let chain_id = ChainId::default();
         let block_with_metadata = BlockWithMetadata::default();
         let block_source = MockBlockSource::new(vec![block_with_metadata]);
         let storage = test_storage();
@@ -684,7 +684,7 @@ mod tests {
     async fn compression_service__syncs_from_scratch_when_database_is_empty() {
         // given: we start the compression service, with a canonical height provider of height 5
         let block_count = 10;
-        let chain_id = ChainId::new(123);
+        let chain_id = ChainId::default();
         let mut blocks = Vec::with_capacity(block_count);
         for i in 0..u32::try_from(block_count).unwrap() {
             blocks.push(BlockWithMetadata::test_block_with_height(i));
@@ -722,7 +722,7 @@ mod tests {
         // given: we start the compression service, with a canonical height provider of height 5,
         // and a config override of starting height 1
         let block_count = 10;
-        let chain_id = ChainId::new(123);
+        let chain_id = ChainId::default();
         let override_starting_height = 1;
         let mut blocks = Vec::with_capacity(block_count);
         for i in 0..u32::try_from(block_count).unwrap() {
@@ -771,7 +771,7 @@ mod tests {
         let storage = test_storage();
         let config_provider = MockConfigProvider::default();
         let canonical_height_provider = MockCanonicalHeightProvider::default();
-        let chain_id = ChainId::new(123);
+        let chain_id = ChainId::default();
 
         let uninit_service = UninitializedCompressionService::new(
             block_source,

--- a/crates/services/compression/src/temporal_registry.rs
+++ b/crates/services/compression/src/temporal_registry.rs
@@ -323,7 +323,7 @@ impl<CS> UtxoIdToPointer for CompressionContext<'_, CS> {
                 output_index: utxo_id.output_index(),
             })
             .ok_or(anyhow::anyhow!(
-                "UtxoId not found in the compression context"
+                "UTxO Id not found in the compression context"
             ))
     }
 }

--- a/crates/services/compression/src/temporal_registry.rs
+++ b/crates/services/compression/src/temporal_registry.rs
@@ -77,6 +77,17 @@ impl<'a, CS> CompressionContext<'a, CS> {
             let tx_index = u16::try_from(tx_index)
                 .map_err(|_| anyhow::anyhow!("Transaction index exceeds u16 limit"))?;
             let tx_id = tx.id(&chain_id);
+            for input in tx.inputs().iter() {
+                if let fuel_core_types::fuel_tx::Input::CoinPredicate(coin) = input {
+                    let utxo_id = coin.utxo_id;
+                    let tx_pointer = coin.tx_pointer;
+                    tx_pointers.insert(utxo_id, tx_pointer);
+                } else if let fuel_core_types::fuel_tx::Input::CoinSigned(coin) = input {
+                    let utxo_id = coin.utxo_id;
+                    let tx_pointer = coin.tx_pointer;
+                    tx_pointers.insert(utxo_id, tx_pointer);
+                }
+            }
             for (index, output) in tx.outputs().iter().enumerate() {
                 let index = u16::try_from(index)
                     .map_err(|_| anyhow::anyhow!("Output index exceeds u16 limit"))?;


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
closes https://github.com/FuelLabs/fuel-core/issues/3066

## Description
<!-- List of detailed changes -->
The `UninitializedCompressionService` relies on the the validation of old blocks. The problem is that if the block was committed too long ago, we can't reproduce the state before it was committed. This will cause the compression service to break if we are trying to sync old blocks.

This removes the need to get the events from execution and instead gets the correct information from inputs and outputs of the block in storage.

This code also improves the performance by sorting all the UTxOs used in each block before looking up the tx_pointer for each tx. So it's O(N) instead of O(N^2).

### Note:
I didn't add any new tests since this should have parity with the old behavior. It might be nice to add a test for the case where we are behind state rewind?

### Before requesting review
- [x] I have reviewed the code myself

### Followup Issues
The work done in this PR wasn't meant to add any behavior, so we didn't add any tests. But it clarified some places we were missing coverage, so I've created a followup issue: https://github.com/FuelLabs/fuel-core/issues/3073 