### PR TITLE
Disable limited-tx-count feature when running benchmarks

### DIFF
--- a/tests/test-helpers/Cargo.toml
+++ b/tests/test-helpers/Cargo.toml
@@ -29,7 +29,6 @@ fuel-core-storage = { path = "../../crates/storage", features = [
 ] }
 fuel-core-trace = { path = "../../crates/trace" }
 
-fuel-core-executor = { workspace = true, features = ["limited-tx-count"] }
 fuel-core-txpool = { path = "../../crates/services/txpool_v2", features = [
   "test-helpers",
 ] }


### PR DESCRIPTION
## Description

The `limited-tx-count` feature in fuel-core-executor caps max_tx_count() at 1024. It was being activated in the benchmark binary via: `benches → test-helpers → fuel-core-executor[limited-tx-count]`.

This caused blocks to be limited to 1024 user transactions, which causes benchmarks to fail.

The `tests/Cargo.toml` independently enables limited-tx-count in its own dev-deps, so the `blocks.rs` test that calls `max_tx_count()` remains correct. Tests crate enables it directly. The `test-helpers` dep on `limited-tx-count` was redundant and was only causing the transitive contamination into the benchmarks.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here
