### PR TITLE
fix(schema): reuse existing change policy for non-requested asset in assemble_tx (#2990)

### DIFF
--- a/crates/fuel-core/src/schema/tx/assemble_tx.rs
+++ b/crates/fuel-core/src/schema/tx/assemble_tx.rs
@@ -285,13 +285,16 @@ where
             // If the user didn't request the asset, we add it to the required balances
             // with minimal amount `0` and `ChangePolicy::Change` policy.
             if !requested_asset.contains(input_asset_id) {
-                let recipient = fee_payer_account.owner();
+                let change_policy = change_output_policies
+                    .get(input_asset_id)
+                    .cloned()
+                    .unwrap_or_else(|| ChangePolicy::Change(fee_payer_account.owner()));
 
                 arguments.required_balances.push(RequiredBalance {
                     account: fee_payer_account.clone(),
                     asset_id: *input_asset_id,
                     amount: 0,
-                    change_policy: ChangePolicy::Change(recipient),
+                    change_policy,
                 });
             }
         }


### PR DESCRIPTION
### Description
Fixes an issue in \ssemble_tx\ where non-requested input assets with existing \Output::Change\ entries were assigned a duplicate \ChangePolicy::Change(fee_payer_account.owner())\ policy instead of preserving the existing \ChangePolicy\ registered for the asset.

### Changes
- Check \change_output_policies\ for existing \ChangePolicy\ when adding synthetic \RequiredBalance\ for non-requested input assets before defaulting to the fee payer account owner.

Closes #2990