### PR TITLE
Block Aggregator Service Scaffolding

### DIFF
--- a/.changes/added/3085.md
+++ b/.changes/added/3085.md
@@ -1,0 +1,1 @@
+Add scaffolding for the new block aggregator service

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,8 +1399,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fuel-core-services",
- "futures-util",
- "rand 0.9.2",
+ "futures",
+ "rand 0.8.5",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,7 @@ dependencies = [
  "fuel-core-services",
  "futures-util",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,6 +1398,7 @@ name = "block_aggregator_api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "fuel-core-services",
  "futures",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,7 @@ dependencies = [
  "anyhow",
  "fuel-core-services",
  "futures-util",
+ "rand 0.9.2",
  "tokio",
  "tracing",
 ]
@@ -6640,7 +6641,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -8024,7 +8025,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
  "rustls 0.23.27",
@@ -8084,9 +8085,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -11575,7 +11576,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.9.1",
+ "rand 0.9.2",
  "static_assertions",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "rand 0.9.2",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1435,7 +1436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata",
  "serde",
 ]
 
@@ -5741,7 +5742,7 @@ dependencies = [
  "lalrpop-util 0.20.2",
  "petgraph",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -5755,7 +5756,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.9",
+ "regex-automata",
 ]
 
 [[package]]
@@ -6434,7 +6435,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "syn 2.0.101",
 ]
 
@@ -6501,11 +6502,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -6858,12 +6859,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7107,12 +7107,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -7779,7 +7773,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -8258,17 +8252,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -8279,7 +8264,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -8287,12 +8272,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -10459,14 +10438,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "fuel-core-services",
+ "fuel-core-types 0.46.0",
  "futures",
  "rand 0.8.5",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block_aggregator_api"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fuel-core-services",
+ "tokio",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,6 +1399,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "fuel-core-services",
+ "futures-util",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/keygen",
     "crates/metrics",
     "crates/services",
+    "crates/services/block_aggregator_api",
     "crates/services/compression",
     "crates/services/consensus_module",
     "crates/services/consensus_module/bft",

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 fuel-core-services = { workspace = true}
 tokio = "1.45.1"
 anyhow = "1.0.98"
+futures-util = "0.3.31"
 
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "block_aggregator_api"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+fuel-core-services = { workspace = true}
+tokio = "1.45.1"
+anyhow = "1.0.98"
+
+[dev-dependencies]
+fuel-core-services = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -9,6 +9,7 @@ fuel-core-services = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+bytes = { workspace = true }
 
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -4,12 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0.98"
+anyhow = { workspace = true }
 fuel-core-services = { workspace = true }
-futures-util = "0.3.31"
-rand = "0.9.2"
-tokio = "1.45.1"
-tracing = "0.1.41"
+rand = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-fuel-core-services = { workspace = true}
-tokio = "1.45.1"
 anyhow = "1.0.98"
+fuel-core-services = { workspace = true }
 futures-util = "0.3.31"
-tracing = "0.1.41"
 rand = "0.9.2"
+tokio = "1.45.1"
+tracing = "0.1.41"
 
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -9,6 +9,7 @@ tokio = "1.45.1"
 anyhow = "1.0.98"
 futures-util = "0.3.31"
 tracing = "0.1.41"
+rand = "0.9.2"
 
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2024"
 
 [dependencies]
 anyhow = { workspace = true }
+bytes = { workspace = true }
 fuel-core-services = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-bytes = { workspace = true }
 
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }
-tracing-subscriber = { workspace = true }
 futures = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -8,6 +8,7 @@ fuel-core-services = { workspace = true}
 tokio = "1.45.1"
 anyhow = "1.0.98"
 futures-util = "0.3.31"
+tracing = "0.1.41"
 
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 anyhow = { workspace = true }
 bytes = { workspace = true }
 fuel-core-services = { workspace = true }
+fuel-core-types = { workspace = true, features = ["std"] }
 rand = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -13,3 +13,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }
 tracing-subscriber = { workspace = true }
+futures = { workspace = true }

--- a/crates/services/block_aggregator_api/Cargo.toml
+++ b/crates/services/block_aggregator_api/Cargo.toml
@@ -13,3 +13,4 @@ rand = "0.9.2"
 
 [dev-dependencies]
 fuel-core-services = { workspace = true, features = ["test-helpers"] }
+tracing-subscriber = { workspace = true }

--- a/crates/services/block_aggregator_api/src/api.rs
+++ b/crates/services/block_aggregator_api/src/api.rs
@@ -6,8 +6,12 @@ use tokio::sync::oneshot::{
     channel,
 };
 
