### PR TITLE
docs: update Ignition source checkout tag

### DIFF
--- a/.changes/fixed/3330.md
+++ b/.changes/fixed/3330.md
@@ -1,0 +1,1 @@
+Update the Ignition source checkout example to the currently documented network version.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ git clone https://github.com/FuelLabs/fuel-core.git
 
 Go to the latest release tag for ignition on the `fuel-core` repository :
 ```
-git checkout v0.45.1
+git checkout v0.48.1
 ```
 
 Build your node binary:


### PR DESCRIPTION
## Description

Updates the Ignition source-build checkout example from `v0.45.1` to `v0.48.1`, matching the README table that lists the versions currently used by Fuel Ignition, Testnet, and Devnet.

Closes #3329.

## Checklist

- [x] I have linked this PR to an issue.
- [x] I have kept the change scoped to documentation.

## Testing

- `git diff --check`