### PR TITLE
fix(gas price): route the PRECOMPUTED_EXP boundary to the closed form

### DIFF
--- a/.changes/fixed/3332.md
+++ b/.changes/fixed/3332.md
@@ -1,0 +1,1 @@
+Fixed an out-of-bounds panic in `cumulative_percentage_change`: the guard around the `PRECOMPUTED_EXP` lookup table used `>` where the table bounds needed `>=`, so `estimateGasPrice(blockHorizon: 25)` panicked on every node.

--- a/crates/fuel-core/src/service/adapters.rs
+++ b/crates/fuel-core/src/service/adapters.rs
@@ -122,9 +122,20 @@ impl StaticGasPrice {
 mod universal_gas_price_provider_tests {
     #![allow(non_snake_case)]
 
-    use proptest::proptest;
+    use proptest::{
+        prop_oneof,
+        proptest,
+    };
 
     use super::*;
+
+    // `cumulative_percentage_change` only consults its lookup table when *both* the block
+    // horizon and the percentage are small, and the table's bounds are 25 x 25. Sampling
+    // the horizon out of `0..10_000` and the percentage out of the whole of `u16` lands
+    // in that region so rarely that a bug confined to it is effectively invisible, so mix
+    // in a strategy that stays inside it -- and reaches past its boundary.
+    const NARROW_HORIZON: std::ops::Range<u32> = 0..50;
+    const NARROW_PERCENTAGE: std::ops::Range<u16> = 0..50;
 
     fn _worst_case__correctly_calculates_value(
         gas_price: u64,
@@ -157,8 +168,8 @@ mod universal_gas_price_provider_tests {
         fn worst_case_gas_price__correctly_calculates_value(
             gas_price: u64,
             starting_height: u32,
-            block_horizon in 0..10_000u32,
-            percentage: u16,
+            block_horizon in prop_oneof![NARROW_HORIZON, 0..10_000u32],
+            percentage in prop_oneof![NARROW_PERCENTAGE, 0..=u16::MAX],
         ) {
             _worst_case__correctly_calculates_value(
                 gas_price,
@@ -174,8 +185,8 @@ mod universal_gas_price_provider_tests {
         fn worst_case_gas_price__never_overflows(
             gas_price: u64,
             starting_height: u32,
-            block_horizon in 0..10_000u32,
-            percentage: u16
+            block_horizon in prop_oneof![NARROW_HORIZON, 0..10_000u32],
+            percentage in prop_oneof![NARROW_PERCENTAGE, 0..=u16::MAX],
         ) {
             // given
             let subject = UniversalGasPriceProvider::new(starting_height, gas_price, percentage);

--- a/crates/fuel-gas-price-algorithm/src/utils.rs
+++ b/crates/fuel-gas-price-algorithm/src/utils.rs
@@ -671,7 +671,7 @@ pub fn cumulative_percentage_change(
     // we gain around 90%
     // if we have blocks / percentage greater than m x n, we have to compute it
     let multiple =
-        if blocks > BLOCK_COUNT_M as u32 || percentage > PERCENTAGE_COUNT_N as u64 {
+        if blocks >= BLOCK_COUNT_M as u32 || percentage >= PERCENTAGE_COUNT_N as u64 {
             f64::exp(blocks as f64 * (1.0 + percentage as f64 / 100.0).ln())
         } else {
             PRECOMPUTED_EXP[blocks as usize][percentage as usize]
@@ -697,6 +697,10 @@ pub fn cumulative_percentage_change(
 
 #[cfg(test)]
 mod tests {
+    #![allow(non_snake_case)]
+    #![allow(clippy::arithmetic_side_effects)]
+    #![allow(clippy::cast_possible_truncation)]
+
     use super::*;
     use proptest::prelude::*;
 
@@ -726,13 +730,38 @@ mod tests {
         approx.ceil() as u64
     }
 
+    // `cumulative_percentage_change` with the lookup table taken out of the picture, i.e.
+    // the branch it falls back to once an index leaves the table. Every entry of
+    // `PRECOMPUTED_EXP` is bit-identical to this, so which branch is taken must never
+    // change the answer.
+    fn cumulative_percentage_change_closed_form(
+        new_exec_price: u64,
+        for_height: u32,
+        percentage: u64,
+        height: u32,
+    ) -> u64 {
+        let blocks = height.saturating_sub(for_height);
+        let multiple = f64::exp(blocks as f64 * (1.0 + percentage as f64 / 100.0).ln());
+        let mut approx = new_exec_price as f64 * multiple;
+        const ROUNDING_ERROR_CUTOFF: f64 = 16948547188989277.0;
+        const ROUNDING_ERROR_COMPENSATION: f64 = 2000.0;
+        approx +=
+            ROUNDING_ERROR_COMPENSATION * ((approx > ROUNDING_ERROR_CUTOFF) as u8 as f64);
+        approx.ceil() as u64
+    }
+
     proptest! {
+        // `powf` and `exp(y * ln(x))` are not bit-identical for every percentage -- they
+        // disagree in the last place at 25, 30 and 34, for instance -- so this comparison
+        // stays inside the percentage range where the two forms agree exactly. The block
+        // axis is widened past `BLOCK_COUNT_M` so that leaving the table is covered here
+        // too; the boundary on both axes is pinned by the two tests below.
         #[test]
         fn plain_and_optimized_produce_same_result(
             start_gas_price in 0..10000u64,
             best_height in 0..100000u32,
-            offset in 0..20u32,
-            percentage in 0..20u64,
+            offset in 0..2 * BLOCK_COUNT_M as u32,
+            percentage in 0..PERCENTAGE_COUNT_N as u64,
         ) {
             #[allow(clippy::arithmetic_side_effects)]
             let target_height = best_height + offset;
@@ -741,6 +770,77 @@ mod tests {
             let optimized = cumulative_percentage_change(start_gas_price, best_height, percentage, target_height);
 
             prop_assert_eq!(plain, optimized);
+        }
+    }
+
+    proptest! {
+        // Both `BLOCK_COUNT_M` and `PERCENTAGE_COUNT_N` are strictly inside these ranges,
+        // so this covers the branch boundary on either axis -- including the percentage
+        // axis, which the comparison above cannot reach. The boundary is where the index
+        // used to run off the end of the table.
+        #[test]
+        fn optimized_matches_the_closed_form_across_the_lookup_table_boundary(
+            start_gas_price in 0..10000u64,
+            best_height in 0..100000u32,
+            offset in 0..2 * BLOCK_COUNT_M as u32,
+            percentage in 0..2 * PERCENTAGE_COUNT_N as u64,
+        ) {
+            let target_height = best_height.saturating_add(offset);
+
+            let closed_form = cumulative_percentage_change_closed_form(start_gas_price, best_height, percentage, target_height);
+            let optimized = cumulative_percentage_change(start_gas_price, best_height, percentage, target_height);
+
+            prop_assert_eq!(closed_form, optimized);
+        }
+    }
+
+    // `PRECOMPUTED_EXP` is `BLOCK_COUNT_M` x `PERCENTAGE_COUNT_N`, so the largest valid
+    // index on either axis is one less than the count. An index _equal_ to the count is
+    // the case random sampling is very unlikely to hit, so pin it explicitly.
+    #[test]
+    fn cumulative_percentage_change__is_correct_at_the_lookup_table_boundary() {
+        const START_GAS_PRICE: u64 = 1_000;
+        const BEST_HEIGHT: u32 = 0;
+
+        let m = BLOCK_COUNT_M as u32;
+        let n = PERCENTAGE_COUNT_N as u64;
+
+        let cases = [
+            // both axes exactly at the count
+            (m, n),
+            // the block axis at the count
+            (m, 0),
+            (m, n.saturating_sub(1)),
+            // the percentage axis at the count
+            (0, n),
+            (m.saturating_sub(1), n),
+            // the last in-table index, for contrast
+            (m.saturating_sub(1), n.saturating_sub(1)),
+        ];
+
+        for (blocks, percentage) in cases {
+            // given
+            let target_height = BEST_HEIGHT.saturating_add(blocks);
+
+            // when
+            let optimized = cumulative_percentage_change(
+                START_GAS_PRICE,
+                BEST_HEIGHT,
+                percentage,
+                target_height,
+            );
+
+            // then
+            let plain = cumulative_percentage_change_plain(
+                START_GAS_PRICE,
+                BEST_HEIGHT,
+                percentage,
+                target_height,
+            );
+            assert_eq!(
+                plain, optimized,
+                "mismatch for blocks={blocks}, percentage={percentage}"
+            );
         }
     }
 }

--- a/tests/tests/gas_price.rs
+++ b/tests/tests/gas_price.rs
@@ -416,6 +416,29 @@ async fn estimate_gas_price__is_greater_than_actual_price_at_desired_height() {
     );
 }
 
+#[tokio::test]
+async fn estimate_gas_price__answers_at_the_lookup_table_boundary() {
+    // given
+    // `cumulative_percentage_change` indexes a 25 x 25 table of precomputed exponentials,
+    // and the block horizon is the first index. A horizon of exactly 25 used to be routed
+    // into the table instead of to the closed form, and read one element past its end --
+    // while 24 and 26 both answered normally, which is what made it easy to miss.
+    let node_config = Config::local_node();
+    let srv = FuelService::new_node(node_config).await.unwrap();
+    let client = FuelClient::from(srv.bound_address);
+
+    for block_horizon in [24u32, 25, 26] {
+        // when
+        let result = client.estimate_gas_price(block_horizon).await;
+
+        // then
+        assert!(
+            result.is_ok(),
+            "estimate_gas_price({block_horizon}) failed: {result:?}"
+        );
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn latest_gas_price__if_node_restarts_gets_latest_value() {
     // given


### PR DESCRIPTION
## Linked Issues/PRs

None — found by reading `cumulative_percentage_change`.

## Description

`crates/fuel-gas-price-algorithm/src/utils.rs:674` guards the precomputed exponential
lookup table with `>` where it needs `>=`:

```rust
const BLOCK_COUNT_M: usize = 25;
const PERCENTAGE_COUNT_N: usize = 25;
const PRECOMPUTED_EXP: &[[f64; PERCENTAGE_COUNT_N]; BLOCK_COUNT_M] = &[ /* 25 rows */ ];

let multiple =
    if blocks > BLOCK_COUNT_M as u32 || percentage > PERCENTAGE_COUNT_N as u64 {
        f64::exp(blocks as f64 * (1.0 + percentage as f64 / 100.0).ln())
    } else {
        PRECOMPUTED_EXP[blocks as usize][percentage as usize]   // utils.rs:677
    };
```

The table is 25 x 25, so the last valid index on either axis is 24. An index of exactly 25
is not `> 25`, so it is routed into the table and reads one element past the end:
`index out of bounds: the len is 25 but the index is 25`.

### It is reachable from an unauthenticated GraphQL query, on any node

`blocks` is the caller's `blockHorizon`, unclamped, all the way down:

- `crates/fuel-core/src/schema/gas_price.rs:116-121` adds `blockHorizon` to the latest
  block height and checks it only for overflow.
- `crates/fuel-core/src/service/adapters.rs:297-308` (`UniversalGasPriceProvider::worst_case_gas_price`)
  passes `height - best_height`, i.e. exactly `blockHorizon`, to `cumulative_percentage_change`.
- `crates/fuel-core/src/service/sub_services.rs:318-321` builds that provider with
  `DEFAULT_GAS_PRICE_CHANGE_PERCENT`, hardcoded to `10` at `sub_services.rs:136` — the
  operator's `--gas-price-change-percent` does not reach this path. So `percentage` is
  always well inside the table and the block horizon is the only variable.

```graphql
query { estimateGasPrice(blockHorizon: 25) { gasPrice } }
```

**`24` and `26` both answer normally** — 26 is `> 25` and takes the `f64::exp` branch.
Only the single value 25 misses. That is what makes it easy to miss by inspection as well
as by sampling.

### What an attacker actually gets — and what they do not

The workspace sets `panic = "unwind"` (`Cargo.toml:182`) and there is no `catch_unwind`
and no panic hook on the request path, so the panic unwinds **the axum task serving that
one request**. The caller's own connection is dropped, a panic line is logged, and the
process keeps running. This is not a node kill and not a chain halt.

Concretely, a caller can:

- make their own query fail, and
- make the node emit a panic line per request, i.e. drive log volume.

They cannot corrupt state, affect other callers' requests, or stall block production.
Block production reads `AlgorithmV1::calculate()`, not `worst_case()`;
`worst_case_gas_price` has exactly one non-test caller in the tree and it is the GraphQL
resolver above. (`SharedGasPriceAlgo::worst_case_gas_price`,
`crates/services/gas_price_service/src/common/gas_price_algorithm.rs:40`, is currently
unused outside tests.) That is the fact that keeps this out of serious territory, and it
is worth re-checking whenever the gas price provider gains a caller.

It is also worth saying that this needs no malice: `blockHorizon: 25` is an unremarkable
value for a wallet or SDK to pick, and today it returns a dropped connection.

## The fix

`>` → `>=` on both bounds. The `f64::exp` branch is already the correct answer for those
inputs — it is only the routing that is wrong.

The change is provably confined to inputs that used to panic. It moves exactly
`{blocks == 25, percentage <= 25}` and `{blocks <= 25, percentage == 25}` from the table
branch to the closed form, and every one of those inputs previously indexed out of bounds.
No input that returned a value before returns a different value now.

The closed form is the right answer there, not merely a fallback: all 625 entries of
`PRECOMPUTED_EXP` are **bit-identical** to `f64::exp(blocks * ln(1 + percentage / 100))`,
which is what the new proptest below asserts across the boundary.

`PRECOMPUTED_EXP` is indexed in exactly one place (`utils.rs:677`); it is a private const
in a private module, so there is no second site with the same off-by-one.

## Why the existing proptests did not catch it

Both of them are structurally unable to generate the input.

| Test | Ranges | Why it misses |
|---|---|---|
| `utils.rs` `plain_and_optimized_produce_same_result` | `offset in 0..20`, `percentage in 0..20` | Both axes stop five short of the boundary. Impossible, not unlikely. |
| `adapters.rs` `worst_case_gas_price__*` | `block_horizon in 0..10_000`, `percentage: u16` | The table branch is taken only when **both** indices are ≤ 25. A case must draw `percentage <= 25` (26/65536) *and* `block_horizon` exactly 25 (1/10000) — about 4e-8 per case, so roughly one run in 10^5 at the default 256 cases. |

More random sampling is not the answer to an off-by-one on a fixed boundary, so the
regression test is deterministic and the range widening is defence in depth.

## Tests

**`cumulative_percentage_change__is_correct_at_the_lookup_table_boundary`** (new,
deterministic) pins index == count on both axes — `(25, 25)`, `(25, 0)`, `(25, 24)`,
`(0, 25)`, `(24, 25)` — and compares against the pre-optimization `powf` reference kept in
the test module. It fails with `index out of bounds: the len is 25 but the index is 25`
before the change and passes after.

**`optimized_matches_the_closed_form_across_the_lookup_table_boundary`** (new proptest)
samples `offset in 0..2 * BLOCK_COUNT_M` and `percentage in 0..2 * PERCENTAGE_COUNT_N`, so
both counts are strictly inside the ranges, and asserts that the value does not depend on
which branch was taken.

**`plain_and_optimized_produce_same_result`** (widened) now samples
`offset in 0..2 * BLOCK_COUNT_M` (was `0..20`) and `percentage in 0..PERCENTAGE_COUNT_N`
(was `0..20`). Note why the percentage range stops at the count rather than crossing it:
`powf(x, y)` and `exp(y * ln x)` are not bit-identical, and at `percentage` 25, 30 and 34
they differ in the last place — `blocks = 3, percentage = 25, start_gas_price = 64` gives
125 through `powf` and 126 through `exp`, for instance. That divergence predates this PR
and is out of its scope, so this comparison stays inside the region where the two forms
agree exactly (verified exhaustively over the whole widened range: every
`start_gas_price in 0..10_000` x `blocks in 0..60` x `percentage in 0..25`), and the
boundary itself is covered by the two tests above.

**`adapters.rs` `worst_case_gas_price__correctly_calculates_value` /
`__never_overflows`** now mix a narrow strategy (`0..50` on both axes) into the existing
wide ones via `prop_oneof!`, so the lookup-table region is actually sampled without losing
the long-horizon and full-`u16` coverage those tests were written for. With the old guard
restored, both fail, at `block_horizon = 25, percentage = 0`.

**`tests/tests/gas_price.rs` `estimate_gas_price__answers_at_the_lookup_table_boundary`**
(new) drives the real GraphQL API at horizons 24, 25 and 26 against a local node, which is
the end-to-end statement of the bug. With the old guard restored it fails exactly as
described above — 24 answers, then:

```
thread '...' panicked at crates/fuel-gas-price-algorithm/src/utils.rs:677:13:
index out of bounds: the len is 25 but the index is 25
...
estimate_gas_price(25) failed: Err(Custom { kind: Other,
  error: error sending request for url (http://127.0.0.1:49607/v1/graphql) })
```

i.e. the request task unwinds, the caller's connection is dropped, and the node carries on.

## Checklist
- [x] Breaking changes are clearly marked as such in the PR description and changelog — not breaking; the only inputs whose behaviour changes are inputs that panicked
- [x] New behavior is reflected in tests
- [x] [The specification](https://github.com/FuelLabs/fuel-specs/) matches the implemented behavior — n/a, the estimate is advisory and not consensus

### Before requesting review
- [x] I have reviewed the code myself
- [ ] I have created follow-up issues caused by this PR and linked them here

### After merging, notify other teams

- [ ] [Rust SDK](https://github.com/FuelLabs/fuels-rs/) — `estimate_gas_price(25)` currently fails against every node
- [ ] [Sway compiler](https://github.com/FuelLabs/sway/)
- [ ] Someone else?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
