### PR TITLE
docs: add repository-local documentation index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Fuel Core Documentation
+
+This directory contains repository-local documentation for developing, debugging, and understanding `fuel-core`.
+
+## Start Here
+
+- [Architecture](architecture.md): high-level overview of the Fuel client architecture and service boundaries
+- [Developer debugging guide](developers/debugging.md): local build, run, and IDE debugging workflows
+- [Fee calculations](fee_calculations.md): notes on how fees are derived in the client
+- [PoA docs](poa/): Proof-of-Authority flows, failover notes, and formal artifacts
+
+## Related Resources
+
+- [Contribution guide](../CONTRIBUTING.md): contribution workflow, changelog requirements, and issue linking
+- [Deployment overview](../deployment/README.md): Docker-related files in this repository
+- [Fuel node operator docs](https://docs.fuel.network/docs/node-operator/): running Fuel nodes outside local development


### PR DESCRIPTION
## Summary
- add a `docs/README.md` index for repository-local documentation
- group the existing architecture, debugging, fee, and PoA docs under a single entrypoint
- link related contributor, deployment, and node-operator resources

## Why
The repository already contains useful documentation, but the `docs/` directory does not currently have an index page to help contributors discover it. This small entrypoint mirrors the structure used by other node/infrastructure repositories where architecture, developer, and operator resources are easier to find.

## Validation
- verified all referenced repository-local paths exist in the current tree
- docs-only change, no runtime behavior changed

This is a docs-only change. The `no changelog` label seems appropriate if maintainers agree.