### PR TITLE
test: add service-level txpool integrity checks

### DIFF
--- a/crates/services/txpool_v2/src/pool_worker.rs
+++ b/crates/services/txpool_v2/src/pool_worker.rs
@@ -19,6 +19,8 @@ use std::{
     sync::Arc,
     time::SystemTime,
 };
+#[cfg(test)]
+use std::collections::HashSet;
 use tokio::{
     sync::{
         broadcast,
@@ -229,6 +231,11 @@ pub(super) enum PoolReadRequest {
         max_txs: usize,
         response_channel: oneshot::Sender<Vec<TxId>>,
     },
+    #[cfg(test)]
+    AssertIntegrity {
+        expected_tx_ids: Vec<TxId>,
+        response_channel: oneshot::Sender<()>,
+    },
 }
 
 #[allow(clippy::upper_case_acronyms)]
@@ -339,6 +346,13 @@ where
                             response_channel,
                         } => {
                             self.get_non_existing_txs(tx_ids, response_channel);
+                        }
+                        #[cfg(test)]
+                        PoolReadRequest::AssertIntegrity {
+                            expected_tx_ids,
+                            response_channel,
+                        } => {
+                            self.assert_integrity(expected_tx_ids, response_channel);
                         }
                     }
                 }
@@ -596,6 +610,19 @@ where
             .collect();
         if response_channel.send(non_existing_txs).is_err() {
             tracing::error!("Failed to send non existing txs");
+        }
+    }
+
+    #[cfg(test)]
+    fn assert_integrity(
+        &mut self,
+        expected_tx_ids: Vec<TxId>,
+        response_channel: oneshot::Sender<()>,
+    ) {
+        self.pool
+            .assert_integrity(expected_tx_ids.into_iter().collect::<HashSet<_>>());
+        if response_channel.send(()).is_err() {
+            tracing::error!("Failed to send assert_integrity result");
         }
     }
 

--- a/crates/services/txpool_v2/src/shared_state.rs
+++ b/crates/services/txpool_v2/src/shared_state.rs
@@ -137,6 +137,23 @@ impl SharedState {
             .map_err(|_| Error::ServiceCommunicationFailed)
     }
 
+    #[cfg(test)]
+    pub async fn assert_integrity(&self, expected_tx_ids: Vec<TxId>) -> Result<(), Error> {
+        let (response_channel, result_receiver) = oneshot::channel();
+
+        self.request_read_sender
+            .send(PoolReadRequest::AssertIntegrity {
+                expected_tx_ids,
+                response_channel,
+            })
+            .await
+            .map_err(|_| Error::ServiceCommunicationFailed)?;
+
+        result_receiver
+            .await
+            .map_err(|_| Error::ServiceCommunicationFailed)
+    }
+
     /// Get a notifier that is notified when new executable transactions are added to the pool.
     pub fn get_new_executable_txs_notifier(&self) -> watch::Receiver<()> {
         self.new_executable_txs_notifier.subscribe()

--- a/crates/services/txpool_v2/src/tests/tests_service.rs
+++ b/crates/services/txpool_v2/src/tests/tests_service.rs
@@ -65,6 +65,14 @@ async fn test_find() {
         .unwrap();
 
     universe.await_expected_tx_statuses_submitted(ids).await;
+    service
+        .shared
+        .assert_integrity(vec![
+            tx1.id(&Default::default()),
+            tx2.id(&Default::default()),
+        ])
+        .await
+        .unwrap();
 
     // When
     let out = service
@@ -82,6 +90,17 @@ async fn test_find() {
     let id = out[0].as_ref().unwrap().tx().id();
     assert_eq!(id, tx1.id(&Default::default()), "Found tx id match{out:?}");
     assert!(out[1].is_none(), "Tx3 should not be found:{out:?}");
+
+    service.stop_and_await().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_service_assert_integrity_handles_empty_pool() {
+    let universe = TestPoolUniverse::default();
+    let service = universe.build_service(None, None);
+    service.start_and_await().await.unwrap();
+
+    service.shared.assert_integrity(vec![]).await.unwrap();
 
     service.stop_and_await().await.unwrap();
 }


### PR DESCRIPTION
## Summary
- add a test-only `SharedState::assert_integrity` helper for txpool service tests
- route the helper through a test-only pool read request handled by the pool worker
- use the helper in service tests, including an empty-pool case

## Why
This is a focused follow-up for `#2581`. The txpool already has integrity assertions in lower-level test helpers, but service-level tests did not have a direct way to trigger the same consistency check through the service surface. This adds that missing hook without changing runtime behavior.

## Validation
- the new helper is gated behind `#[cfg(test)]`
- service-level tests now exercise integrity checks through the shared service interface

Ref #2581

This is a test-only change. The `no changelog` label seems appropriate if maintainers agree.