### PR TITLE
ci: bind chaos-test workflow inputs via env before shell

### DIFF
--- a/.github/workflows/chaos-test.yml
+++ b/.github/workflows/chaos-test.yml
@@ -38,11 +38,12 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - id: matrix
+        env:
+          RANGE: ${{ inputs.seeds }}
+          BATCH_SIZE: ${{ inputs.parallelism }}
         run: |
-          RANGE="${{ inputs.seeds }}"
           START="${RANGE%-*}"
           END="${RANGE#*-}"
-          BATCH_SIZE=${{ inputs.parallelism }}
           BATCHES="["
           FIRST=true
           for ((i=START; i<=END; i+=BATCH_SIZE)); do
@@ -83,17 +84,24 @@ jobs:
         run: cargo build --release -p fuel-core-chaos-test
 
       - name: Run chaos tests (seeds ${{ matrix.batch.start }}-${{ matrix.batch.end }})
+        env:
+          BATCH_START: ${{ matrix.batch.start }}
+          BATCH_END: ${{ matrix.batch.end }}
+          DURATION: ${{ inputs.duration }}
+          BLOCK_TIME: ${{ inputs.block_time }}
+          FAULT_INTERVAL: ${{ inputs.fault_interval }}
+          STALL_THRESHOLD: ${{ inputs.stall_threshold }}
         run: |
           FAILED=0
-          for seed in $(seq ${{ matrix.batch.start }} ${{ matrix.batch.end }}); do
+          for seed in $(seq "$BATCH_START" "$BATCH_END"); do
             echo "=== Seed $seed ==="
             LOG="chaos_seed${seed}.log"
             cargo run --release -p fuel-core-chaos-test -- \
               --seed $seed \
-              --duration ${{ inputs.duration }} \
-              --block-time ${{ inputs.block_time }} \
-              --fault-interval ${{ inputs.fault_interval }} \
-              --stall-threshold ${{ inputs.stall_threshold }} \
+              --duration "$DURATION" \
+              --block-time "$BLOCK_TIME" \
+              --fault-interval "$FAULT_INTERVAL" \
+              --stall-threshold "$STALL_THRESHOLD" \
               > "$LOG" 2>&1
             RC=$?
             if [ $RC -ne 0 ]; then


### PR DESCRIPTION
## Summary
- Bind `inputs.seeds` / `inputs.parallelism` through `env:` before the matrix preparation shell step.
- Bind duration/block-time/fault-interval/stall-threshold (and matrix batch bounds) through `env:` before the chaos cargo run loop.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Chaos-test workflow still builds seed batches from `seeds` + `parallelism`
- [ ] Per-seed cargo runs still receive the configured duration/block-time/fault/stall values


Made with [Cursor](https://cursor.com)