### PR TITLE
Ignore RUSTSEC-2026-{0098, 0099} for now

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2025-0009", # https://github.com/FuelLabs/fuel-core/issues/2814
+    "RUSTSEC-2026-0098", # https://github.com/FuelLabs/fuel-core/issues/3265
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,4 +2,5 @@
 ignore = [
     "RUSTSEC-2025-0009", # https://github.com/FuelLabs/fuel-core/issues/2814
     "RUSTSEC-2026-0098", # https://github.com/FuelLabs/fuel-core/issues/3265
+    "RUSTSEC-2026-0099", # https://github.com/FuelLabs/fuel-core/issues/3265
 ]


### PR DESCRIPTION
See #3265. Ignores RUSTSEC-2026-{0098, 0099} that are currently blocking our CI. My understanding is that these aren't a real issue for us, but I also didn't spend much time researching this.