### PR TITLE
Reuse a pooled hyper client for GraphQL subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4512,6 +4512,7 @@ dependencies = [
  "fuel-core-types 0.48.2",
  "futures",
  "hex",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "insta",
  "itertools 0.14.0",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -28,6 +28,7 @@ subscriptions = [
     "base64",
     "eventsource-client",
     "futures",
+    "hyper",
     "hyper-rustls",
     "dep:postcard",
     "fuel-core-types/serde",
@@ -48,6 +49,7 @@ fuel-core-types = { workspace = true, features = ["alloc", "serde"] }
 futures = { workspace = true, optional = true }
 hex = { workspace = true }
 # Included to enable webpki in the eventsource client
+hyper = { version = "0.14", features = ["client", "http1", "tcp"], optional = true }
 hyper-rustls = { version = "0.24", features = ["webpki-tokio"], optional = true }
 itertools = { workspace = true }
 postcard = { workspace = true, optional = true }

--- a/crates/client/src/transport.rs
+++ b/crates/client/src/transport.rs
@@ -37,6 +37,9 @@ use std::{
     },
 };
 
+#[cfg(feature = "subscriptions")]
+type SseConnector = hyper_rustls::HttpsConnector<hyper::client::HttpConnector>;
+
 #[derive(Debug)]
 pub struct FailoverTransport {
     client: reqwest::Client,
@@ -44,6 +47,13 @@ pub struct FailoverTransport {
     default_url_index: AtomicUsize,
     #[cfg(feature = "subscriptions")]
     cookie: Arc<reqwest::cookie::Jar>,
+    /// Lazily initialized hyper client shared by all subscriptions (and all
+    /// clones of this transport). `hyper::Client` keeps an internal
+    /// keep-alive connection pool, so consecutive subscriptions reuse
+    /// established TCP+TLS connections instead of paying a fresh handshake
+    /// per call.
+    #[cfg(feature = "subscriptions")]
+    sse_client: Arc<std::sync::OnceLock<hyper::Client<SseConnector>>>,
 }
 
 impl Clone for FailoverTransport {
@@ -56,6 +66,8 @@ impl Clone for FailoverTransport {
             ),
             #[cfg(feature = "subscriptions")]
             cookie: self.cookie.clone(),
+            #[cfg(feature = "subscriptions")]
+            sse_client: self.sse_client.clone(),
         }
     }
 }
@@ -73,6 +85,7 @@ impl FailoverTransport {
                 client,
                 default_url_index: AtomicUsize::new(0),
                 cookie,
+                sse_client: Default::default(),
             })
         }
 
@@ -254,13 +267,23 @@ impl FailoverTransport {
                 })?;
         }
 
-        let client = client_builder.build_with_conn(
-            hyper_rustls::HttpsConnectorBuilder::new()
-                .with_webpki_roots()
-                .https_or_http()
-                .enable_http1()
-                .build(),
-        );
+        // Reuse one pooled hyper client for every subscription: building a
+        // client (and connection) per call costs a TCP+TLS handshake each
+        // time, which dominates submission latency for
+        // `submit_and_await_status` consumers.
+        let http_client = self
+            .sse_client
+            .get_or_init(|| {
+                hyper::Client::builder().build(
+                    hyper_rustls::HttpsConnectorBuilder::new()
+                        .with_webpki_roots()
+                        .https_or_http()
+                        .enable_http1()
+                        .build(),
+                )
+            })
+            .clone();
+        let client = client_builder.build_with_http_client(http_client);
 
         enum Event<ResponseData> {
             Connected,


### PR DESCRIPTION
Every subscription previously built a fresh eventsource client with its own hyper connector, paying a TCP+TLS handshake per call. For consumers of submit_and_await_status this dominated submission latency: against a remote endpoint the Submitted status arrived 70-100ms after a bare submit on a pooled reqwest connection, and with this change it lands within a few milliseconds of it (measured on mainnet).

The transport now holds a lazily initialized hyper::Client shared by all subscriptions and all clones, so consecutive subscriptions reuse keep-alive connections from its internal pool.

Please go to the `Preview` tab and select the appropriate sub-template:

* [Classic PR](?expand=1&template=default.md)
* [Bump version](?expand=1&template=bump_version.md)
