### PR TITLE
Release v0.48.2

### DIFF
--- a/.changes/fixed/3289.md
+++ b/.changes/fixed/3289.md
@@ -1,1 +1,0 @@
-shutdown services in parallel to stop poa promptly

--- a/.changes/fixed/3290.md
+++ b/.changes/fixed/3290.md
@@ -1,1 +1,0 @@
-Use semantic JSON comparison in QuorumTransport

--- a/.changes/fixed/3301.md
+++ b/.changes/fixed/3301.md
@@ -1,1 +1,0 @@
-disable coredumps in the fuel-core binary so the rocksdb atexit SIGABRT does not block pod restart for tens of seconds; set `FUEL_CORE_ENABLE_COREDUMP=1` to opt back in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+## [Version 0.48.2]
+
+### Fixed
+- [3289](https://github.com/FuelLabs/fuel-core/pull/3289): shutdown services in parallel to stop poa promptly
+- [3290](https://github.com/FuelLabs/fuel-core/pull/3290): Use semantic JSON comparison in QuorumTransport
+- [3301](https://github.com/FuelLabs/fuel-core/pull/3301): disable coredumps in the fuel-core binary so the rocksdb atexit SIGABRT does not block pod restart for tens of seconds; set `FUEL_CORE_ENABLE_COREDUMP=1` to opt back in.
+
 ## [Version 0.48.1]
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4291,7 +4291,7 @@ dependencies = [
  "fuel-core-trace",
  "fuel-core-tx-status-manager",
  "fuel-core-txpool",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "fuel-core-upgradable-executor",
  "futures",
  "hex",
@@ -4349,7 +4349,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-sync",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "hashbrown 0.14.5",
  "hex",
@@ -4373,11 +4373,11 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-bft"
-version = "0.48.1"
+version = "0.48.2"
 
 [[package]]
 name = "fuel-core-bin"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4393,7 +4393,7 @@ dependencies = [
  "fuel-core-poa",
  "fuel-core-shared-sequencer",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "hex",
  "humantime",
  "itertools 0.14.0",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-block-aggregator-api"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4430,7 +4430,7 @@ dependencies = [
  "fuel-core-protobuf",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "itertools 0.14.0",
  "mockall",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4458,7 +4458,7 @@ dependencies = [
  "educe",
  "fuel-core-chain-config",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "insta",
  "itertools 0.14.0",
  "parquet",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chaos-test"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4484,7 +4484,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "humantime",
  "rand 0.8.5",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4509,7 +4509,7 @@ dependencies = [
  "eventsource-client",
  "flate2",
  "fuel-core-block-aggregator-api",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "hex",
  "hyper-rustls 0.24.2",
@@ -4530,23 +4530,23 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client-bin"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "clap",
  "fuel-core-client",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "enum_dispatch",
  "fuel-core-compression",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "paste",
  "postcard",
  "proptest",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-compression-service"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4570,7 +4570,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "paste",
  "rand 0.8.5",
@@ -4585,30 +4585,30 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "fuel-core-chain-config",
  "fuel-core-poa",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "test-case",
 ]
 
 [[package]]
 name = "fuel-core-database"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
 ]
 
 [[package]]
 name = "fuel-core-e2e-client"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4616,7 +4616,7 @@ dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "hex",
  "humantime-serde",
@@ -4634,13 +4634,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "fuel-core-storage",
  "fuel-core-syscall",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "parking_lot",
  "serde",
  "sha2 0.10.9",
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4657,7 +4657,7 @@ dependencies = [
  "fuel-core-metrics",
  "fuel-core-services",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "fuel-gas-price-algorithm",
  "futures",
  "mockito",
@@ -4677,14 +4677,14 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",
  "fuel-core-metrics",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "mockall",
  "rayon",
  "test-case",
@@ -4694,18 +4694,18 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-keygen"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "clap",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "fuel-core-keygen-bin"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -4718,7 +4718,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "once_cell",
  "parking_lot",
@@ -4733,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-p2p"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4742,7 +4742,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "hex",
  "hickory-resolver",
@@ -4766,12 +4766,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-parallel-executor"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "fuel-core-upgradable-executor",
  "futures",
  "rand 0.8.5",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4788,7 +4788,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "mockall",
  "rand 0.8.5",
  "serde",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-producer"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4810,7 +4810,7 @@ dependencies = [
  "fuel-core-producer",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "mockall",
  "proptest",
  "rand 0.8.5",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-provider"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4869,7 +4869,7 @@ dependencies = [
  "fuel-core-services",
  "fuel-core-storage",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "mockall",
  "once_cell",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-shared-sequencer"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4907,7 +4907,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "fuel-core-services",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "fuel-sequencer-proto",
  "futures",
  "postcard",
@@ -4923,13 +4923,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",
  "enum-iterator",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "fuel-vm 0.66.4",
  "impl-tools",
  "itertools 0.14.0",
@@ -4947,13 +4947,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-sync"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-services",
  "fuel-core-trace",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "mockall",
  "rand 0.8.5",
@@ -4966,9 +4966,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-syscall"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "parking_lot",
  "tracing",
 ]
@@ -5002,7 +5002,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "fuel-core-upgradable-executor",
  "futures",
  "hyper 0.14.32",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-trace"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "ctor",
  "fork",
@@ -5046,13 +5046,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-tx-status-manager"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-metrics",
  "fuel-core-services",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "mockall",
  "parking_lot",
@@ -5067,7 +5067,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-txpool"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5078,7 +5078,7 @@ dependencies = [
  "fuel-core-syscall",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "lru 0.16.3",
  "mockall",
@@ -5110,7 +5110,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -5135,13 +5135,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",
  "fuel-core-executor",
  "fuel-core-storage",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "fuel-core-wasm-executor",
  "futures",
  "parking_lot",
@@ -5152,13 +5152,13 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-wasm-executor"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "anyhow",
  "fuel-core-executor",
  "fuel-core-storage",
  "fuel-core-types 0.35.0",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "postcard",
  "proptest",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.48.1"
+version = "0.48.2"
 dependencies = [
  "proptest",
  "rand 0.8.5",
@@ -10904,7 +10904,7 @@ dependencies = [
  "fuel-core-storage",
  "fuel-core-trace",
  "fuel-core-txpool",
- "fuel-core-types 0.48.1",
+ "fuel-core-types 0.48.2",
  "futures",
  "itertools 0.14.0",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ keywords = ["blockchain", "cryptocurrencies", "fuel-vm", "vm"]
 license = "BUSL-1.1"
 repository = "https://github.com/FuelLabs/fuel-core"
 rust-version = "1.93.0"
-version = "0.48.1"
+version = "0.48.2"
 
 [workspace.dependencies]
 
@@ -90,40 +90,40 @@ educe = { version = "0.6", default-features = false, features = ["Eq", "PartialE
 enum-iterator = "2"
 enum_dispatch = "0.3.13"
 flate2 = "1.1.5"
-fuel-core = { version = "0.48.1", path = "./crates/fuel-core", default-features = false }
-fuel-core-bin = { version = "0.48.1", path = "./bin/fuel-core" }
+fuel-core = { version = "0.48.2", path = "./crates/fuel-core", default-features = false }
+fuel-core-bin = { version = "0.48.2", path = "./bin/fuel-core" }
 # Workspace members
-fuel-core-block-aggregator-api = { version = "0.48.1", path = "./crates/services/block_aggregator_api" }
-fuel-core-chain-config = { version = "0.48.1", path = "./crates/chain-config", default-features = false }
-fuel-core-client = { version = "0.48.1", path = "./crates/client" }
-fuel-core-compression = { version = "0.48.1", path = "./crates/compression" }
-fuel-core-compression-service = { version = "0.48.1", path = "./crates/services/compression" }
-fuel-core-consensus-module = { version = "0.48.1", path = "./crates/services/consensus_module" }
-fuel-core-database = { version = "0.48.1", path = "./crates/database" }
-fuel-core-executor = { version = "0.48.1", path = "./crates/services/executor", default-features = false }
-fuel-core-gas-price-service = { version = "0.48.1", path = "crates/services/gas_price_service" }
-fuel-core-importer = { version = "0.48.1", path = "./crates/services/importer" }
-fuel-core-keygen = { version = "0.48.1", path = "./crates/keygen" }
-fuel-core-metrics = { version = "0.48.1", path = "./crates/metrics" }
-fuel-core-p2p = { version = "0.48.1", path = "./crates/services/p2p" }
-fuel-core-parallel-executor = { version = "0.48.1", path = "./crates/services/parallel-executor" }
-fuel-core-poa = { version = "0.48.1", path = "./crates/services/consensus_module/poa" }
-fuel-core-producer = { version = "0.48.1", path = "./crates/services/producer" }
+fuel-core-block-aggregator-api = { version = "0.48.2", path = "./crates/services/block_aggregator_api" }
+fuel-core-chain-config = { version = "0.48.2", path = "./crates/chain-config", default-features = false }
+fuel-core-client = { version = "0.48.2", path = "./crates/client" }
+fuel-core-compression = { version = "0.48.2", path = "./crates/compression" }
+fuel-core-compression-service = { version = "0.48.2", path = "./crates/services/compression" }
+fuel-core-consensus-module = { version = "0.48.2", path = "./crates/services/consensus_module" }
+fuel-core-database = { version = "0.48.2", path = "./crates/database" }
+fuel-core-executor = { version = "0.48.2", path = "./crates/services/executor", default-features = false }
+fuel-core-gas-price-service = { version = "0.48.2", path = "crates/services/gas_price_service" }
+fuel-core-importer = { version = "0.48.2", path = "./crates/services/importer" }
+fuel-core-keygen = { version = "0.48.2", path = "./crates/keygen" }
+fuel-core-metrics = { version = "0.48.2", path = "./crates/metrics" }
+fuel-core-p2p = { version = "0.48.2", path = "./crates/services/p2p" }
+fuel-core-parallel-executor = { version = "0.48.2", path = "./crates/services/parallel-executor" }
+fuel-core-poa = { version = "0.48.2", path = "./crates/services/consensus_module/poa" }
+fuel-core-producer = { version = "0.48.2", path = "./crates/services/producer" }
 fuel-core-protobuf = { version = "0.5.0" }
-fuel-core-provider = { version = "0.48.1", path = "./crates/provider" }
-fuel-core-relayer = { version = "0.48.1", path = "./crates/services/relayer" }
-fuel-core-services = { version = "0.48.1", path = "./crates/services" }
-fuel-core-shared-sequencer = { version = "0.48.1", path = "crates/services/shared-sequencer" }
-fuel-core-storage = { version = "0.48.1", path = "./crates/storage", default-features = false }
-fuel-core-sync = { version = "0.48.1", path = "./crates/services/sync" }
-fuel-core-syscall = { version = "0.48.1", path = "./crates/syscall", default-features = false }
-fuel-core-trace = { version = "0.48.1", path = "./crates/trace" }
-fuel-core-tx-status-manager = { version = "0.48.1", path = "./crates/services/tx_status_manager" }
-fuel-core-txpool = { version = "0.48.1", path = "./crates/services/txpool_v2" }
-fuel-core-types = { version = "0.48.1", path = "./crates/types", default-features = false }
-fuel-core-upgradable-executor = { version = "0.48.1", path = "./crates/services/upgradable-executor" }
-fuel-core-wasm-executor = { version = "0.48.1", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
-fuel-gas-price-algorithm = { version = "0.48.1", path = "crates/fuel-gas-price-algorithm" }
+fuel-core-provider = { version = "0.48.2", path = "./crates/provider" }
+fuel-core-relayer = { version = "0.48.2", path = "./crates/services/relayer" }
+fuel-core-services = { version = "0.48.2", path = "./crates/services" }
+fuel-core-shared-sequencer = { version = "0.48.2", path = "crates/services/shared-sequencer" }
+fuel-core-storage = { version = "0.48.2", path = "./crates/storage", default-features = false }
+fuel-core-sync = { version = "0.48.2", path = "./crates/services/sync" }
+fuel-core-syscall = { version = "0.48.2", path = "./crates/syscall", default-features = false }
+fuel-core-trace = { version = "0.48.2", path = "./crates/trace" }
+fuel-core-tx-status-manager = { version = "0.48.2", path = "./crates/services/tx_status_manager" }
+fuel-core-txpool = { version = "0.48.2", path = "./crates/services/txpool_v2" }
+fuel-core-types = { version = "0.48.2", path = "./crates/types", default-features = false }
+fuel-core-upgradable-executor = { version = "0.48.2", path = "./crates/services/upgradable-executor" }
+fuel-core-wasm-executor = { version = "0.48.2", path = "./crates/services/upgradable-executor/wasm-executor", default-features = false }
+fuel-gas-price-algorithm = { version = "0.48.2", path = "crates/fuel-gas-price-algorithm" }
 fuel-vm-private = { version = "0.66.4", package = "fuel-vm", default-features = false }
 futures = "0.3"
 hex = { version = "0.4", features = ["serde"] }

--- a/crates/fuel-core/src/graphql_api/api_service.rs
+++ b/crates/fuel-core/src/graphql_api/api_service.rs
@@ -136,6 +136,16 @@ pub struct ServerParams {
 
 pub struct Task {
     server: tokio::task::JoinHandle<hyper::Result<()>>,
+    /// Handle to the inner `AsyncProcessor`'s task tracker. Kept here so
+    /// `Task::shutdown` can `await processor.drain()` and wait for every
+    /// hyper request future to complete before the surrounding service
+    /// teardown reaches `AsyncProcessor::drop`. If we skip this, the
+    /// `Runtime::shutdown_timeout` in `Drop` would detach any task still
+    /// running at its deadline; the detached worker then outlives the
+    /// service and races rocksdb's global `Env::Default()` destructor in
+    /// `__run_exit_handlers`, surfacing as SIGABRT/SIGSEGV at process
+    /// exit.
+    processor: Arc<AsyncProcessor>,
 }
 
 const GRAPHQL_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
@@ -185,14 +195,14 @@ impl RunnableService for GraphqlService {
             number_of_threads,
         } = params;
 
-        let processor = AsyncProcessor::new(
+        let processor = Arc::new(AsyncProcessor::new(
             "GraphQLFutures",
             number_of_threads,
             tokio::sync::Semaphore::MAX_PERMITS,
-        )?;
+        )?);
 
         let executor = ExecutorWithMetrics {
-            processor: Arc::new(processor),
+            processor: processor.clone(),
         };
 
         let server = axum::Server::from_tcp(listener)
@@ -217,6 +227,7 @@ impl RunnableService for GraphqlService {
 
         Ok(Task {
             server: tokio::spawn(server),
+            processor,
         })
     }
 }
@@ -252,9 +263,17 @@ impl RunnableTask for Task {
     }
 
     async fn shutdown(self) -> anyhow::Result<()> {
-        // Nothing to shut down because we don't have any temporary state that should be dumped,
-        // and we don't spawn any sub-tasks that we need to finish or await.
-        // The `axum::Server` was already gracefully shutdown at this point.
+        // The `axum::Server` has already gracefully stopped accepting new
+        // requests, but some hyper request futures may still be running on
+        // the inner `AsyncProcessor` runtime — connection-drain tasks and
+        // any handler whose response was mid-flight when the stop signal
+        // arrived. We must wait for them to complete here, because
+        // `AsyncProcessor::drop` falls back to `Runtime::shutdown_timeout`
+        // which detaches any task still running at its deadline; the
+        // detached worker then outlives the service and races rocksdb's
+        // global `Env::Default()` destructor in `__run_exit_handlers`,
+        // surfacing as SIGABRT/SIGSEGV at process exit.
+        self.processor.drain().await;
         Ok(())
     }
 }

--- a/crates/fuel-core/src/graphql_api/api_service.rs
+++ b/crates/fuel-core/src/graphql_api/api_service.rs
@@ -153,6 +153,14 @@ const GRAPHQL_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
 #[derive(Clone)]
 struct ExecutorWithMetrics {
     processor: Arc<AsyncProcessor>,
+    /// Watched alongside every spawned request future so that the future
+    /// resolves as soon as the service leaves `Started`. This bounds the
+    /// time `Task::shutdown` has to wait inside `processor.drain()`: even
+    /// a handler stuck in a long-running await terminates at the stop
+    /// signal instead of being detached at the end of
+    /// `Runtime::shutdown_timeout` and racing the rocksdb static
+    /// destructors at process atexit.
+    state: StateWatcher,
 }
 
 impl<F> Executor<F> for ExecutorWithMetrics
@@ -161,7 +169,18 @@ where
     F::Output: Send + 'static,
 {
     fn execute(&self, fut: F) {
-        let result = self.processor.try_spawn(fut);
+        let mut state = self.state.clone();
+        let wrapped = async move {
+            // We don't need the future's output (axum/hyper drives the
+            // request lifecycle via I/O on the connection itself), so
+            // dropping it on shutdown is safe — the connection's drop
+            // closes the socket cleanly.
+            tokio::select! {
+                _ = fut => {}
+                _ = state.while_started() => {}
+            }
+        };
+        let result = self.processor.try_spawn(wrapped);
 
         if let Err(err) = result {
             tracing::error!("Failed to spawn a task for GraphQL: {:?}", err);
@@ -203,6 +222,7 @@ impl RunnableService for GraphqlService {
 
         let executor = ExecutorWithMetrics {
             processor: processor.clone(),
+            state: state.clone(),
         };
 
         let server = axum::Server::from_tcp(listener)

--- a/crates/services/src/async_processor.rs
+++ b/crates/services/src/async_processor.rs
@@ -4,12 +4,19 @@ use fuel_core_metrics::futures::{
 };
 use std::{
     future::Future,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{
+            AtomicUsize,
+            Ordering,
+        },
+    },
     time::Duration,
 };
 use tokio::{
     runtime,
     sync::{
+        Notify,
         OwnedSemaphorePermit,
         Semaphore,
     },
@@ -28,6 +35,13 @@ pub struct AsyncProcessor {
     metric: FuturesMetrics,
     semaphore: Arc<Semaphore>,
     thread_pool: Option<runtime::Runtime>,
+    /// Number of spawned tasks that have not yet completed. Used by
+    /// `drain` to wait for in-flight work to finish before the inner
+    /// runtime is shut down — otherwise `shutdown_timeout` would
+    /// detach still-running workers, which then race with rocksdb's
+    /// global `Env::Default()` destructor at process atexit.
+    active: Arc<AtomicUsize>,
+    drained: Arc<Notify>,
 }
 
 impl Drop for AsyncProcessor {
@@ -89,7 +103,31 @@ impl AsyncProcessor {
             metric,
             thread_pool,
             semaphore,
+            active: Arc::new(AtomicUsize::new(0)),
+            drained: Arc::new(Notify::new()),
         })
+    }
+
+    /// Waits until every task previously spawned via this processor has
+    /// finished. Callers must ensure no further tasks will be spawned
+    /// before awaiting this future, otherwise it may resolve and then
+    /// the count is non-zero again.
+    ///
+    /// This is the explicit synchronisation point that must be reached
+    /// before `Drop` runs — without it, `Runtime::shutdown_timeout`
+    /// detaches any task that hasn't finished within its budget and the
+    /// detached worker continues running into the libc `atexit` chain.
+    pub async fn drain(&self) {
+        loop {
+            // Order matters: register interest first, then check the
+            // counter. Reversing it would let a task complete between
+            // load and notify-registration and we'd miss the wakeup.
+            let notified = self.drained.notified();
+            if self.active.load(Ordering::SeqCst) == 0 {
+                return;
+            }
+            notified.await;
+        }
     }
 
     /// Reserve a slot for a task to be executed.
@@ -112,10 +150,16 @@ impl AsyncProcessor {
         F::Output: Send,
     {
         let permit = reservation.0;
+        let active = self.active.clone();
+        let drained = self.drained.clone();
+        active.fetch_add(1, Ordering::SeqCst);
         let future = async move {
             let permit = permit;
             let result = future.await;
             drop(permit);
+            if active.fetch_sub(1, Ordering::SeqCst) == 1 {
+                drained.notify_waiters();
+            }
             result
         };
         let metered_future = MeteredFuture::new(future, self.metric.clone());

--- a/crates/services/src/async_processor.rs
+++ b/crates/services/src/async_processor.rs
@@ -71,6 +71,29 @@ impl Drop for AsyncProcessor {
     }
 }
 
+/// RAII counter for tasks spawned via `spawn_reserved`. The increment
+/// happens at spawn time (outside the future); this guard owns the
+/// matching decrement and the `notify_waiters` call, so the count is
+/// released even if the future panics, is dropped before its first
+/// poll, or is cancelled mid-await. The cooperating helper
+/// `active_guard_inc` performs the matching increment.
+struct ActiveGuard {
+    active: Arc<AtomicUsize>,
+    drained: Arc<Notify>,
+}
+
+impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+        if self.active.fetch_sub(1, Ordering::SeqCst) == 1 {
+            self.drained.notify_waiters();
+        }
+    }
+}
+
+fn active_guard_inc(active: &Arc<AtomicUsize>) {
+    active.fetch_add(1, Ordering::SeqCst);
+}
+
 /// A reservation for a task to be executed by the `AsyncProcessor`.
 pub struct AsyncReservation(OwnedSemaphorePermit);
 
@@ -150,16 +173,20 @@ impl AsyncProcessor {
         F::Output: Send,
     {
         let permit = reservation.0;
-        let active = self.active.clone();
-        let drained = self.drained.clone();
-        active.fetch_add(1, Ordering::SeqCst);
+        // Counted via an RAII guard so the count is decremented and
+        // waiters are notified even if `future` panics or is cancelled
+        // mid-await. Without the guard, a panic in `future.await` would
+        // leak `active` and `drain()` would hang forever.
+        active_guard_inc(&self.active);
+        let guard = ActiveGuard {
+            active: self.active.clone(),
+            drained: self.drained.clone(),
+        };
         let future = async move {
+            let _guard = guard;
             let permit = permit;
             let result = future.await;
             drop(permit);
-            if active.fetch_sub(1, Ordering::SeqCst) == 1 {
-                drained.notify_waiters();
-            }
             result
         };
         let metered_future = MeteredFuture::new(future, self.metric.clone());
@@ -193,6 +220,41 @@ mod tests {
         time::Duration,
     };
     use tokio::time::Instant;
+
+    #[tokio::test]
+    async fn drain__returns_when_panicking_task_completes() {
+        // Regression: a previous version decremented `active` inside the
+        // spawned future *after* `future.await`. A panicking task would
+        // skip the decrement and `drain()` would hang forever.
+        let proc = AsyncProcessor::new("Test", 1, 4).unwrap();
+        let h = proc
+            .try_spawn(async {
+                panic!("intentional panic from spawned task");
+            })
+            .unwrap();
+        // Let the panic propagate and the task end.
+        let _ = h.await;
+        // Should return promptly, not hang.
+        tokio::time::timeout(Duration::from_secs(2), proc.drain())
+            .await
+            .expect("drain must not hang after a panicking task");
+    }
+
+    #[tokio::test]
+    async fn drain__returns_when_cancelled_before_first_poll() {
+        // Another panic-safety path: spawn a future, drop the JoinHandle
+        // before it is polled, ensure `drain()` still terminates because
+        // the `ActiveGuard` is dropped along with the future.
+        let proc = AsyncProcessor::new("Test", 1, 4).unwrap();
+        let h = proc
+            .try_spawn(async { tokio::time::sleep(Duration::from_secs(60)).await })
+            .unwrap();
+        h.abort();
+        let _ = h.await;
+        tokio::time::timeout(Duration::from_secs(2), proc.drain())
+            .await
+            .expect("drain must not hang after task cancellation");
+    }
 
     #[tokio::test]
     async fn one_spawn_single_tasks_works() {

--- a/crates/services/upgradable-executor/src/executor.rs
+++ b/crates/services/upgradable-executor/src/executor.rs
@@ -265,7 +265,9 @@ impl<S, R> Executor<S, R> {
         // We are skipping 0-47-0 because it was not published.
         ("0-47-1", 32),
         ("0-48-0", 33),
-        ("0-48-1", LATEST_STATE_TRANSITION_VERSION),
+        // Changed between 0-48-1 and 0-48-2 are off-chain and doesn't require a state transition
+        // upgrade.
+        ("0-48-2", LATEST_STATE_TRANSITION_VERSION),
     ];
 
     pub fn new(

--- a/tests/tests/poa.rs
+++ b/tests/tests/poa.rs
@@ -253,6 +253,18 @@ mod p2p {
         // The first producer should produce 2 more blocks.
         // The second producer should synchronize 3(1 manual and 2 produced) blocks.
         let second_producer = make_node(second_producer_config, vec![]).await;
+
+        // Anchor the timer before any block reaches `second_producer`.
+        // The invariant we assert below is that `second_producer` cannot enter
+        // `Synced` until `time_until_synced` passes without new blocks, and
+        // every block received from the network restarts that timer
+        // (see `SyncTask::restart_timer` in `consensus_module/poa/src/sync.rs`).
+        // Anchoring after `wait_for_blocks` makes the assertion race-prone on
+        // slow CI because `first_producer` may stop before another block
+        // reaches `second_producer`, leaving the last-block time slightly
+        // before `start_time`.
+        let start_time = tokio::time::Instant::now();
+
         tokio::time::timeout(
             Duration::from_secs(SYNC_TIMEOUT),
             second_producer.wait_for_blocks(3, false /* is_local */),
@@ -260,7 +272,6 @@ mod p2p {
         .await
         .expect("The second should sync with the first");
 
-        let start_time = tokio::time::Instant::now();
         // Stop the first producer.
         tokio::time::timeout(
             Duration::from_secs(1),


### PR DESCRIPTION
## Version 0.48.2

### Fixed
- [3289](https://github.com/FuelLabs/fuel-core/pull/3289): shutdown services in parallel to stop poa promptly
- [3290](https://github.com/FuelLabs/fuel-core/pull/3290): Use semantic JSON comparison in QuorumTransport
- [3301](https://github.com/FuelLabs/fuel-core/pull/3301): disable coredumps in the fuel-core binary so the rocksdb atexit SIGABRT does not block pod restart for tens of seconds; set `FUEL_CORE_ENABLE_COREDUMP=1` to opt back in.