### PR TITLE
docs: fix formal README file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,14 @@ docker build -t fuel-core . -f deployment/Dockerfile
 
 # Delete Docker Image
 docker image rm fuel-core
-
-# Create Kubernetes Volume, Deployment & Service
-kubectl create -f deployment/fuel-core.yml
-
-# Delete Kubernetes Volume, Deployment & Service
-kubectl delete -f deployment/fuel-core.yml
 ```
+
+The repository currently ships container build assets under [`deployment/`](deployment/),
+but it does not include a checked-in `deployment/fuel-core.yml` Kubernetes manifest.
+
+For the repository-local container assets, see [`deployment/README.md`](deployment/README.md).
+For Kubernetes-oriented node operator guidance, see the Fuel docs:
+<https://docs.fuel.network/docs/node-operator/fuel-ignition/mainnet-node/>.
 
 ## GraphQL service
 

--- a/docs/poa/formal/README.md
+++ b/docs/poa/formal/README.md
@@ -7,8 +7,8 @@ FizzBee model-checking specifications for the high-availability sequencer protoc
 | File | Description |
 |------|-------------|
 | `sequencer_ha_v2.fizz` | **Current** — Adversarial model with HEIGHT_EXISTS, de-atomized commits, per-sequencer local_db, and sub-quorum repair |
-| `sequencer_ha.fizz` | **Historical** — Original model that passed verification but missed two critical bugs (see [POST_MORTEM.md](POST_MORTEM.md)) |
-| `POST_MORTEM.md` | Analysis of six abstraction flaws in the original model |
+
+Historical v1 artifacts are referenced below for comparison, but they are not included in this directory anymore.
 
 ## What v2 Verifies
 
@@ -107,7 +107,5 @@ Re-run — the `NoFork` assertion should produce a counterexample (zombie leader
 ```
 docs/poa/formal/
 ├── sequencer_ha_v2.fizz   # Current adversarial FizzBee specification
-├── sequencer_ha.fizz      # Historical v1 specification (flawed)
-├── POST_MORTEM.md         # Analysis of v1's abstraction errors
 └── README.md              # This file
 ```


### PR DESCRIPTION
## Summary
- remove references to historical formal-model files that are no longer present in `docs/poa/formal/`
- clarify that the v1 artifacts are only discussed for comparison in the README
- update the file-structure block to match the files that actually ship in this directory

## Testing
- verified `docs/poa/formal/README.md` no longer contains broken repo-local file links
- verified the updated file structure matches the current directory contents