### PR TITLE
feat: adjust the playground to support the auth token

### DIFF
--- a/.changes/added/3140.md
+++ b/.changes/added/3140.md
@@ -1,0 +1,1 @@
+Add auth token support to the GraphQL playground via `?token=` query parameter.

--- a/crates/fuel-core/src/graphql_api/api_service.rs
+++ b/crates/fuel-core/src/graphql_api/api_service.rs
@@ -44,6 +44,7 @@ use axum::{
     extract::{
         DefaultBodyLimit,
         Extension,
+        Query,
     },
     http::{
         HeaderValue,
@@ -77,6 +78,7 @@ use futures::Stream;
 use hyper::rt::Executor;
 use serde_json::json;
 use std::{
+    collections::HashMap,
     future::Future,
     net::{
         SocketAddr,
@@ -324,7 +326,14 @@ where
     let graphql_subscription_endpoint = "/v1/graphql-sub";
 
     let graphql_playground =
-        || render_graphql_playground(graphql_endpoint, graphql_subscription_endpoint);
+        |Query(params): Query<HashMap<String, String>>| {
+            let token = params.get("token").cloned();
+            render_graphql_playground(
+                graphql_endpoint,
+                graphql_subscription_endpoint,
+                token,
+            )
+        };
 
     let router = Router::new()
         .route("/v1/playground", get(graphql_playground))
@@ -373,43 +382,68 @@ where
     ))
 }
 
-/// Single initialization of the GraphQL playground HTML.
-/// This is because the rendering and replacing is expensive
+/// Single initialization of the GraphQL playground HTML (no-token version).
+/// This is because the rendering and replacing is expensive.
 static GRAPHQL_PLAYGROUND_HTML: OnceLock<Arc<String>> = OnceLock::new();
+
+fn build_playground_html(
+    endpoint: &str,
+    subscription_endpoint: &str,
+    token: Option<&str>,
+) -> String {
+    let mut builder = GraphiQLSource::build()
+        .endpoint(endpoint)
+        .subscription_endpoint(subscription_endpoint)
+        .title("Fuel Graphql Playground");
+
+    if let Some(t) = token {
+        builder = builder.header("Authorization", &format!("Bearer {}", t));
+    }
+
+    let raw_html = builder.finish();
+
+    // this may not be necessary in the future,
+    // but we need it to patch: https://github.com/async-graphql/async-graphql/issues/1703
+    let raw_html = raw_html.replace(
+        "https://unpkg.com/graphiql/graphiql.min.js",
+        "https://unpkg.com/graphiql@3/graphiql.min.js",
+    );
+    raw_html.replace(
+        "https://unpkg.com/graphiql/graphiql.min.css",
+        "https://unpkg.com/graphiql@3/graphiql.min.css",
+    )
+}
 
 fn _render_graphql_playground(
     endpoint: &str,
     subscription_endpoint: &str,
-) -> impl IntoResponse + Send + Sync {
-    let html = GRAPHQL_PLAYGROUND_HTML.get_or_init(|| {
-        let raw_html = GraphiQLSource::build()
-            .endpoint(endpoint)
-            .subscription_endpoint(subscription_endpoint)
-            .title("Fuel Graphql Playground")
-            .finish();
-
-        // this may not be necessary in the future,
-        // but we need it to patch: https://github.com/async-graphql/async-graphql/issues/1703
-        let raw_html = raw_html.replace(
-            "https://unpkg.com/graphiql/graphiql.min.js",
-            "https://unpkg.com/graphiql@3/graphiql.min.js",
-        );
-        let raw_html = raw_html.replace(
-            "https://unpkg.com/graphiql/graphiql.min.css",
-            "https://unpkg.com/graphiql@3/graphiql.min.css",
-        );
-
-        Arc::new(raw_html)
-    });
-
-    Html(html.as_str())
+    token: Option<String>,
+) -> Html<String> {
+    match token {
+        None => {
+            // Use cached static HTML for the common no-token case.
+            let html = GRAPHQL_PLAYGROUND_HTML.get_or_init(|| {
+                Arc::new(build_playground_html(endpoint, subscription_endpoint, None))
+            });
+            Html(html.as_ref().clone())
+        }
+        Some(ref t) => {
+            // Build fresh HTML with the Authorization header injected.
+            Html(build_playground_html(
+                endpoint,
+                subscription_endpoint,
+                Some(t.as_str()),
+            ))
+        }
+    }
 }
 
 async fn render_graphql_playground(
     endpoint: &str,
     subscription_endpoint: &str,
+    token: Option<String>,
 ) -> impl IntoResponse + Send + Sync {
-    _render_graphql_playground(endpoint, subscription_endpoint)
+    _render_graphql_playground(endpoint, subscription_endpoint, token)
 }
 
 async fn health() -> Json<serde_json::Value> {


### PR DESCRIPTION
close #3140

## Summary

Adds auth token support to the GraphQL playground at `/v1/playground`.

Users can now pass an auth token via the `?token=<value>` URL query parameter,
which gets injected as an `Authorization: Bearer <token>` header into the GraphiQL UI.
This enables usage with external data providers like Quicknode, Ankr, etc.

## Changes

- Accept an optional `?token=` query parameter on the `/v1/playground` route
- When a token is present, build fresh GraphiQL HTML with the `Authorization: Bearer` header injected
- When no token is provided, fall back to the existing cached static HTML — no behavior change for current users
- Extracted a `build_playground_html` helper to avoid code duplication

## Testing

- Existing behavior is unchanged when no token is passed
- Navigate to `/v1/playground?token=my-api-key` to verify the header is injected in GraphiQL requests