### PR TITLE
test: run historical v44 compatibility nodes independently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
           # and `--locked` when we build `fuel-core-wasm-executor 0.26.0`).
           - command: check
             args: --manifest-path version-compatibility/Cargo.toml --workspace --locked && cargo test --manifest-path version-compatibility/Cargo.toml --workspace --locked
+            historical-node: true
           - command: build
             args: -p fuel-core-bin --no-default-features --features production
 
@@ -169,6 +170,22 @@ jobs:
         with:
           key: ${{ matrix.command }}-${{ matrix.args }}
           cache-on-failure: true
+      - name: Determine historical node target
+        if: ${{ matrix.historical-node }}
+        id: historical-target
+        run: |
+          echo "host=$(rustc -vV | sed -n 's/^host: //p')" >> "$GITHUB_OUTPUT"
+      - name: Cache historical node and build artifacts
+        if: ${{ matrix.historical-node }}
+        uses: actions/cache@v4
+        with:
+          path: version-compatibility/target/historical
+          key: historical-v0.44.0-${{ runner.os }}-${{ env.RUST_VERSION }}-${{ steps.historical-target.outputs.host }}-release-default-parquet-p2p-${{ hashFiles('version-compatibility/build-historical-node.sh') }}
+      - name: Install historical node
+        if: ${{ matrix.historical-node }}
+        env:
+          FUEL_CORE_V44_TOOLCHAIN: ${{ env.RUST_VERSION }}
+        run: ./version-compatibility/build-historical-node.sh
       - name: Install cargo-nextest
         if: ${{ matrix.command == 'nextest' }}
         uses: taiki-e/install-action@v2

--- a/version-compatibility/Cargo.lock
+++ b/version-compatibility/Cargo.lock
@@ -14,15 +14,6 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli 0.31.1",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
@@ -2913,27 +2904,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4b56ebe316895d3fa37775d0a87b0c889cc933f5c8b253dbcc7c7bcb7fe7e4"
-dependencies = [
- "cranelift-assembler-x64-meta 0.118.0",
-]
-
-[[package]]
-name = "cranelift-assembler-x64"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aadfd45214f09461ba0406f7dacecce5cac39bf0bdb4890eeb468f4ef090e07"
 dependencies = [
- "cranelift-assembler-x64-meta 0.133.3",
+ "cranelift-assembler-x64-meta",
 ]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cabbc01dfbd7dcd6c329ca44f0212910309c221797ac736a67a5bc8857fe1b"
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
@@ -2955,31 +2931,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ffe46df300a45f1dc6f609dc808ce963f0e3a2e971682c479a2d13e3b9b8ef"
-dependencies = [
- "cranelift-entity 0.118.0",
-]
-
-[[package]]
-name = "cranelift-bforest"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1221450f2f9efaa996d916bf53a0a4d13346a4a75468afb828390209a4fdd4"
 dependencies = [
  "cranelift-entity 0.133.3",
  "wasmtime-internal-core",
-]
-
-[[package]]
-name = "cranelift-bitset"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b265bed7c51e1921fdae6419791d31af77d33662ee56d7b0fa0704dc8d231cab"
-dependencies = [
- "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3016,40 +2973,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e606230a7e3a6897d603761baee0d19f88d077f17b996bb5089488a29ae96e41"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64 0.118.0",
- "cranelift-bforest 0.118.0",
- "cranelift-bitset 0.118.0",
- "cranelift-codegen-meta 0.118.0",
- "cranelift-codegen-shared 0.118.0",
- "cranelift-control 0.118.0",
- "cranelift-entity 0.118.0",
- "cranelift-isle 0.118.0",
- "gimli 0.31.1",
- "hashbrown 0.15.5",
- "log",
- "pulley-interpreter 31.0.0",
- "regalloc2 0.11.2",
- "rustc-hash 2.1.3",
- "serde",
- "smallvec",
- "target-lexicon 0.13.5",
-]
-
-[[package]]
-name = "cranelift-codegen"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "432246ee44b2fc0140b412dca55801d200d6fb25d2d7d18c44bb29e8cd71268b"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.133.3",
+ "cranelift-assembler-x64",
  "cranelift-bforest 0.133.3",
- "cranelift-bitset 0.133.3",
+ "cranelift-bitset",
  "cranelift-codegen-meta 0.133.3",
  "cranelift-codegen-shared 0.133.3",
  "cranelift-control 0.133.3",
