### PR TITLE
Add dynamic adjustment for relayer log page size.

### DIFF
--- a/.changes/changed/2175.md
+++ b/.changes/changed/2175.md
@@ -1,0 +1,1 @@
+Automatically adjust relayer log page size to prevent sync failures from oversized Ethereum RPC responses.


### PR DESCRIPTION
## Linked Issues/PRs
Fixes: #2175 

## Description
- Introduced dynamic adjustment logic for --relayer-log-page-size to prevent sync failures caused by oversized Ethereum RPC responses.
- Page size now grows or shrinks based on recent success/failure patterns.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [ ] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [ ] Someone else?
