### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check for a file with the PR number in a sub-directory of the .changes directory" or "no changelog" label.
         run: |
@@ -59,7 +59,7 @@ jobs:
   rustfmt:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install latest nightly
         uses: dtolnay/rust-toolchain@master
         with:
@@ -72,7 +72,7 @@ jobs:
   lint-toml-files:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -84,7 +84,7 @@ jobs:
   prevent-openssl:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # ensure openssl hasn't crept into the dep tree
       - name: Check if openssl is included
         run: ./.github/workflows/scripts/verify_openssl.sh
@@ -154,7 +154,7 @@ jobs:
     timeout-minutes: 45
     continue-on-error: ${{ matrix.skip-error || false }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -187,7 +187,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -214,11 +214,11 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS credentials for integration testing
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: arn:aws:iam::249945542445:role/github_oidc_FuelLabs_fuel-core
           aws-region: us-east-1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -251,7 +251,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify tag version
         run: |
@@ -270,7 +270,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@master
@@ -313,15 +313,15 @@ jobs:
             target: aarch64-apple-darwin
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         if: matrix.job.cross_image
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the ghcr.io registry
         if: matrix.job.os == 'buildjet-4vcpu-ubuntu-2204'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -336,7 +336,7 @@ jobs:
 
       - name: Setup custom cross env ${{ matrix.job.cross_image }}
         if: matrix.job.cross_image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ci
           file: ci/Dockerfile.${{ matrix.job.target }}-clang
@@ -357,7 +357,7 @@ jobs:
           target: ${{ matrix.job.target }},"wasm32-unknown-unknown"
 
       - name: Install cross
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cross
           cache-key: "${{ matrix.job.target }}"
@@ -427,7 +427,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create_version.yml
+++ b/.github/workflows/create_version.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/delete-test-env.yml
+++ b/.github/workflows/delete-test-env.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       
       - name: Set Environment Variables
         id: set_env_var

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -39,13 +39,13 @@ jobs:
         # Remove first line that always just says "Updating crates.io index"
         run: cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
       - name: upload Cargo.lock artifact for use in PR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: Cargo-lock
           path: Cargo.lock
           retention-days: 1
       - name: upload cargo-update log artifact for use in PR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: cargo-updates
           path: cargo_update.log
@@ -63,11 +63,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: download Cargo.lock from update job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v7
         with:
           name: Cargo-lock
       - name: download cargo-update log from update job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v7
         with:
           name: cargo-updates
 

--- a/.github/workflows/deploy-test-env.yml
+++ b/.github/workflows/deploy-test-env.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       
       - name: Set Environment Variables
         id: set_env_var

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -44,7 +44,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -113,7 +113,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -134,7 +134,7 @@ jobs:
           echo "REGISTRY_URL=${REGISTRY@L}/${GIT_REPO@L}" >>${GITHUB_ENV}
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/digests
           pattern: digests-*
@@ -144,7 +144,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials for ECR publishing
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1 # ecr public is only in us-east-1
@@ -207,13 +207,13 @@ jobs:
           echo "REGISTRY_URL=${REGISTRY@L}/${GIT_REPO@L}" >>${GITHUB_ENV}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials for ECR publishing
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1 # ecr public is only in us-east-1
@@ -302,13 +302,13 @@ jobs:
           echo "REGISTRY_URL=${REGISTRY@L}/${GIT_REPO@L}" >>${GITHUB_ENV}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials for ECR publishing
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1 # ecr public is only in us-east-1

--- a/.github/workflows/e2e-test-beta4-dev.yml
+++ b/.github/workflows/e2e-test-beta4-dev.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup e2e config secrets
         run: |
           export e2e_wallet_a="${{ secrets.E2E_WALLET_A }}"

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -23,7 +23,7 @@ jobs:
       benchmark_results: ${{ steps.benchmarks.outputs.benchmark_results }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@master
@@ -44,7 +44,7 @@ jobs:
           cargo run -p fuel-core-benches --bin collect --release -- --input nightly_benchmarks.json --format consensus-parameters --output nightly_benchmarks.json
 
       - name: Archive benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nightly_benchmarks.json
           path: nightly_benchmarks.json
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Parse benchmark results and create/update PR
         run: |

--- a/.github/workflows/nightly-cargo-audit.yml
+++ b/.github/workflows/nightly-cargo-audit.yml
@@ -8,7 +8,7 @@ jobs:
   cargo_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-codecov.yml
+++ b/.github/workflows/publish-codecov.yml
@@ -25,7 +25,7 @@ jobs:
     permissions: # Write access to push changes to pages
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install latest Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -39,7 +39,7 @@ jobs:
         run: cargo  +${{ env.RUST_VERSION_COV }} llvm-cov --all-features --html --branch
 
       - name: Checkout the repo again for pushing pages revision
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: 'codecov-pages'
           path: 'pages-branch'

--- a/.github/workflows/releasy-dependency-commits.yml
+++ b/.github/workflows/releasy-dependency-commits.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }} 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: |
         git clone https://github.com/FuelLabs/releasy && cd releasy && git checkout kayagokalp/releasy-handle && cd ..
         cargo install --path ./releasy/releasy-emit

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Check spelling
       uses: crate-ci/typos@master

--- a/.github/workflows/update_readme_versions.yml
+++ b/.github/workflows/update_readme_versions.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Fetch current versions
       id: get-versions


### PR DESCRIPTION
## Linked Issues/PRs
<!-- List of related issues/PRs -->

## Description
<!-- List of detailed changes -->
Bumping GitHub Actoins versions.

## Checklist
- [ ] Breaking changes are clearly marked as such in the PR description and changelog
- [ ] New behavior is reflected in tests
- [ ] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

[Add or remove entries as needed]

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/)
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] [Platform documentation](https://github.com/FuelLabs/devrel-requests/issues/new?assignees=&labels=new+request&projects=&template=NEW-REQUEST.yml&title=%5BRequest%5D%3A+) (for out-of-organization contributors, the person merging the PR will do this)
- [x] Someone else?

- **Changes:**  
  - Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/nightly-benchmark.yml`  
  - Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/dependencies.yml`  
  - Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci.yml`  
  - Updated `aws-actions/configure-aws-credentials` from `v4` to `v5` in `.github/workflows/ci.yml`  
  - Updated `docker/build-push-action` from `v2` to `v6` in `.github/workflows/ci.yml`  
  - Updated `docker/login-action` from `v1` to `v3` in `.github/workflows/ci.yml`  
  - Updated `docker/setup-buildx-action` from `v1` to `v3` in `.github/workflows/ci.yml`  
  - Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/deploy-test-env.yml`  
  - Updated `actions/download-artifact` from `v3` to `v7` in `.github/workflows/dependencies.yml`  
  - Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/docker-images.yml`  
  - Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/spellcheck.yml`  
  - Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/create_version.yml`  
  - Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docker-images.yml`  
  - Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/publish-codecov.yml`  
  - Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/e2e-test-beta4-dev.yml`  
  - Updated `actions/checkout` from `v3` to `v6` in `.github/workflows/update_readme_versions.yml`  
  - Updated `actions/upload-artifact` from `v3` to `v6` in `.github/workflows/dependencies.yml`  
  - Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/docker-images.yml`  
  - Updated `aws-actions/configure-aws-credentials` from `v4` to `v5` in `.github/workflows/docker-images.yml`  