@@ -3060,7 +2991,7 @@ dependencies = [
  "libm",
  "log",
  "postcard",
- "pulley-interpreter 46.0.3",
+ "pulley-interpreter",
  "regalloc2 0.15.2",
  "rustc-hash 2.1.3",
  "serde",
@@ -3082,26 +3013,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a63bffafc23bc60969ad528e138788495999d935f0adcfd6543cb151ca8637d"
-dependencies = [
- "cranelift-assembler-x64 0.118.0",
- "cranelift-codegen-shared 0.118.0",
- "pulley-interpreter 31.0.0",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aa51eff0949f06a5c8f3d5adefef94a12ea99f71cd8985047b91d45f367150"
 dependencies = [
- "cranelift-assembler-x64-meta 0.133.3",
+ "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared 0.133.3",
  "cranelift-srcgen",
  "heck 0.5.0",
- "pulley-interpreter 46.0.3",
+ "pulley-interpreter",
 ]
 
 [[package]]
@@ -3109,12 +3029,6 @@ name = "cranelift-codegen-shared"
 version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00cde1425b4da28bb0d5ff010030ea9cc9be7aded342ae099b394284f17cefce"
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af50281b67324b58e843170a6a5943cf6d387c06f7eeacc9f5696e4ab7ae7d7e"
 
 [[package]]
 name = "cranelift-codegen-shared"
@@ -3127,15 +3041,6 @@ name = "cranelift-control"
 version = "0.105.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1622125c99f1864aaf44e57971770c4a918d081d4b4af0bb597bdf624660ed66"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
-name = "cranelift-control"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c20c1b38d1abfbcebb0032e497e71156c0e3b8dcb3f0a92b9863b7bcaec290c"
 dependencies = [
  "arbitrary",
 ]
@@ -3161,22 +3066,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2c67d95507c51b4a1ff3f3555fe4bfec36b9e13c1b684ccc602736f5d5f4a2"
-dependencies = [
- "cranelift-bitset 0.118.0",
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "cranelift-entity"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e93867a79a06dd5d9ffeb96f7563dc7b6b142b5d89e42ab77e458a408a8aa9d5"
 dependencies = [
- "cranelift-bitset 0.133.3",
+ "cranelift-bitset",
  "serde",
  "serde_derive",
  "wasmtime-internal-core",
@@ -3192,18 +3086,6 @@ dependencies = [
  "log",
  "smallvec",
  "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e002691cc69c38b54fc7ec93e5be5b744f627d027031d991cc845d1d512d0ce"
-dependencies = [
- "cranelift-codegen 0.118.0",
- "log",
- "smallvec",
- "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -3227,12 +3109,6 @@ checksum = "dbbe4d3ad7bd4bf4a8d916c8460b441cf92417f5cdeacce4dd1d96eee70b18a2"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93588ed1796cbcb0e2ad160403509e2c5d330d80dd6e0014ac6774c7ebac496"
-
-[[package]]
-name = "cranelift-isle"
 version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784546de9988ff6e1df0fd4d2450760469a7607344156c661e69ec28082c5da4"
@@ -3246,17 +3122,6 @@ dependencies = [
  "cranelift-codegen 0.105.4",
  "libc",
  "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-native"
-version = "0.118.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b09bdd6407bf5d89661b80cf926ce731c9e8cc184bf49102267a2369a8358e"
-dependencies = [
- "cranelift-codegen 0.118.0",
- "libc",
- "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -4698,13 +4563,11 @@ dependencies = [
  "cynic 3.12.0",
  "fuel-core 0.48.3",
  "fuel-core-bin 0.26.0",
- "fuel-core-bin 0.44.0",
  "fuel-core-bin 0.48.3",
  "fuel-core-client 0.26.0",
  "fuel-core-client 0.44.0",
  "fuel-core-client 0.48.3",
  "fuel-core-services 0.26.0",
- "fuel-core-services 0.44.0",
  "fuel-core-trace",
  "fuel-core-types 0.44.0",
  "fuel-core-types 0.48.3",
@@ -4713,6 +4576,7 @@ dependencies = [
  "fuel-tx 0.63.0",
  "hex",
  "libp2p 0.55.0",
+ "nix 0.30.1",
  "rand 0.8.8",
  "reqwest 0.12.28",
  "serde_json",
@@ -4807,17 +4671,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-compression"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fad6effad71397dd4ac59451830652e7fc94f382be6f0cb9541027409f1a8a7"
-dependencies = [
- "fuel-derive 0.62.0",
- "fuel-types 0.62.0",
- "serde",
-]
-
-[[package]]
-name = "fuel-compression"
 version = "0.66.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96888e99cf096577b5766a11ea109be46feb3c00fd3e59bb04b52985429a4fd"
@@ -4880,66 +4733,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47e7a7986c480763a0ac97f95cc52e91330df4e75b5662a73dadf553c88aadc"
-dependencies = [
- "anyhow",
- "async-graphql 7.0.15",
- "async-graphql-value 7.0.15",
- "async-trait",
- "axum 0.5.17",
- "clap",
- "derive_more 0.99.20",
- "enum-iterator 1.5.0",
- "fuel-core-chain-config 0.44.0",
- "fuel-core-compression-service 0.44.0",
- "fuel-core-consensus-module 0.44.0",
- "fuel-core-database 0.44.0",
- "fuel-core-executor 0.44.0",
- "fuel-core-gas-price-service 0.44.0",
- "fuel-core-importer 0.44.0",
- "fuel-core-metrics 0.44.0",
- "fuel-core-p2p 0.44.0",
- "fuel-core-poa 0.44.0",
- "fuel-core-producer 0.44.0",
- "fuel-core-relayer 0.44.0",
- "fuel-core-services 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-sync 0.44.0",
- "fuel-core-tx-status-manager 0.44.0",
- "fuel-core-txpool 0.44.0",
- "fuel-core-types 0.44.0",
- "fuel-core-upgradable-executor 0.44.0",
- "futures",
- "hex",
- "hyper 0.14.32",
- "indicatif 0.17.11",
- "itertools 0.12.1",
- "num_cpus",
- "parking_lot",
- "postcard",
- "rand 0.8.8",
- "rocksdb",
- "serde",
- "serde_json",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "tempfile",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rayon",
- "tokio-stream",
- "tokio-util",
- "tower 0.4.13",
- "tower-http 0.4.4",
- "tracing",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "fuel-core"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -4951,11 +4744,11 @@ dependencies = [
  "derive_more 2.1.1",
  "enum-iterator 2.3.0",
  "fuel-core-chain-config 0.48.3",
- "fuel-core-compression-service 0.48.3",
+ "fuel-core-compression-service",
  "fuel-core-consensus-module 0.48.3",
  "fuel-core-database 0.48.3",
  "fuel-core-executor 0.48.3",
- "fuel-core-gas-price-service 0.48.3",
+ "fuel-core-gas-price-service",
  "fuel-core-importer 0.48.3",
  "fuel-core-metrics 0.48.3",
  "fuel-core-p2p 0.48.3",
@@ -4967,7 +4760,7 @@ dependencies = [
  "fuel-core-storage 0.48.3",
  "fuel-core-sync 0.48.3",
  "fuel-core-syscall",
- "fuel-core-tx-status-manager 0.48.3",
+ "fuel-core-tx-status-manager",
  "fuel-core-txpool 0.48.3",
  "fuel-core-types 0.48.3",
  "fuel-core-upgradable-executor 0.48.3",
@@ -5022,35 +4815,6 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "fuel-core-bin"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720424b15d8aa5bcd86f3cc40c82b922d891167cdd90641fe9ac16695ba5bccd"
-dependencies = [
- "anyhow",
- "clap",
- "const_format",
- "dirs",
- "dotenvy",
- "fuel-core 0.44.0",
- "fuel-core-chain-config 0.44.0",
- "fuel-core-metrics 0.44.0",
- "fuel-core-poa 0.44.0",
- "fuel-core-types 0.44.0",
- "hex",
- "humantime",
- "pyroscope",
- "pyroscope_pprofrs",
- "rlimit",
- "serde_json",
- "tikv-jemallocator",
- "tokio",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -5121,26 +4885,6 @@ dependencies = [
  "derivative",
  "fuel-core-storage 0.26.0",
  "fuel-core-types 0.26.0",
- "itertools 0.12.1",
- "parquet 49.0.0",
- "postcard",
- "serde",
- "serde_json",
- "serde_with",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-chain-config"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83173aa86199e86d8be9c0cfbb348808a2b1fb6b6e13db3daf31a151853c3030"
-dependencies = [
- "anyhow",
- "bech32",
- "educe",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
  "itertools 0.12.1",
  "parquet 49.0.0",
  "postcard",
@@ -5245,21 +4989,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-compression"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15361779fde35f3b2fe307c877f66cf8c215c0ba3090142561b81a3544514244"
-dependencies = [
- "anyhow",
- "enum_dispatch",
- "fuel-core-types 0.44.0",
- "paste",
- "serde",
- "strum 0.25.0",
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "fuel-core-compression"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -5273,36 +5002,12 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-compression-service"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31d3b2977b3a09167cb778b779421eacb070258f4ba7e4a084bf164ec3beaa"
-dependencies = [
- "anyhow",
- "async-trait",
- "enum-iterator 1.5.0",
- "fuel-core-compression 0.44.0",
- "fuel-core-metrics 0.44.0",
- "fuel-core-services 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "futures",
- "paste",
- "serde",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-compression-service"
 version = "0.48.3"
 dependencies = [
  "anyhow",
  "async-trait",
  "enum-iterator 2.3.0",
- "fuel-core-compression 0.48.3",
+ "fuel-core-compression",
  "fuel-core-metrics 0.48.3",
  "fuel-core-services 0.48.3",
  "fuel-core-storage 0.48.3",
@@ -5332,19 +5037,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-consensus-module"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530ca4c3dd59b6acd3bc1cfda2192146c0314435b67372343b4bcf1386376fc7"
-dependencies = [
- "anyhow",
- "fuel-core-chain-config 0.44.0",
- "fuel-core-poa 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
-]
-
-[[package]]
-name = "fuel-core-consensus-module"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -5364,18 +5056,6 @@ dependencies = [
  "derive_more 0.99.20",
  "fuel-core-storage 0.26.0",
  "fuel-core-types 0.26.0",
-]
-
-[[package]]
-name = "fuel-core-database"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7efcdf3c974530476bc53a7e64c41adbbe4fefe8242319129cfe0984ee04a839"
-dependencies = [
- "anyhow",
- "derive_more 0.99.20",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
 ]
 
 [[package]]
@@ -5405,20 +5085,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-executor"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610f4f55e9d838efd18bdcc86ff961da6b59cf0ddfc8bd079b68ef134acdc5d8"
-dependencies = [
- "anyhow",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "parking_lot",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-executor"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -5433,35 +5099,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-gas-price-service"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebe369b06d60dd7045cee3877085e8bf9d04b8178a146f25ec4ecc61dd9dfa8"
-dependencies = [
- "anyhow",
- "async-trait",
- "enum-iterator 1.5.0",
- "fuel-core-metrics 0.44.0",
- "fuel-core-services 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "fuel-gas-price-algorithm 0.44.0",
- "futures",
- "num_enum",
- "parking_lot",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "fuel-core-gas-price-service"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -5471,7 +5108,7 @@ dependencies = [
  "fuel-core-services 0.48.3",
  "fuel-core-storage 0.48.3",
  "fuel-core-types 0.48.3",
- "fuel-gas-price-algorithm 0.48.3",
+ "fuel-gas-price-algorithm",
  "futures",
  "num_enum",
  "parking_lot",
@@ -5505,22 +5142,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-importer"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a11125ab2dfef10fd5e8f283ed717c9b404c884fcb85d1c106a88ec3df4bab"
-dependencies = [
- "anyhow",
- "derive_more 0.99.20",
- "fuel-core-metrics 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "rayon",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-importer"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -5545,22 +5166,6 @@ dependencies = [
  "pin-project-lite",
  "prometheus-client",
  "regex",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-metrics"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0412e48072faab1ea533feb8ef45c80d533c688524bd298c8f518c54209ccd"
-dependencies = [
- "once_cell",
- "parking_lot",
- "pin-project-lite",
- "prometheus-client",
- "regex",
- "strum 0.25.0",
- "strum_macros 0.25.3",
  "tracing",
 ]
 
@@ -5604,37 +5209,6 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "fuel-core-p2p"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b87ef07cd23c73147d1a3e87df60b54671941532920d5c4c4d18e0253fd4470"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-chain-config 0.44.0",
- "fuel-core-metrics 0.44.0",
- "fuel-core-services 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "futures",
- "hex",
- "hickory-resolver 0.24.4",
- "libp2p 0.54.1",
- "parking_lot",
- "postcard",
- "quick_cache",
- "rand 0.8.8",
- "serde",
- "sha2 0.10.9",
- "strum 0.25.0",
- "strum_macros 0.25.3",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -5691,26 +5265,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e35411b14efaa725f337d3d9d1145eac1ee2338ee78dd1cd9e0f689e7f61fe"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-chain-config 0.44.0",
- "fuel-core-services 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-poa"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -5738,22 +5292,6 @@ dependencies = [
  "derive_more 0.99.20",
  "fuel-core-storage 0.26.0",
  "fuel-core-types 0.26.0",
- "tokio",
- "tokio-rayon",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-producer"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e436d8cd820b9ed360a33315ee2872e5d298c785f95f624e1eebb80c01bd67ca"
-dependencies = [
- "anyhow",
- "async-trait",
- "derive_more 0.99.20",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
  "tokio",
  "tokio-rayon",
  "tracing",
@@ -5830,31 +5368,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-relayer"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf527a6b44480051727f050741391624088d0bd00672b85c1b9747c254831773"
-dependencies = [
- "anyhow",
- "async-trait",
- "enum-iterator 1.5.0",
- "ethereum-types",
- "ethers-contract",
- "ethers-core",
- "ethers-providers",
- "fuel-core-services 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "futures",
- "once_cell",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "fuel-core-relayer"
 version = "0.48.3"
 dependencies = [
  "alloy-primitives",
@@ -5888,23 +5401,6 @@ dependencies = [
  "fuel-core-metrics 0.26.0",
  "futures",
  "parking_lot",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-services"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78c38923404ddacb253113bd096fc009ccdcce4aeb53110a0974159b9b93f0e"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-metrics 0.44.0",
- "futures",
- "parking_lot",
- "pin-project-lite",
- "rayon",
  "tokio",
  "tracing",
 ]
@@ -5970,28 +5466,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecc0a879234546d38f234943e7e7253b9d4c169cc52862595ba5b26aaea40b9"
-dependencies = [
- "anyhow",
- "derive_more 0.99.20",
- "enum-iterator 1.5.0",
- "fuel-core-types 0.44.0",
- "fuel-vm 0.62.0",
- "impl-tools",
- "itertools 0.12.1",
- "num_enum",
- "paste",
- "postcard",
- "primitive-types",
- "serde",
- "strum 0.25.0",
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "fuel-core-storage"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -6025,23 +5499,6 @@ dependencies = [
  "futures",
  "rand 0.8.8",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-sync"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bffee4e347ac3112500598fbc79d538afd856965bc98f8576bbadda2a0bbdad"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-services 0.44.0",
- "fuel-core-types 0.44.0",
- "futures",
- "rand 0.8.8",
- "tokio",
- "tokio-stream",
  "tracing",
 ]
 
@@ -6087,25 +5544,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-tx-status-manager"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a0cb6d71070fab94e9e6be48d19ff9f19ec1012e1508bc1e82a1f7718dca3d"
-dependencies = [
- "anyhow",
- "async-trait",
- "fuel-core-metrics 0.44.0",
- "fuel-core-services 0.44.0",
- "fuel-core-types 0.44.0",
- "futures",
- "parking_lot",
- "postcard",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-tx-status-manager"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -6138,28 +5576,6 @@ dependencies = [
  "tokio",
  "tokio-rayon",
  "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "fuel-core-txpool"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff0567203041efdb291e4835b7e759c4837f758bb15cd51ec1d0307878ff2e3"
-dependencies = [
- "anyhow",
- "async-trait",
- "derive_more 0.99.20",
- "fuel-core-metrics 0.44.0",
- "fuel-core-services 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "futures",
- "lru 0.13.0",
- "num-rational",
- "parking_lot",
- "petgraph",
- "tokio",
  "tracing",
 ]
 
@@ -6279,25 +5695,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-upgradable-executor"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fd68ccd52be74e297cf342b4e3e619630c98f23bb41d8880df049944a236b0"
-dependencies = [
- "anyhow",
- "derive_more 0.99.20",
- "fuel-core-executor 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.44.0",
- "fuel-core-wasm-executor 0.44.0",
- "futures",
- "parking_lot",
- "postcard",
- "tracing",
- "wasmtime 31.0.0",
-]
-
-[[package]]
-name = "fuel-core-upgradable-executor"
 version = "0.48.3"
 dependencies = [
  "anyhow",
@@ -6325,23 +5722,6 @@ dependencies = [
  "fuel-core-types 0.26.0",
  "postcard",
  "serde",
-]
-
-[[package]]
-name = "fuel-core-wasm-executor"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a4e82ac07c27065c24f656e665eaca72f2354b67617a74bee7697bd02040b8"
-dependencies = [
- "anyhow",
- "fuel-core-executor 0.44.0",
- "fuel-core-storage 0.44.0",
- "fuel-core-types 0.35.0",
- "fuel-core-types 0.44.0",
- "futures",
- "postcard",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -6521,17 +5901,6 @@ dependencies = [
 
 [[package]]
 name = "fuel-gas-price-algorithm"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13d6ed750d67d1563f0c954ed5000c1884c881cd13022c9357bee71fee64983"
-dependencies = [
- "serde",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "fuel-gas-price-algorithm"
 version = "0.48.3"
 dependencies = [
  "serde",
@@ -6698,7 +6067,6 @@ dependencies = [
  "derive_more 1.0.0",
  "educe",
  "fuel-asm 0.62.0",
- "fuel-compression 0.62.0",
  "fuel-crypto 0.62.0",
  "fuel-merkle 0.62.0",
  "fuel-types 0.62.0",
@@ -6743,7 +6111,7 @@ dependencies = [
  "derive_more 1.0.0",
  "educe",
  "fuel-asm 0.66.4",
- "fuel-compression 0.66.4",
+ "fuel-compression",
  "fuel-crypto 0.66.4",
  "fuel-merkle 0.66.4",
  "fuel-types 0.66.4",
@@ -6892,7 +6260,6 @@ dependencies = [
  "educe",
  "ethnum",
  "fuel-asm 0.62.0",
- "fuel-compression 0.62.0",
  "fuel-crypto 0.62.0",
  "fuel-merkle 0.62.0",
  "fuel-storage 0.62.0",
@@ -6928,7 +6295,7 @@ dependencies = [
  "educe",
  "ethnum",
  "fuel-asm 0.66.4",
- "fuel-compression 0.66.4",
+ "fuel-compression",
  "fuel-crypto 0.66.4",
  "fuel-merkle 0.66.4",
  "fuel-storage 0.66.4",
@@ -7184,17 +6551,6 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-dependencies = [
- "fallible-iterator",
- "indexmap 2.14.0",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
@@ -7358,7 +6714,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -8667,41 +8022,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom 0.2.17",
- "libp2p-allow-block-list 0.4.0",
- "libp2p-connection-limits 0.4.0",
- "libp2p-core 0.42.0",
- "libp2p-dns 0.42.0",
- "libp2p-gossipsub 0.47.0",
- "libp2p-identify 0.45.0",
- "libp2p-identity",
- "libp2p-kad 0.46.2",
- "libp2p-mdns 0.46.0",
- "libp2p-metrics 0.15.0",
- "libp2p-noise 0.45.0",
- "libp2p-quic 0.11.1",
- "libp2p-request-response 0.27.0",
- "libp2p-swarm 0.45.1",
- "libp2p-tcp 0.42.0",
- "libp2p-upnp 0.3.0",
- "libp2p-websocket 0.44.0",
- "libp2p-yamux 0.46.0",
- "multiaddr",
- "pin-project",
- "rw-stream-sink",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "libp2p"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9"
@@ -8749,18 +8069,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
-dependencies = [
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "void",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
@@ -8784,18 +8092,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
-dependencies = [
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "void",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
@@ -8810,34 +8106,6 @@ name = "libp2p-core"
 version = "0.41.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5a8920cbd8540059a01950c1e5c96ea8d89eb50c51cd366fc18bdf540a6e48f"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select",
- "once_cell",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.8",
- "rw-stream-sink",
- "smallvec",
- "thiserror 1.0.69",
- "tracing",
- "unsigned-varint 0.8.0",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
 dependencies = [
  "either",
  "fnv",
@@ -8904,22 +8172,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
-dependencies = [
- "async-trait",
- "futures",
- "hickory-resolver 0.24.4",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "parking_lot",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-dns"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7"
@@ -8967,37 +8219,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-ticker",
- "getrandom 0.2.17",
- "hex_fmt",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "prometheus-client",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand 0.8.8",
- "regex",
- "sha2 0.10.9",
- "smallvec",
- "tracing",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-gossipsub"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
@@ -9041,29 +8262,6 @@ dependencies = [
  "libp2p-core 0.41.3",
  "libp2p-identity",
  "libp2p-swarm 0.44.2",
- "lru 0.12.5",
- "quick-protobuf",
- "quick-protobuf-codec",
- "smallvec",
- "thiserror 1.0.69",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-identify"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1711b004a273be4f30202778856368683bd9a83c4c7dcc8f848847606831a4e3"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "either",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
  "lru 0.12.5",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -9145,35 +8343,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
-dependencies = [
- "arrayvec",
- "asynchronous-codec 0.7.0",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "quick-protobuf",
- "quick-protobuf-codec",
- "rand 0.8.8",
- "sha2 0.10.9",
- "smallvec",
- "thiserror 1.0.69",
- "tracing",
- "uint 0.9.5",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-kad"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
@@ -9222,27 +8391,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
-dependencies = [
- "data-encoding",
- "futures",
- "hickory-proto 0.24.4",
- "if-watch",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "rand 0.8.8",
- "smallvec",
- "socket2 0.5.10",
- "tokio",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-mdns"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc"
@@ -9276,24 +8424,6 @@ dependencies = [
  "libp2p-swarm 0.44.2",
  "pin-project",
  "prometheus-client",
-]
-
-[[package]]
-name = "libp2p-metrics"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
-dependencies = [
- "futures",
- "libp2p-core 0.42.0",
- "libp2p-gossipsub 0.47.0",
- "libp2p-identify 0.45.0",
- "libp2p-identity",
- "libp2p-kad 0.46.2",
- "libp2p-swarm 0.45.1",
- "pin-project",
- "prometheus-client",
- "web-time",
 ]
 
 [[package]]
@@ -9361,32 +8491,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b137cb1ae86ee39f8e5d6245a296518912014eaa87427d24e6ff58cfc1b28c"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "bytes",
- "curve25519-dalek",
- "futures",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "once_cell",
- "quick-protobuf",
- "rand 0.8.8",
- "sha2 0.10.9",
- "snow",
- "static_assertions",
- "thiserror 1.0.69",
- "tracing",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-noise"
 version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
@@ -9421,30 +8525,6 @@ dependencies = [
  "libp2p-core 0.41.3",
  "libp2p-identity",
  "libp2p-tls 0.4.1",
- "parking_lot",
- "quinn",
- "rand 0.8.8",
- "ring 0.17.14",
- "rustls 0.23.43",
- "socket2 0.5.10",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-quic"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
-dependencies = [
- "bytes",
- "futures",
- "futures-timer",
- "if-watch",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-tls 0.5.0",
  "parking_lot",
  "quinn",
  "rand 0.8.8",
@@ -9500,26 +8580,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
-dependencies = [
- "async-trait",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "rand 0.8.8",
- "smallvec",
- "tracing",
- "void",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-request-response"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548fe44a80ff275d400f1b26b090d441d83ef73efabbeb6415f4ce37e5aed865"
@@ -9557,30 +8617,6 @@ dependencies = [
  "tokio",
  "tracing",
  "void",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm-derive 0.35.0",
- "lru 0.12.5",
- "multistream-select",
- "once_cell",
- "rand 0.8.8",
- "smallvec",
- "tokio",
- "tracing",
- "void",
- "web-time",
 ]
 
 [[package]]
@@ -9649,23 +8685,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libc",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "socket2 0.5.10",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-tcp"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0"
@@ -9689,25 +8708,6 @@ dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core 0.41.3",
- "libp2p-identity",
- "rcgen 0.11.3",
- "ring 0.17.14",
- "rustls 0.23.43",
- "rustls-webpki 0.101.7",
- "thiserror 1.0.69",
- "x509-parser 0.16.0",
- "yasna",
-]
-
-[[package]]
-name = "libp2p-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
-dependencies = [
- "futures",
- "futures-rustls",
- "libp2p-core 0.42.0",
  "libp2p-identity",
  "rcgen 0.11.3",
  "ring 0.17.14",
@@ -9755,22 +8755,6 @@ dependencies = [
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
-dependencies = [
- "futures",
- "futures-timer",
- "igd-next 0.14.3",
- "libp2p-core 0.42.0",
- "libp2p-swarm 0.45.1",
- "tokio",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "libp2p-upnp"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a"
@@ -9794,27 +8778,6 @@ dependencies = [
  "futures",
  "futures-rustls",
  "libp2p-core 0.41.3",
- "libp2p-identity",
- "parking_lot",
- "pin-project-lite",
- "rw-stream-sink",
- "soketto",
- "thiserror 1.0.69",
- "tracing",
- "url",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
-name = "libp2p-websocket"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888b2ff2e5d8dcef97283daab35ad1043d18952b65e05279eecbe02af4c6e347"
-dependencies = [
- "either",
- "futures",
- "futures-rustls",
- "libp2p-core 0.42.0",
  "libp2p-identity",
  "parking_lot",
  "pin-project-lite",
@@ -9856,21 +8819,6 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core 0.41.3",
- "thiserror 1.0.69",
- "tracing",
- "yamux 0.12.1",
- "yamux 0.13.5",
-]
-
-[[package]]
-name = "libp2p-yamux"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788b61c80789dba9760d8c669a5bedb642c8267555c803fabd8396e4ca5c5882"
-dependencies = [
- "either",
- "futures",
- "libp2p-core 0.42.0",
  "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
@@ -10016,15 +8964,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
@@ -10071,15 +9010,6 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
@@ -10625,18 +9555,6 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.5",
- "indexmap 2.14.0",
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "crc32fast",
- "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "memchr",
 ]
@@ -11543,22 +10461,11 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3325791708ad50580aeacfcce06cb5e462c9ba7a2368e109cb2012b944b70e"
-dependencies = [
- "cranelift-bitset 0.118.0",
- "log",
- "wasmtime-math",
-]
-
-[[package]]
-name = "pulley-interpreter"
 version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f647f8aefd39efd5e38b484a8b7a926dd035ae366127df75c1d94d196f0a4ba"
 dependencies = [
- "cranelift-bitset 0.133.3",
+ "cranelift-bitset",
  "log",
  "pulley-macros",
  "wasmtime-internal-core",
@@ -11960,20 +10867,6 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc06e6b318142614e4a48bc725abbf08ff166694835c43c9dae5a9009704639a"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.15.5",
- "log",
- "rustc-hash 2.1.3",
- "smallvec",
-]
-
-[[package]]
-name = "regalloc2"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
@@ -12214,15 +11107,6 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
-name = "rlimit"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "rlp"
@@ -14219,26 +13103,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "bitflags 2.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
@@ -14723,16 +13587,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.226.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d81b727619aec227dce83e7f7420d4e56c79acd044642a356ea045b98d4e13"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.226.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
@@ -14767,19 +13621,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.226.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc28600dcb2ba68d7e5f1c3ba4195c2bddc918c0243fd702d0b6dbd05689b681"
-dependencies = [
- "bitflags 2.13.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver 1.0.28",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
@@ -14789,17 +13630,6 @@ dependencies = [
  "indexmap 2.14.0",
  "semver 1.0.28",
  "serde",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.226.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "753a0516fa6c01756ee861f36878dfd9875f273aea9409d9ea390a333c5bcdc2"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.226.0",
 ]
 
 [[package]]
@@ -14837,56 +13667,12 @@ dependencies = [
  "serde_json",
  "target-lexicon 0.12.16",
  "wasmparser 0.121.2",
- "wasmtime-cache 18.0.4",
- "wasmtime-cranelift 18.0.4",
+ "wasmtime-cache",
+ "wasmtime-cranelift",
  "wasmtime-environ 18.0.4",
- "wasmtime-jit-icache-coherence 18.0.4",
+ "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "wasmtime"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fe78033c72da8741e724d763daf1375c93a38bfcea99c873ee4415f6098c3f"
-dependencies = [
- "addr2line 0.24.2",
- "anyhow",
- "bitflags 2.13.1",
- "bumpalo",
- "cc",
- "cfg-if",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "libc",
- "log",
- "mach2 0.4.3",
- "memfd",
- "object 0.36.7",
- "once_cell",
- "paste",
- "postcard",
- "psm",
- "pulley-interpreter 31.0.0",
- "rayon",
- "rustix 0.38.44",
- "serde",
- "serde_derive",
- "smallvec",
- "sptr",
- "target-lexicon 0.13.5",
- "wasmparser 0.226.0",
- "wasmtime-asm-macros 31.0.0",
- "wasmtime-cache 31.0.0",
- "wasmtime-cranelift 31.0.0",
- "wasmtime-environ 31.0.0",
- "wasmtime-fiber",
- "wasmtime-jit-icache-coherence 31.0.0",
- "wasmtime-math",
- "wasmtime-slab",
- "wasmtime-versioned-export-macros 31.0.0",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14904,12 +13690,12 @@ dependencies = [
  "futures",
  "libc",
  "log",
- "mach2 0.6.0",
+ "mach2",
  "memfd",
  "object 0.39.1",
  "once_cell",
  "postcard",
- "pulley-interpreter 46.0.3",
+ "pulley-interpreter",
  "rayon",
  "rustix 1.1.4",
  "serde",
@@ -14939,15 +13725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-asm-macros"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f3d44ae977d70ccf80938b371d5ec60b6adedf60800b9e8dd1223bb69f4cbc"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "wasmtime-cache"
 version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14965,26 +13742,6 @@ dependencies = [
  "toml 0.5.11",
  "windows-sys 0.52.0",
  "zstd 0.11.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "wasmtime-cache"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e209505770c7f38725513dba37246265fa6f724c30969de1e9d2a9e6c8f55099"
-dependencies = [
- "anyhow",
- "base64 0.21.7",
- "directories-next",
- "log",
- "postcard",
- "rustix 0.38.44",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "toml 0.8.23",
- "windows-sys 0.59.0",
- "zstd 0.13.3",
 ]
 
 [[package]]
@@ -15009,33 +13766,7 @@ dependencies = [
  "wasmparser 0.121.2",
  "wasmtime-cranelift-shared",
  "wasmtime-environ 18.0.4",
- "wasmtime-versioned-export-macros 18.0.4",
-]
-
-[[package]]
-name = "wasmtime-cranelift"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fc12eb8ea695a30007a4849a5fd56209dd86a15579e92e0c27c27122818505"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen 0.118.0",
- "cranelift-control 0.118.0",
- "cranelift-entity 0.118.0",
- "cranelift-frontend 0.118.0",
- "cranelift-native 0.118.0",
- "gimli 0.31.1",
- "itertools 0.12.1",
- "log",
- "object 0.36.7",
- "pulley-interpreter 31.0.0",
- "smallvec",
- "target-lexicon 0.13.5",
- "thiserror 1.0.69",
- "wasmparser 0.226.0",
- "wasmtime-environ 31.0.0",
- "wasmtime-versioned-export-macros 31.0.0",
+ "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
@@ -15077,29 +13808,6 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6b4bf08e371edf262cccb62de10e214bd4aaafaa069f1cd49c9c1c3a5ae8e4"
-dependencies = [
- "anyhow",
- "cranelift-bitset 0.118.0",
- "cranelift-entity 0.118.0",
- "gimli 0.31.1",
- "indexmap 2.14.0",
- "log",
- "object 0.36.7",
- "postcard",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasm-encoder 0.226.0",
- "wasmparser 0.226.0",
- "wasmprinter 0.226.0",
-]
-
-[[package]]
-name = "wasmtime-environ"
 version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2595a168541e8a7faeacf21e3d59da93628ee71468cd69fee9fc2a92c9b1c7d8"
@@ -15107,7 +13815,7 @@ dependencies = [
  "anyhow",
  "cpp_demangle",
  "cranelift-bforest 0.133.3",
- "cranelift-bitset 0.133.3",
+ "cranelift-bitset",
  "cranelift-entity 0.133.3",
  "gimli 0.33.0",
  "hashbrown 0.17.1",
@@ -15124,24 +13832,9 @@ dependencies = [
  "target-lexicon 0.13.5",
  "wasm-encoder 0.251.0",
  "wasmparser 0.251.0",
- "wasmprinter 0.251.0",
+ "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8828d7d8fbe90d087a9edea9223315caf7eb434848896667e5d27889f1173"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "rustix 0.38.44",
- "wasmtime-asm-macros 31.0.0",
- "wasmtime-versioned-export-macros 31.0.0",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15198,7 +13891,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object 0.39.1",
- "pulley-interpreter 46.0.3",
+ "pulley-interpreter",
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.20",
@@ -15282,27 +13975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f6c6c7e9d7eeee32dfcc10db7f29d505ee7dd28d00593ea241d5f70698e64"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wasmtime-math"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1108aad2e6965698f9207ea79b80eda2b3dcc57dcb69f4258296d4664ae32cd"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "wasmtime-runtime"
 version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15322,18 +13994,12 @@ dependencies = [
  "rustix 0.38.44",
  "sptr",
  "wasm-encoder 0.41.2",
- "wasmtime-asm-macros 18.0.4",
+ "wasmtime-asm-macros",
  "wasmtime-environ 18.0.4",
- "wasmtime-versioned-export-macros 18.0.4",
+ "wasmtime-versioned-export-macros",
  "wasmtime-wmemcheck",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "wasmtime-slab"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d6a321317281b721c5530ef733e8596ecc6065035f286ccd155b3fa8e0ab2f"
 
 [[package]]
 name = "wasmtime-types"
@@ -15353,17 +14019,6 @@ name = "wasmtime-versioned-export-macros"
 version = "18.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5399c175ddba4a471b9da45105dea3493059d52b2d54860eadb0df04c813948d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "wasmtime-versioned-export-macros"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5732a5c86efce7bca121a61d8c07875f6b85c1607aa86753b40f7f8bd9d3a780"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/version-compatibility/build-historical-node.sh
+++ b/version-compatibility/build-historical-node.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install the historical node independently of the compatibility workspace.
+set -euo pipefail
+
+compatibility_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+install_root="$compatibility_dir/target/historical/v0.44.0"
+
+check_version() {
+  local binary="$1" version
+  if [[ ! -x "$binary" ]]; then
+    echo "Historical node is not executable: $binary" >&2
+    exit 1
+  fi
+  if ! version=$("$binary" --version); then
+    echo "Failed to read historical node version: $binary" >&2
+    exit 1
+  fi
+  if [[ "$version" != "fuel-core 0.44.0" ]]; then
+    echo "Expected fuel-core 0.44.0, got '$version' from $binary" >&2
+    exit 1
+  fi
+  echo "Historical node ready: $binary"
+}
+
+if [[ ${FUEL_CORE_V44_BIN+x} ]]; then
+  check_version "$FUEL_CORE_V44_BIN"
+  exit 0
+fi
+
+cargo_command=(cargo)
+rustc_command=(rustc)
+if [[ -n "${FUEL_CORE_V44_TOOLCHAIN:-}" ]]; then
+  cargo_command+=("+$FUEL_CORE_V44_TOOLCHAIN")
+  rustc_command+=("+$FUEL_CORE_V44_TOOLCHAIN")
+fi
+host=$("${rustc_command[@]}" -vV | sed -n 's/^host: //p')
+if [[ -z "$host" ]]; then
+  echo "Could not determine the historical Rust toolchain's native target" >&2
+  exit 1
+fi
+
+# Old sources must not inherit the current workspace's warning-as-error policy.
+# Keep build artifacts outside the installation root, reusable across installs.
+RUSTFLAGS= CARGO_ENCODED_RUSTFLAGS= \
+  CARGO_TARGET_DIR="$compatibility_dir/target/historical/build/v0.44.0" \
+  "${cargo_command[@]}" install fuel-core-bin --version '=0.44.0' --locked \
+  --features parquet,p2p --target "$host" --root "$install_root"
+
+check_version "$install_root/bin/fuel-core"

--- a/version-compatibility/forkless-upgrade/Cargo.toml
+++ b/version-compatibility/forkless-upgrade/Cargo.toml
@@ -5,18 +5,16 @@ name = "forkless-upgrade"
 publish = false
 version = "0.0.0"
 build = "build.rs"
+[dependencies]
+tracing = "0.1.41"
 
 [dev-dependencies]
 anyhow = "1.0"
+
+# pin async-graphql because they bumped msrv in a patch release
+async-graphql = "=7.0.15"
 clap = "4.4"
-libp2p = "0.55.0"
-hex = "0.4.3"
-rand = "0.8"
-tempfile = "3.4"
-tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
 cynic = { version = "=3.12.0" }
-reqwest = { version = "0.12", features = ["json"] }
-serde_json = "1.0"
 
 # Neutral deps
 fuel-core = { path = "../../crates/fuel-core", default-features = false, features = ["test-helpers"] }
@@ -24,40 +22,40 @@ fuel-core-trace = { path = "../../crates/trace" }
 fuel-crypto = { version = "0.63.0" }
 fuel-tx = { version = "0.63.0", features = ["random"] }
 
-# Latest fuel-core
-latest-fuel-core-bin = { path = "../../bin/fuel-core", package = "fuel-core-bin", default-features = false, features = [
-  "relayer",
-  "parquet",
-  "p2p",
-] }
-latest-fuel-core-type = { path = "../../crates/types", package = "fuel-core-types", features = [
-  "test-helpers",
-] }
-latest-fuel-core-client = { path = "../../crates/client", package = "fuel-core-client" }
-latest-fuel-core-upgradable-executor = { path = "../../crates/services/upgradable-executor", package = "fuel-core-upgradable-executor", features = [
-  "wasm-executor",
-] }
-
 # Genesis fuel-core
 genesis-fuel-core-bin = { version = "0.26.0", package = "fuel-core-bin", features = [
-  "parquet",
-  "p2p",
+    "parquet",
+    "p2p",
 ] }
 genesis-fuel-core-client = { version = "0.26.0", package = "fuel-core-client" }
 genesis-fuel-core-services = { version = "0.26.0", package = "fuel-core-services" }
+hex = "0.4.3"
+
+# Latest fuel-core
+latest-fuel-core-bin = { path = "../../bin/fuel-core", package = "fuel-core-bin", default-features = false, features = [
+    "relayer",
+    "parquet",
+    "p2p",
+] }
+latest-fuel-core-client = { path = "../../crates/client", package = "fuel-core-client" }
+latest-fuel-core-type = { path = "../../crates/types", package = "fuel-core-types", features = [
+    "test-helpers",
+] }
+latest-fuel-core-upgradable-executor = { path = "../../crates/services/upgradable-executor", package = "fuel-core-upgradable-executor", features = [
+    "wasm-executor",
+] }
+libp2p = "0.55.0"
+rand = "0.8"
+reqwest = { version = "0.12", features = ["json"] }
+serde_json = "1.0"
+tempfile = "3.4"
+tokio = { version = "1.37.0", features = ["rt-multi-thread", "time"] }
+version-44-fuel-core-client = { version = "0.44.0", package = "fuel-core-client" }
 
 # Fuel core version 0.44.0
-version-44-fuel-core-bin = { version = "0.44.0", package = "fuel-core-bin", features = [
-  "parquet",
-  "p2p",
-] }
 version-44-fuel-core-type = { version = "0.44.0", package = "fuel-core-types", features = [
-  "test-helpers",
+    "test-helpers",
 ] }
-version-44-fuel-core-client = { version = "0.44.0", package = "fuel-core-client" }
-version-44-fuel-core-services = { version = "0.44.0", package = "fuel-core-services" }
 
-# pin async-graphql because they bumped msrv in a patch release
-async-graphql = "=7.0.15"
-[dependencies]
-tracing = "0.1.41"
+[target.'cfg(unix)'.dev-dependencies]
+nix = { version = "0.30", features = ["signal"] }

--- a/version-compatibility/forkless-upgrade/README.md
+++ b/version-compatibility/forkless-upgrade/README.md
@@ -71,9 +71,14 @@ In the case of breaking API, we need to remove old tests(usually, we need to cre
 If at any point the state transition function becomes forward incompatible, we need to update 
 `latest_state_transition_function_is_forward_compatible_with_v44_binary` to use the latest version of `fuel-core`.
 
+Advancing the historical node baseline does not change which older clients are
+supported. Retain their compatibility tests and dependencies unless the client
+support policy explicitly retires them; do not upgrade those fixtures merely
+because the node baseline advances.
+
 To update the test, we need to:
 - Update the historical release in `build-historical-node.sh`, the CI cache key, and the driver's executable path and expected node version.
-- Update the historical client/type dependencies and verify the new release's CLI arguments and structured GraphQL startup message.
+- Update the client/type dependencies used by the historical node driver, preserving dependencies still needed by older-client tests, and verify the new release's CLI arguments and structured GraphQL startup message.
 - Add a new `chain-configurations` entry for the new version
 - Copy over the contents of the previous version. i.e. if we are updating from `v36` to `v44`, we should create a new 
 `v44` directory and copy over the contents of `v36` to `v44`.
@@ -84,3 +89,24 @@ To update the test, we need to:
         - "genesis_state_transition_version" in `chain_config.json`
         - "state_transition_version" for the `latest_block` in `state_config.json`
         - Bump the versions in the test asserts. i.e. if the version in the configs is `28`, then the asserts will be `29` and `30` respectively.
+
+### Refreshing the lockfile and verifying
+
+After changing the baseline dependencies, run the compatibility check once without
+`--locked` to refresh `version-compatibility/Cargo.lock`. Keep the existing lockfile
+so unrelated dependencies remain pinned; do not delete it or run an unrestricted
+`cargo update` as part of a baseline bump.
+
+From the repository root:
+
+```sh
+./version-compatibility/build-historical-node.sh
+cargo check --manifest-path version-compatibility/Cargo.toml --workspace --tests
+cargo check --manifest-path version-compatibility/Cargo.toml --workspace --tests --locked
+cargo test --manifest-path version-compatibility/Cargo.toml --workspace --locked
+```
+
+Review the lockfile changes for the intended dependency updates and removals, and
+commit them with the baseline change. The final locked check and test commands
+verify that the committed dependency graph supports the updated compatibility
+tests without further lockfile changes.

--- a/version-compatibility/forkless-upgrade/README.md
+++ b/version-compatibility/forkless-upgrade/README.md
@@ -4,6 +4,58 @@ This crate tests that state transition functions for all releases of `fuel-core`
 
 In addition, we also test that releases are forward-compatible unless we introduce a breaking change in the API.
 
+## Running locally
+
+Build the historical native node explicitly before running the compatibility workspace:
+
+```sh
+./version-compatibility/build-historical-node.sh
+cargo check --manifest-path version-compatibility/Cargo.toml --workspace --locked
+cargo test --manifest-path version-compatibility/Cargo.toml --workspace --locked
+```
+
+The setup script works from any working directory and installs exactly `fuel-core-bin`
+`0.44.0` with its published lockfile, original default features, and `parquet,p2p`.
+It uses Cargo's default release profile and the selected toolchain's native target.
+The executable is `version-compatibility/target/historical/v0.44.0/bin/fuel-core`;
+intermediate build artifacts are reused from
+`version-compatibility/target/historical/build/v0.44.0`. Re-running setup does not
+force a reinstall. CI runs this setup only for the compatibility matrix entry and
+caches both directories by historical version, toolchain, native target, profile,
+features, and setup script.
+
+By default setup uses the active Rust toolchain. To select another already-installed
+toolchain, run `FUEL_CORE_V44_TOOLCHAIN=<toolchain> ./version-compatibility/build-historical-node.sh`.
+CI selects its pinned `RUST_VERSION`. Historical sources can require an older
+toolchain or native build prerequisites even when the current workspace builds;
+setup clears inherited `RUSTFLAGS` and `CARGO_ENCODED_RUSTFLAGS` so warnings in old
+sources are not promoted to errors.
+
+To use an existing executable instead, export an absolute path before both setup
+and tests:
+
+```sh
+export FUEL_CORE_V44_BIN=/absolute/path/to/fuel-core
+./version-compatibility/build-historical-node.sh
+cargo check --manifest-path version-compatibility/Cargo.toml --workspace --locked
+cargo test --manifest-path version-compatibility/Cargo.toml --workspace --locked
+```
+
+With this override, setup validates that the executable reports `fuel-core 0.44.0`
+and skips installation. Supply a native binary built with the same default features
+plus `parquet,p2p`. Tests use the override at runtime, or the default installation
+path derived from the crate directory; they never install the binary themselves.
+Keep the initial `cargo check`: the existing v0.26 WASM executor build needs its
+locked dependencies fetched before its offline build.
+
+The v0.44 forward-compatibility node runs as a subprocess and is exercised through
+its historical GraphQL client. Its executable has an independent dependency graph,
+so the old libp2p stack is not unified with the current node's stack and needs no
+test-only vendor patch. The v0.26 backward-compatibility and historical WASM executor
+coverage remains in-process; this isolation change applies only to the v0.44 node.
+The driver binds historical GraphQL and P2P listeners to loopback. These old
+dependencies are intentionally preserved for testing, not suitable for deployment.
+
 ## Adding new test
 
 We need to add a new backward compatibility test for each new release. To add tests, we need to duplicate tests that are using the latest `fuel-core` and replace usage of the latest crate with a new release.
@@ -20,6 +72,8 @@ If at any point the state transition function becomes forward incompatible, we n
 `latest_state_transition_function_is_forward_compatible_with_v44_binary` to use the latest version of `fuel-core`.
 
 To update the test, we need to:
+- Update the historical release in `build-historical-node.sh`, the CI cache key, and the driver's executable path and expected node version.
+- Update the historical client/type dependencies and verify the new release's CLI arguments and structured GraphQL startup message.
 - Add a new `chain-configurations` entry for the new version
 - Copy over the contents of the previous version. i.e. if we are updating from `v36` to `v44`, we should create a new 
 `v44` directory and copy over the contents of `v36` to `v44`.

--- a/version-compatibility/forkless-upgrade/src/backward_compatibility.rs
+++ b/version-compatibility/forkless-upgrade/src/backward_compatibility.rs
@@ -143,8 +143,7 @@ async fn latest_binary_serves_consensus_parameters_to_v44_client() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn latest_binary_serves_ignition_snapshot_consensus_parameters_to_v44_client()
- {
+async fn latest_binary_serves_ignition_snapshot_consensus_parameters_to_v44_client() {
     // given
     let latest_node = LatestFuelCoreDriver::spawn(&[
         "--debug",
@@ -272,8 +271,8 @@ async fn latest_binary_is_backward_compatible_and_follows_blocks_created_by_gene
     for i in 0..BLOCKS_TO_PRODUCE {
         let _ = tokio::time::timeout(BLOCK_INCLUSION_TIMEOUT, imported_blocks.next())
             .await
-            .expect(format!("Timed out waiting for block import {i}").as_str())
-            .expect(format!("Failed to import block {i}").as_str());
+            .unwrap_or_else(|_| panic!("Timed out waiting for block import {i}"))
+            .unwrap_or_else(|| panic!("Failed to import block {i}"));
     }
 }
 
@@ -335,9 +334,10 @@ async fn latest_binary_is_backward_compatible_and_follows_blocks_created_by_v44_
     for i in 0..BLOCKS_TO_PRODUCE {
         let _ = tokio::time::timeout(BLOCK_INCLUSION_TIMEOUT, imported_blocks.next())
             .await
-            .expect(format!("Timed out waiting for block import {i}").as_str())
-            .expect(format!("Failed to import block {i}").as_str());
+            .unwrap_or_else(|_| panic!("Timed out waiting for block import {i}"))
+            .unwrap_or_else(|| panic!("Failed to import block {i}"));
     }
+    drop(_v44_node.kill().await);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/version-compatibility/forkless-upgrade/src/forward_compatibility.rs
+++ b/version-compatibility/forkless-upgrade/src/forward_compatibility.rs
@@ -13,16 +13,43 @@ use crate::{
         upgrade_transaction,
     },
 };
-use libp2p::{
-    futures::StreamExt,
-    identity::secp256k1::Keypair as SecpKeypair,
-};
+use libp2p::identity::secp256k1::Keypair as SecpKeypair;
 use rand::{
     SeedableRng,
     rngs::StdRng,
 };
 use std::time::Duration;
+use version_44_fuel_core_client::client::{
+    FuelClient,
+    types::{
+        Block,
+        TransactionStatus,
+    },
+};
 use version_44_fuel_core_type::fuel_tx::field::ChargeableBody;
+
+async fn await_v44_block(client: &FuelClient, height: u32, timeout: Duration) -> Block {
+    tokio::time::timeout(timeout, async {
+        loop {
+            let block =
+                client
+                    .block_by_height(height.into())
+                    .await
+                    .unwrap_or_else(|error| {
+                        panic!("Failed to query v44 validator block {height}: {error}")
+                    });
+            if let Some(block) = block {
+                assert_eq!(block.header.height, height);
+                return block;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!("Timed out after {timeout:?} waiting for v44 validator block {height}")
+    })
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn latest_state_transition_function_is_forward_compatible_with_v44_binary() {
@@ -88,25 +115,26 @@ async fn latest_state_transition_function_is_forward_compatible_with_v44_binary(
     .unwrap();
 
     // Given
-    let mut imported_blocks = validator_node.node.shared.block_importer.events();
     const BLOCKS_TO_PRODUCE: u32 = 10;
-    for i in 0..BLOCKS_TO_PRODUCE {
-        tracing::warn!("beep");
-        let block = tokio::time::timeout(Duration::from_secs(10), imported_blocks.next())
+    const BLOCK_IMPORT_TIMEOUT: Duration = Duration::from_secs(10);
+    // Capture the starting height once, then inspect every subsequent block.
+    let initial_height =
+        tokio::time::timeout(BLOCK_IMPORT_TIMEOUT, validator_node.client.chain_info())
             .await
-            .expect(format!("Timed out waiting for block import {i}").as_str())
-            .expect(format!("Failed to import block {i}").as_str());
-        tracing::warn!("boop");
+            .expect("Timed out querying the v44 validator's initial height")
+            .expect("Failed to query the v44 validator's initial height")
+            .latest_block
+            .header
+            .height;
+    for offset in 1..=BLOCKS_TO_PRODUCE {
+        let height = initial_height.checked_add(offset).expect("Height overflow");
+        let block =
+            await_v44_block(&validator_node.client, height, BLOCK_IMPORT_TIMEOUT).await;
         assert_eq!(
-            block
-                .sealed_block
-                .entity
-                .header()
-                .state_transition_bytecode_version(),
-            29
+            block.header.state_transition_bytecode_version, 29,
+            "Unexpected STF version before upgrade at height {height}"
         );
     }
-    drop(imported_blocks);
 
     // When
     let subsections =
@@ -121,11 +149,17 @@ async fn latest_state_transition_function_is_forward_compatible_with_v44_binary(
     let root = transactions[0].body().root;
     for upload in transactions {
         let tx = version_44_fuel_core_type::fuel_tx::Transaction::Upload(upload);
-        validator_node
-            .client
-            .submit_and_await_commit(&tx)
-            .await
-            .unwrap();
+        let status = tokio::time::timeout(
+            BLOCK_IMPORT_TIMEOUT,
+            validator_node.client.submit_and_await_commit(&tx),
+        )
+        .await
+        .expect("Timed out committing a bytecode upload")
+        .expect("Failed to submit a bytecode upload");
+        assert!(
+            matches!(status, TransactionStatus::Success { .. }),
+            "Bytecode upload did not succeed: {status:?}"
+        );
     }
     let upgrade = upgrade_transaction(
         version_44_fuel_core_type::fuel_tx::UpgradePurpose::StateTransition { root },
@@ -133,28 +167,40 @@ async fn latest_state_transition_function_is_forward_compatible_with_v44_binary(
         amount,
     );
     let upgrade_tx = version_44_fuel_core_type::fuel_tx::Transaction::Upgrade(upgrade);
-    validator_node
-        .client
-        .submit_and_await_commit(&upgrade_tx)
-        .await
-        .unwrap();
+    let upgrade_status = tokio::time::timeout(
+        BLOCK_IMPORT_TIMEOUT,
+        validator_node.client.submit_and_await_commit(&upgrade_tx),
+    )
+    .await
+    .expect("Timed out committing the STF upgrade")
+    .expect("Failed to submit the STF upgrade");
+    let upgrade_height = match upgrade_status {
+        TransactionStatus::Success { block_height, .. } => u32::from(block_height),
+        status => panic!("STF upgrade did not succeed: {status:?}"),
+    };
 
     // Then
-    let mut imported_blocks = validator_node.node.shared.block_importer.events();
-    for i in 0..BLOCKS_TO_PRODUCE {
+    // The upgrade executes under version 29 and stores version 30 for the next
+    // block's header. Anchor to its committed height, not a moving chain tip, so
+    // delayed polling cannot skip an incorrect first block after activation.
+    let upgrade_block =
+        await_v44_block(&validator_node.client, upgrade_height, BLOCK_IMPORT_TIMEOUT)
+            .await;
+    assert_eq!(
+        upgrade_block.header.state_transition_bytecode_version, 29,
+        "Unexpected STF version in the upgrade block at height {upgrade_height}"
+    );
+    for offset in 1..=BLOCKS_TO_PRODUCE {
+        let height = upgrade_height.checked_add(offset).expect("Height overflow");
         // Big timeout because we need to compile the state transition function.
         let block =
-            tokio::time::timeout(Duration::from_secs(360), imported_blocks.next())
-                .await
-                .expect(format!("Timed out waiting for block import {i}").as_str())
-                .expect(format!("Failed to import block {i}").as_str());
+            await_v44_block(&validator_node.client, height, Duration::from_secs(360))
+                .await;
         assert_eq!(
-            block
-                .sealed_block
-                .entity
-                .header()
-                .state_transition_bytecode_version(),
-            30
+            block.header.state_transition_bytecode_version, 30,
+            "Unexpected STF version after activation at height {height}"
         );
     }
+    drop(validator_node.kill().await);
+    drop(_v44_node.kill().await);
 }

--- a/version-compatibility/forkless-upgrade/src/tests_helper.rs
+++ b/version-compatibility/forkless-upgrade/src/tests_helper.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use anyhow::Context;
 use genesis_fuel_core_bin::FuelService as GenesisFuelService;
 use genesis_fuel_core_client::client::FuelClient as GenesisClient;
 use genesis_fuel_core_services::Service as _;
@@ -9,10 +10,22 @@ use rand::{
     Rng,
     prelude::StdRng,
 };
-use std::str::FromStr;
-use version_44_fuel_core_bin::FuelService as Version44FuelService;
+use std::{
+    io::{
+        BufRead,
+        BufReader,
+    },
+    net::SocketAddr,
+    path::PathBuf,
+    process::{
+        Child,
+        Command,
+        Stdio,
+    },
+    str::FromStr,
+    time::Duration,
+};
 use version_44_fuel_core_client::client::FuelClient as Version44Client;
-use version_44_fuel_core_services as _;
 use version_44_fuel_core_type::{
     fuel_crypto::{
         SecretKey,
@@ -101,20 +114,175 @@ define_core_driver!(
     false
 );
 
-define_core_driver!(
-    version_44_fuel_core_bin,
-    Version44FuelService,
-    Version44Client,
-    Version44FuelCoreDriver,
-    true
-);
+/// The historical binary has its own dependency graph and lockfile.
+pub struct Version44FuelCoreDriver {
+    // Reap the child before removing its database.
+    process: HistoricalProcess,
+    pub _db_dir: tempfile::TempDir,
+    pub client: Version44Client,
+}
+
+struct HistoricalProcess {
+    child: Child,
+    log: tempfile::NamedTempFile,
+}
+
+impl HistoricalProcess {
+    fn ensure_running(&mut self) -> anyhow::Result<()> {
+        if let Some(status) = self.child.try_wait()? {
+            anyhow::bail!("Historical node exited unexpectedly: {status}");
+        }
+        Ok(())
+    }
+
+    fn logs(&self) -> String {
+        std::fs::read_to_string(self.log.path()).unwrap_or_else(|error| {
+            format!("Unable to read historical node logs: {error}")
+        })
+    }
+
+    async fn client(&mut self) -> anyhow::Result<Version44Client> {
+        // Let the OS allocate the port. Reading the pinned release's structured
+        // startup log avoids the race inherent in reserving and releasing a port.
+        let mut reader = BufReader::new(self.log.reopen()?);
+        let mut line = String::new();
+        let client = 'endpoint: loop {
+            self.ensure_running()?;
+            while reader.read_line(&mut line)? != 0 {
+                if !line.ends_with('\n') {
+                    break;
+                }
+                if let Ok(record) = serde_json::from_str::<serde_json::Value>(&line)
+                    && let Some(address) =
+                        record["fields"]["message"].as_str().and_then(|message| {
+                            message.strip_prefix("Binding GraphQL provider to ")
+                        })
+                {
+                    break 'endpoint Version44Client::from(address.parse::<SocketAddr>()?);
+                }
+                line.clear();
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        };
+        loop {
+            self.ensure_running()?;
+            if client.health().await.unwrap_or(false) {
+                let version = client.node_info().await?.node_version;
+                anyhow::ensure!(
+                    version == "0.44.0",
+                    "Expected historical node 0.44.0, got {version}"
+                );
+                self.ensure_running()?;
+                return Ok(client);
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+}
+
+impl Drop for HistoricalProcess {
+    fn drop(&mut self) {
+        // Drop also runs during unwinding and cancelled async startup. Always
+        // reap before TempDir cleanup; a detached node must never outlive a test.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        if std::thread::panicking() {
+            eprintln!("Historical node logs:\n{}", self.logs());
+        }
+    }
+}
 
 impl Version44FuelCoreDriver {
-    pub async fn kill(self) -> tempfile::TempDir {
-        self.node
-            .send_stop_signal_and_await_shutdown()
+    pub async fn spawn(extra_args: &[&str]) -> anyhow::Result<Self> {
+        Self::spawn_with_directory(tempfile::tempdir()?, extra_args).await
+    }
+
+    pub async fn spawn_with_directory(
+        db_dir: tempfile::TempDir,
+        extra_args: &[&str],
+    ) -> anyhow::Result<Self> {
+        let executable = std::env::var_os("FUEL_CORE_V44_BIN")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("../target/historical/v0.44.0/bin/fuel-core")
+                    .with_extension(std::env::consts::EXE_EXTENSION)
+            });
+        let log = tempfile::NamedTempFile::new()?;
+        let child = Command::new(&executable)
+            .arg("run")
+            .arg("--db-path")
+            .arg(db_dir.path())
+            .args(["--ip", "127.0.0.1", "--port", "0"])
+            .args(["--address", "127.0.0.1"])
+            .args(extra_args)
+            .env("HUMAN_LOGGING", "false")
+            .env("RUST_LOG", "info")
+            .stdin(Stdio::null())
+            .stdout(log.as_file().try_clone()?)
+            .stderr(log.as_file().try_clone()?)
+            .spawn()
+            .with_context(|| {
+                format!(
+                    "Unable to launch {}. Run version-compatibility/build-historical-node.sh first",
+                    executable.display()
+                )
+            })?;
+        let mut process = HistoricalProcess { child, log };
+        let result =
+            tokio::time::timeout(Duration::from_secs(60), process.client()).await;
+        let client = match result {
+            Ok(Ok(client)) => client,
+            Ok(Err(error)) => {
+                return Err(error.context(process.logs()));
+            }
+            Err(error) => {
+                return Err(anyhow::anyhow!(
+                    "Historical node startup timed out: {error}\n{}",
+                    process.logs()
+                ));
+            }
+        };
+        Ok(Self {
+            process,
+            _db_dir: db_dir,
+            client,
+        })
+    }
+
+    pub async fn kill(mut self) -> tempfile::TempDir {
+        #[cfg(unix)]
+        {
+            use nix::{
+                sys::signal::{
+                    Signal,
+                    kill,
+                },
+                unistd::Pid,
+            };
+            kill(
+                Pid::from_raw(self.process.child.id() as i32),
+                Signal::SIGTERM,
+            )
+            .expect("Failed to signal historical node shutdown");
+            tokio::time::timeout(Duration::from_secs(30), async {
+                loop {
+                    if let Some(status) = self.process.child.try_wait().unwrap() {
+                        assert!(
+                            status.success(),
+                            "Historical node shutdown failed: {status}\n{}",
+                            self.process.logs()
+                        );
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+            })
             .await
-            .expect("Failed to stop the node");
+            .expect("Historical node shutdown timed out");
+        }
+        // On platforms without SIGTERM, Drop still kills and reaps the child.
+        drop(self.process);
         self._db_dir
     }
 }
@@ -138,8 +306,7 @@ impl LatestFuelCoreDriver {
 }
 
 pub const IGNITION_TESTNET_SNAPSHOT: &str = "./chain-configurations/ignition";
-pub const IGNITION_V21_TESTNET_SNAPSHOT: &str =
-    "./chain-configurations/ignition-v21";
+pub const IGNITION_V21_TESTNET_SNAPSHOT: &str = "./chain-configurations/ignition-v21";
 
 pub const V44_TESTNET_SNAPSHOT: &str = "./chain-configurations/v44";
 pub const POA_SECRET_KEY: &str =


### PR DESCRIPTION
## Summary

Run historical v0.44 compatibility nodes as independently built executables instead of linking their service implementation into the current test binary.

This is the first part of the split from #3334. It stands on its own against `master`: production sources, the root dependency manifests/lockfile, and current libp2p 0.55 are unchanged. The P2P advisory remediation will follow in #3334.

## Changes

- Add explicit `version-compatibility/build-historical-node.sh` setup using `cargo install fuel-core-bin --version '=0.44.0' --locked`, the published release lockfile, original default features, and `parquet,p2p`.
- Cache the historical release executable/build artifacts in the compatibility CI job. Support an installed historical toolchain or a version-checked `FUEL_CORE_V44_BIN` override. Tests and build.rs do not install this node implicitly.
- Replace only the v0.44 driver with a subprocess: OS-assigned GraphQL port discovered from the pinned release's structured startup log, bounded readiness/version checks, captured logs, graceful explicit shutdown, and kill/reap on drop or unwinding before database cleanup. Historical GraphQL and P2P listeners bind to loopback.
- Observe imported blocks through the historical GraphQL client. Preserve consecutive-block STF assertions: version 29 before activation and in the committed upgrade block, followed by version 30 at the next ten heights.
- Remove v0.44 binary/service dependencies from the compatibility test executable. Keep historical clients/types, snapshots, and v0.26 backward-compatibility coverage. No vendored dependency patch is introduced.

## Verification

On macOS arm64 with Rust 1.94.1:

- Historical v0.44 executable builds with its published lockfile and passes the setup version check.
- `cargo check --manifest-path version-compatibility/Cargo.toml --workspace --tests`
- `cargo clippy --manifest-path version-compatibility/Cargo.toml --workspace --tests --locked -- -D warnings`
- `cargo test --manifest-path version-compatibility/Cargo.toml --workspace --locked` — all 8 tests passed with the existing libp2p 0.55 dependency graph.
- CI-nightly rustfmt apply/check for both the root and compatibility workspaces (`nightly-2025-09-28`).
- Cargo manifest sorting, installer shell syntax, and spelling checks passed.

During the preceding implementation experiment, a real-process lifecycle smoke also exercised persisted-height restart, normal/panic cleanup, and invalid-CLI early-exit diagnostics. The temporary smoke source was removed.

## Review considerations

This trades historical dependency-resolution coupling for owned process-lifecycle code and a pinned startup-log format. The historical release intentionally retains old dependencies; it is a compatibility fixture, not a deployment recommendation. v0.26 remains in-process.

The initial historical release setup measured 10m12s on an Apple M5, with compilation running concurrently elsewhere; cached setup measured 0.34s, and the executable/build cache occupied 2.3 GiB. These are local observations, not Linux CI or clean-cache end-to-end benchmark claims. Historical compilation may eventually require an older toolchain/native environment.

This PR is test/CI-only and uses the `no changelog` label. Merge this first; then rebase #3334 onto master and merge its advisory-only commit separately.
