### PR TITLE
docs: expand deployment asset overview

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,3 +1,58 @@
-# Overview
+# Deployment Assets
 
-The folder contains docker files for the `fuel-core` and for `fuel-core-e2e-client` binaries.
+This directory contains the container build assets for the `fuel-core` node binary
+and the `fuel-core-e2e-client` helper binary.
+
+## Files
+
+- `Dockerfile`
+  Builds a production-oriented `fuel-core` image.
+  The final image is based on distroless and includes the node binary together
+  with the chain configuration files fetched during the build stage.
+
+- `e2e-client.Dockerfile`
+  Builds a container image for the `fuel-core-e2e-client` binary used in
+  end-to-end and integration-style workflows.
+
+- `../docker-compose.yml`
+  Provides a minimal local setup for running a `fuel-core` node with a
+  persistent database volume.
+
+## Build The Node Image
+
+From the repository root:
+
+```sh
+docker build -t fuel-core -f deployment/Dockerfile .
+```
+
+The resulting image starts `fuel-core run` by default.
+
+## Run With Docker Compose
+
+From the repository root:
+
+```sh
+docker compose up --build fuel-core
+```
+
+This uses [`docker-compose.yml`](../docker-compose.yml) to:
+
+- expose GraphQL on port `4000`
+- mount a persistent Docker volume at `/mnt/db`
+- build the image from [`deployment/Dockerfile`](Dockerfile)
+
+## Build The E2E Client Image
+
+From the repository root:
+
+```sh
+docker build -t fuel-core-e2e-client -f deployment/e2e-client.Dockerfile .
+```
+
+## Notes
+
+- These assets are intended for container-based local development and packaging.
+- Kubernetes manifests are not currently stored in this directory.
+- For operator-focused node setup guidance, see the Fuel node operator docs:
+  <https://docs.fuel.network/docs/node-operator/>


### PR DESCRIPTION
## Summary
- expand `deployment/README.md` from a one-line overview into a usable deployment entrypoint
- document the purpose of `Dockerfile`, `e2e-client.Dockerfile`, and `docker-compose.yml`
- add minimal build and `docker compose` usage examples from the repository root
- clarify that Kubernetes manifests are not currently stored in `deployment/`

## Why
Compared with other infrastructure repositories, `fuel-core` already ships container assets but the deployment directory did not explain how they fit together. This makes the repository harder to approach for operators and contributors trying to understand the container-based workflow.

## Validation
- verified all referenced files exist in the current tree
- docs-only change, no runtime behavior changed

This is a docs-only change. The `no changelog` label seems appropriate if maintainers agree.