### PR TITLE
ci: pass the PR description through env instead of interpolating it into the shell

### DIFF
--- a/.github/workflows/create_version.yml
+++ b/.github/workflows/create_version.yml
@@ -21,9 +21,11 @@ jobs:
 
       - name: Get the version number in the PR description
         id: get_version
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Extract the version number from the PR description
-          version=$(echo "${{ github.event.pull_request.body }}" | grep -oP '## Version \K[0-9]+\.[0-9]+\.[0-9]+')
+          version=$(echo "$PR_BODY" | grep -oP '## Version \K[0-9]+\.[0-9]+\.[0-9]+')
           echo "NEW_VERSION=${version}" >> $GITHUB_OUTPUT
 
       - name: Gather all changes


### PR DESCRIPTION
Hi, and thanks for fuel-core.

In `.github/workflows/create_version.yml`, the PR description is pasted straight into a shell command:

```yaml
version=$(echo "${{ github.event.pull_request.body }}" | grep -oP '## Version \K[0-9]+\.[0-9]+\.[0-9]+')
```

Actions expands `${{ ... }}` before the shell ever sees the line, so the PR body becomes part of the script text rather than data passed to `echo`. Inside double quotes, `$(...)` and backticks still run, so a PR body containing something like `$(id > /tmp/x)` executes on the runner.

It is not wide open, and I want to be accurate about that: the job only runs behind `if: github.event.label.name == 'pr release'`, so someone with write access has to apply the `pr release` label first, and on a fork PR the `GITHUB_TOKEN` is read-only regardless of the `contents: write` request. What is left is that the label is the only thing standing between an arbitrary PR description and code execution on the runner — and the person applying it is reviewing the diff, not the description.

The change here is the standard fix from GitHub's own hardening guidance: pass the value through `env:` so it arrives as a shell variable instead of being substituted into the script.

```yaml
        env:
          PR_BODY: ${{ github.event.pull_request.body }}
        run: |
          version=$(echo "$PR_BODY" | grep -oP '## Version \K[0-9]+\.[0-9]+\.[0-9]+')
```

Behaviour is unchanged — the same `grep` runs against the same text. Two lines added, one changed.

I checked the other `${{ }}` uses in this workflow while I was here; the rest are refs and outputs rather than free text, so I left them alone rather than widen the diff.

Disclosure: I used AI assistance to help spot this and prepare the change, and I verified the workflow and its trigger conditions myself.
