### PR TITLE
Make gas price service optional for node operators

### DIFF
--- a/.changes/added/2720.md
+++ b/.changes/added/2720.md
@@ -1,0 +1,2 @@
+Added `--gas-price-algorithm-disabled` flag to allow non-block-producing nodes to run without the full gas price algorithm, reducing resource usage while maintaining transaction validation capabilities.
+

--- a/bin/fuel-core/src/cli/run.rs
+++ b/bin/fuel-core/src/cli/run.rs
@@ -659,6 +659,7 @@ impl Command {
             da_committer_url,
             block_activity_threshold: 0,
             da_poll_interval: gas_price.da_poll_interval.map(Into::into),
+            algorithm_disabled: gas_price.gas_price_algorithm_disabled,
         };
 
         let tx_pool_ttl: Duration = tx_pool_ttl.into();

--- a/bin/fuel-core/src/cli/run/gas_price.rs
+++ b/bin/fuel-core/src/cli/run/gas_price.rs
@@ -82,4 +82,8 @@ pub struct GasPriceArgs {
     /// i.e. If you want the Gas Price Service to look for the costs of block 1000, set to 999
     #[arg(long = "da-starting-recorded-height", env)]
     pub da_starting_recorded_height: Option<u32>,
+
+    /// Disable the gas price algorithm (for non-block-producing nodes)
+    #[arg(long = "gas-price-algorithm-disabled", env, default_value = "false")]
+    pub gas_price_algorithm_disabled: bool,
 }

--- a/crates/fuel-core/src/service.rs
+++ b/crates/fuel-core/src/service.rs
@@ -71,6 +71,21 @@ pub mod sub_services;
 pub mod vm_pool;
 
 #[derive(Clone)]
