### PR TITLE
Ignore audits blocking CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,4 +4,6 @@ ignore = [
     "RUSTSEC-2026-0098", # https://github.com/FuelLabs/fuel-core/issues/3265
     "RUSTSEC-2026-0099", # https://github.com/FuelLabs/fuel-core/issues/3265
     "RUSTSEC-2026-0104", # https://github.com/FuelLabs/fuel-core/issues/3279
+    "RUSTSEC-2026-0114", # https://github.com/FuelLabs/fuel-core/issues/3293
+    "RUSTSEC-2026-0119", # https://github.com/FuelLabs/fuel-core/issues/3296
 ]


### PR DESCRIPTION
Ignores the following hopefully non-critical vulnerabilities in dependencies to unblock CI:
- https://github.com/FuelLabs/fuel-core/issues/3296
- https://github.com/FuelLabs/fuel-core/issues/3293