+/// The API for querying the block aggregator service.
 pub trait BlockAggregatorApi: Send + Sync {
+    /// The type of the block range response.
     type BlockRangeResponse;
+
+    /// Awaits the next query to the block aggregator service.
     fn await_query(
         &mut self,
     ) -> impl Future<Output = Result<BlockAggregatorQuery<Self::BlockRangeResponse>>> + Send;

--- a/crates/services/block_aggregator_api/src/api.rs
+++ b/crates/services/block_aggregator_api/src/api.rs
@@ -1,9 +1,6 @@
 use crate::{
     blocks::Block,
-    result::{
-        Error,
-        Result,
-    },
+    result::Result,
 };
 use fuel_core_services::stream::BoxStream;
 use tokio::sync::oneshot::{

--- a/crates/services/block_aggregator_api/src/api.rs
+++ b/crates/services/block_aggregator_api/src/api.rs
@@ -53,7 +53,7 @@ impl BlockAggregatorQuery {
         (query, receiver)
     }
 
-    pub(crate) fn get_current_height() -> (Self, Receiver<u64>) {
+    pub fn get_current_height() -> (Self, Receiver<u64>) {
         let (sender, receiver) = channel();
         let query = Self::GetCurrentHeight { response: sender };
         (query, receiver)

--- a/crates/services/block_aggregator_api/src/api.rs
+++ b/crates/services/block_aggregator_api/src/api.rs
@@ -1,0 +1,38 @@
+use crate::{
+    blocks::Block,
+    result::{
+        Error,
+        Result,
+    },
+};
+use tokio::sync::mpsc::{
+    Receiver,
+    Sender,
+    channel,
+};
+
+pub trait BlockAggregatorApi: Send + Sync {
+    fn await_query(
+        &mut self,
+    ) -> impl Future<Output = Result<BlockAggregatorQuery>> + Send;
+}
+
+pub enum BlockAggregatorQuery {
+    GetBlockRange {
+        first: u64,
+        last: u64,
+        response: Sender<Result<Block>>,
+    },
+}
+
+impl BlockAggregatorQuery {
+    pub fn get_block_range(first: u64, last: u64) -> (Self, Receiver<Result<Block>>) {
+        let (sender, receiver) = channel(100);
+        let query = Self::GetBlockRange {
+            first,
+            last,
+            response: sender,
+        };
+        (query, receiver)
+    }
+}

--- a/crates/services/block_aggregator_api/src/api.rs
+++ b/crates/services/block_aggregator_api/src/api.rs
@@ -3,6 +3,7 @@ use crate::{
     result::Result,
 };
 use fuel_core_services::stream::BoxStream;
+use std::fmt;
 use tokio::sync::oneshot::{
     Receiver,
     Sender,
@@ -21,6 +22,18 @@ pub enum BlockAggregatorQuery {
         last: u64,
         response: Sender<BoxStream<Block>>,
     },
+}
+
+impl fmt::Debug for BlockAggregatorQuery {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BlockAggregatorQuery::GetBlockRange { first, last, .. } => f
+                .debug_struct("GetBlockRange")
+                .field("first", first)
+                .field("last", last)
+                .finish(),
+        }
+    }
 }
 
 impl BlockAggregatorQuery {

--- a/crates/services/block_aggregator_api/src/api.rs
+++ b/crates/services/block_aggregator_api/src/api.rs
@@ -5,7 +5,8 @@ use crate::{
         Result,
     },
 };
-use tokio::sync::mpsc::{
+use fuel_core_services::stream::BoxStream;
+use tokio::sync::oneshot::{
     Receiver,
     Sender,
     channel,
@@ -21,13 +22,13 @@ pub enum BlockAggregatorQuery {
     GetBlockRange {
         first: u64,
         last: u64,
-        response: Sender<Result<Block>>,
+        response: Sender<BoxStream<Block>>,
     },
 }
 
 impl BlockAggregatorQuery {
-    pub fn get_block_range(first: u64, last: u64) -> (Self, Receiver<Result<Block>>) {
-        let (sender, receiver) = channel(100);
+    pub fn get_block_range(first: u64, last: u64) -> (Self, Receiver<BoxStream<Block>>) {
+        let (sender, receiver) = channel();
         let query = Self::GetBlockRange {
             first,
             last,

--- a/crates/services/block_aggregator_api/src/api.rs
+++ b/crates/services/block_aggregator_api/src/api.rs
@@ -22,6 +22,9 @@ pub enum BlockAggregatorQuery {
         last: u64,
         response: Sender<BoxStream<Block>>,
     },
+    GetCurrentHeight {
+        response: Sender<u64>,
+    },
 }
 
 impl fmt::Debug for BlockAggregatorQuery {
@@ -32,6 +35,9 @@ impl fmt::Debug for BlockAggregatorQuery {
                 .field("first", first)
                 .field("last", last)
                 .finish(),
+            BlockAggregatorQuery::GetCurrentHeight { .. } => {
+                f.debug_struct("GetCurrentHeight").finish()
+            }
         }
     }
 }
@@ -44,6 +50,12 @@ impl BlockAggregatorQuery {
             last,
             response: sender,
         };
+        (query, receiver)
+    }
+
+    pub(crate) fn get_current_height() -> (Self, Receiver<u64>) {
+        let (sender, receiver) = channel();
+        let query = Self::GetCurrentHeight { response: sender };
         (query, receiver)
     }
 }

--- a/crates/services/block_aggregator_api/src/block_range_response.rs
+++ b/crates/services/block_aggregator_api/src/block_range_response.rs
@@ -1,0 +1,10 @@
+use fuel_core_services::stream::BoxStream;
+use crate::blocks::Block;
+
+/// The response to a block range query, either as a literal stream of blocks or as a remote URL
+pub enum BlockRangeResponse {
+    /// A literal stream of blocks
+    Literal(BoxStream<Block>),
+    /// A remote URL where the blocks can be fetched
+    Remote(String),
+}

--- a/crates/services/block_aggregator_api/src/block_range_response.rs
+++ b/crates/services/block_aggregator_api/src/block_range_response.rs
@@ -1,5 +1,5 @@
-use fuel_core_services::stream::BoxStream;
 use crate::blocks::Block;
+use fuel_core_services::stream::BoxStream;
 
 /// The response to a block range query, either as a literal stream of blocks or as a remote URL
 pub enum BlockRangeResponse {

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -9,6 +9,7 @@ pub trait BlockSource: Send + Sync {
     fn next_block(&mut self)
     -> impl Future<Output = Result<(BlockHeight, Block)>> + Send;
 
+    /// Drain any remaining blocks from the source
     fn drain(&mut self) -> impl Future<Output = Result<()>> + Send;
 }
 

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -1,10 +1,10 @@
 use crate::result::Result;
 
 pub trait BlockSource: Send + Sync {
-    fn next_block(&mut self) -> impl Future<Output = Result<Block>> + Send;
+    fn next_block(&mut self) -> impl Future<Output = Result<(u64, Block)>> + Send;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Block {
     bytes: Vec<u8>,
 }
@@ -21,7 +21,7 @@ impl Block {
     }
 
     #[cfg(test)]
-    pub fn arb<Rng: rand::Rng + ?Sized>(rng: &mut Rng) -> Self {
+    pub fn random<Rng: rand::Rng + ?Sized>(rng: &mut Rng) -> Self {
         const SIZE: usize = 100;
         Self::arb_size(rng, SIZE)
     }

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -5,7 +5,9 @@ use std::fmt::{
     Formatter,
 };
 
+/// Source from which blocks can be gathered for aggregation
 pub trait BlockSource: Send + Sync {
+    /// Asynchronously fetch the next block and its height
     fn next_block(&mut self) -> impl Future<Output = Result<(u64, Block)>> + Send;
 }
 

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -1,0 +1,11 @@
+use crate::result::{
+    Error,
+    Result,
+};
+
+pub trait BlockSource: Send + Sync {
+    fn next_block(&mut self) -> impl Future<Output = Result<Block>>;
+}
+
+#[derive(Clone, Copy)]
+pub struct Block;

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -1,22 +1,58 @@
 use crate::result::Result;
+use bytes::Bytes;
+use std::fmt::{
+    Debug,
+    Formatter,
+};
 
 pub trait BlockSource: Send + Sync {
     fn next_block(&mut self) -> impl Future<Output = Result<(u64, Block)>> + Send;
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Block {
-    bytes: Vec<u8>,
+    bytes: Bytes,
+}
+
+#[cfg(test)]
+impl Debug for Block {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        const BYTES_DISPLAY: usize = 8;
+        if self.bytes.len() <= BYTES_DISPLAY {
+            let bytes = &self
+                .bytes
+                .iter()
+                .map(|b| format!("{}", b))
+                .collect::<Vec<_>>();
+            let bytes_string = bytes.join(", ");
+            write!(f, "Block {{ bytes: [{}] }}", bytes_string)?;
+        } else {
+            let bytes_string = &self
+                .bytes
+                .iter()
+                .take(BYTES_DISPLAY)
+                .map(|b| format!("{}", b))
+                .collect::<Vec<_>>();
+            let bytes_string = bytes_string.join(", ");
+            let len = self.bytes.len();
+            write!(
+                f,
+                "Block {{ bytes: [{}, ...] (total {} bytes) }}",
+                bytes_string, len
+            )?;
+        }
+        Ok(())
+    }
 }
 
 impl Block {
-    pub fn new(bytes: Vec<u8>) -> Self {
+    pub fn new(bytes: Bytes) -> Self {
         Self { bytes }
     }
 
     #[cfg(test)]
     pub fn arb_size<Rng: rand::Rng + ?Sized>(rng: &mut Rng, size: usize) -> Self {
-        let bytes: Vec<u8> = (0..size).map(|_| rng.r#gen()).collect();
+        let bytes: Bytes = (0..size).map(|_| rng.r#gen()).collect();
         Self::new(bytes)
     }
 
@@ -32,7 +68,8 @@ impl Block {
 }
 
 impl From<Vec<u8>> for Block {
-    fn from(bytes: Vec<u8>) -> Self {
+    fn from(value: Vec<u8>) -> Self {
+        let bytes = Bytes::from(value);
         Self::new(bytes)
     }
 }

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -16,7 +16,7 @@ impl Block {
 
     #[cfg(test)]
     pub fn arb_size<Rng: rand::Rng + ?Sized>(rng: &mut Rng, size: usize) -> Self {
-        let bytes: Vec<u8> = (0..size).map(|_| rng.random()).collect();
+        let bytes: Vec<u8> = (0..size).map(|_| rng.r#gen()).collect();
         Self::new(bytes)
     }
 

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -1,9 +1,6 @@
 use crate::result::Result;
 use bytes::Bytes;
-use std::fmt::{
-    Debug,
-    Formatter,
-};
+use std::fmt::Debug;
 
 /// Source from which blocks can be gathered for aggregation
 pub trait BlockSource: Send + Sync {
@@ -11,40 +8,9 @@ pub trait BlockSource: Send + Sync {
     fn next_block(&mut self) -> impl Future<Output = Result<(u64, Block)>> + Send;
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Block {
     bytes: Bytes,
-}
-
-#[cfg(test)]
-impl Debug for Block {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        const BYTES_DISPLAY: usize = 8;
-        if self.bytes.len() <= BYTES_DISPLAY {
-            let bytes = &self
-                .bytes
-                .iter()
-                .map(|b| format!("{}", b))
-                .collect::<Vec<_>>();
-            let bytes_string = bytes.join(", ");
-            write!(f, "Block {{ bytes: [{}] }}", bytes_string)?;
-        } else {
-            let bytes_string = &self
-                .bytes
-                .iter()
-                .take(BYTES_DISPLAY)
-                .map(|b| format!("{}", b))
-                .collect::<Vec<_>>();
-            let bytes_string = bytes_string.join(", ");
-            let len = self.bytes.len();
-            write!(
-                f,
-                "Block {{ bytes: [{}, ...] (total {} bytes) }}",
-                bytes_string, len
-            )?;
-        }
-        Ok(())
-    }
 }
 
 impl Block {

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -8,6 +8,8 @@ pub trait BlockSource: Send + Sync {
     /// Asynchronously fetch the next block and its height
     fn next_block(&mut self)
     -> impl Future<Output = Result<(BlockHeight, Block)>> + Send;
+
+    fn drain(&mut self) -> impl Future<Output = Result<()>> + Send;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -1,11 +1,13 @@
 use crate::result::Result;
 use bytes::Bytes;
+use fuel_core_types::fuel_types::BlockHeight;
 use std::fmt::Debug;
 
 /// Source from which blocks can be gathered for aggregation
 pub trait BlockSource: Send + Sync {
     /// Asynchronously fetch the next block and its height
-    fn next_block(&mut self) -> impl Future<Output = Result<(u64, Block)>> + Send;
+    fn next_block(&mut self)
+    -> impl Future<Output = Result<(BlockHeight, Block)>> + Send;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -1,8 +1,38 @@
 use crate::result::Result;
 
 pub trait BlockSource: Send + Sync {
-    fn next_block(&mut self) -> impl Future<Output = Result<Block>>;
+    fn next_block(&mut self) -> impl Future<Output = Result<Block>> + Send;
 }
 
-#[derive(Clone, Copy)]
-pub struct Block;
+#[derive(Clone)]
+pub struct Block {
+    bytes: Vec<u8>,
+}
+
+impl Block {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    #[cfg(test)]
+    pub fn arb_size<Rng: rand::Rng + ?Sized>(rng: &mut Rng, size: usize) -> Self {
+        let bytes: Vec<u8> = (0..size).map(|_| rng.random()).collect();
+        Self::new(bytes)
+    }
+
+    #[cfg(test)]
+    pub fn arb<Rng: rand::Rng + ?Sized>(rng: &mut Rng) -> Self {
+        const SIZE: usize = 100;
+        Self::arb_size(rng, SIZE)
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl From<Vec<u8>> for Block {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self::new(bytes)
+    }
+}

--- a/crates/services/block_aggregator_api/src/blocks.rs
+++ b/crates/services/block_aggregator_api/src/blocks.rs
@@ -1,7 +1,4 @@
-use crate::result::{
-    Error,
-    Result,
-};
+use crate::result::Result;
 
 pub trait BlockSource: Send + Sync {
     fn next_block(&mut self) -> impl Future<Output = Result<Block>>;

--- a/crates/services/block_aggregator_api/src/db.rs
+++ b/crates/services/block_aggregator_api/src/db.rs
@@ -5,8 +5,9 @@ use crate::{
         Result,
     },
 };
+use fuel_core_services::stream::BoxStream;
 
 pub trait BlockAggregatorDB: Send + Sync {
     fn store_block(&mut self, block: Block) -> Result<()>;
-    fn get_block_range(&self, first: u64, last: u64) -> Result<Vec<Block>>;
+    fn get_block_range(&self, first: u64, last: u64) -> Result<BoxStream<Block>>;
 }

--- a/crates/services/block_aggregator_api/src/db.rs
+++ b/crates/services/block_aggregator_api/src/db.rs
@@ -5,6 +5,14 @@ use crate::{
 use fuel_core_services::stream::BoxStream;
 
 pub trait BlockAggregatorDB: Send + Sync {
-    fn store_block(&mut self, block: Block) -> Result<()>;
-    fn get_block_range(&self, first: u64, last: u64) -> Result<BoxStream<Block>>;
+    fn store_block(
+        &mut self,
+        id: u64,
+        block: Block,
+    ) -> impl Future<Output = Result<()>> + Send;
+    fn get_block_range(
+        &self,
+        first: u64,
+        last: u64,
+    ) -> impl Future<Output = Result<BoxStream<Block>>> + Send;
 }

--- a/crates/services/block_aggregator_api/src/db.rs
+++ b/crates/services/block_aggregator_api/src/db.rs
@@ -15,4 +15,6 @@ pub trait BlockAggregatorDB: Send + Sync {
         first: u64,
         last: u64,
     ) -> impl Future<Output = Result<BoxStream<Block>>> + Send;
+
+    fn get_current_height(&self) -> impl Future<Output = Result<u64>> + Send;
 }

--- a/crates/services/block_aggregator_api/src/db.rs
+++ b/crates/services/block_aggregator_api/src/db.rs
@@ -1,9 +1,6 @@
 use crate::{
     blocks::Block,
-    result::{
-        Error,
-        Result,
-    },
+    result::Result,
 };
 use fuel_core_services::stream::BoxStream;
 

--- a/crates/services/block_aggregator_api/src/db.rs
+++ b/crates/services/block_aggregator_api/src/db.rs
@@ -3,19 +3,27 @@ use crate::{
     result::Result,
 };
 
+/// The definition of the block aggregator database.
 pub trait BlockAggregatorDB: Send + Sync {
+    /// The type used to report a range of blocks
     type BlockRange;
 
+    /// Stores a block with the given ID
     fn store_block(
         &mut self,
         id: u64,
         block: Block,
     ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Retrieves a range of blocks from the database
     fn get_block_range(
         &self,
         first: u64,
         last: u64,
     ) -> impl Future<Output = Result<Self::BlockRange>> + Send;
 
+    /// Retrieves the current height of the aggregated blocks If there is a break in the blocks,
+    /// i.e. the blocks are being aggregated out of order, return the height of the last
+    /// contiguous block
     fn get_current_height(&self) -> impl Future<Output = Result<u64>> + Send;
 }

--- a/crates/services/block_aggregator_api/src/db.rs
+++ b/crates/services/block_aggregator_api/src/db.rs
@@ -2,9 +2,10 @@ use crate::{
     blocks::Block,
     result::Result,
 };
-use fuel_core_services::stream::BoxStream;
 
 pub trait BlockAggregatorDB: Send + Sync {
+    type BlockRange;
+
     fn store_block(
         &mut self,
         id: u64,
@@ -14,7 +15,7 @@ pub trait BlockAggregatorDB: Send + Sync {
         &self,
         first: u64,
         last: u64,
-    ) -> impl Future<Output = Result<BoxStream<Block>>> + Send;
+    ) -> impl Future<Output = Result<Self::BlockRange>> + Send;
 
     fn get_current_height(&self) -> impl Future<Output = Result<u64>> + Send;
 }

--- a/crates/services/block_aggregator_api/src/db.rs
+++ b/crates/services/block_aggregator_api/src/db.rs
@@ -1,0 +1,12 @@
+use crate::{
+    blocks::Block,
+    result::{
+        Error,
+        Result,
+    },
+};
+
+pub trait BlockAggregatorDB: Send + Sync {
+    fn store_block(&mut self, block: Block) -> Result<()>;
+    fn get_block_range(&self, first: u64, last: u64) -> Result<Vec<Block>>;
+}

--- a/crates/services/block_aggregator_api/src/db.rs
+++ b/crates/services/block_aggregator_api/src/db.rs
@@ -2,6 +2,7 @@ use crate::{
     blocks::Block,
     result::Result,
 };
+use fuel_core_types::fuel_types::BlockHeight;
 
 /// The definition of the block aggregator database.
 pub trait BlockAggregatorDB: Send + Sync {
@@ -11,19 +12,19 @@ pub trait BlockAggregatorDB: Send + Sync {
     /// Stores a block with the given ID
     fn store_block(
         &mut self,
-        id: u64,
+        height: BlockHeight,
         block: Block,
     ) -> impl Future<Output = Result<()>> + Send;
 
     /// Retrieves a range of blocks from the database
     fn get_block_range(
         &self,
-        first: u64,
-        last: u64,
+        first: BlockHeight,
+        last: BlockHeight,
     ) -> impl Future<Output = Result<Self::BlockRange>> + Send;
 
     /// Retrieves the current height of the aggregated blocks If there is a break in the blocks,
     /// i.e. the blocks are being aggregated out of order, return the height of the last
     /// contiguous block
-    fn get_current_height(&self) -> impl Future<Output = Result<u64>> + Send;
+    fn get_current_height(&self) -> impl Future<Output = Result<BlockHeight>> + Send;
 }

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -22,6 +22,8 @@ pub mod blocks;
 pub mod db;
 pub mod result;
 
+pub mod block_range_response;
+
 #[cfg(test)]
 mod tests;
 

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -1,0 +1,86 @@
+use fuel_core_services::{
+    RunnableTask,
+    StateWatcher,
+    TaskNextAction,
+    try_or_stop,
+};
+
+use crate::{
+    api::{
+        BlockAggregatorApi,
+        BlockAggregatorQuery,
+    },
+    blocks::BlockSource,
+    db::BlockAggregatorDB,
+};
+use result::Result;
+
+pub mod api;
+pub mod blocks;
+pub mod db;
+pub mod result;
+
+#[cfg(test)]
+mod tests;
+
+// TODO: this doesn't need to limited to the blocks,
+//   but we can change the name later
+pub struct BlockAggregator<Api, DB, Blocks> {
+    query: Api,
+    database: DB,
+    block_source: Blocks,
+}
+
+impl<Api, DB, Blocks> RunnableTask for BlockAggregator<Api, DB, Blocks>
+where
+    Api: BlockAggregatorApi,
+    DB: BlockAggregatorDB,
+    Blocks: BlockSource,
+{
+    async fn run(&mut self, watcher: &mut StateWatcher) -> TaskNextAction {
+        tokio::select! {
+            res = self.query.await_query() => self.handle_query(res),
+            _ = watcher.while_started() => self.stop(),
+        }
+    }
+
+    async fn shutdown(self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+impl<Api, DB, Blocks> BlockAggregator<Api, DB, Blocks>
+where
+    Api: BlockAggregatorApi,
+    DB: BlockAggregatorDB,
+    Blocks: BlockSource,
+{
+    pub fn new(query: Api, database: DB, block_source: Blocks) -> Self {
+        Self {
+            query,
+            database,
+            block_source,
+        }
+    }
+
+    pub fn stop(&self) -> TaskNextAction {
+        TaskNextAction::Stop
+    }
+
+    pub fn handle_query(&mut self, res: Result<BlockAggregatorQuery>) -> TaskNextAction {
+        let query = try_or_stop!(res);
+        match query {
+            BlockAggregatorQuery::GetBlockRange {
+                first,
+                last,
+                response,
+            } => {
+                let blocks = try_or_stop!(self.database.get_block_range(first, last));
+                for block in blocks {
+                    let _ = try_or_stop!(response.try_send(Ok(block)));
+                }
+                TaskNextAction::Continue
+            }
+        }
+    }
+}

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -54,7 +54,10 @@ where
         }
     }
 
-    async fn shutdown(self) -> anyhow::Result<()> {
+    async fn shutdown(mut self) -> anyhow::Result<()> {
+        self.block_source.drain().await.map_err(|e| {
+            anyhow::anyhow!("Error draining block source during shutdown: {e:?}")
+        })?;
         Ok(())
     }
 }

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -10,7 +10,10 @@ use crate::{
         BlockAggregatorApi,
         BlockAggregatorQuery,
     },
-    blocks::BlockSource,
+    blocks::{
+        Block,
+        BlockSource,
+    },
     db::BlockAggregatorDB,
 };
 use result::Result;
@@ -39,7 +42,8 @@ where
 {
     async fn run(&mut self, watcher: &mut StateWatcher) -> TaskNextAction {
         tokio::select! {
-            res = self.query.await_query() => self.handle_query(res),
+            query_res = self.query.await_query() => self.handle_query(query_res),
+            block_res = self._block_source.next_block() => self.handle_block(block_res),
             _ = watcher.while_started() => self.stop(),
         }
     }
@@ -88,5 +92,9 @@ where
                 TaskNextAction::Continue
             }
         }
+    }
+
+    pub fn handle_block(&mut self, _res: Result<Block>) -> TaskNextAction {
+        todo!()
     }
 }

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -29,6 +29,8 @@ mod tests;
 
 // TODO: this doesn't need to limited to the blocks,
 //   but we can change the name later
+/// The Block Aggregator service, which aggregates blocks from a source and stores them in a database
+/// Queries can be made to the service to retrieve data from the `DB`
 pub struct BlockAggregator<Api, DB, Blocks> {
     query: Api,
     database: DB,

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -15,6 +15,7 @@ use fuel_core_services::{
     TaskNextAction,
     try_or_stop,
 };
+use fuel_core_types::fuel_types::BlockHeight;
 use result::Result;
 
 pub mod api;
@@ -102,8 +103,8 @@ where
 
     async fn handle_get_block_range_query(
         &mut self,
-        first: u64,
-        last: u64,
+        first: BlockHeight,
+        last: BlockHeight,
         response: tokio::sync::oneshot::Sender<BlockRange>,
     ) -> TaskNextAction {
         let res = self.database.get_block_range(first, last).await;
@@ -119,7 +120,7 @@ where
 
     async fn handle_get_current_height_query(
         &mut self,
-        response: tokio::sync::oneshot::Sender<u64>,
+        response: tokio::sync::oneshot::Sender<BlockHeight>,
     ) -> TaskNextAction {
         let res = self.database.get_current_height().await;
         let height = try_or_stop!(res, |e| {
@@ -132,7 +133,10 @@ where
         TaskNextAction::Continue
     }
 
-    pub async fn handle_block(&mut self, res: Result<(u64, Block)>) -> TaskNextAction {
+    pub async fn handle_block(
+        &mut self,
+        res: Result<(BlockHeight, Block)>,
+    ) -> TaskNextAction {
         tracing::debug!("Handling block: {res:?}");
         let (id, block) = try_or_stop!(res, |e| {
             tracing::error!("Error receiving block from source: {e:?}");

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -75,10 +75,10 @@ where
                 last,
                 response,
             } => {
-                let blocks = try_or_stop!(self.database.get_block_range(first, last));
-                for block in blocks {
-                    let _ = try_or_stop!(response.try_send(Ok(block)));
-                }
+                let res = self.database.get_block_range(first, last);
+                let block_stream = try_or_stop!(res);
+                let res = response.send(block_stream);
+                try_or_stop!(res);
                 TaskNextAction::Continue
             }
         }

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -60,11 +60,11 @@ where
     DB: BlockAggregatorDB,
     Blocks: BlockSource,
 {
-    pub fn new(query: Api, database: DB, _block_source: Blocks) -> Self {
+    pub fn new(query: Api, database: DB, block_source: Blocks) -> Self {
         Self {
             query,
             database,
-            block_source: _block_source,
+            block_source,
         }
     }
 

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -88,27 +88,9 @@ where
             } => {
                 self.handle_get_block_range_query(first, last, response)
                     .await
-                // let res = self.database.get_block_range(first, last).await;
-                // let block_stream = try_or_stop!(res, |e| {
-                //     tracing::error!("Error getting block range from database: {e:?}");
-                // });
-                // let res = response.send(block_stream);
-                // try_or_stop!(res, |_| {
-                //     tracing::error!("Error sending block range response");
-                // });
-                // TaskNextAction::Continue
             }
             BlockAggregatorQuery::GetCurrentHeight { response } => {
                 self.handle_get_current_height_query(response).await
-                // let res = self.database.get_current_height().await;
-                // let height = try_or_stop!(res, |e| {
-                //     tracing::error!("Error getting current height from database: {e:?}");
-                // });
-                // let res = response.send(height);
-                // try_or_stop!(res, |_| {
-                //     tracing::error!("Error sending current height response");
-                // });
-                // TaskNextAction::Continue
             }
         }
     }

--- a/crates/services/block_aggregator_api/src/lib.rs
+++ b/crates/services/block_aggregator_api/src/lib.rs
@@ -96,6 +96,17 @@ where
                 });
                 TaskNextAction::Continue
             }
+            BlockAggregatorQuery::GetCurrentHeight { response } => {
+                let res = self.database.get_current_height().await;
+                let height = try_or_stop!(res, |e| {
+                    tracing::error!("Error getting current height from database: {e:?}");
+                });
+                let res = response.send(height);
+                try_or_stop!(res, |_| {
+                    tracing::error!("Error sending current height response");
+                });
+                TaskNextAction::Continue
+            }
         }
     }
 

--- a/crates/services/block_aggregator_api/src/result.rs
+++ b/crates/services/block_aggregator_api/src/result.rs
@@ -1,0 +1,4 @@
+pub enum Error {
+    ApiError,
+}
+pub type Result<T, E = Error> = core::result::Result<T, E>;

--- a/crates/services/block_aggregator_api/src/result.rs
+++ b/crates/services/block_aggregator_api/src/result.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub enum Error {
     ApiError,
 }

--- a/crates/services/block_aggregator_api/src/result.rs
+++ b/crates/services/block_aggregator_api/src/result.rs
@@ -1,5 +1,6 @@
 #[derive(Debug)]
 pub enum Error {
     ApiError,
+    BlockSourceError,
 }
 pub type Result<T, E = Error> = core::result::Result<T, E>;

--- a/crates/services/block_aggregator_api/src/tests.rs
+++ b/crates/services/block_aggregator_api/src/tests.rs
@@ -123,10 +123,8 @@ async fn run__get_block_range__returns_expected_blocks() {
     let (query, response) = BlockAggregatorQuery::get_block_range(2, 3);
 
     // when
-    tokio::spawn(async move {
-        let _ = srv.run(&mut watcher).await;
-    });
     sender.send(query).await.unwrap();
+    let _ = srv.run(&mut watcher).await;
 
     // then
     let stream = response.await.unwrap();
@@ -154,10 +152,8 @@ async fn run__new_block_gets_added_to_db() {
     let mut watcher = StateWatcher::started();
 
     // when
-    tokio::spawn(async move {
-        let _ = srv.run(&mut watcher).await;
-    });
     source_sender.send((id, block.clone())).await.unwrap();
+    let _ = srv.run(&mut watcher).await;
 
     // then
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
@@ -183,10 +179,8 @@ async fn run__get_current_height__returns_expected_height() {
     let (query, response) = BlockAggregatorQuery::get_current_height();
 
     // when
-    tokio::spawn(async move {
-        let _ = srv.run(&mut watcher).await;
-    });
     sender.send(query).await.unwrap();
+    let _ = srv.run(&mut watcher).await;
 
     // then
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;

--- a/crates/services/block_aggregator_api/src/tests.rs
+++ b/crates/services/block_aggregator_api/src/tests.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use super::*;
 use crate::blocks::Block;
 use fuel_core_services::stream::BoxStream;
@@ -46,7 +48,7 @@ impl FakeDB {
 }
 
 impl BlockAggregatorDB for FakeDB {
-    fn store_block(&mut self, block: Block) -> Result<()> {
+    fn store_block(&mut self, _block: Block) -> Result<()> {
         todo!()
     }
 
@@ -72,8 +74,7 @@ impl BlockSource for FakeBlockSource {
 #[tokio::test]
 async fn run__get_block_range__returns_expected_blocks() {
     // given
-    let (sender, receiver) = tokio::sync::mpsc::channel(1);
-    let api = FakeApi { receiver };
+    let (api, sender) = FakeApi::new();
     let mut db = FakeDB::new();
     db.add_block(1, Block);
     db.add_block(2, Block);
@@ -88,7 +89,7 @@ async fn run__get_block_range__returns_expected_blocks() {
     tokio::spawn(async move {
         let _ = srv.run(&mut watcher).await;
     });
-    let (query, mut response) = BlockAggregatorQuery::get_block_range(2, 3);
+    let (query, response) = BlockAggregatorQuery::get_block_range(2, 3);
     sender.send(query).await.unwrap();
 
     // then

--- a/crates/services/block_aggregator_api/src/tests.rs
+++ b/crates/services/block_aggregator_api/src/tests.rs
@@ -115,6 +115,10 @@ impl BlockSource for FakeBlockSource {
     async fn next_block(&mut self) -> Result<(BlockHeight, Block)> {
         self.blocks.recv().await.ok_or(Error::BlockSourceError)
     }
+
+    async fn drain(&mut self) -> Result<()> {
+        todo!()
+    }
 }
 
 #[tokio::test]

--- a/crates/services/block_aggregator_api/src/tests.rs
+++ b/crates/services/block_aggregator_api/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{
     result::Error,
 };
 use fuel_core_services::stream::BoxStream;
-use futures_util::StreamExt;
+use futures::StreamExt;
 use rand::{
     SeedableRng,
     prelude::StdRng,
@@ -78,7 +78,7 @@ impl BlockAggregatorDB for FakeDB {
                 blocks.push(block.to_owned());
             }
         }
-        Ok(Box::pin(futures_util::stream::iter(blocks)))
+        Ok(Box::pin(futures::stream::iter(blocks)))
     }
 
     async fn get_current_height(&self) -> Result<u64> {

--- a/crates/services/block_aggregator_api/src/tests.rs
+++ b/crates/services/block_aggregator_api/src/tests.rs
@@ -135,9 +135,6 @@ async fn run__get_block_range__returns_expected_blocks() {
 
 #[tokio::test]
 async fn run__new_block_gets_added_to_db() {
-    // let _ = tracing_subscriber::fmt()
-    //     .with_max_level(tracing::Level::DEBUG)
-    //     .try_init();
     let mut rng = StdRng::seed_from_u64(42);
     // given
     let (api, _sender) = FakeApi::new();

--- a/crates/services/block_aggregator_api/src/tests.rs
+++ b/crates/services/block_aggregator_api/src/tests.rs
@@ -4,6 +4,10 @@ use super::*;
 use crate::blocks::Block;
 use fuel_core_services::stream::BoxStream;
 use futures_util::StreamExt;
+use rand::{
+    SeedableRng,
+    prelude::StdRng,
+};
 use std::{
     collections::HashMap,
     future,
@@ -56,7 +60,7 @@ impl BlockAggregatorDB for FakeDB {
         let mut blocks = vec![];
         for id in first..=last {
             if let Some(block) = self.map.get(&id) {
-                blocks.push(*block);
+                blocks.push(block.to_owned());
             }
         }
         Ok(Box::pin(futures_util::stream::iter(blocks)))
@@ -74,11 +78,12 @@ impl BlockSource for FakeBlockSource {
 #[tokio::test]
 async fn run__get_block_range__returns_expected_blocks() {
     // given
+    let mut rng = StdRng::seed_from_u64(42);
     let (api, sender) = FakeApi::new();
     let mut db = FakeDB::new();
-    db.add_block(1, Block);
-    db.add_block(2, Block);
-    db.add_block(3, Block);
+    db.add_block(1, Block::arb(&mut rng));
+    db.add_block(2, Block::arb(&mut rng));
+    db.add_block(3, Block::arb(&mut rng));
 
     let source = FakeBlockSource;
 
@@ -98,4 +103,9 @@ async fn run__get_block_range__returns_expected_blocks() {
 
     // TODO: Check values
     assert_eq!(blocks.len(), 2);
+}
+
+#[tokio::test]
+async fn run__new_block_gets_added_to_db() {
+    todo!()
 }

--- a/crates/services/block_aggregator_api/src/tests.rs
+++ b/crates/services/block_aggregator_api/src/tests.rs
@@ -1,0 +1,98 @@
+use super::*;
+use crate::blocks::Block;
+use std::{
+    collections::HashMap,
+    future,
+};
+use tokio::sync::mpsc::{
+    Receiver,
+    Sender,
+};
+
+struct FakeApi {
+    receiver: Receiver<BlockAggregatorQuery>,
+}
+
+impl FakeApi {
+    fn new() -> (Self, Sender<BlockAggregatorQuery>) {
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
+        let api = Self { receiver };
+        (api, sender)
+    }
+}
+
+impl BlockAggregatorApi for FakeApi {
+    async fn await_query(&mut self) -> Result<BlockAggregatorQuery> {
+        Ok(self.receiver.recv().await.unwrap())
+    }
+}
+
+struct FakeDB {
+    map: HashMap<u64, Block>,
+}
+
+impl FakeDB {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    fn add_block(&mut self, id: u64, block: Block) {
+        self.map.insert(id, block);
+    }
+}
+
+impl BlockAggregatorDB for FakeDB {
+    fn store_block(&mut self, block: Block) -> Result<()> {
+        todo!()
+    }
+
+    fn get_block_range(&self, first: u64, last: u64) -> Result<Vec<Block>> {
+        let mut blocks = vec![];
+        for id in first..=last {
+            if let Some(block) = self.map.get(&id) {
+                blocks.push(*block);
+            }
+        }
+        Ok(blocks)
+    }
+}
+
+struct FakeBlockSource;
+
+impl BlockSource for FakeBlockSource {
+    async fn next_block(&mut self) -> Result<Block> {
+        future::pending().await
+    }
+}
+
+#[tokio::test]
+async fn run__get_block_range__returns_expected_blocks() {
+    // given
+    let (sender, receiver) = tokio::sync::mpsc::channel(1);
+    let api = FakeApi { receiver };
+    let mut db = FakeDB::new();
+    db.add_block(1, Block);
+    db.add_block(2, Block);
+    db.add_block(3, Block);
+
+    let source = FakeBlockSource;
+
+    let mut srv = BlockAggregator::new(api, db, source);
+
+    // when
+    let mut watcher = StateWatcher::started();
+    tokio::spawn(async move {
+        let _ = srv.run(&mut watcher).await;
+    });
+    let (query, mut response) = BlockAggregatorQuery::get_block_range(2, 3);
+    sender.send(query).await.unwrap();
+
+    // then
+    let mut buffer = vec![];
+    let response = response.recv_many(&mut buffer, 3).await;
+
+    // TODO: Check values
+    assert_eq!(buffer.len(), 2);
+}

--- a/crates/services/block_aggregator_api/src/tests.rs
+++ b/crates/services/block_aggregator_api/src/tests.rs
@@ -10,7 +10,6 @@ use rand::{
 };
 use std::{
     collections::HashMap,
-    future,
     sync::{
         Arc,
         Mutex,
@@ -136,9 +135,9 @@ async fn run__new_block_gets_added_to_db() {
     let mut rng = StdRng::seed_from_u64(42);
     // given
     let (api, _sender) = FakeApi::new();
-    let mut db = FakeDB::new();
+    let db = FakeDB::new();
     let db_map = db.clone_inner();
-    let (mut source, source_sender) = FakeBlockSource::new();
+    let (source, source_sender) = FakeBlockSource::new();
     let mut srv = BlockAggregator::new(api, db, source);
 
     // when


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->
Starts https://github.com/FuelLabs/fuel-core/issues/3086

Follow-up Issues:
https://github.com/FuelLabs/fuel-core/issues/3087
https://github.com/FuelLabs/fuel-core/issues/3088
https://github.com/FuelLabs/fuel-core/issues/3089
https://github.com/FuelLabs/fuel-core/issues/3090
https://github.com/FuelLabs/fuel-core/issues/3091

## Description
<!-- List of detailed changes -->
This PR adds the core logic of the block aggregator service. The domain includes:
1. Receiving the block from some abstracted source. This will be implemented later as a combination of block importer and access to the a on-chain db, where it will sync any missing blocks before subscribing to the importer values
2. Storing the blocks as raw bytes (? maybe we can abstract the serialization format). This will be implemented as a normal Fuel DB
3. An API abstraction with queries for ranges of blocks as well as info on the current height of the aggregator's db. This could be implemented as some protobuf server or something else.

We don't want this service to block the initialization of other services. This means that syncing will happen in the `run` function (rather than in some `UninitializedTask`). As the syncing progresses, the users can query the current height with the `BlockAggregatorQuery::GetCurrentHeight`.

The response type for a block range query is a assoc type because we are still up in the air about how it will be handled. There is a kinda of example type added, but it's not used anywhere yet, including the tests:
```rs
/// The response to a block range query, either as a literal stream of blocks or as a remote URL
pub enum BlockRangeResponse {
    /// A literal stream of blocks
    Literal(BoxStream<Block>),
    /// A remote URL where the blocks can be fetched
    Remote(String),
}
```

## Checklist
- [x] New behavior is reflected in tests

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