+pub enum GasPriceServiceState {
+    Full(fuel_core_gas_price_service::v1::service::SharedData),
+    Lightweight(fuel_core_gas_price_service::updater_service::SharedData),
+}
+
+impl GasPriceServiceState {
+    pub async fn await_synced(&self) -> anyhow::Result<()> {
+        match self {
+            GasPriceServiceState::Full(shared) => shared.await_synced().await,
+            GasPriceServiceState::Lightweight(shared) => shared.await_synced().await,
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct SharedState {
     /// The PoA adaptor around the shared state of the consensus module.
     pub poa_adapter: PoAAdapter,
@@ -97,7 +112,7 @@ pub struct SharedState {
     /// The compression service shared data.
     pub compression: Option<fuel_core_compression_service::service::SharedData>,
     /// The gas price service shared data.
-    pub gas_price_service: fuel_core_gas_price_service::v1::service::SharedData,
+    pub gas_price_service: GasPriceServiceState,
 }
 
 pub struct FuelService {

--- a/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
+++ b/crates/fuel-core/src/service/adapters/gas_price_adapters.rs
@@ -86,6 +86,7 @@ impl From<Config> for V1AlgorithmConfig {
             activity_capped_range_size,
             activity_decrease_range_size,
             block_activity_threshold,
+            algorithm_disabled: _,
         } = value.gas_price_config;
         V1AlgorithmConfig {
             new_exec_gas_price: starting_exec_gas_price.max(min_exec_gas_price),

--- a/crates/fuel-core/src/service/config.rs
+++ b/crates/fuel-core/src/service/config.rs
@@ -329,6 +329,7 @@ pub struct GasPriceConfig {
     pub activity_capped_range_size: u16,
     pub activity_decrease_range_size: u16,
     pub block_activity_threshold: u8,
+    pub algorithm_disabled: bool,
 }
 
 impl GasPriceConfig {
@@ -359,6 +360,7 @@ impl GasPriceConfig {
             da_committer_url: None,
             block_activity_threshold: 0,
             da_poll_interval: Some(Duration::from_secs(1)),
+            algorithm_disabled: false,
         }
     }
 }

--- a/crates/services/gas_price_service/src/lib.rs
+++ b/crates/services/gas_price_service/src/lib.rs
@@ -12,5 +12,6 @@ pub mod v0;
 pub mod common;
 
 pub mod sync_state;
+pub mod updater_service;
 #[allow(unused)]
 pub mod v1;

--- a/crates/services/gas_price_service/src/updater_service.rs
+++ b/crates/services/gas_price_service/src/updater_service.rs
@@ -1,0 +1,163 @@
+use crate::{
+    common::fuel_core_storage_adapter::mint_values,
+    sync_state::{
+        SyncState,
+        SyncStateNotifier,
+        SyncStateObserver,
+        new_sync_state_channel,
+    },
+    v1::service::LatestGasPrice,
+};
+use anyhow::anyhow;
+use async_trait::async_trait;
+use fuel_core_services::{
+    RunnableService,
+    RunnableTask,
+    StateWatcher,
+    TaskNextAction,
+    stream::BoxStream,
+};
+use fuel_core_types::services::block_importer::SharedImportResult;
+use tokio_stream::StreamExt;
+
+#[derive(Debug, Clone)]
+pub struct SharedData {
+    pub latest_gas_price: LatestGasPrice<u32, u64>,
+    sync_observer: SyncStateObserver,
+}
+
+impl SharedData {
+    pub async fn await_synced(&self) -> anyhow::Result<()> {
+        let mut observer = self.sync_observer.clone();
+        loop {
+            if observer.borrow_and_update().is_synced() {
+                break;
+            }
+            observer.changed().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn await_synced_until(&self, block_height: &u32) -> anyhow::Result<()> {
+        let mut observer = self.sync_observer.clone();
+        loop {
+            if observer.borrow_and_update().is_synced_until(block_height) {
+                break;
+            }
+            observer.changed().await?;
+        }
+        Ok(())
+    }
+}
+
+pub struct GasPriceUpdaterService {
+    latest_gas_price: LatestGasPrice<u32, u64>,
+    block_stream: BoxStream<SharedImportResult>,
+    sync_notifier: SyncStateNotifier,
+}
+
+impl GasPriceUpdaterService {
+    fn update_gas_price_from_block(
+        &mut self,
+        import_result: &SharedImportResult,
+    ) -> anyhow::Result<()> {
+        let block = &import_result.sealed_block.entity;
+        let height: u32 = (*block.header().height()).into();
+
+        let (_, gas_price) = mint_values(block).map_err(|e| {
+            anyhow!("Failed to extract gas price from block {}: {:?}", height, e)
+        })?;
+
+        self.latest_gas_price.set(height, gas_price);
+        tracing::debug!(
+            "Updated latest gas price to {} at height {}",
+            gas_price,
+            height
+        );
+
+        self.sync_notifier.send_replace(SyncState::Synced(height));
+
+        Ok(())
+    }
+}
+
+pub struct UninitializedTask {
+    latest_gas_price: LatestGasPrice<u32, u64>,
+    block_stream: BoxStream<SharedImportResult>,
+    sync_notifier: SyncStateNotifier,
+}
+
+impl UninitializedTask {
+    pub fn new(
+        latest_gas_price: LatestGasPrice<u32, u64>,
+        block_stream: BoxStream<SharedImportResult>,
+    ) -> Self {
+        let (sync_notifier, _) = new_sync_state_channel();
+        Self {
+            latest_gas_price,
+            block_stream,
+            sync_notifier,
+        }
+    }
+}
+
+#[async_trait]
+impl RunnableService for UninitializedTask {
+    const NAME: &'static str = "GasPriceUpdaterService";
+    type SharedData = SharedData;
+    type Task = GasPriceUpdaterService;
+    type TaskParams = ();
+
+    fn shared_data(&self) -> Self::SharedData {
+        SharedData {
+            latest_gas_price: self.latest_gas_price.clone(),
+            sync_observer: self.sync_notifier.subscribe(),
+        }
+    }
+
+    async fn into_task(
+        self,
+        _state_watcher: &StateWatcher,
+        _params: Self::TaskParams,
+    ) -> anyhow::Result<Self::Task> {
+        Ok(GasPriceUpdaterService {
+            latest_gas_price: self.latest_gas_price,
+            block_stream: self.block_stream,
+            sync_notifier: self.sync_notifier,
+        })
+    }
+}
+
+impl RunnableTask for GasPriceUpdaterService {
+    async fn run(&mut self, watcher: &mut StateWatcher) -> TaskNextAction {
+        tokio::select! {
+            biased;
+            _ = watcher.while_started() => {
+                TaskNextAction::Stop
+            }
+            maybe_import_result = self.block_stream.next() => {
+                match maybe_import_result {
+                    Some(import_result) => {
+                        let res = self.update_gas_price_from_block(&import_result);
+                        TaskNextAction::always_continue(res)
+                    }
+                    None => {
+                        TaskNextAction::Stop
+                    }
+                }
+            }
+        }
+    }
+
+    async fn shutdown(self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+pub fn new_gas_price_updater_service(
+    latest_gas_price: LatestGasPrice<u32, u64>,
+    block_stream: BoxStream<SharedImportResult>,
+) -> fuel_core_services::ServiceRunner<UninitializedTask> {
+    let task = UninitializedTask::new(latest_gas_price, block_stream);
+    fuel_core_services::ServiceRunner::new(task)
+}

--- a/tests/test-helpers/src/builder.rs
+++ b/tests/test-helpers/src/builder.rs
@@ -106,6 +106,7 @@ pub struct TestSetupBuilder {
     pub database_config: DatabaseConfig,
     pub chain_config: Option<ChainConfig>,
     pub number_threads_pool_verif: usize,
+    pub gas_price_algorithm_disabled: bool,
 }
 
 impl TestSetupBuilder {
@@ -256,6 +257,7 @@ impl TestSetupBuilder {
 
         let gas_price_config = GasPriceConfig {
             starting_exec_gas_price: self.starting_gas_price,
+            algorithm_disabled: self.gas_price_algorithm_disabled,
             ..GasPriceConfig::local_node()
         };
 
@@ -297,6 +299,7 @@ impl Default for TestSetupBuilder {
             database_type: DbType::RocksDb,
             database_config: DatabaseConfig::config_for_tests(),
             chain_config: None,
+            gas_price_algorithm_disabled: false,
             number_threads_pool_verif: 0,
         }
     }


### PR DESCRIPTION
Closes #2720

## What

Adds a lightweight gas price updater service that allows regular nodes to track gas prices without running the full algorithm. Block producers continue using the complete service.

## Why

As noted in FuelLabs/fuel-vm#888, there's now a consensus-level max percentage for gas price changes between blocks. Regular nodes don't need the full algorithm - they can estimate worst-case gas prices using this percentage from the previous block's price.

Running the full service (with DA source, metadata storage, etc.) is overkill for non-producing nodes.

## Changes

- New `--gas-price-algorithm-disabled` CLI flag
- `GasPriceUpdaterService`: lightweight service that only updates `LatestGasPrice` from imported blocks
- `ProducerGasPriceProvider` enum with `Full` and `Disabled` variants
- Clear error message when attempting block production with algorithm disabled
- `dry_run` and `estimate_gas_price` work in both modes using the consensus percentage

## For node operators

If you're not producing blocks, you can now run with:
```
--gas-price-algorithm-disabled
```

This reduces resource usage while maintaining full transaction validation and gas estimation capabilities.

