### PR TITLE
Use semantic JSON comparison in QuorumTransport

### DIFF
--- a/.changes/fixed/3290.md
+++ b/.changes/fixed/3290.md
@@ -1,0 +1,1 @@
+Use semantic JSON comparison in QuorumTransport

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4847,6 +4847,7 @@ dependencies = [
  "fuel-core-provider",
  "futures",
  "parking_lot",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -31,9 +31,9 @@ alloy-transport-http = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }
 parking_lot = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-serde_json = { workspace = true }
 tower = "0.5.2"
 url = { workspace = true }
 

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -33,6 +33,7 @@ futures = { workspace = true }
 parking_lot = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+serde_json = { workspace = true }
 tower = "0.5.2"
 url = { workspace = true }
 

--- a/crates/provider/src/quorum/transport.rs
+++ b/crates/provider/src/quorum/transport.rs
@@ -235,7 +235,16 @@ fn compare_responses(a: &Response, b: &Response) -> bool {
     }
 
     match (&a.payload, &b.payload) {
-        (ResponsePayload::Success(a), ResponsePayload::Success(b)) => a.get() == b.get(),
+        (ResponsePayload::Success(a), ResponsePayload::Success(b)) => {
+            // Semantic JSON comparison, ignores key ordering and formatting differences
+            match (
+                serde_json::from_str::<serde_json::Value>(a.get()),
+                serde_json::from_str::<serde_json::Value>(b.get()),
+            ) {
+                (Ok(a), Ok(b)) => a == b,
+                _ => a.get() == b.get(),
+            }
+        }
         (ResponsePayload::Failure(a), ResponsePayload::Failure(b)) => a.code == b.code,
         _ => false,
     }
@@ -248,5 +257,128 @@ fn compare_response_packets(a: &ResponsePacket, b: &ResponsePacket) -> bool {
             a.iter().zip(b).all(|(x, y)| compare_responses(x, y))
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_rpc::{
+        Id,
+        Response,
+        ResponsePacket,
+        ResponsePayload,
+    };
+    use alloy_transport::{
+        IntoBoxTransport,
+        mock::{
+            Asserter,
+            MockTransport,
+        },
+    };
+    use serde_json::value::RawValue;
+
+    fn success_packet(raw_json: &str) -> ResponsePacket {
+        ResponsePacket::Single(Response {
+            id: Id::Number(1),
+            payload: ResponsePayload::Success(
+                RawValue::from_string(raw_json.to_string()).unwrap(),
+            ),
+        })
+    }
+
+    fn dummy_weighted_transport() -> WeightedTransport {
+        WeightedTransport::new(MockTransport::new(Asserter::new()).into_box_transport())
+    }
+
+    /// Builds a QuorumRequest with two providers returning the given JSON payloads.
+    /// quorum_weight = 2 means both providers must agree, so both responses are always
+    /// compared before quorum can be reached or declared missing.
+    fn make_quorum_request(
+        json_a: &'static str,
+        json_b: &'static str,
+    ) -> QuorumRequest<'static> {
+        let transports: Arc<[WeightedTransport]> =
+            vec![dummy_weighted_transport(), dummy_weighted_transport()].into();
+
+        let quorum_transport = QuorumTransport {
+            transports,
+            quorum_weight: 2,
+        };
+
+        QuorumRequest {
+            inner: quorum_transport,
+            responses: Vec::new(),
+            errors: Vec::new(),
+            requests: vec![
+                PendingRequest {
+                    future: Box::pin(std::future::ready(Ok(success_packet(json_a)))),
+                    id: 0,
+                },
+                PendingRequest {
+                    future: Box::pin(std::future::ready(Ok(success_packet(json_b)))),
+                    id: 1,
+                },
+            ],
+        }
+    }
+
+    // --- Unit tests: compare_response_packets ---
+
+    #[test]
+    fn identical_json_is_equal() {
+        let a = success_packet(r#"{"address":"0xabc","data":"0x01"}"#);
+        let b = success_packet(r#"{"address":"0xabc","data":"0x01"}"#);
+        assert!(compare_response_packets(&a, &b));
+    }
+
+    #[test]
+    fn different_key_order_is_equal() {
+        let a = success_packet(r#"{"address":"0xabc","data":"0x01","logIndex":"0x0"}"#);
+        let b = success_packet(r#"{"logIndex":"0x0","data":"0x01","address":"0xabc"}"#);
+        assert!(compare_response_packets(&a, &b));
+    }
+
+    #[test]
+    fn different_whitespace_is_equal() {
+        let a = success_packet(r#"{"a":1,"b":2}"#);
+        let b = success_packet(r#"{ "a" : 1 , "b" : 2 }"#);
+        assert!(compare_response_packets(&a, &b));
+    }
+
+    #[test]
+    fn genuinely_different_values_not_equal() {
+        let a = success_packet(r#"{"address":"0xabc"}"#);
+        let b = success_packet(r#"{"address":"0xdef"}"#);
+        assert!(!compare_response_packets(&a, &b));
+    }
+
+    // --- Integration tests: QuorumRequest resolution ---
+
+    #[tokio::test]
+    async fn quorum_reached_with_different_json_key_ordering() {
+        // Reproduces the production failure: two QuickNode backends return the same
+        // eth_getLogs data but with different JSON field ordering (e.g. Geth vs Reth
+        // serialization). Before the fix, string comparison caused NoQuorumReached.
+        let json_a = r#"{"address":"0xdeadbeef","blockHash":"0x1234","data":"0xabcd","logIndex":"0x0"}"#;
+        let json_b = r#"{"logIndex":"0x0","data":"0xabcd","blockHash":"0x1234","address":"0xdeadbeef"}"#;
+
+        let result = make_quorum_request(json_a, json_b).await;
+        assert!(
+            result.is_ok(),
+            "quorum must be reached when providers return identical data with different key ordering"
+        );
+    }
+
+    #[tokio::test]
+    async fn quorum_not_reached_for_genuinely_different_values() {
+        let json_a = r#"{"address":"0xabc","data":"0x01"}"#;
+        let json_b = r#"{"address":"0xdef","data":"0x02"}"#;
+
+        let result = make_quorum_request(json_a, json_b).await;
+        assert!(
+            result.is_err(),
+            "quorum must not be reached when providers return genuinely different values"
+        );
     }
 }


### PR DESCRIPTION
Using string equality comparison caused quorum to fail when different Ethereum nodes returned the same log data with different JSON field ordering.

Fix: Parse both payloads to `serde_json::Value` before comparing, falling back to string equality if either payload is unparseable.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior (link update PR if changes are needed)

### Before requesting review
- [x] I have reviewed the code myself
- [x] I have created follow-up issues caused by this PR and linked them here

