### PR TITLE
refactor: replace manual mocks with mockall in producer

### DIFF
--- a/crates/services/producer/src/block_producer.rs
+++ b/crates/services/producer/src/block_producer.rs
@@ -1,33 +1,61 @@
 use crate::{
     Config,
     block_producer::gas_price::{
-        ChainStateInfoProvider, GasPriceProvider as GasPriceProviderConstraint,
+        ChainStateInfoProvider,
+        GasPriceProvider as GasPriceProviderConstraint,
     },
-    ports::{self, BlockProducerDatabase, RelayerBlockInfo},
+    ports::{
+        self,
+        BlockProducerDatabase,
+        RelayerBlockInfo,
+    },
 };
-use anyhow::{Context, anyhow};
-use fuel_core_storage::transactional::{AtomicView, Changes, HistoricalView};
+use anyhow::{
+    Context,
+    anyhow,
+};
+use fuel_core_storage::transactional::{
+    AtomicView,
+    Changes,
+    HistoricalView,
+};
 use fuel_core_types::{
     blockchain::{
         block::Block,
         header::{
-            ApplicationHeader, ConsensusHeader, ConsensusParametersVersion,
-            PartialBlockHeader, StateTransitionBytecodeVersion,
+            ApplicationHeader,
+            ConsensusHeader,
+            ConsensusParametersVersion,
+            PartialBlockHeader,
+            StateTransitionBytecodeVersion,
         },
         primitives::DaBlockHeight,
     },
     fuel_tx::{
         Transaction,
-        field::{InputContract, MintGasPrice},
+        field::{
+            InputContract,
+            MintGasPrice,
+        },
     },
-    fuel_types::{BlockHeight, Bytes32},
+    fuel_types::{
+        BlockHeight,
+        Bytes32,
+    },
     services::{
         block_producer::Components,
-        executor::{DryRunResult, StorageReadReplayEvent, UncommittedResult},
+        executor::{
+            DryRunResult,
+            StorageReadReplayEvent,
+            UncommittedResult,
+        },
     },
     tai64::Tai64,
 };
-use std::{future::Future, sync::Arc};
+use std::{
+    future::Future,
+    sync::Arc,
+};
 use tokio::sync::Mutex;
 use tracing::debug;
 

--- a/crates/services/producer/src/block_producer.rs
+++ b/crates/services/producer/src/block_producer.rs
@@ -1,61 +1,33 @@
 use crate::{
     Config,
     block_producer::gas_price::{
-        ChainStateInfoProvider,
-        GasPriceProvider as GasPriceProviderConstraint,
+        ChainStateInfoProvider, GasPriceProvider as GasPriceProviderConstraint,
     },
-    ports::{
-        self,
-        BlockProducerDatabase,
-        RelayerBlockInfo,
-    },
+    ports::{self, BlockProducerDatabase, RelayerBlockInfo},
 };
-use anyhow::{
-    Context,
-    anyhow,
-};
-use fuel_core_storage::transactional::{
-    AtomicView,
-    Changes,
-    HistoricalView,
-};
+use anyhow::{Context, anyhow};
+use fuel_core_storage::transactional::{AtomicView, Changes, HistoricalView};
 use fuel_core_types::{
     blockchain::{
         block::Block,
         header::{
-            ApplicationHeader,
-            ConsensusHeader,
-            ConsensusParametersVersion,
-            PartialBlockHeader,
-            StateTransitionBytecodeVersion,
+            ApplicationHeader, ConsensusHeader, ConsensusParametersVersion,
+            PartialBlockHeader, StateTransitionBytecodeVersion,
         },
         primitives::DaBlockHeight,
     },
     fuel_tx::{
         Transaction,
-        field::{
-            InputContract,
-            MintGasPrice,
-        },
+        field::{InputContract, MintGasPrice},
     },
-    fuel_types::{
-        BlockHeight,
-        Bytes32,
-    },
+    fuel_types::{BlockHeight, Bytes32},
     services::{
         block_producer::Components,
-        executor::{
-            DryRunResult,
-            StorageReadReplayEvent,
-            UncommittedResult,
-        },
+        executor::{DryRunResult, StorageReadReplayEvent, UncommittedResult},
     },
     tai64::Tai64,
 };
-use std::{
-    future::Future,
-    sync::Arc,
-};
+use std::{future::Future, sync::Arc};
 use tokio::sync::Mutex;
 use tracing::debug;
 
