### PR TITLE
disable coredumps in fuel-core-bin to keep pod restarts fast

### DIFF
--- a/.changes/fixed/3301.md
+++ b/.changes/fixed/3301.md
@@ -1,0 +1,1 @@
+disable coredumps in the fuel-core binary so the rocksdb atexit SIGABRT does not block pod restart for tens of seconds; set `FUEL_CORE_ENABLE_COREDUMP=1` to opt back in.

--- a/bin/fuel-core/src/main.rs
+++ b/bin/fuel-core/src/main.rs
@@ -27,10 +27,22 @@ const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// the canonical workaround.
 ///
 /// To keep coredumps on (e.g. when debugging a real crash) set
-/// `FUEL_CORE_ENABLE_COREDUMP=1`.
+/// `FUEL_CORE_ENABLE_COREDUMP` to a truthy value (`1`, `true`, `yes`, `on`,
+/// case-insensitive). Any other value — including `0`, `false`, or an empty
+/// string — leaves coredumps disabled, so operators can explicitly opt out
+/// in their manifests without accidentally re-enabling them.
 #[cfg(feature = "rocksdb")]
 fn disable_coredump_unless_opted_in() {
-    if std::env::var_os("FUEL_CORE_ENABLE_COREDUMP").is_some() {
+    let opted_in = std::env::var("FUEL_CORE_ENABLE_COREDUMP")
+        .ok()
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false);
+    if opted_in {
         return;
     }
     if let Err(e) = rlimit::setrlimit(rlimit::Resource::CORE, 0, 0) {

--- a/bin/fuel-core/src/main.rs
+++ b/bin/fuel-core/src/main.rs
@@ -14,7 +14,34 @@ use std::time::Duration;
 /// synchronously before `main` returns avoids that race.
 const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Disable coredumps for this process unless explicitly enabled.
+///
+/// Rocksdb's C++ static destructors race fuel-core's own DB teardown at libc
+/// `atexit`, raising `SIGABRT` ("pthread lock: Invalid argument"). The
+/// application-level shutdown is already clean by that point — the WAL is
+/// synced and rocksdb recovers on next start — but the `SIGABRT` triggers a
+/// kernel coredump of the entire RSS (~2.5 GB), which dominates pod-restart
+/// time on Kubernetes (~60 s vs ~6 s) without producing actionable
+/// diagnostics. The race is upstream of us (see `rust-lang/rust#83994`,
+/// `rust-rocksdb#270`, `facebook/rocksdb#3453`); skipping the coredump is
+/// the canonical workaround.
+///
+/// To keep coredumps on (e.g. when debugging a real crash) set
+/// `FUEL_CORE_ENABLE_COREDUMP=1`.
+#[cfg(feature = "rocksdb")]
+fn disable_coredump_unless_opted_in() {
+    if std::env::var_os("FUEL_CORE_ENABLE_COREDUMP").is_some() {
+        return;
+    }
+    if let Err(e) = rlimit::setrlimit(rlimit::Resource::CORE, 0, 0) {
+        eprintln!("Warning: failed to disable coredumps: {e}");
+    }
+}
+
 fn main() -> anyhow::Result<()> {
+    #[cfg(feature = "rocksdb")]
+    disable_coredump_unless_opted_in();
+
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;


### PR DESCRIPTION
Rocksdb's C++ static destructors race fuel-core's own DB teardown during libc atexit, raising SIGABRT with "pthread lock: Invalid argument". The application-level shutdown has already completed cleanly at that point (WAL synced, sub-services drained, runtime workers joined), and rocksdb recovers from the WAL on the next start — so the abort is functionally harmless. But the SIGABRT triggers a kernel coredump of fuel-core's full RSS (~2.5 GB on devnet), and writing that out dominates Kubernetes pod-restart time: ~60 s with the coredump vs ~6 s without.

Validated on devnet: with `core_pattern` redirected so the kernel discards the coredump pipe, restart of an authority pod consistently takes 6-8 s. With the default systemd-coredump pipe handler, the same restart takes 57-86 s. The fuel-core process itself exits in the same ~5 s either way.

Since the coredump produces no actionable diagnostic (it's the rocksdb static-destructor race, not a fuel-core bug), disable it via `setrlimit(RLIMIT_CORE, 0, 0)` early in `main`. An escape hatch `FUEL_CORE_ENABLE_COREDUMP=1` keeps coredumps on for cases where a genuine crash needs debugging.

The race itself is upstream and well-known:
  rust-lang/rust#83994       (exit() not thread-safe)
  rust-rocksdb#270           (can't gracefully close rocksdb)
  facebook/rocksdb#3453      (Env threads outlive DB)

Please go to the `Preview` tab and select the appropriate sub-template:

* [Classic PR](?expand=1&template=default.md)
* [Bump version](?expand=1&template=bump_version.md)
