### PR TITLE
docs: remove stale Kubernetes manifest reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,14 @@ docker build -t fuel-core . -f deployment/Dockerfile
 
 # Delete Docker Image
 docker image rm fuel-core
-
-# Create Kubernetes Volume, Deployment & Service
-kubectl create -f deployment/fuel-core.yml
-
-# Delete Kubernetes Volume, Deployment & Service
-kubectl delete -f deployment/fuel-core.yml
 ```
+
+The repository currently ships container build assets under [`deployment/`](deployment/),
+but it does not include a checked-in `deployment/fuel-core.yml` Kubernetes manifest.
+
+For the repository-local container assets, see [`deployment/README.md`](deployment/README.md).
+For Kubernetes-oriented node operator guidance, see the Fuel docs:
+<https://docs.fuel.network/docs/node-operator/fuel-ignition/mainnet-node/>.
 
 ## GraphQL service
 


### PR DESCRIPTION
## Summary
- remove the stale `deployment/fuel-core.yml` example from the root README
- clarify that the repository currently ships container build assets under `deployment/`, but not a checked-in Kubernetes manifest
- point readers to `deployment/README.md` and the Fuel node operator docs instead

## Why
The current README still tells readers to run `kubectl create -f deployment/fuel-core.yml`, but that file is not present in the repository. Replacing the stale command with pointers to the current deployment assets and operator docs makes the entrypoint more accurate for contributors and operators.

## Validation
- verified that `deployment/fuel-core.yml` does not exist in the current tree
- verified that `deployment/README.md` exists and is the repository-local deployment entrypoint
- docs-only change, no runtime behavior changed

This is a docs-only change. A no-changelog path seems appropriate if maintainers agree.