@@ -159,7 +131,7 @@ where
                 height,
                 previous_block: latest_height,
             }
-            .into())
+            .into());
         }
 
         let maybe_mint_tx = transactions_source.pop();

--- a/crates/services/producer/src/block_producer/tests.rs
+++ b/crates/services/producer/src/block_producer/tests.rs
@@ -518,12 +518,11 @@ mod produce_and_execute_block_txpool {
     #[tokio::test]
     async fn production_fails_on_execution_error() {
         let db = TestContext::<MockExecutor>::default_db();
-        let ctx = TestContext::default_from_executor(
-            crate::mocks::create_failing_mock_executor(
-                ExecutorError::TransactionIdCollision(Default::default()),
-                db,
-            ),
+        let executor = crate::mocks::create_failing_mock_executor(
+            ExecutorError::TransactionIdCollision(Default::default()),
+            db.clone(),
         );
+        let ctx = TestContext::default_from_db_and_executor(db, executor);
 
         let producer = ctx.producer();
 

--- a/crates/services/producer/src/block_producer/tests.rs
+++ b/crates/services/producer/src/block_producer/tests.rs
@@ -1,30 +1,62 @@
 #![allow(non_snake_case)]
 
 use crate::{
-    Config, Producer,
+    Config,
+    Producer,
     block_producer::{
-        Bytes32, Error,
-        gas_price::{GasPriceProvider, MockChainStateInfoProvider},
+        Bytes32,
+        Error,
+        gas_price::{
+            GasPriceProvider,
+            MockChainStateInfoProvider,
+        },
     },
-    mocks::{MockDb, MockExecutor, MockExecutorWithCapture, MockRelayer, MockTxPool},
+    mocks::{
+        MockDb,
+        MockExecutor,
+        MockExecutorWithCapture,
+        MockRelayer,
+        MockTxPool,
+    },
 };
 use fuel_core_producer as _;
 use fuel_core_types::{
     blockchain::{
-        block::{Block, CompressedBlock, PartialFuelBlock},
-        header::{ApplicationHeader, ConsensusHeader, PartialBlockHeader},
+        block::{
+            Block,
+            CompressedBlock,
+            PartialFuelBlock,
+        },
+        header::{
+            ApplicationHeader,
+            ConsensusHeader,
+            PartialBlockHeader,
+        },
         primitives::DaBlockHeight,
     },
     fuel_tx,
-    fuel_tx::{ConsensusParameters, Mint, Script, Transaction, field::InputContract},
+    fuel_tx::{
+        ConsensusParameters,
+        Mint,
+        Script,
+        Transaction,
+        field::InputContract,
+    },
     fuel_types::BlockHeight,
     services::executor::Error as ExecutorError,
     tai64::Tai64,
 };
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use rand::{
+    Rng,
+    SeedableRng,
+    rngs::StdRng,
+};
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc,
+        Mutex,
+    },
 };
 
 pub struct MockProducerGasPrice {
@@ -814,7 +846,10 @@ mod dry_run {
 }
 
 use fuel_core_types::fuel_tx::field::MintGasPrice;
-use proptest::{prop_compose, proptest};
+use proptest::{
+    prop_compose,
+    proptest,
+};
 
 prop_compose! {
     fn arb_block()(height in 1..255u8, da_height in 1..255u64, gas_price: u64, coinbase_recipient: [u8; 32], num_txs in 0..100u32) -> Block {

--- a/crates/services/producer/src/block_producer/tests.rs
+++ b/crates/services/producer/src/block_producer/tests.rs
@@ -485,9 +485,11 @@ mod produce_and_execute_block_txpool {
 
     #[tokio::test]
     async fn production_fails_on_execution_error() {
+        let db = TestContext::<MockExecutor>::default_db();
         let ctx = TestContext::default_from_executor(
             crate::mocks::create_failing_mock_executor(
                 ExecutorError::TransactionIdCollision(Default::default()),
+                db,
             ),
         );
 

--- a/crates/services/producer/src/mocks.rs
+++ b/crates/services/producer/src/mocks.rs
@@ -1,23 +1,45 @@
 use crate::ports::{
-    BlockProducer, BlockProducerDatabase, DryRunner, Relayer, RelayerBlockInfo, TxPool,
+    BlockProducer,
+    BlockProducerDatabase,
+    DryRunner,
+    Relayer,
+    RelayerBlockInfo,
+    TxPool,
 };
 use fuel_core_storage::{
-    Result as StorageResult, not_found,
-    transactional::{AtomicView, Changes},
+    Result as StorageResult,
+    not_found,
+    transactional::{
+        AtomicView,
+        Changes,
+    },
 };
 use fuel_core_types::{
     blockchain::{
-        block::{Block, CompressedBlock},
-        header::{ConsensusParametersVersion, StateTransitionBytecodeVersion},
+        block::{
+            Block,
+            CompressedBlock,
+        },
+        header::{
+            ConsensusParametersVersion,
+            StateTransitionBytecodeVersion,
+        },
         primitives::DaBlockHeight,
     },
     fuel_tx::Transaction,
-    fuel_types::{BlockHeight, Bytes32, ChainId},
+    fuel_types::{
+        BlockHeight,
+        Bytes32,
+        ChainId,
+    },
     services::{
         block_producer::Components,
         executor::{
-            DryRunResult, Error as ExecutorError, ExecutionResult,
-            Result as ExecutorResult, UncommittedResult,
+            DryRunResult,
+            Error as ExecutorError,
+            ExecutionResult,
+            Result as ExecutorResult,
+            UncommittedResult,
         },
     },
 };
@@ -25,7 +47,10 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     ops::Deref,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc,
+        Mutex,
+    },
 };
 // Mockall-generated mocks for testing
 #[cfg(feature = "test-helpers")]

--- a/crates/services/producer/src/ports.rs
+++ b/crates/services/producer/src/ports.rs
@@ -1,38 +1,21 @@
-use fuel_core_storage::{
-    Result as StorageResult,
-    transactional::Changes,
-};
+use fuel_core_storage::{Result as StorageResult, transactional::Changes};
 use fuel_core_types::{
     blockchain::{
-        block::{
-            Block,
-            CompressedBlock,
-        },
-        header::{
-            ConsensusParametersVersion,
-            StateTransitionBytecodeVersion,
-        },
+        block::{Block, CompressedBlock},
+        header::{ConsensusParametersVersion, StateTransitionBytecodeVersion},
         primitives::DaBlockHeight,
     },
-    fuel_tx::{
-        Bytes32,
-        Transaction,
-    },
+    fuel_tx::{Bytes32, Transaction},
     fuel_types::BlockHeight,
     services::{
         block_producer::Components,
         executor::{
-            DryRunResult,
-            Result as ExecutorResult,
-            StorageReadReplayEvent,
+            DryRunResult, Result as ExecutorResult, StorageReadReplayEvent,
             UncommittedResult,
         },
     },
 };
-use std::{
-    borrow::Cow,
-    future::Future,
-};
+use std::{borrow::Cow, future::Future};
 
 pub trait BlockProducerDatabase: Send + Sync {
     /// Returns the latest block height.

--- a/crates/services/producer/src/ports.rs
+++ b/crates/services/producer/src/ports.rs
@@ -1,21 +1,38 @@
-use fuel_core_storage::{Result as StorageResult, transactional::Changes};
+use fuel_core_storage::{
+    Result as StorageResult,
+    transactional::Changes,
+};
 use fuel_core_types::{
     blockchain::{
-        block::{Block, CompressedBlock},
-        header::{ConsensusParametersVersion, StateTransitionBytecodeVersion},
+        block::{
+            Block,
+            CompressedBlock,
+        },
+        header::{
+            ConsensusParametersVersion,
+            StateTransitionBytecodeVersion,
+        },
         primitives::DaBlockHeight,
     },
-    fuel_tx::{Bytes32, Transaction},
+    fuel_tx::{
+        Bytes32,
+        Transaction,
+    },
     fuel_types::BlockHeight,
     services::{
         block_producer::Components,
         executor::{
-            DryRunResult, Result as ExecutorResult, StorageReadReplayEvent,
+            DryRunResult,
+            Result as ExecutorResult,
+            StorageReadReplayEvent,
             UncommittedResult,
         },
     },
 };
-use std::{borrow::Cow, future::Future};
+use std::{
+    borrow::Cow,
+    future::Future,
+};
 
 pub trait BlockProducerDatabase: Send + Sync {
     /// Returns the latest block height.


### PR DESCRIPTION
Migrated manual mock implementations in `producer/src/mocks.rs` to `mockall` to address internal TODOs and standardize testing infrastructure.